### PR TITLE
Hardcoded firedoors for elevators

### DIFF
--- a/code/modules/turbolift/turbolift_map.dm
+++ b/code/modules/turbolift/turbolift_map.dm
@@ -11,6 +11,7 @@
 	var/wall_type =  /turf/simulated/wall/elevator
 	var/floor_type = /turf/simulated/floor/tiled/dark
 	var/door_type =  /obj/machinery/door/airlock/lift
+	var/firedoor_type = /obj/machinery/door/firedoor/glass //CHOMP Edit for adding a firedoor to the exterior door
 
 	var/list/areas_to_use = list()
 
@@ -179,12 +180,15 @@
 							qdel(thing)
 				if(checking.type == floor_type) // Don't build over empty space on lower levels.
 					var/obj/machinery/door/airlock/lift/newdoor = new door_type(checking)
+					var/obj/machinery/door/firedoor/glass/firedoor = new firedoor_type(checking) //CHOMP Addition for fire doors
 					if(internal)
 						lift.doors += newdoor
 						newdoor.lift = cfloor
 					else
 						cfloor.doors += newdoor
 						newdoor.floor = cfloor
+						cfloor.doors += firedoor //CHOMP Addition for fire doors
+						firedoor.glass = cfloor //CHOMP Addition for fire doors
 
 		// Place exterior control panel.
 		var/turf/placing = locate(ext_panel_x, ext_panel_y, cz)


### PR DESCRIPTION
So a certain PR #75 got red firedoors in front of the elevators, but there are several problems with them:
1. Takes a bite out of the hallway when they deploy.
2. Blocks shit on the walls.
3. Somewhat difficult to use the editor to rotate the sprite properly to look not-tackey on the map.
4. No animation of a red door coming out of the ground. They immediately morph into the sprites and animations of the yellow door.

![image](https://user-images.githubusercontent.com/15962836/72138525-3485c580-334a-11ea-9353-90cfc666faa2.png)
![image](https://user-images.githubusercontent.com/15962836/72138692-93e3d580-334a-11ea-8d71-2981e95aa4fb.png)

We discovered that stuff gets deleted when you try to put anything on the tile that elevator doors spawn, because those doors are hardcoded. So I coded in firedoors myself. They work better than expected and improves safety of elevators tremendously. You can preemptively close them, they will remain closed if you navigate away from a floor that has an emergency, they all respond well to atmosphere alerts on their floor, etc.

![image](https://user-images.githubusercontent.com/15962836/72138835-e1f8d900-334a-11ea-81bb-650316b47cb6.png)



