### PR TITLE
Exploration closet fixes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/misc_vr.dm
+++ b/code/game/objects/structures/crates_lockers/closets/misc_vr.dm
@@ -160,7 +160,7 @@
 		starts_with += /obj/item/weapon/storage/backpack/satchel/norm
 	return ..()
 
-/obj/structure/closet/secure_closet/pathfinder
+/obj/structure/closet/secure_closet/pathfinder //CHOMPedit: Changes bluespaceradio/tether_prelinked to bluespaceradio because we don't have Tether here
 	name = "pathfinder locker"
 	icon = 'icons/obj/closet_vr.dmi'
 	icon_state = "secureexp1"
@@ -187,7 +187,7 @@
 		/obj/item/device/geiger,
 		/obj/item/weapon/cell/device,
 		/obj/item/device/radio,
-		/obj/item/device/bluespaceradio/tether_prelinked,
+		/obj/item/device/bluespaceradio,
 		/obj/item/stack/marker_beacon/thirty,
 		/obj/item/weapon/material/knife/tacknife/survival,
 		/obj/item/weapon/material/knife/machete/deluxe,

--- a/maps/southern_cross/structures/closets/misc.dm
+++ b/maps/southern_cross/structures/closets/misc.dm
@@ -34,7 +34,9 @@
 		/obj/item/clothing/accessory/permit/gun/planetside)
 
 //Explorer Lockers
-
+//CHOMPedit: replaces the starts_with list for explorer, sar, and pilot lockers with the contents listed in
+//code/game/objects/structures/crates_lockers/closets/misc_vr.dm because those are what we were using and now they're getting overwritten
+//with the equipment here.
 /obj/structure/closet/secure_closet/explorer
 	name = "explorer locker"
 	req_access = list(access_explorer)
@@ -46,6 +48,8 @@
 		/obj/item/clothing/shoes/boots/winter/explorer,
 		/obj/item/clothing/gloves/black,
 		/obj/item/device/radio/headset/explorer,
+		/obj/item/device/radio/headset/explorer/alt,
+		/obj/item/weapon/cartridge/explorer,
 		/obj/item/device/flashlight,
 		/obj/item/device/gps/explorer,
 		/obj/item/weapon/storage/box/flare,
@@ -53,8 +57,12 @@
 		/obj/item/weapon/cell/device,
 		/obj/item/device/radio,
 		/obj/item/stack/marker_beacon/thirty,
-		/obj/item/device/cataloguer
-		)
+		/obj/item/weapon/material/knife/tacknife/survival,
+		/obj/item/weapon/material/knife/machete,
+		/obj/item/clothing/accessory/holster/machete,
+		/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+		/obj/item/weapon/reagent_containers/food/snacks/liquidprotein,
+		/obj/item/device/cataloguer)
 
 /obj/structure/closet/secure_closet/explorer/Initialize()
 	if(prob(50))
@@ -89,25 +97,32 @@
 		/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
 		/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
 		/obj/item/weapon/storage/belt/medical/emt,
-		/obj/item/clothing/mask/gas,
+		/obj/item/weapon/material/knife/tacknife/survival,
+		/obj/item/weapon/gun/energy/locked/frontier/holdout,
+		/obj/item/clothing/mask/gas/explorer,
+		/obj/item/clothing/suit/storage/hooded/explorer/medic,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/medical/sar,
 		/obj/item/clothing/shoes/boots/winter/explorer,
 		/obj/item/device/radio/headset/sar,
-		/obj/item/weapon/cartridge/medical,
+		/obj/item/device/radio/headset/sar/alt,
+		/obj/item/weapon/cartridge/sar,
 		/obj/item/device/flashlight,
 		/obj/item/weapon/tank/emergency/oxygen/engi,
 		/obj/item/clothing/glasses/hud/health,
 		/obj/item/device/healthanalyzer,
 		/obj/item/device/radio/off,
 		/obj/random/medical,
+		/obj/item/weapon/reagent_containers/food/snacks/liquidfood = 2,
+		/obj/item/weapon/reagent_containers/food/snacks/liquidprotein = 2,
 		/obj/item/weapon/tool/crowbar,
 		/obj/item/weapon/extinguisher/mini,
 		/obj/item/weapon/storage/box/freezer,
 		/obj/item/clothing/accessory/storage/white_vest,
 		/obj/item/taperoll/medical,
-		/obj/item/device/gps,
+		/obj/item/device/gps/medical,
 		/obj/item/device/geiger,
-		/obj/item/bodybag/cryobag)
+		/obj/item/bodybag/cryobag,
+		/obj/item/device/cataloguer/compact)
 
 //Pilot Locker
 
@@ -118,20 +133,27 @@
 	starts_with = list(
 		/obj/item/weapon/storage/backpack/parachute,
 		/obj/item/weapon/material/knife/tacknife/survival,
+		/obj/item/weapon/gun/energy/locked/frontier/holdout,
 		/obj/item/clothing/head/pilot,
 		/obj/item/clothing/under/rank/pilot1,
 		/obj/item/clothing/suit/storage/toggle/bomber/pilot,
+		/obj/item/clothing/shoes/boots/winter/explorer,
 		/obj/item/clothing/mask/gas/half,
 		/obj/item/clothing/shoes/black,
 		/obj/item/clothing/gloves/fingerless,
+		/obj/item/device/radio/headset/pilot,
 		/obj/item/device/radio/headset/pilot/alt,
+		/obj/item/weapon/cartridge/explorer,
 		/obj/item/device/flashlight,
 		/obj/item/weapon/reagent_containers/food/snacks/liquidfood,
+		/obj/item/weapon/reagent_containers/food/snacks/liquidprotein,
 		/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
 		/obj/item/weapon/storage/box/flare,
 		/obj/item/weapon/cell/device,
-		/obj/item/device/radio)
-
+		/obj/item/device/radio,
+		/obj/item/device/gps/explorer,
+		/obj/item/device/cataloguer/compact)
+//End CHOMPedit
 /obj/structure/closet/secure_closet/pilot/Initialize()
 	if(prob(50))
 		starts_with += /obj/item/weapon/storage/backpack


### PR DESCRIPTION
Changes explorer, SAR, and pilot lockers back to their previous contents before an upstream PR broke this.
Also removes the tether_prelinked bluespace radio from the pathfinder locker. It is now just a bluespace radio. 

Fixes #372 