### PR TITLE
Undigestable Noms (CHOMP re-addition)

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -21,7 +21,7 @@
 	var/vore_pounce_falloff = 1			// Success rate falloff per %health of target mob.
 	var/vore_pounce_maxhealth = 80		// Mob will not attempt to pounce targets above this %health
 	var/vore_standing_too = 0			// Can also eat non-stunned mobs
-	var/vore_ignores_undigestable = 1	// Refuse to eat mobs who are undigestable by the prefs toggle.
+	var/vore_ignores_undigestable = 0	// Refuse to eat mobs who are undigestable by the prefs toggle. //CHOMPedit:Re-enable mob vore for indigestible players with mob vore on
 	var/swallowsound = null				// What noise plays when you succeed in eating the mob.
 
 	var/vore_default_mode = DM_DIGEST	// Default bellymode (DM_DIGEST, DM_HOLD, DM_ABSORB)


### PR DESCRIPTION
Re-implements digest mobs eating undigestable players by default. As before turning mob vore off will prevent players from being eaten. 

If you want a mob to _only_ eat digestable players you can set "mob_ignores_digestable" to 1 in the mob file. 