### PR TITLE
Aurora Cooking Pre-heating bugfix

### DIFF
--- a/code/modules/food/kitchen/cooking_machines/fryer.dm
+++ b/code/modules/food/kitchen/cooking_machines/fryer.dm
@@ -12,7 +12,7 @@
 	circuit = /obj/item/weapon/circuitboard/fryer
 	appliancetype = FRYER
 	active_power_usage = 12 KILOWATTS
-	heating_power = 12000
+	heating_power = 12 KILOWATTS
 	
 	min_temp = 140 + T0C	// Same as above, increasing this to just under 2x to make the % increase on efficiency not quite so painful as it would be at 80.
 	optimal_temp = 400 + T0C // Increasing this to be 2x Oven to allow for a much higher/realistic frying temperatures. Doesn't really do anything but make heating the fryer take a bit longer.
@@ -22,7 +22,7 @@
 	// Power used to maintain temperature once it's heated.
 	// Going with 25% of the active power. This is a somewhat arbitrary value.
 
-	resistance = 60000	// Approx. 10 minutes to heat up.
+	resistance = 10 KILOWATTS	// Approx. 10 minutes to heat up.
 
 	max_contents = 2
 	container_type = /obj/item/weapon/reagent_containers/cooking_container/fryer

--- a/code/modules/food/kitchen/cooking_machines/oven.dm
+++ b/code/modules/food/kitchen/cooking_machines/oven.dm
@@ -10,10 +10,10 @@
 	circuit = /obj/item/weapon/circuitboard/oven
 	cooked_sound = 'sound/machines/ding.ogg'
 	active_power_usage = 6 KILOWATTS
-	heating_power = 6000
+	heating_power = 6 KILOWATTS
 	//Based on a double deck electric convection oven
 
-	resistance = 30000 // Approx. 12 minutes to heat up.
+	resistance = 12 KILOWATTS // Approx. 12 minutes to heat up.
 	idle_power_usage = 2 KILOWATTS
 	//uses ~30% power to stay warm
 	optimal_power = 0.8 // Oven cooks .2 faster than the default speed.


### PR DESCRIPTION
Appliances previously had 60k resist and 30k resist, for fryer and oven respectively.

This meant that fryer would heat up in 62 minutes and oven would heat in 35-45. Obviously completely out of wack.

Now grill heats in at 6:50, fryer at 10:35, and oven at 12:10 to reach peak/cap temperatures!
