### PR TITLE
Fix for energy guns not having recoil for micros

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -437,7 +437,7 @@
 		//VOREStation Edit End
 		
 	//YAWNEDIT: Recoil knockdown for micros, ported from CHOMPStation
-	if(recoil_mode && iscarbon(user) && !istype(src,/obj/item/weapon/gun/energy))
+	if(recoil_mode && iscarbon(user))
 		var/mob/living/carbon/nerd = user
 		var/mysize = nerd.size_multiplier
 		if(mysize <= 0.5)


### PR DESCRIPTION
Accidentally left a bit of code in there that would cause the recoil to ignore energy guns entirely. It should now cause the micro to drop the gun and finally reach the 'else' part of the code.