### PR TITLE
Drinks with Nutriment Factors

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -1190,7 +1190,7 @@
 	id = "grapesoda"
 	description = "Grapes made into a fine drank."
 	taste_description = "grape soda"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#421C52"
 	adj_drowsy = -3
 
@@ -1218,7 +1218,7 @@
 	id = "lemonade"
 	description = "Oh the nostalgia..."
 	taste_description = "lemonade"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#FFFF00"
 	adj_temp = -5
 
@@ -1231,7 +1231,7 @@
 	id = "melonade"
 	description = "Oh the.. nostalgia?"
 	taste_description = "watermelon"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#FFB3BB"
 	adj_temp = -5
 
@@ -1244,7 +1244,7 @@
 	id = "appleade"
 	description = "Applejuice, improved."
 	taste_description = "apples"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#FFD1B3"
 	adj_temp = -5
 
@@ -1257,7 +1257,7 @@
 	id = "pineappleade"
 	description = "Spineapple, juiced up."
 	taste_description = "sweet`n`sour pineapples"
-	nutriment_factor = 5
+	nutriment_factor = 5 //CS Edit
 	color = "#FFFF00"
 	adj_temp = -5
 
@@ -1270,7 +1270,7 @@
 	id = "kiraspecial"
 	description = "Long live the guy who everyone had mistaken for a girl. Baka!"
 	taste_description = "fruity sweetness"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#CCCC99"
 	adj_temp = -5
 
@@ -1283,7 +1283,7 @@
 	id = "brownstar"
 	description = "It's not what it sounds like..."
 	taste_description = "orange and cola soda"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#9F3400"
 	adj_temp = -2
 
@@ -1377,7 +1377,7 @@
 	id = "rewriter"
 	description = "The secret of the sanctuary of the Libarian..."
 	taste_description = "citrus and coffee"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#485000"
 	adj_temp = -5
 
@@ -1393,7 +1393,7 @@
 	id = "nuka_cola"
 	description = "Cola, cola never changes."
 	taste_description = "cola"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#100800"
 	adj_temp = -5
 	adj_sleepy = -2
@@ -1426,7 +1426,7 @@
 	id = "cola"
 	description = "A refreshing beverage."
 	taste_description = "cola"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	reagent_state = LIQUID
 	color = "#100800"
 	adj_drowsy = -3
@@ -1441,7 +1441,7 @@
 	id = "spacemountainwind"
 	description = "Blows right through you like a space wind."
 	taste_description = "sweet citrus soda"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#102000"
 	adj_drowsy = -7
 	adj_sleepy = -1
@@ -1456,7 +1456,7 @@
 	id = "dr_gibb"
 	description = "A delicious blend of 42 different flavors"
 	taste_description = "cherry soda"
-	nutriment_factor = 3
+	nutriment_factor = 3 //CS Edit
 	color = "#102000"
 	adj_drowsy = -6
 	adj_temp = -5
@@ -1469,7 +1469,7 @@
 	id = "space_up"
 	description = "Tastes like a hull breach in your mouth."
 	taste_description = "citrus soda"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#202800"
 	adj_temp = -8
 
@@ -1482,7 +1482,7 @@
 	id = "lemon_lime"
 	description = "A tangy substance made of 0.5% natural citrus!"
 	taste_description = "tangy lime and lemon soda"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#878F00"
 	adj_temp = -8
 
@@ -1495,7 +1495,7 @@
 	id = "gingerale"
 	description = "The original."
 	taste_description = "somewhat tangy ginger ale"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#edcf8f"
 	adj_temp = -8
 
@@ -1520,7 +1520,7 @@
 	id = "roy_rogers"
 	description = "I'm a cowboy, on a steel horse I ride."
 	taste_description = "cola and fruit"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#4F1811"
 	adj_temp = -8
 
@@ -1533,7 +1533,7 @@
 	id = "collins_mix"
 	description = "Best hope it isn't a hoax."
 	taste_description = "gin and lemonade"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#D7D0B3"
 	adj_temp = -8
 
@@ -1546,7 +1546,7 @@
 	id = "arnold_palmer"
 	description = "Tastes just like the old man."
 	taste_description = "lemon and sweet tea"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#AF5517"
 	adj_temp = -8
 
@@ -1669,7 +1669,7 @@
 	id = "dreamcream"
 	description = "A smoothy, silky mix of honey and dairy."
 	taste_description = "sweet, soothing dairy"
-	nutriment_factor = 5
+	nutriment_factor = 5 //CS Edit
 	color = "#fcfcc9" // rgb(252, 252, 201)
 
 	glass_name = "Dream Cream"
@@ -1680,7 +1680,7 @@
 	id = "vilelemon"
 	description = "A fizzy, sour lemonade mix."
 	taste_description = "fizzy, sour lemon"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#c6c603" // rgb(198, 198, 3)
 
 	glass_name = "Vile Lemon"
@@ -1692,7 +1692,7 @@
 	id = "entdraught"
 	description = "A natural, earthy combination of all things peaceful."
 	taste_description = "fresh rain and sweet memories"
-	nutriment_factor = 5
+	nutriment_factor = 5 //CS Edit
 	color = "#3a6617" // rgb(58, 102, 23)
 
 	glass_name = "Ent's Draught"
@@ -1713,7 +1713,7 @@
 	id = "oilslick"
 	description = "A viscous, but sweet, ooze."
 	taste_description = "honey"
-	nutriment_factor = 15
+	nutriment_factor = 15 //CS Edit
 	color = "#FDF5E6" // rgb(253,245,230)
 	water_based = FALSE
 
@@ -1749,7 +1749,7 @@
 	id = "nuclearwaste"
 	description = "A viscous, glowing slurry."
 	taste_description = "sour honey drops"
-	nutriment_factor = 15
+	nutriment_factor = 15 //CS Edit
 	color = "#7FFF00" // rgb(127,255,0)
 	water_based = FALSE
 
@@ -1775,7 +1775,7 @@
 	id = "sodaoil"
 	description = "A thick, bubbling soda."
 	taste_description = "chewy water"
-	nutriment_factor = 10
+	nutriment_factor = 10 //CS Edit
 	color = "#F0FFF0" // rgb(245,255,250)
 	water_based = FALSE
 
@@ -1862,7 +1862,7 @@
 	id = "fauxfizz"
 	description = "One sip and you're in the bahamas... maybe."
 	taste_description = "slightly tropical"
-	nutriment_factor = 4
+	nutriment_factor = 4 //CS Edit
 	color = "#69375C"
 
 	glass_name = "tropical fizz"
@@ -2418,7 +2418,7 @@
 	id = "cubalibre"
 	description = "Rum, mixed with cola. Viva la revolucion."
 	taste_description = "cola"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#3E1B00"
 	strength = 30
 
@@ -2431,7 +2431,7 @@
 	description = "This thing makes the hair on the back of your neck stand up."
 	taste_description = "sweet tasting iron"
 	taste_mult = 1.5
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#820000"
 	strength = 15
 
@@ -2804,7 +2804,7 @@
 	id = "snowwhite"
 	description = "A cold refreshment"
 	taste_description = "refreshing cold"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#FFFFFF"
 	strength = 30
 
@@ -2816,7 +2816,7 @@
 	id = "suidream"
 	description = "Comprised of: White soda, blue curacao, melon liquor."
 	taste_description = "fruit"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#00A86B"
 	strength = 100
 
@@ -2912,7 +2912,7 @@
 	id = "whiskeycola"
 	description = "Whiskey, mixed with cola. Surprisingly refreshing."
 	taste_description = "cola with an alcoholic undertone"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#3E1B00"
 	strength = 25
 
@@ -2925,7 +2925,7 @@
 	id = "whiskeysoda"
 	description = "Ultimate refreshment."
 	taste_description = "carbonated whiskey"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#EAB300"
 	strength = 15
 
@@ -3085,7 +3085,7 @@
 	id = "xanaducannon"
 	description = "Common in the entertainment districts of Titan."
 	taste_description = "sweet alcohol"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#614126"
 	strength = 50
 
@@ -3097,7 +3097,7 @@
 	id = "debugger"
 	description = "From Shelf. Not for human consumption."
 	taste_description = "oily bitterness"
-	nutriment_factor = 10
+	nutriment_factor = 10 //CS Edit
 	color = "#d3d3d3"
 	strength = 32
 
@@ -3109,7 +3109,7 @@
 	id = "spacersbrew"
 	description = "Ethanol and orange soda. A common emergency drink on frontier colonies."
 	taste_description = "bitter oranges"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#ffc04c"
 	strength = 43
 
@@ -3204,7 +3204,7 @@
 	id = "rotgut"
 	description = "A heinous combination of clashing flavors."
 	taste_description = "plague and coldsweats"
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#3a6617" // rgb(58, 102, 23)
 	strength = 10
 
@@ -3475,7 +3475,7 @@
 	description = "This thing makes the hair on the back of your neck stand up."
 	taste_description = "sweet victory and sour iron"
 	taste_mult = 1.5
-	nutriment_factor = 1.5
+	nutriment_factor = 1.5 //CS Edit
 	color = "#F3C906"
 	strength = 30
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -641,6 +641,7 @@
 	var/adj_drowsy = 0
 	var/adj_sleepy = 0
 	var/adj_temp = 0
+	var/nutriment_factor = 0
 	var/water_based = TRUE
 
 /datum/reagent/drink/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -659,11 +660,14 @@
 		M.bodytemperature = min(310, M.bodytemperature + (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
 	if(adj_temp < 0 && M.bodytemperature > 310)
 		M.bodytemperature = min(310, M.bodytemperature - (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
+	if(issmall(M)) removed *= 2 // Small bodymass, more effect from lower volume.
+	if(M.species.gets_food_nutrition) //VOREStation edit. If this is set to 0, they don't get nutrition from food.
+		M.nutrition += nutriment_factor * removed // For hunger and fatness
 	/* VOREStation Removal
 	if(alien == IS_SLIME && water_based)
 		M.adjustToxLoss(removed * 2)
 	*/ //VOREStation Removal End
-
+	
 /datum/reagent/drink/overdose(var/mob/living/carbon/M, var/alien) //Add special interactions here in the future if desired.
 	..()
 
@@ -1186,6 +1190,7 @@
 	id = "grapesoda"
 	description = "Grapes made into a fine drank."
 	taste_description = "grape soda"
+	nutriment_factor = 1.5
 	color = "#421C52"
 	adj_drowsy = -3
 
@@ -1213,6 +1218,7 @@
 	id = "lemonade"
 	description = "Oh the nostalgia..."
 	taste_description = "lemonade"
+	nutriment_factor = 1.5
 	color = "#FFFF00"
 	adj_temp = -5
 
@@ -1225,6 +1231,7 @@
 	id = "melonade"
 	description = "Oh the.. nostalgia?"
 	taste_description = "watermelon"
+	nutriment_factor = 1.5
 	color = "#FFB3BB"
 	adj_temp = -5
 
@@ -1237,6 +1244,7 @@
 	id = "appleade"
 	description = "Applejuice, improved."
 	taste_description = "apples"
+	nutriment_factor = 1.5
 	color = "#FFD1B3"
 	adj_temp = -5
 
@@ -1249,6 +1257,7 @@
 	id = "pineappleade"
 	description = "Spineapple, juiced up."
 	taste_description = "sweet`n`sour pineapples"
+	nutriment_factor = 5
 	color = "#FFFF00"
 	adj_temp = -5
 
@@ -1261,6 +1270,7 @@
 	id = "kiraspecial"
 	description = "Long live the guy who everyone had mistaken for a girl. Baka!"
 	taste_description = "fruity sweetness"
+	nutriment_factor = 1.5
 	color = "#CCCC99"
 	adj_temp = -5
 
@@ -1273,6 +1283,7 @@
 	id = "brownstar"
 	description = "It's not what it sounds like..."
 	taste_description = "orange and cola soda"
+	nutriment_factor = 1.5
 	color = "#9F3400"
 	adj_temp = -2
 
@@ -1366,6 +1377,7 @@
 	id = "rewriter"
 	description = "The secret of the sanctuary of the Libarian..."
 	taste_description = "citrus and coffee"
+	nutriment_factor = 1.5
 	color = "#485000"
 	adj_temp = -5
 
@@ -1381,6 +1393,7 @@
 	id = "nuka_cola"
 	description = "Cola, cola never changes."
 	taste_description = "cola"
+	nutriment_factor = 1.5
 	color = "#100800"
 	adj_temp = -5
 	adj_sleepy = -2
@@ -1413,6 +1426,7 @@
 	id = "cola"
 	description = "A refreshing beverage."
 	taste_description = "cola"
+	nutriment_factor = 1.5
 	reagent_state = LIQUID
 	color = "#100800"
 	adj_drowsy = -3
@@ -1427,6 +1441,7 @@
 	id = "spacemountainwind"
 	description = "Blows right through you like a space wind."
 	taste_description = "sweet citrus soda"
+	nutriment_factor = 1.5
 	color = "#102000"
 	adj_drowsy = -7
 	adj_sleepy = -1
@@ -1441,6 +1456,7 @@
 	id = "dr_gibb"
 	description = "A delicious blend of 42 different flavors"
 	taste_description = "cherry soda"
+	nutriment_factor = 3
 	color = "#102000"
 	adj_drowsy = -6
 	adj_temp = -5
@@ -1453,6 +1469,7 @@
 	id = "space_up"
 	description = "Tastes like a hull breach in your mouth."
 	taste_description = "citrus soda"
+	nutriment_factor = 1.5
 	color = "#202800"
 	adj_temp = -8
 
@@ -1465,6 +1482,7 @@
 	id = "lemon_lime"
 	description = "A tangy substance made of 0.5% natural citrus!"
 	taste_description = "tangy lime and lemon soda"
+	nutriment_factor = 1.5
 	color = "#878F00"
 	adj_temp = -8
 
@@ -1477,6 +1495,7 @@
 	id = "gingerale"
 	description = "The original."
 	taste_description = "somewhat tangy ginger ale"
+	nutriment_factor = 1.5
 	color = "#edcf8f"
 	adj_temp = -8
 
@@ -1501,6 +1520,7 @@
 	id = "roy_rogers"
 	description = "I'm a cowboy, on a steel horse I ride."
 	taste_description = "cola and fruit"
+	nutriment_factor = 1.5
 	color = "#4F1811"
 	adj_temp = -8
 
@@ -1513,6 +1533,7 @@
 	id = "collins_mix"
 	description = "Best hope it isn't a hoax."
 	taste_description = "gin and lemonade"
+	nutriment_factor = 1.5
 	color = "#D7D0B3"
 	adj_temp = -8
 
@@ -1525,6 +1546,7 @@
 	id = "arnold_palmer"
 	description = "Tastes just like the old man."
 	taste_description = "lemon and sweet tea"
+	nutriment_factor = 1.5
 	color = "#AF5517"
 	adj_temp = -8
 
@@ -1647,6 +1669,7 @@
 	id = "dreamcream"
 	description = "A smoothy, silky mix of honey and dairy."
 	taste_description = "sweet, soothing dairy"
+	nutriment_factor = 5
 	color = "#fcfcc9" // rgb(252, 252, 201)
 
 	glass_name = "Dream Cream"
@@ -1657,6 +1680,7 @@
 	id = "vilelemon"
 	description = "A fizzy, sour lemonade mix."
 	taste_description = "fizzy, sour lemon"
+	nutriment_factor = 1.5
 	color = "#c6c603" // rgb(198, 198, 3)
 
 	glass_name = "Vile Lemon"
@@ -1668,6 +1692,7 @@
 	id = "entdraught"
 	description = "A natural, earthy combination of all things peaceful."
 	taste_description = "fresh rain and sweet memories"
+	nutriment_factor = 5
 	color = "#3a6617" // rgb(58, 102, 23)
 
 	glass_name = "Ent's Draught"
@@ -1688,6 +1713,7 @@
 	id = "oilslick"
 	description = "A viscous, but sweet, ooze."
 	taste_description = "honey"
+	nutriment_factor = 15
 	color = "#FDF5E6" // rgb(253,245,230)
 	water_based = FALSE
 
@@ -1700,6 +1726,7 @@
 	id = "slimeslammer"
 	description = "A viscous, but savory, ooze."
 	taste_description = "peanuts`n`slime"
+	nutriment_factor = 20
 	color = "#93604D"
 	water_based = FALSE
 
@@ -1722,6 +1749,7 @@
 	id = "nuclearwaste"
 	description = "A viscous, glowing slurry."
 	taste_description = "sour honey drops"
+	nutriment_factor = 15
 	color = "#7FFF00" // rgb(127,255,0)
 	water_based = FALSE
 
@@ -1747,6 +1775,7 @@
 	id = "sodaoil"
 	description = "A thick, bubbling soda."
 	taste_description = "chewy water"
+	nutriment_factor = 10
 	color = "#F0FFF0" // rgb(245,255,250)
 	water_based = FALSE
 
@@ -1833,6 +1862,7 @@
 	id = "fauxfizz"
 	description = "One sip and you're in the bahamas... maybe."
 	taste_description = "slightly tropical"
+	nutriment_factor = 4
 	color = "#69375C"
 
 	glass_name = "tropical fizz"
@@ -2388,6 +2418,7 @@
 	id = "cubalibre"
 	description = "Rum, mixed with cola. Viva la revolucion."
 	taste_description = "cola"
+	nutriment_factor = 1.5
 	color = "#3E1B00"
 	strength = 30
 
@@ -2400,6 +2431,7 @@
 	description = "This thing makes the hair on the back of your neck stand up."
 	taste_description = "sweet tasting iron"
 	taste_mult = 1.5
+	nutriment_factor = 1.5
 	color = "#820000"
 	strength = 15
 
@@ -2772,6 +2804,7 @@
 	id = "snowwhite"
 	description = "A cold refreshment"
 	taste_description = "refreshing cold"
+	nutriment_factor = 1.5
 	color = "#FFFFFF"
 	strength = 30
 
@@ -2783,6 +2816,7 @@
 	id = "suidream"
 	description = "Comprised of: White soda, blue curacao, melon liquor."
 	taste_description = "fruit"
+	nutriment_factor = 1.5
 	color = "#00A86B"
 	strength = 100
 
@@ -2878,6 +2912,7 @@
 	id = "whiskeycola"
 	description = "Whiskey, mixed with cola. Surprisingly refreshing."
 	taste_description = "cola with an alcoholic undertone"
+	nutriment_factor = 1.5
 	color = "#3E1B00"
 	strength = 25
 
@@ -2890,6 +2925,7 @@
 	id = "whiskeysoda"
 	description = "Ultimate refreshment."
 	taste_description = "carbonated whiskey"
+	nutriment_factor = 1.5
 	color = "#EAB300"
 	strength = 15
 
@@ -3049,6 +3085,7 @@
 	id = "xanaducannon"
 	description = "Common in the entertainment districts of Titan."
 	taste_description = "sweet alcohol"
+	nutriment_factor = 1.5
 	color = "#614126"
 	strength = 50
 
@@ -3060,6 +3097,7 @@
 	id = "debugger"
 	description = "From Shelf. Not for human consumption."
 	taste_description = "oily bitterness"
+	nutriment_factor = 10
 	color = "#d3d3d3"
 	strength = 32
 
@@ -3071,6 +3109,7 @@
 	id = "spacersbrew"
 	description = "Ethanol and orange soda. A common emergency drink on frontier colonies."
 	taste_description = "bitter oranges"
+	nutriment_factor = 1.5
 	color = "#ffc04c"
 	strength = 43
 
@@ -3165,6 +3204,7 @@
 	id = "rotgut"
 	description = "A heinous combination of clashing flavors."
 	taste_description = "plague and coldsweats"
+	nutriment_factor = 1.5
 	color = "#3a6617" // rgb(58, 102, 23)
 	strength = 10
 
@@ -3435,6 +3475,7 @@
 	description = "This thing makes the hair on the back of your neck stand up."
 	taste_description = "sweet victory and sour iron"
 	taste_mult = 1.5
+	nutriment_factor = 1.5
 	color = "#F3C906"
 	strength = 30
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -1726,7 +1726,7 @@
 	id = "slimeslammer"
 	description = "A viscous, but savory, ooze."
 	taste_description = "peanuts`n`slime"
-	nutriment_factor = 20
+	nutriment_factor = 20 //CS Edit
 	color = "#93604D"
 	water_based = FALSE
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -641,7 +641,7 @@
 	var/adj_drowsy = 0
 	var/adj_sleepy = 0
 	var/adj_temp = 0
-	var/nutriment_factor = 0
+	var/nutriment_factor = 0 //CHOMPStation addition
 	var/water_based = TRUE
 
 /datum/reagent/drink/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -660,9 +660,9 @@
 		M.bodytemperature = min(310, M.bodytemperature + (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
 	if(adj_temp < 0 && M.bodytemperature > 310)
 		M.bodytemperature = min(310, M.bodytemperature - (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
-	if(issmall(M)) removed *= 2 // Small bodymass, more effect from lower volume.
-	if(M.species.gets_food_nutrition) //VOREStation edit. If this is set to 0, they don't get nutrition from food.
-		M.nutrition += nutriment_factor * removed // For hunger and fatness
+	if(issmall(M)) removed *= 2 //CHOMP Station addition Small bodymass, more effect from lower volume.
+	if(M.species.gets_food_nutrition) //CHOMPStation addition. If this is set to 0, they don't get nutrition from food.
+		M.nutrition += nutriment_factor * removed //CHOMPStation addition For hunger and fatness
 	/* VOREStation Removal
 	if(alien == IS_SLIME && water_based)
 		M.adjustToxLoss(removed * 2)
@@ -1190,7 +1190,7 @@
 	id = "grapesoda"
 	description = "Grapes made into a fine drank."
 	taste_description = "grape soda"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#421C52"
 	adj_drowsy = -3
 
@@ -1218,7 +1218,7 @@
 	id = "lemonade"
 	description = "Oh the nostalgia..."
 	taste_description = "lemonade"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#FFFF00"
 	adj_temp = -5
 
@@ -1244,7 +1244,7 @@
 	id = "appleade"
 	description = "Applejuice, improved."
 	taste_description = "apples"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#FFD1B3"
 	adj_temp = -5
 
@@ -1257,7 +1257,7 @@
 	id = "pineappleade"
 	description = "Spineapple, juiced up."
 	taste_description = "sweet`n`sour pineapples"
-	nutriment_factor = 5 //CS Edit
+	nutriment_factor = 5 //CHOMPStation addition
 	color = "#FFFF00"
 	adj_temp = -5
 
@@ -1270,7 +1270,7 @@
 	id = "kiraspecial"
 	description = "Long live the guy who everyone had mistaken for a girl. Baka!"
 	taste_description = "fruity sweetness"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#CCCC99"
 	adj_temp = -5
 
@@ -1283,7 +1283,7 @@
 	id = "brownstar"
 	description = "It's not what it sounds like..."
 	taste_description = "orange and cola soda"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#9F3400"
 	adj_temp = -2
 
@@ -1377,7 +1377,7 @@
 	id = "rewriter"
 	description = "The secret of the sanctuary of the Libarian..."
 	taste_description = "citrus and coffee"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#485000"
 	adj_temp = -5
 
@@ -1393,7 +1393,7 @@
 	id = "nuka_cola"
 	description = "Cola, cola never changes."
 	taste_description = "cola"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#100800"
 	adj_temp = -5
 	adj_sleepy = -2
@@ -1426,7 +1426,7 @@
 	id = "cola"
 	description = "A refreshing beverage."
 	taste_description = "cola"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	reagent_state = LIQUID
 	color = "#100800"
 	adj_drowsy = -3
@@ -1441,7 +1441,7 @@
 	id = "spacemountainwind"
 	description = "Blows right through you like a space wind."
 	taste_description = "sweet citrus soda"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#102000"
 	adj_drowsy = -7
 	adj_sleepy = -1
@@ -1456,7 +1456,7 @@
 	id = "dr_gibb"
 	description = "A delicious blend of 42 different flavors"
 	taste_description = "cherry soda"
-	nutriment_factor = 3 //CS Edit
+	nutriment_factor = 3 //CHOMPStation addition
 	color = "#102000"
 	adj_drowsy = -6
 	adj_temp = -5
@@ -1469,7 +1469,7 @@
 	id = "space_up"
 	description = "Tastes like a hull breach in your mouth."
 	taste_description = "citrus soda"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#202800"
 	adj_temp = -8
 
@@ -1482,7 +1482,7 @@
 	id = "lemon_lime"
 	description = "A tangy substance made of 0.5% natural citrus!"
 	taste_description = "tangy lime and lemon soda"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#878F00"
 	adj_temp = -8
 
@@ -1495,7 +1495,7 @@
 	id = "gingerale"
 	description = "The original."
 	taste_description = "somewhat tangy ginger ale"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#edcf8f"
 	adj_temp = -8
 
@@ -1520,7 +1520,7 @@
 	id = "roy_rogers"
 	description = "I'm a cowboy, on a steel horse I ride."
 	taste_description = "cola and fruit"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#4F1811"
 	adj_temp = -8
 
@@ -1533,7 +1533,7 @@
 	id = "collins_mix"
 	description = "Best hope it isn't a hoax."
 	taste_description = "gin and lemonade"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#D7D0B3"
 	adj_temp = -8
 
@@ -1546,7 +1546,7 @@
 	id = "arnold_palmer"
 	description = "Tastes just like the old man."
 	taste_description = "lemon and sweet tea"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#AF5517"
 	adj_temp = -8
 
@@ -1669,7 +1669,7 @@
 	id = "dreamcream"
 	description = "A smoothy, silky mix of honey and dairy."
 	taste_description = "sweet, soothing dairy"
-	nutriment_factor = 5 //CS Edit
+	nutriment_factor = 5 //CHOMPStation addition
 	color = "#fcfcc9" // rgb(252, 252, 201)
 
 	glass_name = "Dream Cream"
@@ -1680,7 +1680,7 @@
 	id = "vilelemon"
 	description = "A fizzy, sour lemonade mix."
 	taste_description = "fizzy, sour lemon"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#c6c603" // rgb(198, 198, 3)
 
 	glass_name = "Vile Lemon"
@@ -1692,7 +1692,7 @@
 	id = "entdraught"
 	description = "A natural, earthy combination of all things peaceful."
 	taste_description = "fresh rain and sweet memories"
-	nutriment_factor = 5 //CS Edit
+	nutriment_factor = 5 //CHOMPStation addition
 	color = "#3a6617" // rgb(58, 102, 23)
 
 	glass_name = "Ent's Draught"
@@ -1713,7 +1713,7 @@
 	id = "oilslick"
 	description = "A viscous, but sweet, ooze."
 	taste_description = "honey"
-	nutriment_factor = 15 //CS Edit
+	nutriment_factor = 15 //CHOMPStation addition
 	color = "#FDF5E6" // rgb(253,245,230)
 	water_based = FALSE
 
@@ -1726,7 +1726,7 @@
 	id = "slimeslammer"
 	description = "A viscous, but savory, ooze."
 	taste_description = "peanuts`n`slime"
-	nutriment_factor = 20 //CS Edit
+	nutriment_factor = 20 //CHOMPStation addition
 	color = "#93604D"
 	water_based = FALSE
 
@@ -1749,7 +1749,7 @@
 	id = "nuclearwaste"
 	description = "A viscous, glowing slurry."
 	taste_description = "sour honey drops"
-	nutriment_factor = 15 //CS Edit
+	nutriment_factor = 15 //CHOMPStation addition
 	color = "#7FFF00" // rgb(127,255,0)
 	water_based = FALSE
 
@@ -1775,7 +1775,7 @@
 	id = "sodaoil"
 	description = "A thick, bubbling soda."
 	taste_description = "chewy water"
-	nutriment_factor = 10 //CS Edit
+	nutriment_factor = 10 //CHOMPStation addition
 	color = "#F0FFF0" // rgb(245,255,250)
 	water_based = FALSE
 
@@ -1862,7 +1862,7 @@
 	id = "fauxfizz"
 	description = "One sip and you're in the bahamas... maybe."
 	taste_description = "slightly tropical"
-	nutriment_factor = 4 //CS Edit
+	nutriment_factor = 4 //CHOMPStation addition
 	color = "#69375C"
 
 	glass_name = "tropical fizz"
@@ -2418,7 +2418,7 @@
 	id = "cubalibre"
 	description = "Rum, mixed with cola. Viva la revolucion."
 	taste_description = "cola"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#3E1B00"
 	strength = 30
 
@@ -2431,7 +2431,7 @@
 	description = "This thing makes the hair on the back of your neck stand up."
 	taste_description = "sweet tasting iron"
 	taste_mult = 1.5
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#820000"
 	strength = 15
 
@@ -2804,7 +2804,7 @@
 	id = "snowwhite"
 	description = "A cold refreshment"
 	taste_description = "refreshing cold"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#FFFFFF"
 	strength = 30
 
@@ -2816,7 +2816,7 @@
 	id = "suidream"
 	description = "Comprised of: White soda, blue curacao, melon liquor."
 	taste_description = "fruit"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#00A86B"
 	strength = 100
 
@@ -2912,7 +2912,7 @@
 	id = "whiskeycola"
 	description = "Whiskey, mixed with cola. Surprisingly refreshing."
 	taste_description = "cola with an alcoholic undertone"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#3E1B00"
 	strength = 25
 
@@ -2925,7 +2925,7 @@
 	id = "whiskeysoda"
 	description = "Ultimate refreshment."
 	taste_description = "carbonated whiskey"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#EAB300"
 	strength = 15
 
@@ -3085,7 +3085,7 @@
 	id = "xanaducannon"
 	description = "Common in the entertainment districts of Titan."
 	taste_description = "sweet alcohol"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#614126"
 	strength = 50
 
@@ -3097,7 +3097,7 @@
 	id = "debugger"
 	description = "From Shelf. Not for human consumption."
 	taste_description = "oily bitterness"
-	nutriment_factor = 10 //CS Edit
+	nutriment_factor = 10 //CHOMPStation addition
 	color = "#d3d3d3"
 	strength = 32
 
@@ -3109,7 +3109,7 @@
 	id = "spacersbrew"
 	description = "Ethanol and orange soda. A common emergency drink on frontier colonies."
 	taste_description = "bitter oranges"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#ffc04c"
 	strength = 43
 
@@ -3204,7 +3204,7 @@
 	id = "rotgut"
 	description = "A heinous combination of clashing flavors."
 	taste_description = "plague and coldsweats"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#3a6617" // rgb(58, 102, 23)
 	strength = 10
 
@@ -3475,7 +3475,7 @@
 	description = "This thing makes the hair on the back of your neck stand up."
 	taste_description = "sweet victory and sour iron"
 	taste_mult = 1.5
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#F3C906"
 	strength = 30
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -1231,7 +1231,7 @@
 	id = "melonade"
 	description = "Oh the.. nostalgia?"
 	taste_description = "watermelon"
-	nutriment_factor = 1.5 //CS Edit
+	nutriment_factor = 1.5 //CHOMPStation addition
 	color = "#FFB3BB"
 	adj_temp = -5
 


### PR DESCRIPTION
Gives nutriment values to sodas, (most) drinks that have soda in their recipe, as well as gives high nutriment values to drinks that use honey, peanut butter, or corn oil. Also makes it easier for people to add nutrient values to any new drink they wish to add.

+Adds in nutriment calculation for drinks (base of 0)
+Most sodas have gained a nutriment factor of around 1.5-4
+Most drinks that contain honey, corn oil, or peanut oil have a nutriment factor now as well (ranging between 4-20)
