### PR TITLE
Re porting unified fabricators

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer_unify.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer_unify.dm
@@ -1,0 +1,19 @@
+//UNIFY start
+/obj/machinery/drone_fabricator/unify	//Non-Specific dronetype
+	drone_type = null //var filled by drone choice.
+	fabricator_tag = "Unified Drone Fabricator"
+
+	var/list/possible_drones = list("Construction Module" = /mob/living/silicon/robot/drone/construction,
+									"Maintenance Module" = /mob/living/silicon/robot/drone,
+									) //List of drone types to choose from.//Changeable in mapping.
+
+	create_drone(var/client/player)
+		choose_dronetype(possible_drones) //Call Drone choice before executing create_drone
+		..()
+
+/obj/machinery/drone_fabricator/proc/choose_dronetype(possible_drones)
+	var/choice
+	choice = input(usr,"What module would you like to use?") as null|anything in possible_drones
+	if(!choice) return
+	drone_type = possible_drones[choice]
+//UNIFY end

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2457,6 +2457,7 @@
 #include "code\modules\mob\living\silicon\robot\drone\drone_damage.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_items.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_manufacturer.dm"
+#include "code\modules\mob\living\silicon\robot\drone\drone_manufacturer_unify.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_say.dm"
 #include "code\modules\mob\living\silicon\robot\drone\drone_vr.dm"
 #include "code\modules\mob\living\silicon\robot\drone\swarm.dm"


### PR DESCRIPTION
This time you can set what drones they are allowed to make on the mapping side, so 1 item can be set to produce whatever drone you want mapped, meaning you can still have a unify fab that can only print mining drones. Just gotta map the tag appropriately