### PR TITLE
Doors Don't need Blueshield Access

### DIFF
--- a/vorestation.dme
+++ b/vorestation.dme
@@ -897,7 +897,6 @@
 #include "code\game\machinery\doors\airlock_control.dm"
 #include "code\game\machinery\doors\airlock_electronics.dm"
 #include "code\game\machinery\doors\airlock_vr.dm"
-#include "code\game\machinery\doors\airlock_yw.dm"
 #include "code\game\machinery\doors\alarmlock.dm"
 #include "code\game\machinery\doors\blast_door.dm"
 #include "code\game\machinery\doors\blast_door_yw.dm"


### PR DESCRIPTION
Remove airlock_yw.dm from .dme. Unneeded.