### PR TITLE
removes carpmeat from chaos cake recipe.

### DIFF
--- a/code/modules/food/food/thecake_ch.dm
+++ b/code/modules/food/food/thecake_ch.dm
@@ -233,11 +233,7 @@
 			/obj/item/weapon/reagent_containers/food/snacks/meat/,
 			/obj/item/weapon/reagent_containers/food/snacks/meat/,
 			/obj/item/weapon/reagent_containers/food/snacks/meat/,
-			/obj/item/weapon/reagent_containers/food/snacks/meat/,
-			/obj/item/weapon/reagent_containers/food/snacks/carpmeat,
-			/obj/item/weapon/reagent_containers/food/snacks/carpmeat/,
-			/obj/item/weapon/reagent_containers/food/snacks/carpmeat/,
-			/obj/item/weapon/reagent_containers/food/snacks/carpmeat/
+			/obj/item/weapon/reagent_containers/food/snacks/meat/
 		)
 	result = /obj/structure/chaoscake
 


### PR DESCRIPTION
Too tedious, you don't need to leave the station for any of the other steps.