### PR TITLE
Changing blob allowances so blob types can correctly use blob buildings.

### DIFF
--- a/code/modules/blob2/overmind/powers.dm
+++ b/code/modules/blob2/overmind/powers.dm
@@ -53,7 +53,7 @@
 	set desc = "Create a resource tower which will generate resources for you."
 
 	if(!blob_type.can_build_resources)
-		return FALSE
+		return TRUE
 
 	createSpecial(40, blob_type.resource_type, 4, 1)
 
@@ -63,7 +63,7 @@
 	set desc = "Automatically places a resource tower near a node or your core, at a sufficent distance."
 
 	if(!blob_type.can_build_resources)
-		return FALSE
+		return TRUE
 
 	var/obj/structure/blob/B = null
 	var/list/potential_blobs = blobs.Copy()
@@ -94,7 +94,7 @@
 	set desc = "Create a spore tower that will spawn spores to harass your enemies."
 
 	if(!blob_type.can_build_factories)
-		return FALSE
+		return TRUE
 
 	createSpecial(60, blob_type.factory_type, 7, 1)
 
@@ -104,7 +104,7 @@
 	set desc = "Automatically places a resource tower near a node or your core, at a sufficent distance."
 
 	if(!blob_type.can_build_factories)
-		return FALSE
+		return TRUE
 
 	var/obj/structure/blob/B = null
 	var/list/potential_blobs = blobs.Copy()
@@ -136,7 +136,7 @@
 	set desc = "Create a node, which will expand blobs around it, and power nearby factory and resource blobs."
 
 	if(!blob_type.can_build_nodes)
-		return FALSE
+		return TRUE
 
 	createSpecial(100, blob_type.node_type, 5, 0)
 
@@ -146,7 +146,7 @@
 	set desc = "Automatically places a node blob at a sufficent distance."
 
 	if(!blob_type.can_build_nodes)
-		return FALSE
+		return TRUE
 
 	var/obj/structure/blob/B = null
 	var/list/potential_blobs = blobs.Copy()


### PR DESCRIPTION
Player blobs had hard-coded restrictions for some buildings, preventing all blobs types from using them. This edit changes that, so the blob type restrictions are what prevent a player blob from making a building it should not be able to, not a hard coded restriction for all player blobs. Nodes, Factories, and Resource buildings can now be used and made by a player blob if their blob type allows it. There are no known balance issues with these buildings, nor any known bugs. The blob resource building was already pre-balanced for a MRP/HRP server in the distant past, so no action needs to be taken for balancing.