### PR TITLE
Misc memory improvements

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -275,15 +275,15 @@
 // Second argument is the path the list is expected to contain. Note that children will also get added to the global list.
 // If the GLOB system is ever ported, you can change this macro in one place and have less work to do than you otherwise would.
 #define GLOBAL_LIST_BOILERPLATE(LIST_NAME, PATH)\
-var/global/list/##LIST_NAME = list();\
+GLOBAL_LIST_EMPTY(##LIST_NAME);\
 ##PATH/Initialize(mapload, ...)\
 	{\
-	##LIST_NAME += src;\
+	GLOB.##LIST_NAME += src;\
 	return ..();\
 	}\
 ##PATH/Destroy(force, ...)\
 	{\
-	##LIST_NAME -= src;\
+	GLOB.##LIST_NAME -= src;\
 	return ..();\
 	}\
 

--- a/code/_global_vars/lists/mapping.dm
+++ b/code/_global_vars/lists/mapping.dm
@@ -30,3 +30,20 @@ GLOBAL_LIST_INIT(cww_dir, list( // cww_dir[dir] = counter-clockwise rotation of 
 	32, 40, 36, 44, 33, 41, 37, 45, 34, 42, 38, 46, 35, 43, 39, 47, // DOWN - Same as first line but +32
 	48, 56, 52, 60, 49, 57, 53, 61, 50, 58, 54, 62, 51, 59, 55, 63  // UP+DOWN - Same as first line but +48
 ))
+
+GLOBAL_LIST_INIT(ore_types, list(
+	"hematite" = /obj/item/weapon/ore/iron,
+	"uranium" = /obj/item/weapon/ore/uranium,
+	"gold" = /obj/item/weapon/ore/gold,
+	"silver" = /obj/item/weapon/ore/silver,
+	"diamond" = /obj/item/weapon/ore/diamond,
+	"phoron" = /obj/item/weapon/ore/phoron,
+	"osmium" = /obj/item/weapon/ore/osmium,
+	"hydrogen" = /obj/item/weapon/ore/hydrogen,
+	"silicates" = /obj/item/weapon/ore/glass,
+	"carbon" = /obj/item/weapon/ore/coal,
+	"verdantium" = /obj/item/weapon/ore/verdantium,
+	"marble" = /obj/item/weapon/ore/marble,
+	"lead" = /obj/item/weapon/ore/lead,
+	"rutile" = /obj/item/weapon/ore/rutile //VOREStation Add
+))

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -69,11 +69,11 @@ var/list/gamemode_cache = list()
 	var/static/allow_ai_shells = FALSE			// allow AIs to enter and leave special borg shells at will, and for those shells to be buildable.
 	var/static/give_free_ai_shell = FALSE		// allows a specific spawner object to instantiate a premade AI Shell
 	var/static/hostedby = null
-	
+
 	var/static/respawn = 1
 	var/static/respawn_time = 3000			// time before a dead player is allowed to respawn (in ds, though the config file asks for minutes, and it's converted below)
 	var/static/respawn_message = "<span class='notice'><B>Make sure to play a different character, and please roleplay correctly!</B></span>"
-	
+
 	var/static/guest_jobban = 1
 	var/static/usewhitelist = 0
 	var/static/kick_inactive = 0				//force disconnect for inactive players after this many minutes, if non-0
@@ -281,7 +281,7 @@ var/list/gamemode_cache = list()
 
 	// whether or not to use the nightshift subsystem to perform lighting changes
 	var/static/enable_night_shifts = FALSE
-	
+
 	var/static/vgs_access_identifier = null	// VOREStation Edit - VGS
 	var/static/vgs_server_port = null	// VOREStation Edit - VGS
 
@@ -435,15 +435,15 @@ var/list/gamemode_cache = list()
 
 				if ("allow_admin_spawning")
 					config.allow_admin_spawning = 1
-					
+
 				if ("allow_byond_links")
 					allow_byond_links = 1
 
 				if ("allow_discord_links")
-					allow_discord_links = 1	
+					allow_discord_links = 1
 
 				if ("allow_url_links")
-					allow_url_links = 1					
+					allow_url_links = 1
 
 				if ("no_dead_vote")
 					config.vote_no_dead = 1
@@ -493,7 +493,7 @@ var/list/gamemode_cache = list()
 				if ("respawn_time")
 					var/raw_minutes = text2num(value)
 					config.respawn_time = raw_minutes MINUTES
-				
+
 				if ("respawn_message")
 					config.respawn_message = value
 
@@ -924,7 +924,7 @@ var/list/gamemode_cache = list()
 
 				if("enable_night_shifts")
 					config.enable_night_shifts = TRUE
-				
+
 				// VOREStation Edit Start - Can't be in _vr file because it is loaded too late.
 				if("vgs_access_identifier")
 					config.vgs_access_identifier = value

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -71,7 +71,7 @@
 	var/TC_uses = 0
 	var/uplink_true = 0
 	var/purchases = ""
-	for(var/obj/item/device/uplink/H in world_uplinks)
+	for(var/obj/item/device/uplink/H in GLOB.world_uplinks)
 		if(H && H.uplink_owner && H.uplink_owner == ply)
 			TC_uses += H.used_TC
 			uplink_true = 1
@@ -85,7 +85,7 @@
 
 /proc/print_ownerless_uplinks()
 	var/has_printed = 0
-	for(var/obj/item/device/uplink/H in world_uplinks)
+	for(var/obj/item/device/uplink/H in GLOB.world_uplinks)
 		if(isnull(H.uplink_owner) && H.used_TC)
 			if(!has_printed)
 				has_printed = 1

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -1,7 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
 
-/obj/var/list/req_access = list()
-/obj/var/list/req_one_access = list()
+/obj/var/list/req_access
+/obj/var/list/req_one_access
 
 //returns 1 if this mob has sufficient access to use this object
 /obj/proc/allowed(mob/M)
@@ -28,22 +28,23 @@
 	return check_access_list(I ? I.GetAccess() : list())
 
 /obj/proc/check_access_list(var/list/L)
-	if(!req_access)		req_access = list()
-	if(!req_one_access)	req_one_access = list()
 	if(!L)	return 0
 	if(!istype(L, /list))	return 0
 	return has_access(req_access, req_one_access, L)
 
 /proc/has_access(var/list/req_access, var/list/req_one_access, var/list/accesses)
-	for(var/req in req_access)
-		if(!(req in accesses)) //doesn't have this access
-			return 0
-	if(req_one_access.len)
-		for(var/req in req_one_access)
-			if(req in accesses) //has an access from the single access list
-				return 1
-		return 0
-	return 1
+	var/has_RA = LAZYLEN(req_access)
+	var/has_ROA = LAZYLEN(req_one_access)
+	var/has_A = LAZYLEN(accesses)
+	if(!has_RA && !has_ROA)		//we need none
+		return TRUE
+	if(!has_A)					//we need them but don't have them
+		return FALSE
+	if(has_RA && length(req_access - accesses))			//we don't have every access we need
+		return FALSE
+	if(has_ROA && !length(req_one_access & accesses))	//we have atleast one access from this list
+		return FALSE
+	return TRUE
 
 /proc/get_centcom_access(job)
 	switch(job)
@@ -106,35 +107,35 @@
 	if(!priv_all_access)
 		priv_all_access = get_access_ids()
 
-	return priv_all_access
+	return priv_all_access.Copy()
 
 /var/list/priv_station_access
 /proc/get_all_station_access()
 	if(!priv_station_access)
 		priv_station_access = get_access_ids(ACCESS_TYPE_STATION)
 
-	return priv_station_access
+	return priv_station_access.Copy()
 
 /var/list/priv_centcom_access
 /proc/get_all_centcom_access()
 	if(!priv_centcom_access)
 		priv_centcom_access = get_access_ids(ACCESS_TYPE_CENTCOM)
 
-	return priv_centcom_access
+	return priv_centcom_access.Copy()
 
 /var/list/priv_syndicate_access
 /proc/get_all_syndicate_access()
 	if(!priv_syndicate_access)
 		priv_syndicate_access = get_access_ids(ACCESS_TYPE_SYNDICATE)
 
-	return priv_syndicate_access
+	return priv_syndicate_access.Copy()
 
 /var/list/priv_private_access
 /proc/get_all_private_access()
 	if(!priv_private_access)
 		priv_private_access = get_access_ids(ACCESS_TYPE_PRIVATE)
 
-	return priv_syndicate_access
+	return priv_syndicate_access.Copy()
 
 /var/list/priv_region_access
 /proc/get_region_accesses(var/code)
@@ -148,7 +149,8 @@
 				priv_region_access["[A.region]"] = list()
 			priv_region_access["[A.region]"] += A.id
 
-	return priv_region_access["[code]"]
+	var/list/L = priv_region_access["[code]"]
+	return L.Copy()
 
 /proc/get_region_accesses_name(var/code)
 	switch(code)

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -259,7 +259,7 @@ GLOBAL_LIST_BOILERPLATE(all_deactivated_AI_cores, /obj/structure/AIcore/deactiva
 	set category = "Admin"
 
 	var/list/cores = list()
-	for(var/obj/structure/AIcore/deactivated/D in all_deactivated_AI_cores)
+	for(var/obj/structure/AIcore/deactivated/D in GLOB.all_deactivated_AI_cores)
 		cores["[D] ([D.loc.loc])"] = D
 
 	var/id = input("Which core?", "Toggle AI Core Latejoin", null) as null|anything in cores

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -30,7 +30,7 @@
 		else if(screen == 1)
 			dat += "<HR>Chemical Implants<BR>"
 			var/turf/Tr = null
-			for(var/obj/item/weapon/implant/chem/C in all_chem_implants)
+			for(var/obj/item/weapon/implant/chem/C in GLOB.all_chem_implants)
 				Tr = get_turf(C)
 				if(!Tr)	continue//Out of range
 				if(!C.implanted) continue
@@ -40,7 +40,7 @@
 				dat += "<A href='?src=\ref[src];inject10=\ref[C]'>(<font color=red>(10)</font>)</A><BR>"
 				dat += "********************************<BR>"
 			dat += "<HR>Tracking Implants<BR>"
-			for(var/obj/item/weapon/implant/tracking/T in all_tracking_implants)
+			for(var/obj/item/weapon/implant/tracking/T in GLOB.all_tracking_implants)
 				Tr = get_turf(T)
 				if(!Tr) continue//Out of range
 				if(!T.implanted) continue

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -28,9 +28,9 @@
 	return attack_hand(user)
 
 /obj/machinery/button/remote/emag_act(var/remaining_charges, var/mob/user)
-	if(req_access.len || req_one_access.len)
-		req_access = list()
-		req_one_access = list()
+	if(LAZYLEN(req_access) || LAZYLEN(req_one_access.len))
+		req_access = req_access ? list() : null
+		req_one_access = req_one_access ? list() : null // if it's not set keep it not set
 		playsound(src, "sparks", 100, 1)
 		return 1
 

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -47,7 +47,7 @@
 		if(F.id == src.id)
 			LAZYADD(targets,F)
 
-	for(var/obj/structure/closet/secure_closet/brig/C in all_brig_closets)
+	for(var/obj/structure/closet/secure_closet/brig/C in GLOB.all_brig_closets)
 		if(C.id == src.id)
 			LAZYADD(targets,C)
 

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -97,7 +97,7 @@
 	alert_readers(FC.announcement)
 
 /datum/feed_network/proc/alert_readers(var/annoncement)
-	for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
+	for(var/obj/machinery/newscaster/NEWSCASTER in GLOB.allCasters)
 		NEWSCASTER.newsAlert(annoncement)
 		NEWSCASTER.update_icon()
 
@@ -178,7 +178,7 @@ GLOBAL_LIST_BOILERPLATE(allCasters, /obj/machinery/newscaster)
 
 /obj/machinery/newscaster/Initialize()
 	..() //Not returning . because lateload below
-	allCasters += src
+	GLOB.allCasters += src
 	unit_no = ++unit_no_cur
 	paper_remaining = 15
 	update_icon()
@@ -188,7 +188,7 @@ GLOBAL_LIST_BOILERPLATE(allCasters, /obj/machinery/newscaster)
 	node = get_exonet_node()
 
 /obj/machinery/newscaster/Destroy()
-	allCasters -= src
+	GLOB.allCasters -= src
 	node = null
 	return ..()
 
@@ -654,7 +654,7 @@ GLOBAL_LIST_BOILERPLATE(allCasters, /obj/machinery/newscaster)
 			var/choice = alert("Please confirm Wanted Issue removal","Network Security Handler","Confirm","Cancel")
 			if(choice=="Confirm")
 				news_network.wanted_issue = null
-				for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
+				for(var/obj/machinery/newscaster/NEWSCASTER in GLOB.allCasters)
 					NEWSCASTER.update_icon()
 				screen=17
 			updateUsrDialog()

--- a/code/game/machinery/pointdefense.dm
+++ b/code/game/machinery/pointdefense.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_BOILERPLATE(pointdefense_turrets, /obj/machinery/power/pointdefense)
 	. = ..()
 	if(id_tag)
 		//No more than 1 controller please.
-		for(var/thing in pointdefense_controllers)
+		for(var/thing in GLOB.pointdefense_controllers)
 			var/obj/machinery/pointdefense_control/PC = thing
 			if(PC != src && PC.id_tag == id_tag)
 				warning("Two [src] with the same id_tag of [id_tag]")
@@ -82,8 +82,8 @@ GLOBAL_LIST_BOILERPLATE(pointdefense_turrets, /obj/machinery/power/pointdefense)
 	var/list/turrets = list()
 	if(id_tag)
 		var/list/connected_z_levels = GetConnectedZlevels(get_z(src))
-		for(var/i = 1 to LAZYLEN(pointdefense_turrets))
-			var/obj/machinery/power/pointdefense/PD = pointdefense_turrets[i]
+		for(var/i = 1 to LAZYLEN(GLOB.pointdefense_turrets))
+			var/obj/machinery/power/pointdefense/PD = GLOB.pointdefense_turrets[i]
 			if(!(PD.id_tag == id_tag && get_z(PD) in connected_z_levels))
 				continue
 			var/list/turret = list()
@@ -104,7 +104,7 @@ GLOBAL_LIST_BOILERPLATE(pointdefense_turrets, /obj/machinery/power/pointdefense)
 		var/new_ident = input(user, "Enter a new ident tag.", "[src]", id_tag) as null|text
 		if(new_ident && new_ident != id_tag && user.Adjacent(src) && CanInteract(user, physical_state))
 			// Check for duplicate controllers with this ID
-			for(var/thing in pointdefense_controllers)
+			for(var/thing in GLOB.pointdefense_controllers)
 				var/obj/machinery/pointdefense_control/PC = thing
 				if(PC != src && PC.id_tag == id_tag)
 					to_chat(user, "<span class='warning'>The [new_ident] network already has a controller.</span>")
@@ -210,7 +210,7 @@ GLOBAL_LIST_BOILERPLATE(pointdefense_turrets, /obj/machinery/power/pointdefense)
 	if(!id_tag)
 		return null
 	var/list/connected_z_levels = GetConnectedZlevels(get_z(src))
-	for(var/thing in pointdefense_controllers)
+	for(var/thing in GLOB.pointdefense_controllers)
 		var/obj/machinery/pointdefense_control/PDC = thing
 		if(PDC.id_tag == id_tag && (get_z(PDC) in connected_z_levels))
 			return PDC

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -90,7 +90,7 @@
 		if(user)
 			to_chat(user, "<span class='notice'>The connected wire doesn't have enough current.</span>")
 		return
-	for(var/obj/singularity/singulo in all_singularities)
+	for(var/obj/singularity/singulo in GLOB.all_singularities)
 		if(singulo.z == z)
 			singulo.target = src
 	icon_state = "[icontype]1"
@@ -100,7 +100,7 @@
 		to_chat(user, "<span class='notice'>You activate the beacon.</span>")
 
 /obj/machinery/power/singularity_beacon/proc/Deactivate(mob/user = null)
-	for(var/obj/singularity/singulo in all_singularities)
+	for(var/obj/singularity/singulo in GLOB.all_singularities)
 		if(singulo.target == src)
 			singulo.target = null
 	icon_state = "[icontype]0"

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -24,7 +24,7 @@
 	teleport_control = new(src)
 	var/obj/machinery/teleport/station/station = null
 	var/obj/machinery/teleport/hub/hub = null
-	
+
 	// Search surrounding turfs for the station, and then search the station's surrounding turfs for the hub.
 	for(var/direction in cardinal)
 		station = locate(/obj/machinery/teleport/station, get_step(src, direction))
@@ -122,12 +122,12 @@
 
 /datum/nano_module/program/teleport_control/Topic(href, href_list)
 	if(..()) return 1
-	
+
 	if(href_list["select_target"])
 		var/list/L = list()
 		var/list/areaindex = list()
 
-		for(var/obj/item/device/radio/beacon/R in all_beacons)
+		for(var/obj/item/device/radio/beacon/R in GLOB.all_beacons)
 			var/turf/T = get_turf(R)
 			if(!T)
 				continue
@@ -140,7 +140,7 @@
 				areaindex[tmpname] = 1
 			L[tmpname] = R
 
-		for (var/obj/item/weapon/implant/tracking/I in all_tracking_implants)
+		for (var/obj/item/weapon/implant/tracking/I in GLOB.all_tracking_implants)
 			if(!I.implanted || !ismob(I.loc))
 				continue
 			else
@@ -175,12 +175,12 @@
 	if(href_list["toggle_on"])
 		if(!station)
 			return 0
-		
+
 		if(station.engaged)
 			station.disengage()
 		else
 			station.engage()
-		
+
 		return 1
 
 /datum/nano_module/program/teleport_control/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1, var/datum/topic_state/state = default_state)

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -476,7 +476,7 @@ var/list/civilian_cartridges = list(
 		else
 			JaniData["user_loc"] = list("x" = 0, "y" = 0)
 		var/MopData[0]
-		for(var/obj/item/weapon/mop/M in all_mops)
+		for(var/obj/item/weapon/mop/M in GLOB.all_mops)
 			var/turf/ml = get_turf(M)
 			if(ml)
 				if(ml.z != cl.z)
@@ -489,7 +489,7 @@ var/list/civilian_cartridges = list(
 
 
 		var/BucketData[0]
-		for(var/obj/structure/mopbucket/B in all_mopbuckets)
+		for(var/obj/structure/mopbucket/B in GLOB.all_mopbuckets)
 			var/turf/bl = get_turf(B)
 			if(bl)
 				if(bl.z != cl.z)
@@ -513,7 +513,7 @@ var/list/civilian_cartridges = list(
 		if(!CbotData.len)
 			CbotData[++CbotData.len] = list("x" = 0, "y" = 0, dir=null, status = null)
 		var/CartData[0]
-		for(var/obj/structure/janitorialcart/B in all_janitorial_carts)
+		for(var/obj/structure/janitorialcart/B in GLOB.all_janitorial_carts)
 			var/turf/bl = get_turf(B)
 			if(bl)
 				if(bl.z != cl.z)

--- a/code/game/objects/items/devices/communicator/helper.dm
+++ b/code/game/objects/items/devices/communicator/helper.dm
@@ -292,7 +292,7 @@
 	// Fetch janitorial locator
 	var/janidata[0]
 	var/list/cleaningList = list()
-	cleaningList += all_mops + all_mopbuckets + all_janitorial_carts
+	cleaningList += GLOB.all_mops + GLOB.all_mopbuckets + GLOB.all_janitorial_carts
 
 	// User's location
 	var/turf/userloc = get_turf(src)

--- a/code/game/objects/items/devices/translocator_vr.dm
+++ b/code/game/objects/items/devices/translocator_vr.dm
@@ -66,21 +66,21 @@
 
 /obj/item/device/perfect_tele/proc/rebuild_radial_images()
 	radial_images.Cut()
-	
+
 	var/index = 1
 	for(var/bcn in beacons) //Grumble
 		var/image/I = image(icon = 'icons/mob/radial_vr.dmi', icon_state = "tl_[index]")
-		
+
 		var/obj/item/device/perfect_tele_beacon/beacon = beacons[bcn]
 		if(destination == beacon)
 			I.overlays += radial_seton
 		else
 			I.overlays += radial_set
-		
+
 		radial_images[bcn] = I
-		
+
 		index++
-	
+
 	if(beacons_left)
 		var/image/I = image(icon = 'icons/mob/radial_vr.dmi', icon_state = "tl_[index]")
 		I.overlays += radial_plus
@@ -113,7 +113,7 @@
 
 /obj/item/device/perfect_tele/attack_self(mob/user)
 	if(loc_network)
-		for(var/obj/item/device/perfect_tele_beacon/stationary/nb in premade_tele_beacons)
+		for(var/obj/item/device/perfect_tele_beacon/stationary/nb in GLOB.premade_tele_beacons)
 			if(nb.tele_network == loc_network)
 				beacons[nb.tele_name] = nb
 		loc_network = null //Consumed
@@ -124,12 +124,12 @@
 		and tele-vore. Make sure you carefully examine someone's OOC prefs before teleporting them if you are \
 		going to use this device for ERP purposes. This device records all warnings given and teleport events for \
 		admin review in case of pref-breaking, so just don't do it.","OOC WARNING")
-	
+
 	var/choice = show_radial_menu(user, src, radial_images, custom_check = CALLBACK(src, .proc/check_menu, user), require_near = TRUE, tooltips = TRUE)
-	
+
 	if(!choice)
 		return
-	
+
 	else if(choice == "New Beacon")
 		if(beacons_left <= 0)
 			to_chat(user, "<span class='warning'>The translocator can't support any more beacons!</span>")
@@ -492,7 +492,7 @@ GLOBAL_LIST_BOILERPLATE(premade_tele_beacons, /obj/item/device/perfect_tele_beac
 	battery_lock = 1
 	unacidable = 1
 	failure_chance = 0 //Percent
-	
+
 	var/phase_power = 75
 	var/recharging = 0
 

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -59,7 +59,7 @@ Frequency:
 			if (sr)
 				src.temp += "<B>Located Beacons:</B><BR>"
 
-				for(var/obj/item/device/radio/beacon/W in all_beacons)
+				for(var/obj/item/device/radio/beacon/W in GLOB.all_beacons)
 					if (W.frequency == src.frequency)
 						var/turf/tr = get_turf(W)
 						if (tr.z == sr.z && tr)
@@ -77,7 +77,7 @@ Frequency:
 							src.temp += "[W.code]-[dir2text(get_dir(sr, tr))]-[direct]<BR>"
 
 				src.temp += "<B>Extraneous Signals:</B><BR>"
-				for (var/obj/item/weapon/implant/tracking/W in all_tracking_implants)
+				for (var/obj/item/weapon/implant/tracking/W in GLOB.all_tracking_implants)
 					if (!W.implanted || !(istype(W.loc,/obj/item/organ/external) || ismob(W.loc) || W.malfunction))
 						continue
 
@@ -164,7 +164,7 @@ Frequency:
 	if ((user.get_active_hand() != src || user.stat || user.restrained()))
 		return
 	var/count = 0	//num of portals from this teleport in world
-	for(var/obj/effect/portal/PO in all_portals)
+	for(var/obj/effect/portal/PO in GLOB.all_portals)
 		if(PO.creator == src)	count++
 	if(count >= 3)
 		user.show_message("<span class='notice'>\The [src] is recharging!</span>")

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -344,7 +344,7 @@ GLOBAL_LIST_BOILERPLATE(all_crematoriums, /obj/structure/morgue/crematorium)
 	if(..())
 		return
 	if(src.allowed(user))
-		for (var/obj/structure/morgue/crematorium/C in all_crematoriums)
+		for (var/obj/structure/morgue/crematorium/C in GLOB.all_crematoriums)
 			if (C.id == id)
 				if (!C.cremating)
 					C.cremate(user)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1806,7 +1806,7 @@
 					WANTED.backup_author = src.admincaster_signature                  //Submitted by
 					WANTED.is_admin_message = 1
 					news_network.wanted_issue = WANTED
-					for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
+					for(var/obj/machinery/newscaster/NEWSCASTER in GLOB.allCasters)
 						NEWSCASTER.newsAlert()
 						NEWSCASTER.update_icon()
 					src.admincaster_screen = 15
@@ -1822,7 +1822,7 @@
 		var/choice = alert("Please confirm Wanted Issue removal","Network Security Handler","Confirm","Cancel")
 		if(choice=="Confirm")
 			news_network.wanted_issue = null
-			for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
+			for(var/obj/machinery/newscaster/NEWSCASTER in GLOB.allCasters)
 				NEWSCASTER.update_icon()
 			src.admincaster_screen=17
 		src.access_news_network()

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_BOILERPLATE(all_debugging_effects, /obj/effect/debugging)
 
 
 
-	for(var/obj/effect/debugging/camera_range/C in all_debugging_effects)
+	for(var/obj/effect/debugging/camera_range/C in GLOB.all_debugging_effects)
 		qdel(C)
 
 	if(camera_range_display_status)
@@ -115,7 +115,7 @@ GLOBAL_LIST_BOILERPLATE(all_debugging_effects, /obj/effect/debugging)
 	else
 		intercom_range_display_status = 1
 
-	for(var/obj/effect/debugging/marker/M in all_debugging_effects)
+	for(var/obj/effect/debugging/marker/M in GLOB.all_debugging_effects)
 		qdel(M)
 
 	if(intercom_range_display_status)

--- a/code/modules/hydroponics/seed_controller.dm
+++ b/code/modules/hydroponics/seed_controller.dm
@@ -88,7 +88,7 @@ var/global/datum/controller/plants/plant_controller // Set in New().
 
 	// Make sure any seed packets that were mapped in are updated
 	// correctly (since the seed datums did not exist a tick ago).
-	for(var/obj/item/seeds/S in all_seed_packs)
+	for(var/obj/item/seeds/S in GLOB.all_seed_packs)
 		S.update_seed()
 
 	//Might as well mask the gene types while we're at it.

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -63,7 +63,7 @@
 	cell = /obj/item/weapon/cell/high
 
 /obj/machinery/mining/drill/get_cell()
-	return cell	
+	return cell
 
 /obj/machinery/mining/drill/process()
 
@@ -110,7 +110,7 @@
 		var/total_harvest = harvest_speed //Ore harvest-per-tick.
 		var/found_resource = 0 //If this doesn't get set, the area is depleted and the drill errors out.
 
-		for(var/metal in ore_types)
+		for(var/metal in GLOB.ore_types)
 
 			if(contents.len >= capacity)
 				system_error("Insufficient storage space.")
@@ -138,7 +138,7 @@
 					harvesting.resources[metal] = 0
 
 				for(var/i=1, i <= create_ore, i++)
-					var/oretype = ore_types[metal]
+					var/oretype = GLOB.ore_types[metal]
 					new oretype(src)
 
 		if(!found_resource)	// If a drill can't see an advanced material, it will destroy it while going through.

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -49,23 +49,6 @@ var/list/mining_overlay_cache = list()
 	var/datum/artifact_find/artifact_find
 	var/ignore_mapgen
 
-	var/ore_types = list(
-		"hematite" = /obj/item/weapon/ore/iron,
-		"uranium" = /obj/item/weapon/ore/uranium,
-		"gold" = /obj/item/weapon/ore/gold,
-		"silver" = /obj/item/weapon/ore/silver,
-		"diamond" = /obj/item/weapon/ore/diamond,
-		"phoron" = /obj/item/weapon/ore/phoron,
-		"osmium" = /obj/item/weapon/ore/osmium,
-		"hydrogen" = /obj/item/weapon/ore/hydrogen,
-		"silicates" = /obj/item/weapon/ore/glass,
-		"carbon" = /obj/item/weapon/ore/coal,
-		"verdantium" = /obj/item/weapon/ore/verdantium,
-		"marble" = /obj/item/weapon/ore/marble,
-		"lead" = /obj/item/weapon/ore/lead,
-		"rutile" = /obj/item/weapon/ore/rutile //VOREStation Add
-	)
-
 	has_resources = 1
 
 // Alternative rock wall sprites.
@@ -244,7 +227,7 @@ turf/simulated/mineral/floor/light_corner
 			for(var/ore in resources)
 				var/amount_to_give = rand(CEILING(resources[ore]/2, 1), resources[ore])  // Should result in at least one piece of ore.
 				for(var/i=1, i <= amount_to_give, i++)
-					var/oretype = ore_types[ore]
+					var/oretype = GLOB.ore_types[ore]
 					new oretype(src)
 				resources[ore] = 0
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -326,7 +326,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		A = input(usr, "Select an area:", "Ghost Teleport") as null|anything in return_sorted_areas()
 	if(!A)
 		return
-	
+
 	usr.forceMove(pick(get_area_turfs(A)))
 	usr.on_mob_jump()
 
@@ -339,7 +339,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		input = input(usr, "Select a mob:", "Ghost Follow") as null|anything in getmobs()
 	if(!input)
 		return
-	
+
 	var/target = getmobs()[input]
 	if(!target) return
 	ManualFollow(target)
@@ -859,10 +859,10 @@ mob/observer/dead/MayRespawn(var/feedback = 0)
 	set category = "Ghost"
 	set name = "Blank pAI alert"
 	set desc = "Flash an indicator light on available blank pAI devices for a smidgen of hope."
-	
+
 	if(usr.client.prefs?.be_special & BE_PAI)
 		var/count = 0
-		for(var/obj/item/device/paicard/p in all_pai_cards)
+		for(var/obj/item/device/paicard/p in GLOB.all_pai_cards)
 			var/obj/item/device/paicard/PP = p
 			if(PP.pai == null)
 				count++

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -938,7 +938,7 @@
 	restore_all_organs()       // Reapply robotics/amputated status from preferences.
 
 	if(!client || !key) //Don't boot out anyone already in the mob.
-		for (var/obj/item/organ/internal/brain/H in all_brain_organs)
+		for (var/obj/item/organ/internal/brain/H in GLOB.all_brain_organs)
 			if(H.brainmob)
 				if(H.brainmob.real_name == src.real_name)
 					if(H.brainmob.mind)

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -87,7 +87,7 @@ var/datum/paiController/paiController			// Global handler for pAI candidates
 			if("submit")
 				if(candidate)
 					candidate.ready = 1
-					for(var/obj/item/device/paicard/p in all_pai_cards)
+					for(var/obj/item/device/paicard/p in GLOB.all_pai_cards)
 						if(p.looking_for_personality == 1)
 							p.alertUpdate()
 				usr << browse(null, "window=paiRecruit")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -343,7 +343,7 @@
 
 /mob/proc/set_respawn_timer(var/time)
 	// Try to figure out what time to use
-	
+
 	// Special cases, can never respawn
 	if(ticker?.mode?.deny_respawn)
 		time = -1
@@ -351,22 +351,22 @@
 		time = -1
 	else if(!config.respawn)
 		time = -1
-	
+
 	// Special case for observing before game start
 	else if(ticker?.current_state <= GAME_STATE_SETTING_UP)
 		time = 1 MINUTE
-	
+
 	// Wasn't given a time, use the config time
 	else if(!time)
 		time = config.respawn_time
-	
+
 	var/keytouse = ckey
 	// Try harder to find a key to use
 	if(!keytouse && key)
 		keytouse = ckey(key)
 	else if(!keytouse && mind?.key)
 		keytouse = ckey(mind.key)
-	
+
 	GLOB.respawn_timers[keytouse] = world.time + time
 
 /mob/observer/dead/set_respawn_timer()
@@ -388,7 +388,7 @@
 		var/choice = alert(usr, "Returning to the menu will prevent your character from being revived in-round. Are you sure?", "Confirmation", "No, wait", "Yes, leave")
 		if(choice == "No, wait")
 			return
-	
+
 	// Beyond this point, you're going to respawn
 	to_chat(usr, config.respawn_message)
 
@@ -441,7 +441,7 @@
 
 
 	targets += observe_list_format(nuke_disks)
-	targets += observe_list_format(all_singularities)
+	targets += observe_list_format(GLOB.all_singularities)
 	targets += getmobs()
 	targets += observe_list_format(sortAtom(mechas_list))
 	targets += observe_list_format(SSshuttles.ships)

--- a/code/modules/power/supermatter/setup_supermatter.dm
+++ b/code/modules/power/supermatter/setup_supermatter.dm
@@ -32,7 +32,7 @@
 
 	// CONFIGURATION PHASE
 	// Coolant canisters, set types according to response.
-	for(var/obj/effect/engine_setup/coolant_canister/C in all_engine_setup_markers)
+	for(var/obj/effect/engine_setup/coolant_canister/C in GLOB.all_engine_setup_markers)
 		switch(response)
 			if("N2")
 				C.canister_type = /obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup/
@@ -44,7 +44,7 @@
 				C.canister_type = /obj/machinery/portable_atmospherics/canister/phoron/engine_setup/
 				continue
 
-	for(var/obj/effect/engine_setup/core/C in all_engine_setup_markers)
+	for(var/obj/effect/engine_setup/core/C in GLOB.all_engine_setup_markers)
 		switch(response)
 			if("N2")
 				C.energy_setting = ENERGY_NITROGEN
@@ -56,12 +56,12 @@
 				C.energy_setting = ENERGY_PHORON
 				continue
 
-	for(var/obj/effect/engine_setup/atmo_filter/F in all_engine_setup_markers)
+	for(var/obj/effect/engine_setup/atmo_filter/F in GLOB.all_engine_setup_markers)
 		F.coolant = response
 
 	var/list/delayed_objects = list()
 	// SETUP PHASE
-	for(var/obj/effect/engine_setup/S in all_engine_setup_markers)
+	for(var/obj/effect/engine_setup/S in GLOB.all_engine_setup_markers)
 		var/result = S.activate(0)
 		switch(result)
 			if(SETUP_OK)

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -119,7 +119,7 @@
 	if(!loc)
 		return
 	var/obj/singularity/energy_ball/EB = new(loc, 0, TRUE)
-	all_singularities -= EB //why are these miniballs even singularities in the first place, they don't do anything
+	GLOB.all_singularities -= EB //why are these miniballs even singularities in the first place, they don't do anything
 
 	EB.transform *= pick(0.3, 0.4, 0.5, 0.6, 0.7)
 	var/icon/I = icon(icon,icon_state,dir)

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -155,7 +155,7 @@
 
 GLOBAL_LIST_BOILERPLATE(papers_dockingcode, /obj/item/weapon/paper/dockingcodes)
 /hook/roundstart/proc/populate_dockingcodes()
-	for(var/paper in global.papers_dockingcode)
+	for(var/paper in GLOB.papers_dockingcode)
 		var/obj/item/weapon/paper/dockingcodes/dcp = paper
 		dcp.populate_info()
 	return TRUE

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -257,7 +257,7 @@
 					if(datum_flags & DF_ISPROCESSING)
 						//scan radios in the world to try and find one
 						var/cur_dist = 999
-						for(var/obj/item/device/radio/beacon/R in all_beacons)
+						for(var/obj/item/device/radio/beacon/R in GLOB.all_beacons)
 							if(R.z == src.z && R.frequency == src.frequency)
 								var/check_dist = get_dist(src,R)
 								if(check_dist < cur_dist)


### PR DESCRIPTION
This PR reduces memory usage by... rough estimate, about 200mb. Enough to let the server survive a 6hr round without OOM'ing.

Moves the associative ore_types list into a global list to reduce the memory usage of every single mineral turf having an associative list. Lists are expensive in byond.

Changes how airlocks generate their access lists, to only generate the list if they need them.

And some misc GLOB list improvements in cases where they were needed.