### PR TITLE
Earlyport Xenoarch Fixy

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -434,7 +434,7 @@ turf/simulated/mineral/floor/light_corner
 				var/datum/find/F = finds[1]
 				if(newDepth > F.excavation_required) // Digging too deep can break the item. At least you won't summon a Balrog (probably)
 					fail_message = ". <b>[pick("There is a crunching noise","[W] collides with some different rock","Part of the rock face crumbles away","Something breaks under [W]")]</b>"
-				wreckfinds(P.destroy_artefacts)
+					wreckfinds(P.destroy_artefacts)
 			to_chat(user, "<span class='notice'>You start [P.drill_verb][fail_message].</span>")
 
 			if(do_after(user,P.digspeed))


### PR DESCRIPTION
Title. Earlyports fix for Xenoarch bug that wrecks a high number of finds even with the field used. https://github.com/VOREStation/VOREStation/pull/6849

Changelong Notes:

- Fixes bug that made finding, well, finds get destroyed at a high frequency.