### PR TITLE
Backport Quick-NIF Perms

### DIFF
--- a/code/modules/admin/verbs/debug_vr.dm
+++ b/code/modules/admin/verbs/debug_vr.dm
@@ -3,7 +3,7 @@
 	set name = "Quick NIF"
 	set desc = "Spawns a NIF into someone in quick-implant mode."
 
-	if(!check_rights(R_ADMIN))
+	if(!check_rights(R_ADMIN|R_EVENT|R_DEBUG))	//TFF 24/4/19: Allow Devs to use Quick-NIF verb.
 		return
 
 	var/mob/living/carbon/human/H = input("Pick a mob with a player","Quick NIF") as null|anything in player_list

--- a/code/modules/admin/verbs/debug_vr.dm
+++ b/code/modules/admin/verbs/debug_vr.dm
@@ -3,7 +3,7 @@
 	set name = "Quick NIF"
 	set desc = "Spawns a NIF into someone in quick-implant mode."
 
-	if(!check_rights(R_ADMIN|R_EVENT|R_DEBUG))	//TFF 24/4/19: Allow Devs to use Quick-NIF verb.
+	if(!check_rights(R_ADMIN|R_EVENT|R_DEBUG))	//CHOMPStation Edit TFF 24/4/19: Allow Devs to use Quick-NIF verb.
 		return
 
 	var/mob/living/carbon/human/H = input("Pick a mob with a player","Quick NIF") as null|anything in player_list


### PR DESCRIPTION
Re-add ability for other staff to be able to quick-NIF others. Would allow testing devs to give themselves a NIF back if they lost it after a shift and so forth.