### PR TITLE
Remove 'savetofile' from NIF and transcore

### DIFF
--- a/code/controllers/subsystems/transcore_vr.dm
+++ b/code/controllers/subsystems/transcore_vr.dm
@@ -137,7 +137,7 @@ SUBSYSTEM_DEF(transcore)
 		MR.one_time = one_time
 
 		//Pass a 0 to not change NIF status (because the elseif is checking for null)
-		if(nif && nif.savetofile) //This is to allow Transcore to skip over saving NIFs that have already been saved.
+		if(nif)
 			MR.nif_path = nif.type
 			MR.nif_durability = nif.durability
 			var/list/nifsofts = list()
@@ -147,7 +147,6 @@ SUBSYSTEM_DEF(transcore)
 					nifsofts += nifsoft.type
 			MR.nif_software = nifsofts
 			MR.nif_savedata = nif.save_data.Copy()
-			nif.savetofile = FALSE
 		else if(isnull(nif)) //Didn't pass anything, so no NIF
 			MR.nif_path = null
 			MR.nif_durability = null

--- a/code/modules/nifsoft/nif.dm
+++ b/code/modules/nifsoft/nif.dm
@@ -26,8 +26,6 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 
 	var/durability = 100					// Durability remaining
 	var/bioadap = FALSE						// If it'll work in fancy species
-	var/savetofile = TRUE					/*Start True so that Transcore saves any NIF that's newly installed with the correct scans or implant.
-											DO NOT CHANGE durability WITHOUT SETTING THIS TO TRUE. */
 
 	var/tmp/power_usage = 0						// Nifsoft adds to this
 	var/tmp/mob/living/carbon/human/human		// Our owner!
@@ -98,7 +96,6 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 	//If given wear (like when spawned) then done
 	if(wear)
 		durability = wear
-		savetofile = TRUE
 		wear(0) //Just make it update.
 
 	//Draw me yo.
@@ -191,7 +188,6 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 /obj/item/device/nif/proc/wear(var/wear = 0)
 	wear *= (rand(85,115) / 100) //Apparently rand() only takes integers.
 	durability -= wear
-	savetofile = TRUE
 
 	if(durability <= 0)
 		stat = NIF_TEMPFAIL
@@ -230,7 +226,6 @@ You can also set the stat of a NIF to NIF_TEMPFAIL without any issues to disable
 			playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 			open = FALSE
 			durability = initial(durability)
-			savetofile = TRUE
 			stat = NIF_PREINSTALL
 			update_icon()
 


### PR DESCRIPTION
Long shot, but in hopes of fixing a crashing bug involving NIF info saving to character file.