### PR TITLE
Bandaid fix for transcore resource consumption

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -349,3 +349,6 @@ var/global/list/##LIST_NAME = list();\
 #define JOB_SILICON_ROBOT	0x2
 #define JOB_SILICON_AI		0x4
 #define JOB_SILICON			0x6 // 2|4, probably don't set jobs to this, but good for checking
+
+//Preference save/load cooldown. This is in deciseconds.
+#define PREF_SAVELOAD_COOLDOWN 2 //Should be sufficiently hard to achieve without a broken mouse or autoclicker while still fulfilling its intended goal.

--- a/code/controllers/subsystems/transcore_vr.dm
+++ b/code/controllers/subsystems/transcore_vr.dm
@@ -172,7 +172,7 @@ SUBSYSTEM_DEF(transcore)
 /datum/controller/subsystem/transcore/proc/add_backup(datum/transhuman/mind_record/MR)
 	ASSERT(MR)
 	backed_up[MR.mindname] = MR
-	backed_up = sortTim(backed_up)
+	backed_up = sortAssoc(backed_up)
 	log_debug("Added [MR.mindname] to transcore DB.")
 
 // Remove a mind_record from the backup-checking list.  Keeps track of it in has_left // Why do we do that? ~Leshana
@@ -187,7 +187,7 @@ SUBSYSTEM_DEF(transcore)
 /datum/controller/subsystem/transcore/proc/add_body(datum/transhuman/body_record/BR)
 	ASSERT(BR)
 	body_scans[BR.mydna.name] = BR
-	body_scans = sortTim(body_scans)
+	body_scans = sortAssoc(body_scans)
 	log_debug("Added [BR.mydna.name] to transcore body DB.")
 
 // Remove a body record from the database (Usually done when someone cryos)  // Why? ~Leshana

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -14,6 +14,12 @@ datum/preferences
 	var/last_ip
 	var/last_id
 
+	//Cooldowns for saving/loading. These are four are all separate due to loading code calling these one after another
+	var/saveprefcooldown
+	var/loadprefcooldown
+	var/savecharcooldown
+	var/loadcharcooldown
+
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
 	var/ooccolor = "#010000"			//Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color
@@ -227,7 +233,7 @@ datum/preferences
 		to_chat(user, "<span class='danger'>No mob exists for the given client!</span>")
 		close_load_dialog(user)
 		return
-	
+
 	if(!char_render_holders)
 		update_preview_icon()
 	show_character_previews()
@@ -272,7 +278,7 @@ datum/preferences
 		client.screen |= BG
 	BG.icon_state = bgstate
 	BG.screen_loc = preview_screen_locs["BG"]
-	
+
 	for(var/D in global.cardinal)
 		var/obj/screen/setup_preview/O = LAZYACCESS(char_render_holders, "[D]")
 		if(!O)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -33,6 +33,11 @@
 
 /datum/preferences/proc/load_preferences()
 	if(!path)				return 0
+	if(world.time < loadprefcooldown) //This is done before checking if the file exists to ensure that the server can't hang on read attempts
+		if(istype(client))
+			to_chat(client, "<span class='warning'>You're attempting to load your preferences a little too fast. Wait half a second, then try again.</span>")
+		return 0
+	loadprefcooldown = world.time + PREF_SAVELOAD_COOLDOWN
 	if(!fexists(path))		return 0
 	var/savefile/S = new /savefile(path)
 	if(!S)					return 0
@@ -52,6 +57,11 @@
 
 /datum/preferences/proc/save_preferences()
 	if(!path)				return 0
+	if(world.time < saveprefcooldown)
+		if(istype(client))
+			to_chat(client, "<span class='warning'>You're attempting to save your preferences a little too fast. Wait half a second, then try again.</span>")
+		return 0
+	saveprefcooldown = world.time + PREF_SAVELOAD_COOLDOWN
 	var/savefile/S = new /savefile(path)
 	if(!S)					return 0
 	S.cd = "/"
@@ -62,6 +72,11 @@
 
 /datum/preferences/proc/load_character(slot)
 	if(!path)				return 0
+	if(world.time < loadcharcooldown)
+		if(istype(client))
+			to_chat(client, "<span class='warning'>You're attempting to load your character a little too fast. Wait half a second, then try again.</span>")
+		return 0
+	loadcharcooldown = world.time + PREF_SAVELOAD_COOLDOWN
 	if(!fexists(path))		return 0
 	var/savefile/S = new /savefile(path)
 	if(!S)					return 0
@@ -90,6 +105,11 @@
 
 /datum/preferences/proc/save_character()
 	if(!path)				return 0
+	if(world.time < savecharcooldown)
+		if(istype(client))
+			to_chat(client, "<span class='warning'>You're attempting to save your character a little too fast. Wait half a second, then try again.</span>")
+		return 0
+	savecharcooldown = world.time + PREF_SAVELOAD_COOLDOWN
 	var/savefile/S = new /savefile(path)
 	if(!S)					return 0
 	S.cd = "/character[default_slot]"
@@ -109,7 +129,7 @@
 			default_slot = slot
 			nif_path = nif_durability = nif_savedata = null //VOREStation Add - Don't copy NIF
 			S["default_slot"] << slot
-			
+
 	else
 		S["default_slot"] << default_slot
 

--- a/code/modules/resleeving/implant.dm
+++ b/code/modules/resleeving/implant.dm
@@ -32,8 +32,9 @@
 /obj/item/weapon/implant/backup/post_implant(var/mob/living/carbon/human/H)
 	if(istype(H))
 		BITSET(H.hud_updateflag, BACKUP_HUD)
-		SStranscore.implants |= src
-
+		if(H.mind && H.stat < DEAD)
+			SStranscore.m_backup(H.mind,H.nif)
+			persist_nif_data(H)
 		return 1
 
 //New, modern implanter instead of old style implanter.


### PR DESCRIPTION
NOTE: I'd recommend test merging this for a while first to see if it alleviates the issue. Don't just full merge it off the bat.

So funny thing, the transcore saves the character slot and prefs of every mob that has a backup implant installed approximately every minute, per number of implants.

A body with 100 implants in it will be saved 100 times in one tick.

Yeah probably not a good idea.

-Disables the transcore implant mind backup
-Moves the implant mind backup to the post_implant proc on a backup implant, so you backup when you backup. (note, this means you need to backup again if you get an NIF to save it)
-Also adds some save preference stuff so you can't spam save/load to hitch the server

This is just treating a symptom however, the cause is of course how transcore is coded.
But uhh, figured it'd be a good idea to deal with the current issue earlier since stripping transcore is a big project.


EDIT: After test merging this for a full round, transcore is not responsible for the servers recent persistent OOM'ing.
Though this PR does still dramatically reduce transcore's cpu usage.