### PR TITLE
Makes the teleporter stop killing you all the time.

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -217,7 +217,9 @@
 				for(var/rider in L.buckled_mobs)
 					R.force_dismount(rider)
 		//VOREStation Addition End: Prevent taurriding abuse
+		//CHOMPStation start: Removes prob(5) of being yeeted
 		do_teleport(M, com.locked) //dead-on precision
+		//CHOMPStation end: Removes prob(5) of being yeeted
 
 		if(com.one_time_use) //Make one-time-use cards only usable one time!
 			com.one_time_use = 0

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -217,10 +217,7 @@
 				for(var/rider in L.buckled_mobs)
 					R.force_dismount(rider)
 		//VOREStation Addition End: Prevent taurriding abuse
-		if(prob(5) && !accurate) //oh dear a problem, put em in deep space
-			do_teleport(M, locate(rand((2*TRANSITIONEDGE), world.maxx - (2*TRANSITIONEDGE)), rand((2*TRANSITIONEDGE), world.maxy - (2*TRANSITIONEDGE)), 3), 2)
-		else
-			do_teleport(M, com.locked) //dead-on precision
+		do_teleport(M, com.locked) //dead-on precision
 
 		if(com.one_time_use) //Make one-time-use cards only usable one time!
 			com.one_time_use = 0


### PR DESCRIPTION
That prob(5) is the defining reason why nobody ever wants to use the teleporter.
It's supposed to be called when the teleporter is inaccurate, such as back when teleporter calibration was a thing. But the teleporter doesn't do calibration anymore, so that accuracy var is always 0.

Stop throwing command staff into space plz.