### PR TITLE
Re-enable custom_items.txt

### DIFF
--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -304,7 +304,7 @@ var/global/datum/controller/gameticker/ticker
 				if(!player_is_antag(player.mind, only_offstation_roles = 1))
 					job_master.EquipRank(player, player.mind.assigned_role, 0)
 					UpdateFactionList(player)
-					//equip_custom_items(player)	//VOREStation Removal
+					equip_custom_items(player)	//CHOMPEdit readded to enable custom_item.txt
 					//player.apply_traits() //VOREStation Removal
 		if(captainless)
 			for(var/mob/M in player_list)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -491,7 +491,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(equipment)
 		if(charjob)
 			job_master.EquipRank(new_character, charjob, 1)
-		//equip_custom_items(new_character)	//VOREStation Removal
+		equip_custom_items(new_character)	//CHOMPEdit readded to enable custom_item.txt
 
 	//If desired, add records.
 	if(records)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -191,7 +191,7 @@
 			return 0
 
 		var/datum/species/S = GLOB.all_species[client.prefs.species]
-		
+
 		if(!(S.spawn_flags & SPECIES_CAN_JOIN))
 			src << alert("Your current species, [client.prefs.species], is not available for play on the station.")
 			return 0
@@ -388,7 +388,7 @@
 		return
 
 	// Equip our custom items only AFTER deploying to spawn points eh?
-	//equip_custom_items(character)	//VOREStation Removal
+	equip_custom_items(character)	//CHOMPEdit readded to enable custom_item.txt
 
 	//character.apply_traits() //VOREStation Removal
 

--- a/code/modules/vore/fluffstuff/custom_boxes_ch.dm
+++ b/code/modules/vore/fluffstuff/custom_boxes_ch.dm
@@ -1,0 +1,22 @@
+//Kassc
+/obj/item/weapon/storage/box/fluff/Kassc
+	name = ""
+	desc = ""
+	has_items = list(
+		/obj/item/clothing/accessory/medal/silver/valor)
+
+//Keith Winters
+/obj/item/weapon/storage/box/fluff/Keith_Winters
+	name = ""
+	desc = ""
+	has_items = list(
+		/obj/item/clothing/accessory/medal/silver/valor)
+		
+//Taaa
+/obj/item/weapon/storage/box/fluff/Taaa
+	name = ""
+	desc = ""
+	has_items = list(
+		/obj/item/clothing/accessory/medal/silver/valor,
+		/obj/item/clothing/accessory/medal/conduct,
+		/obj/item/clothing/accessory/medal/gold/heroism)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3447,6 +3447,7 @@
 #include "code\modules\vore\eating\vorehooks_vr.dm"
 #include "code\modules\vore\eating\vorepanel_ch.dm"
 #include "code\modules\vore\eating\vorepanel_vr.dm"
+#include "code\modules\vore\fluffstuff\custom_boxes_ch.dm"
 #include "code\modules\vore\fluffstuff\custom_boxes_vr.dm"
 #include "code\modules\vore\fluffstuff\custom_boxes_yw.dm"
 #include "code\modules\vore\fluffstuff\custom_clothes_ch.dm"


### PR DESCRIPTION
Reinstating commented out code that will let custom_items.txt do its job. This makes it easier for us to do casino items without having to do a PR, and also increases anonymity.