### PR TITLE
Restore Predator Crates

### DIFF
--- a/vorestation.dme
+++ b/vorestation.dme
@@ -403,6 +403,7 @@
 #include "code\datums\supplypacks\robotics.dm"
 #include "code\datums\supplypacks\robotics_vr.dm"
 #include "code\datums\supplypacks\science.dm"
+#include "code\datums\supplypacks\science_vr.dm"
 #include "code\datums\supplypacks\security.dm"
 #include "code\datums\supplypacks\security_vr.dm"
 #include "code\datums\supplypacks\supply.dm"


### PR DESCRIPTION
Title. By popular demand.

Changelog Notes:

- Re-adds science_vr.dm supplypack file to the .dme so Predator Crates are orderable.