### PR TITLE
No more solargrubs in docks

### DIFF
--- a/code/game/area/Space Station 13 areas_ch.dm
+++ b/code/game/area/Space Station 13 areas_ch.dm
@@ -1,4 +1,3 @@
-
 /area/casino/casino_ship
 	name = "\improper Casino Ship"
 	icon_state = "yellow"

--- a/code/game/area/Space Station 13 areas_ch.dm
+++ b/code/game/area/Space Station 13 areas_ch.dm
@@ -30,3 +30,6 @@
 
 /area/shuttle/casino/station
 	icon_state = "shuttlegrn2"
+	
+/area/surface/outpost/main/dorms
+	//further defined in southern_cross_areas.dm for chompstation

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -11,7 +11,7 @@
 	spawncount = rand(2 * severity, 6 * severity)
 
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep && /area/hallway/secondary/entry))
+		if(istype(get_area(temp_vent), /area/crew_quarters/sleep && /area/hallway/secondary/entry && /area/surface/outpost/main/dorms)) //CHOMPEdit: Added a couple areas to the exclusion.
 			continue
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)
 			if(temp_vent.network.normal_members.len > 50)

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -11,7 +11,7 @@
 	spawncount = rand(2 * severity, 6 * severity)
 
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep))
+		if(istype(get_area(temp_vent), /area/crew_quarters/sleep, /area/hallway/secondary/entry))
 			continue
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)
 			if(temp_vent.network.normal_members.len > 50)

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -11,7 +11,7 @@
 	spawncount = rand(2 * severity, 6 * severity)
 
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep && /area/hallway/secondary/entry && /area/surface/outpost/main/dorms)) //CHOMPEdit: Added a couple areas to the exclusion.
+		if(istype(get_area(temp_vent), /area/crew_quarters/sleep && /area/hallway/secondary/entry && /area/surface/outpost/main/dorms/dorm_1)) //CHOMPEdit: Added a couple areas to the exclusion.
 			continue
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)
 			if(temp_vent.network.normal_members.len > 50)

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -12,7 +12,7 @@
 
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
 		//CHOMPEdit: Added a couple areas to the exclusion.
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep && /area/surface/outpost/main/dorms/dorm_1))
+		if(istype(get_area(temp_vent), /area/crew_quarters/sleep && /area/hallway/secondary/entry && /area/surface/outpost/main/dorms))
 			continue
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)
 			if(temp_vent.network.normal_members.len > 50)

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -12,7 +12,7 @@
 
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
 		//CHOMPEdit: Added a couple areas to the exclusion.
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep && /area/hallway/secondary/entry && /area/surface/outpost/main/dorms/dorm_1))
+		if(istype(get_area(temp_vent), /area/crew_quarters/sleep && /area/surface/outpost/main/dorms/dorm_1))
 			continue
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)
 			if(temp_vent.network.normal_members.len > 50)

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -11,9 +11,9 @@
 	spawncount = rand(2 * severity, 6 * severity)
 
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep))
+		if(istype(get_area(temp_vent), /area/crew_quarters/sleep && /area/hallway/secondary/entry))
 			continue
-		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels && !/area/hallway/secondary/entry)
+		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)
 			if(temp_vent.network.normal_members.len > 50)
 				vents += temp_vent
 

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -11,7 +11,8 @@
 	spawncount = rand(2 * severity, 6 * severity)
 
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep && /area/hallway/secondary/entry && /area/surface/outpost/main/dorms/dorm_1)) //CHOMPEdit: Added a couple areas to the exclusion.
+		//CHOMPEdit: Added a couple areas to the exclusion.
+		if(istype(get_area(temp_vent), /area/crew_quarters/sleep && /area/hallway/secondary/entry && /area/surface/outpost/main/dorms/dorm_1))
 			continue
 		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)
 			if(temp_vent.network.normal_members.len > 50)

--- a/code/modules/events/grubinfestation_vr.dm
+++ b/code/modules/events/grubinfestation_vr.dm
@@ -11,9 +11,9 @@
 	spawncount = rand(2 * severity, 6 * severity)
 
 	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
-		if(istype(get_area(temp_vent), /area/crew_quarters/sleep, /area/hallway/secondary/entry))
+		if(istype(get_area(temp_vent), /area/crew_quarters/sleep))
 			continue
-		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels)
+		if(!temp_vent.welded && temp_vent.network && temp_vent.loc.z in using_map.station_levels && !/area/hallway/secondary/entry)
 			if(temp_vent.network.normal_members.len > 50)
 				vents += temp_vent
 

--- a/maps/southern_cross/southern_cross_areas.dm
+++ b/maps/southern_cross/southern_cross_areas.dm
@@ -407,7 +407,7 @@
 /area/surface/outpost/main/bar
 	name = "\improper Main Outpost Bar"
 	icon_state = "bar"
-
+/*
 /area/surface/outpost/main/dorms
 	name = "\improper Main Outpost Dorms"
 
@@ -428,7 +428,7 @@
 
 /area/surface/outpost/main/dorms/dorm_6
 	name = "\improper Main Outpost Dorm Six"
-
+*/
 /area/surface/outpost/main/airlock
 	name = "\improper Main Outpost Airlock"
 	icon_state = "red"


### PR DESCRIPTION
Solargrubs don't seem to end up in any interesting places. Rather, they keep ending up in the docks. I think I'll just exclude the docks from the list and monitor where they spawn.

Also excluded them from spawning in dorms at the outpost.