### PR TITLE
Blueshield removal

### DIFF
--- a/code/game/jobs/job/blueshield_ch.dm
+++ b/code/game/jobs/job/blueshield_ch.dm
@@ -1,0 +1,3 @@
+/datum/job/blueshield
+	whitelist_only = 1
+	latejoin_only = 1

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -698,6 +698,7 @@
 #include "code\game\jobs\job\assistant.dm"
 #include "code\game\jobs\job\assistant_vr.dm"
 #include "code\game\jobs\job\blueshield.dm"
+#include "code\game\jobs\job\blueshield_ch.dm"
 #include "code\game\jobs\job\captain.dm"
 #include "code\game\jobs\job\captain_vr.dm"
 #include "code\game\jobs\job\civilian.dm"


### PR DESCRIPTION
Makes Blueshield whitelist only and latespawn only. Hopefully this will make the job event-only.