### PR TITLE
Shuttle Transfer, Not Tram

### DIFF
--- a/code/modules/busy_space/air_traffic.dm
+++ b/code/modules/busy_space/air_traffic.dm
@@ -43,9 +43,11 @@ var/datum/lore/atc_controller/atc = new/datum/lore/atc_controller
 		squelched = 0
 
 /datum/lore/atc_controller/proc/shift_ending(var/evac = 0)
-	msg("Automated Tram departing [using_map.station_name] for [using_map.dock_name] on routine transfer route.","NT Automated Tram") //VOREStation Edit - Tram, tho.
+	//CHOMPStation Edit Start TFF 28/12/19 - Shuttle transfer, not Tram.
+	msg("Automated Shuttle departing [using_map.station_name] for [using_map.dock_name] on routine transfer route.","NT Automated Shuttle")
 	sleep(5 SECONDS)
-	msg("Automated Tram, cleared to complete routine transfer from [using_map.station_name] to [using_map.dock_name].") //VOREStation Edit - Tram, tho.
+	msg("Automated Shuttle, cleared to complete routine transfer from [using_map.station_name] to [using_map.dock_name].")
+	//CHOMPStation Edit End
 
 /datum/lore/atc_controller/proc/random_convo()
 	var/one = pick(loremaster.organizations) //These will pick an index, not an instance


### PR DESCRIPTION
Title.

Changelog Notes: 

- Makes transfer stuff show Shuttle as transfer vehicle/mode. Not the Tram.