### PR TITLE
Recoil knockdown for micros

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -51,6 +51,7 @@
 	zoomdevicename = "scope"
 	drop_sound = 'sound/items/drop/gun.ogg'
 
+	var/recoil_mode = 1 //0 = no micro recoil, 1 = regular, anything higher than 1 is a multiplier //YAWN Addition, ported from CHOMP
 	var/automatic = 0
 	var/burst = 1
 	var/fire_delay = 6 	//delay after shooting before the gun can be used again
@@ -434,6 +435,20 @@
 		else
 			set_light(0)
 		//VOREStation Edit End
+		
+	//YAWNEDIT: Recoil knockdown for micros, ported from CHOMPStation
+	if(recoil_mode && iscarbon(user) && !istype(src,/obj/item/weapon/gun/energy))
+		var/mob/living/carbon/nerd = user
+		var/mysize = nerd.size_multiplier
+		if(mysize <= 0.5)
+			nerd.Weaken(1*recoil_mode)
+			if(!istype(src,/obj/item/weapon/gun/energy))
+				nerd.adjustBruteLoss((5-mysize*4)*recoil_mode)
+				to_chat(nerd, "<span class='danger'>You're so tiny that you drop the gun and hurt yourself from the recoil!</span>")
+			else
+				to_chat(nerd, "<span class='danger'>You're so tiny that the pull of the trigger causes you to drop the gun!</span>")
+				
+	//YAWNEDIT: Knockdown code end
 
 // Similar to the above proc, but does not require a user, which is ideal for things like turrets.
 /obj/item/weapon/gun/proc/Fire_userless(atom/target)


### PR DESCRIPTION
Old content port of https://github.com/CHOMPstation/CHOMPstation/pull/619. Early port of https://github.com/Yawn-Wider/YWPolarisVore/pull/746, enhancement of @Sharkmare's pull https://github.com/CHOMPStation2/CHOMPStation2/pull/144

Kelshark and I got to talking about balance stuff and we decided to implement the recoil for micros from old chomp. Lasers will not cause brute damage, but slugthrowers will.

![image](https://user-images.githubusercontent.com/15962836/81464998-5a499c80-917b-11ea-892f-98ee118eb392.png)
