### PR TITLE
Disable constant ambiance

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -370,7 +370,8 @@ var/list/mob/living/forced_ambiance_list = new
 		L.update_floating( L.Check_Dense_Object() )
 
 	L.lastarea = newarea
-	L.lastareachange = world.time
+//CHOMP Edit: disable constant ambience
+//	L.lastareachange = world.time
 	play_ambience(L, initial = TRUE)
 	if(no_spoilers)
 		L.disable_spoiler_vision()

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -46,8 +46,8 @@
 	//Check if we're on fire
 	handle_fire()
 	
-	if(client)	// Handle re-running ambience to mobs if they've remained in an area, AND have an active client assigned to them.
-		handle_ambience()
+	if(client)	// Handle re-running ambience to mobs if they've remained in an area, AND have an active client assigned to them. CHOMP Edit: Disabled
+//		handle_ambience()
 	
 	//stuff in the stomach
 	//handle_stomach() //VOREStation Code

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -91,13 +91,13 @@
 
 /mob/living/proc/handle_stomach()
 	return
-
+/* CHOMP Edit: Disable constant ambience
 /mob/living/proc/handle_ambience() // If you're in an ambient area and have not moved out of it for x time, we're going to play ambience again to you, to help break up the silence.
 	if(world.time >= (lastareachange + 30 SECONDS)) // Every 30 seconds, we're going to run a 35% chance to play ambience.
 		var/area/A = get_area(src)
 		if(A)
 			A.play_ambience(src, initial = FALSE)
-
+*/
 /mob/living/proc/update_pulling()
 	if(pulling)
 		if(incapacitated())

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -46,7 +46,7 @@
 	//Check if we're on fire
 	handle_fire()
 	
-	if(client)	// Handle re-running ambience to mobs if they've remained in an area, AND have an active client assigned to them. CHOMP Edit: Disabled
+//	if(client)	// Handle re-running ambience to mobs if they've remained in an area, AND have an active client assigned to them. CHOMP Edit: Disabled
 //		handle_ambience()
 	
 	//stuff in the stomach


### PR DESCRIPTION
Reverts change from upstream, https://github.com/PolarisSS13/Polaris/pull/7366
Ambiance will go back to playing only upon entering into a new area.