### PR TITLE
Prison break no longer opens the blast doors

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -422,7 +422,7 @@ var/list/mob/living/forced_ambiance_list = new
 		to_chat(mob, "<span class='notice'>The sudden appearance of gravity makes you fall to the floor!</span>")
 		playsound(mob, "bodyfall", 50, 1)
 
-/area/proc/prison_break(break_lights = TRUE, open_doors = TRUE, open_blast_doors = TRUE)
+/area/proc/prison_break(break_lights = TRUE, open_doors = TRUE, open_blast_doors = FALSE) //CHOMP Edit set blast doors to FALSE
 	var/obj/machinery/power/apc/theAPC = get_apc()
 	if(theAPC.operating)
 		if(break_lights)

--- a/code/modules/gamemaster/event2/events/security/prison_break.dm
+++ b/code/modules/gamemaster/event2/events/security/prison_break.dm
@@ -126,7 +126,7 @@
 	var/list/areas_to_break = list()
 	var/list/area_types_to_break = null // Area types to include.
 	var/list/area_types_to_ignore = null // Area types to exclude, usually due to undesired inclusion from inheritence.
-	var/ignore_blast_doors = FALSE
+	var/ignore_blast_doors = TRUE //CHOMP Edit
 
 /datum/event2/event/prison_break/brig
 	area_display_name = "Brig"


### PR DESCRIPTION
Helps out Xenobio from being royally screwed. Pays off for the wise who use the blast doors.