### PR TITLE
Job Icons Ahoy

### DIFF
--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -19,6 +19,7 @@
 
 	lobby_icon = 'icons/misc/title_ch.dmi'	//CHOMPStation Edit TFF 24/12/19 - _ch.dmi
 	lobby_screens = list("mockingjay00") //CHOMPStation Edit TFF 24/12/19 - CHOMPStation image
+	id_hud_icons = 'icons/mob/hud_jobs_vr.dmi'	//CHOMPStation Edit 25/1/20 TFF - Job icons for off-duty/exploration
 
 	holomap_smoosh = list(list(
 		Z_LEVEL_STATION_ONE,


### PR DESCRIPTION
Resolves #132 

Changelog Notes:

- Gives the long awaited job icons everyone desires for off-duty titles as well as exploration.