### PR TITLE
Fixes mecha weapons locking up after killing mobs

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -58,8 +58,8 @@
 	var/target_for_log
 	if(ismob(target))
 		target_for_log = target
-	else
-		target_for_log = "[target.name]"
+//	else
+//		target_for_log = "[target.name]" //CHOMPedit, commenting out. Fixes mecha weapon lock on mob kill. Not sure why this works. Hope this doesn't cause issues later.
 
 	add_attack_logs(chassis.occupant,target_for_log,"Fired exosuit weapon [src.name] (MANUAL)")
 


### PR DESCRIPTION
I have no idea why this works. Tested with most mecha weapons and no more errors occurred.
Can anyone explain why this works?
My best GUESS is that when a mob dies it's form changes instantly and is triggering the "else" code at the same time as the normal code which hangs up the code and prevents the auto-rearm check from going through. Which would explain why weapons such as the Shrapnel Cannon avoided this problem, it's fire rare/ rearm was so slow that the code had enough time to restart it's checks. This is a GUESS, however.