### PR TITLE
Solar Moth nerfs

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/solarmoth_ch.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/solarmoth_ch.dm
@@ -17,19 +17,15 @@
 
 	var/mycolour = COLOR_BLUE //Variable Lighting colours
 	var/original_temp = null //Value to remember temp
-	var/set_temperature = T0C + 10000	//Sets the target point of 10k degrees celsius
-	var/heating_power = 100000		//This controls the strength at which it heats the environment.
-	var/emp_heavy = 2
-	var/emp_med = 4
-	var/emp_light = 7
-	var/emp_long = 10
+	var/set_temperature = T0C + 450	//Sets the target point of 450 degrees celsius
+	var/heating_power = 100000	//This controls the strength at which it heats the environment. // The number seems ridiculous but this is actually pretty reasonable - Lunar
 
 	faction = "grubs"
-	maxHealth = 400 // Tanky fuckers.
-	health = 400 // Tanky fuckers.
+	maxHealth = 75 // Tanky fuckers.
+	health = 75 // Tanky fuckers.
 
-	melee_damage_lower = 1
-	melee_damage_upper = 5
+	melee_damage_lower = 5
+	melee_damage_upper = 10
 
 	movement_cooldown = 5
 
@@ -59,18 +55,18 @@
 	minbodytemp = 0
 	heat_damage_per_tick = 0 //Even if the atmos stuff doesn't work, at least it won't take any damage.
 
-	armor = list(			
+	armor = list(
 				"melee" = 0,
-				"bullet" = 90,
-				"laser" = 100,
-				"energy" = 100,
-				"bomb" = 100,
-				"bio" = 100,
-				"rad" = 100)
+				"bullet" = 0,
+				"laser" = 0,
+				"energy" = 0,
+				"bomb" = 0,
+				"bio" = 0,
+				"rad" = 0)
 
 /datum/say_list/solarmoth
 	emote_see = list("flutters")
-	
+
 /mob/living/simple_mob/vore/solarmoth/apply_melee_effects(var/atom/A)
 	if(isliving(A))
 		var/mob/living/L = A
@@ -106,37 +102,22 @@
 		if(heat_transfer > 0 && env.temperature < T0C + 200)	//This should start heating the room at a moderate pace up to 200 degrees celsius.
 			heat_transfer = min(heat_transfer , heating_power) //limit by the power rating of the heater
 			removed.add_thermal_energy(heat_transfer)
-			
-		else if(heat_transfer > 0 && env.temperature < set_temperature) //Set temperature is 10,000 degrees celsius. So this thing will start cooking crazy hot between the temperatures of 200C and 10,000C.
-			heating_power = original_temp*100 //Changed to work variable -shark //FLAME ON! This will make the moth heat up the room at an incredible rate.
+
+		else if(heat_transfer > 0 && env.temperature < set_temperature) //Set temperature is 450 degrees celsius. Heating rate should increase between 200 and 450 C.
+			heating_power = original_temp*100
 			heat_transfer = min(heat_transfer , heating_power) //limit by the power rating of the heater. Except it's hot, so yeah.
 			removed.add_thermal_energy(heat_transfer)
-			
+
 		else
 			return
 
 		env.merge(removed)
-		
+
 
 
 	//Since I'm changing hyper mode to be variable we need to store old power
 	original_temp = heating_power //We remember our old goal, for use in non perpetual heating level increase
 
-/mob/living/simple_mob/vore/solarmoth/proc/explode()
-	src.anchored = 0
-	set_light(0)
-	if(empulse(src, emp_heavy, emp_med, emp_light, emp_long))
-		qdel(src)
-	return
-
-/mob/living/simple_mob/vore/solarmoth/death()
-	explode()
-	..()
-	
-/mob/living/simple_mob/vore/solarmoth/gib() //This baby will explode no matter what you do to it.
-	explode()
-	..()
-	
 
 
 /mob/living/simple_mob/vore/solarmoth/handle_light()
@@ -157,38 +138,11 @@
 /mob/living/simple_mob/vore/solarmoth/lunarmoth
 	name = "lunarmoth"
 	desc = "A majestic sparkling lunarmoth. Also a slight engineering hazard."
-	
-	var/nospampls = 0
-	
 	cold_damage_per_tick = 0
 	//ATMOS
-	set_temperature = T0C - 10000
+	set_temperature = T0C - 450
 	heating_power = -100000
 	//light
 	mycolour = COLOR_WHITE
 
-/mob/living/simple_mob/vore/solarmoth/lunarmoth/proc/chilltheglass() //Why does a coldfusion moth do this? science -shark
-	nospampls = 1
-	if(prob(25))
-		for(var/obj/machinery/light/light in range(5, src))
-			if(prob(50))
-				light.broken() 
-	if(prob(10))
-		for(var/obj/structure/window/window in range(5, src))
-			if(prob(50))
-				window.shatter()
-	if(prob(20))
-		for(var/obj/machinery/door/firedoor/door in range(14, src)) //double viewrange
-			if(prob(5))
-				visible_message("<span class='danger'>Emergency Shutter malfunction!</span>")
-				door.blocked = 0
-				door.open(1)
-	
-	spawn(100)
-		nospampls = 0
 
-/mob/living/simple_mob/vore/solarmoth/lunarmoth/Life()
-	..()
-	if(!nospampls)
-		chilltheglass() //shatter and broken calls for glass and lights. Also some special thing.
-	

--- a/code/modules/mob/living/simple_mob/subtypes/vore/solarmoth_ch.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/solarmoth_ch.dm
@@ -21,8 +21,8 @@
 	var/heating_power = 100000	//This controls the strength at which it heats the environment. // The number seems ridiculous but this is actually pretty reasonable - Lunar
 
 	faction = "grubs"
-	maxHealth = 75 // Tanky fuckers.
-	health = 75 // Tanky fuckers.
+	maxHealth = 200 // Tanky fuckers.
+	health = 200 // Tanky fuckers.
 
 	melee_damage_lower = 5
 	melee_damage_upper = 10
@@ -56,13 +56,13 @@
 	heat_damage_per_tick = 0 //Even if the atmos stuff doesn't work, at least it won't take any damage.
 
 	armor = list(
-				"melee" = 0,
+				"melee" = -50,
 				"bullet" = 0,
-				"laser" = 0,
-				"energy" = 0,
-				"bomb" = 0,
-				"bio" = 0,
-				"rad" = 0)
+				"laser" = 50,
+				"energy" = 50,
+				"bomb" = 25,
+				"bio" = 100,
+				"rad" = 100)
 
 /datum/say_list/solarmoth
 	emote_see = list("flutters")
@@ -138,11 +138,37 @@
 /mob/living/simple_mob/vore/solarmoth/lunarmoth
 	name = "lunarmoth"
 	desc = "A majestic sparkling lunarmoth. Also a slight engineering hazard."
+	var/nospampls = 0
 	cold_damage_per_tick = 0
 	//ATMOS
-	set_temperature = T0C - 450
+	set_temperature = T0C - 10000
 	heating_power = -100000
 	//light
 	mycolour = COLOR_WHITE
+
+/mob/living/simple_mob/vore/solarmoth/lunarmoth/proc/chilltheglass() //Why does a coldfusion moth do this? science -shark
+	nospampls = 1
+	if(prob(25))
+		for(var/obj/machinery/light/light in range(5, src))
+			if(prob(50))
+				light.broken()
+	if(prob(10))
+		for(var/obj/structure/window/window in range(5, src))
+			if(prob(50))
+				window.shatter()
+	if(prob(20))
+		for(var/obj/machinery/door/firedoor/door in range(14, src)) //double viewrange
+			if(prob(5))
+				visible_message("<span class='danger'>Emergency Shutter malfunction!</span>")
+				door.blocked = 0
+				door.open(1)
+
+	spawn(100)
+		nospampls = 0
+
+/mob/living/simple_mob/vore/solarmoth/lunarmoth/Life()
+	..()
+	if(!nospampls)
+		chilltheglass() //shatter and broken calls for glass and lights. Also some special thing.
 
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/solarmoth_ch.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/solarmoth_ch.dm
@@ -19,6 +19,10 @@
 	var/original_temp = null //Value to remember temp
 	var/set_temperature = T0C + 450	//Sets the target point of 450 degrees celsius
 	var/heating_power = 100000	//This controls the strength at which it heats the environment. // The number seems ridiculous but this is actually pretty reasonable - Lunar
+	var/emp_heavy = 2
+	var/emp_med = 4
+	var/emp_light = 7
+	var/emp_long = 10
 
 	faction = "grubs"
 	maxHealth = 200 // Tanky fuckers.
@@ -118,6 +122,20 @@
 	//Since I'm changing hyper mode to be variable we need to store old power
 	original_temp = heating_power //We remember our old goal, for use in non perpetual heating level increase
 
+/mob/living/simple_mob/vore/solarmoth/proc/explode()
+	src.anchored = 0
+	set_light(0)
+	if(empulse(src, emp_heavy, emp_med, emp_light, emp_long))
+		qdel(src)
+	return
+
+/mob/living/simple_mob/vore/solarmoth/death()
+	explode()
+	..()
+
+/mob/living/simple_mob/vore/solarmoth/gib() //This baby will explode no matter what you do to it.
+	explode()
+	..()
 
 
 /mob/living/simple_mob/vore/solarmoth/handle_light()


### PR DESCRIPTION
Reduces the maximum temperature to 450 C, instead of being 10k C, which is twice the temperature of the sun. Also reduces some other stats, which made very little sense, such as solar moths being immune to lasers.