### PR TITLE
[Bugfix] The Hype of Medals Fixed

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_ch.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_ch.dm
@@ -1,87 +1,82 @@
 //GENERIC ITEMS keep this at the bottom of the file pls thx -shark
-/datum/gear/fluff/medals
-	display_name = "some medal"
-	path = /obj/item/clothing/accessory/medal
-	description = "some medal, Made of bronze"
-	ckeywhitelist = list("Sharkmare")
-	character_name = list("Kiri")
 
+//////////////////MEDALS GO BELOW
 //////////////////CONDUCT
-/datum/gear/fluff/medals/conductnadyr
+/datum/gear/fluff/medalofconductnadyr
 	ckeywhitelist = list("nadyr")
 	character_name = list("Taaa")
 	path = /obj/item/clothing/accessory/medal/conduct
-	display_name = "distinguished conduct medal"
+	display_name = "Taaa's Medal"
 	description = "A bronze medal awarded for distinguished conduct. Whilst a great honor, this is most basic award on offer. It is often awarded by a captain to a member of their crew."
 
-/datum/gear/fluff/medals/conductdraycu
+/datum/gear/fluff/medalofconductdraycu
 	ckeywhitelist = list("draycu")
 	character_name = list("Vuhbar Groor")
 	path = /obj/item/clothing/accessory/medal/conduct
-	display_name = "distinguished conduct medal"
+	display_name = "Vuhbar Groor's Medal"
 	description = "A bronze medal awarded for distinguished conduct. Whilst a great honor, this is most basic award on offer. It is often awarded by a captain to a member of their crew."
 
-/datum/gear/fluff/medals/conductlowpowermia
+/datum/gear/fluff/medalofconductlowpowermia
 	ckeywhitelist = list("lowpowermia")
 	character_name = list("Mia Sceline")
 	description = "A bronze medal awarded for distinguished conduct. Whilst a great honor, this is most basic award on offer. It is often awarded by a captain to a member of their crew. It has a shitty '=3' carved into it."
 	path = /obj/item/clothing/accessory/medal/conduct
-	display_name = "distinguished conduct medal"
+	display_name = "Mia Sceline's Medal"
 
 //////////////////SILVER VALOR
-/datum/gear/fluff/medals/silvervalorkazzc
+/datum/gear/fluff/medalofsilvervalorkazzc
 	ckeywhitelist = list("kazzc")
 	character_name = list("Kassc Zeravla")
 	path = /obj/item/clothing/accessory/medal/silver/valor
-	display_name = "medal of valor"
+	display_name = "Kassc Zeravla's Medal"
 	description = "A silver medal awarded for acts of exceptional valor."
 
-/datum/gear/fluff/medals/silvervalorsomememeguy
+/datum/gear/fluff/medalofsilvervalorsomememeguy
 	ckeywhitelist = list("somememeguy")
 	character_name = list("Uboiezb")
 	path = /obj/item/clothing/accessory/medal/silver/valor
-	display_name = "medal of valor"
+	display_name = "Uboiezb's Medal"
 	description = "A silver medal awarded for acts of exceptional valor."
 
-/datum/gear/fluff/medals/silvervalorkeithwinters
+/datum/gear/fluff/medalofsilvervalorkeithwinters
 	ckeywhitelist = list("keithwinters")
 	character_name = list("Keith Winters")
 	path = /obj/item/clothing/accessory/medal/silver/valor
-	display_name = "medal of valor"
+	display_name = "Keith Winters' Medal"
 	description = "A silver medal awarded for acts of exceptional valor."
 
-/datum/gear/fluff/medals/silvervalornadyr
+/datum/gear/fluff/medalofsilvervalornadyr
 	ckeywhitelist = list("nadyr")
 	character_name = list("Taaa")
 	path = /obj/item/clothing/accessory/medal/silver/valor
-	display_name = "medal of valor"
+	display_name = "Taaa's Medal"
 	description = "A silver medal awarded for acts of exceptional valor."
 
 //////////////////GOLD HEROISM
-/datum/gear/fluff/medals/nadyr
+/datum/gear/fluff/medalofgoldheroismnadyr
 	ckeywhitelist = list("nadyr")
 	character_name = list("Taaa")
 	path = /obj/item/clothing/accessory/medal/gold/heroism
-	display_name = "medal of exceptional heroism"
+	display_name = "Taaa's Medal"
 	description = "An extremely rare golden medal awarded only by high ranking officials. To recieve such a medal is the highest honor and as such, very few exist. This medal is almost never awarded to anybody but distinguished veteran staff."
 
-/datum/gear/fluff/medals/erikthedog
+/datum/gear/fluff/medalofgoldheroismerikthedog
 	ckeywhitelist = list("erikthedog")
 	character_name = list("Erik Ramadwood")
 	path = /obj/item/clothing/accessory/medal/gold/heroism
-	display_name = "medal of exceptional heroism"
+	display_name = "Erik Ramadwood's Medal"
 	description = "An extremely rare golden medal awarded only by high ranking officials. To recieve such a medal is the highest honor and as such, very few exist. This medal is almost never awarded to anybody but distinguished veteran staff."
 
-/datum/gear/fluff/medals/thefurryfeline
+/datum/gear/fluff/medalofgoldheroismthefurryfeline
 	ckeywhitelist = list("thefurryfeline")
 	character_name = list("Samantha Janice Softfur")
 	path = /obj/item/clothing/accessory/medal/gold/heroism
-	display_name = "medal of exceptional heroism"
+	display_name = "Samantha Janice Softfur's Medal"
 	description = "An extremely rare golden medal awarded only by high ranking officials. To recieve such a medal is the highest honor and as such, very few exist. This medal is almost never awarded to anybody but distinguished veteran staff."
 
-/datum/gear/fluff/medals/sharkmare
+/datum/gear/fluff/medalofgoldheroismsharkmare
 	ckeywhitelist = list("Sharkmare")
 	character_name = list("Kiri")
 	path = /obj/item/clothing/accessory/medal/gold/heroism
-	display_name = "medal of exceptional heroism"
+	display_name = "Kiri's Medal"
 	description = "An extremely rare golden medal awarded only by high ranking officials. To recieve such a medal is the highest honor and as such, very few exist. This medal is almost never awarded to anybody but distinguished veteran staff."

--- a/code/modules/client/preference_setup/loadout/loadout_fluffitems_ch.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_fluffitems_ch.dm
@@ -6,7 +6,7 @@
 	ckeywhitelist = list("nadyr")
 	character_name = list("Taaa")
 	path = /obj/item/clothing/accessory/medal/conduct
-	display_name = "Taaa's Medal"
+	display_name = "Taaa's Medal of Conduct"
 	description = "A bronze medal awarded for distinguished conduct. Whilst a great honor, this is most basic award on offer. It is often awarded by a captain to a member of their crew."
 
 /datum/gear/fluff/medalofconductdraycu
@@ -49,7 +49,7 @@
 	ckeywhitelist = list("nadyr")
 	character_name = list("Taaa")
 	path = /obj/item/clothing/accessory/medal/silver/valor
-	display_name = "Taaa's Medal"
+	display_name = "Taaa's Medal of Valor"
 	description = "A silver medal awarded for acts of exceptional valor."
 
 //////////////////GOLD HEROISM
@@ -57,7 +57,7 @@
 	ckeywhitelist = list("nadyr")
 	character_name = list("Taaa")
 	path = /obj/item/clothing/accessory/medal/gold/heroism
-	display_name = "Taaa's Medal"
+	display_name = "Taaa's Medal of Exceptional Heroism"
 	description = "An extremely rare golden medal awarded only by high ranking officials. To recieve such a medal is the highest honor and as such, very few exist. This medal is almost never awarded to anybody but distinguished veteran staff."
 
 /datum/gear/fluff/medalofgoldheroismerikthedog


### PR DESCRIPTION
Medals are fixed now. If you have a medal on the list here, you'll be able to select it in the loadout. I've also taken the liberty to just nix the fluff/medal subtype for now. Unneeded spaghetti. Blep.

Thanks to @Arokha for the assistance here. :> Turned out that our issue was display_name being all the same and cancelling each other out until you get to the bottom of the Distinguisheds, Valors, and Heroisms. 

Changelog notes:

- Fixes modals not being selectable in loadout even with your name and ckey being correct.