### PR TITLE
Shuttle, Not Tram

### DIFF
--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -348,8 +348,8 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
             </div>
             <div class="itemContent">
                 {{:helper.link('Clear', 'trash', {'cartmenu' : "1", 'choice' : "Status", 'statdisp' : "blank"}, null, null)}}
-                <!-- VOREStation Edit TFF 21/12/19 - Virgo = Tram. Not shuttle -->
-                {{:helper.link('Tram ETA', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "shuttle"}, null, null)}}
+                <!-- CHOMPStation Edit TFF 14/1/20 - Southern Cross, Shuttle, not Tram -->
+                {{:helper.link('Shuttle ETA', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "shuttle"}, null, null)}}
                 {{:helper.link('Message', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "message"}, null, null)}}
             </div>
         </div>


### PR DESCRIPTION
Reverts my edit upstream.

Changelog Notes:

- Reverts edit that replaced shuttle ETA with Tram ETA for the Status Display Toggling on PDAs with appropriate cartridges.