### PR TITLE
Assembly (Drone) buff

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies/generic.dm
+++ b/code/modules/integrated_electronics/core/assemblies/generic.dm
@@ -154,8 +154,8 @@
 	icon_state = "setup_drone"
 	desc = "It's a case, for building mobile electronics with."
 	w_class = ITEMSIZE_NORMAL
-	max_components = IC_COMPONENTS_BASE * 1.5 //CHOMP Edit ;Changing this to be 3 instead because as it stands its worthless
-	max_complexity = IC_COMPLEXITY_BASE * 1.5 //CHOMP Edit ;Changing this to be 3 instead because as it stands its worthless
+	max_components = IC_COMPONENTS_BASE * 3 //CHOMP Edit ;Changing this to be 3 instead because as it stands its worthless
+	max_complexity = IC_COMPLEXITY_BASE * 3 //CHOMP Edit ;Changing this to be 3 instead because as it stands its worthless
 	can_anchor = FALSE
 
 /obj/item/device/electronic_assembly/drone/can_move()

--- a/code/modules/integrated_electronics/core/assemblies/generic.dm
+++ b/code/modules/integrated_electronics/core/assemblies/generic.dm
@@ -154,8 +154,8 @@
 	icon_state = "setup_drone"
 	desc = "It's a case, for building mobile electronics with."
 	w_class = ITEMSIZE_NORMAL
-	max_components = IC_COMPONENTS_BASE * 1.5
-	max_complexity = IC_COMPLEXITY_BASE * 1.5
+	max_components = IC_COMPONENTS_BASE * 1.5 //CHOMP Edit ;Changing this to be 3 instead because as it stands its worthless
+	max_complexity = IC_COMPLEXITY_BASE * 1.5 //CHOMP Edit ;Changing this to be 3 instead because as it stands its worthless
 	can_anchor = FALSE
 
 /obj/item/device/electronic_assembly/drone/can_move()


### PR DESCRIPTION
Upgrades drone assembles to be between medium and large assembly size.
As it currently stands all you can make with drone assemblies really is meme shit and nothing that would actually be beneficial, unless you remove the locomotion circuit at which point you can just use an unmovable large assembly.

Assemblies could use an overhaul in general but this is the biggest flaw.