### PR TITLE
Sif Snow Fix

### DIFF
--- a/maps/southern_cross/turfs/outdoors.dm
+++ b/maps/southern_cross/turfs/outdoors.dm
@@ -164,7 +164,7 @@
 /obj/effect/step_trigger/teleporter/planetary_fall/sif/find_planet()
 	planet = planet_sif
 
-//CHOMPedit: Attempt to make Sif snow work properly, it was broken by YW edits.
+//CHOMPedit: Changes to sif/planetuse snow to make it work properly as it does on Polaris, it was broken by YW edits.
 /turf/simulated/floor/outdoors/snow/sif/planetuse
 	name = "snow"
 	icon_state = "snow"
@@ -175,3 +175,38 @@
 		/turf/simulated/floor/outdoors/rocks,
 		/turf/simulated/floor/outdoors/dirt
 		)
+
+/turf/simulated/floor/outdoors/snow/sif/planetuse/Entered(atom/A)
+	if(isliving(A))
+		var/mob/living/L = A
+		if(L.hovering) // Flying things shouldn't make footprints.
+			return ..()
+		var/mdir = "[A.dir]"
+		crossed_dirs[mdir] = 1
+		update_icon()
+	. = ..()
+
+/turf/simulated/floor/outdoors/snow/sif/planetuse/update_icon()
+	..()
+	for(var/d in crossed_dirs)
+		add_overlay(image(icon = 'icons/turf/outdoors.dmi', icon_state = "snow_footprints", dir = text2num(d)))
+
+/turf/simulated/floor/outdoors/snow/sif/planetuse/attackby(var/obj/item/W, var/mob/user)
+	if(istype(W, /obj/item/weapon/shovel))
+		to_chat(user, "<span class='notice'>You begin to remove \the [src] with your [W].</span>")
+		if(do_after(user, 4 SECONDS * W.toolspeed))
+			to_chat(user, "<span class='notice'>\The [src] has been dug up, and now lies in a pile nearby.</span>")
+			new /obj/item/stack/material/snow(src)
+			demote()
+		else
+			to_chat(user, "<span class='notice'>You decide to not finish removing \the [src].</span>")
+	else
+		..()
+
+/turf/simulated/floor/outdoors/snow/sif/planetuse/attack_hand(mob/user as mob)
+	visible_message("[user] starts scooping up some snow.", "You start scooping up some snow.")
+	if(do_after(user, 1 SECOND))
+		var/obj/S = new /obj/item/stack/material/snow(user.loc)
+		user.put_in_hands(S)
+		visible_message("[user] scoops up a pile of snow.", "You scoop up a pile of snow.")
+	return

--- a/maps/southern_cross/turfs/outdoors.dm
+++ b/maps/southern_cross/turfs/outdoors.dm
@@ -163,3 +163,15 @@
 // Step trigger to fall down to planet Sif
 /obj/effect/step_trigger/teleporter/planetary_fall/sif/find_planet()
 	planet = planet_sif
+
+//CHOMPedit: Attempt to make Sif snow work properly, it was broken by YW edits.
+/turf/simulated/floor/outdoors/snow/sif/planetuse
+	name = "snow"
+	icon_state = "snow"
+	edge_blending_priority = 6
+	movement_cost = 2
+	initial_flooring = /decl/flooring/snow
+	turf_layers = list(
+		/turf/simulated/floor/outdoors/rocks,
+		/turf/simulated/floor/outdoors/dirt
+		)


### PR DESCRIPTION
You know how walking through planet snow is slow as balls? Turns out it's not supposed to be like that, YW changes to snow turfs broke the map a bit. This PR fixes planet-side snow to perform as designed on Polaris. Changes include:
-No extreme slow down. Snow will still slow you but it's not nearly as bad as before.
-Stepping in slow leaves footprints now.
-Crunchy snow walking sound effects.
-You can dig up snow by hand (or with a shovel if you want to destroy the tile) to make snowballs and snow bricks (i.e. you can build igloos now).
-Did I mention you can build igloos now?
-Seriously go build a snow village and have a snowball fight.