### PR TITLE
Adds Spice Resistence/Intolerance Traits, Makes Frost Oil COLD

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -100,6 +100,7 @@
 	var/chemOD_mod =		1						// Damage modifier for overdose; higher = more damage from ODs
 	var/alcohol_mod =		1						// Multiplier to alcohol strength; 0.5 = half, 0 = no effect at all, 2 = double, etc.
 	var/pain_mod =			1						// Multiplier to pain effects; 0.5 = half, 0 = no effect (equal to NO_PAIN, really), 2 = double, etc.
+	var/spice_mod =			1						// Multiplier to spice/capsaicin/frostoil effects; 0.5 = half, 0 = no effect (immunity), 2 = double, etc.
 	// set below is EMP interactivity for nonsynth carbons
 	var/emp_sensitivity =		0			// bitflag. valid flags are: EMP_PAIN, EMP_BLIND, EMP_DEAFEN, EMP_CONFUSE, EMP_STUN, and EMP_(BRUTE/BURN/TOX/OXY)_DMG
 	var/emp_dmg_mod =		1			// Multiplier to all EMP damage sustained by the mob, if it's EMP-sensitive

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -192,6 +192,44 @@ YW change end */
 	..(S,H)
 	H.verbs |= /mob/living/proc/glow_toggle
 	H.verbs |= /mob/living/proc/glow_color
+
+// Spicy Food Traits, from negative to positive.
+/datum/trait/spice_intolerance_extreme
+	name = "Extreme Spice Intolerance"
+	desc = "Spicy (and chilly) peppers are three times as strong. (This does not affect pepperspray.)"
+	cost = 0
+	var_changes = list("spice_mod" = 3) // 300% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
+	
+/datum/trait/spice_intolerance_basic
+	name = "Heavy Spice Intolerance"
+	desc = "Spicy (and chilly) peppers are twice as strong. (This does not affect pepperspray.)"
+	cost = 0
+	var_changes = list("spice_mod" = 2) // 200% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
+
+/datum/trait/spice_intolerance_slight
+	name = "Slight Spice Intolerance"
+	desc = "You have a slight struggle with spicy foods. Spicy (and chilly) peppers are one and a half times stronger. (This does not affect pepperspray.)"
+	cost = 0
+	var_changes = list("spice_mod" = 1.5) // 150% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
+
+/datum/trait/spice_tolerance_basic
+	name = "Spice Tolerance"
+	desc = "Spicy (and chilly) peppers are only three-quarters as strong. (This does not affect pepperspray.)"
+	cost = 0
+	var_changes = list("spice_mod" = 0.75) // 75% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
+	
+/datum/trait/spice_tolerance_advanced
+	name = "Strong Spice Tolerance"
+	desc = "Spicy (and chilly) peppers are only half as strong. (This does not affect pepperspray.)"
+	cost = 0
+	var_changes = list("spice_mod" = 0.5) // 50% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
+
+/datum/trait/spice_immunity
+	name = "Extreme Spice Tolerance"
+	desc = "Spicy (and chilly) peppers are basically ineffective! (This does not affect pepperspray.)"
+	cost = 0
+	var_changes = list("spice_mod" = 0.25) // 25% as effective if spice_mod is set to 1. If it's not 1 in species.dm, update this!
+
 /*YW CHANGE START: Commented out because we got our own variants	
 // Alcohol Traits Start Here, from negative to positive.
 /datum/trait/alcohol_intolerance_advanced

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food-Drinks.dm
@@ -619,6 +619,28 @@
 		M.emote("shiver")
 	holder.remove_reagent("capsaicin", 5)
 
+/datum/reagent/frostoil/affect_ingest(var/mob/living/carbon/M, var/alien, var/removed) // Eating frostoil now acts like capsaicin. Wee!
+	if(alien == IS_DIONA)
+		return
+	if(alien == IS_ALRAUNE) // VOREStation Edit: It wouldn't affect plants that much.
+		if(prob(5))
+			to_chat(M, "<span class='rose'>You feel a chilly, tingling sensation in your mouth.</span>")
+		M.bodytemperature -= rand(10, 25)
+		return
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(!H.can_feel_pain())
+			return
+	var/effective_dose = (dose * M.species.spice_mod)
+	if((effective_dose < 5) && (dose == metabolism || prob(5)))
+		to_chat(M, "<span class='danger'>Your insides suddenly feel a spreading chill!</span>")
+	if(effective_dose >= 5)
+		M.apply_effect(2 * M.species.spice_mod, AGONY, 0)
+		M.bodytemperature -= rand(1, 5) * M.species.spice_mod // Really fucks you up, cause it makes you cold.
+		if(prob(5))
+			M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>", pick("<span class='danger'>You feel like your insides are freezing!</span>", "<span class='danger'>Your insides feel like they're turning to ice!</span>"))
+	holder.remove_reagent("capsaicin", 5)
+
 /datum/reagent/frostoil/cryotoxin //A longer lasting version of frost oil.
 	name = "Cryotoxin"
 	id = "cryotoxin"
@@ -654,13 +676,15 @@
 		var/mob/living/carbon/human/H = M
 		if(!H.can_feel_pain())
 			return
-
-	if(dose < 5 && (dose == metabolism || prob(5)))
+	
+	var/effective_dose = (dose * M.species.spice_mod)
+	if((effective_dose < 5) && (dose == metabolism || prob(5)))
 		to_chat(M, "<span class='danger'>Your insides feel uncomfortably hot!</span>")
-	if(dose >= 5)
-		M.apply_effect(2, AGONY, 0)
+	if(effective_dose >= 5)
+		M.apply_effect(2 * M.species.spice_mod, AGONY, 0)
+		M.bodytemperature += rand(1, 5) * M.species.spice_mod // Really fucks you up, cause it makes you overheat, too.
 		if(prob(5))
-			M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>", "<span class='danger'>You feel like your insides are burning!</span>")
+			M.visible_message("<span class='warning'>[M] [pick("dry heaves!","coughs!","splutters!")]</span>", pick("<span class='danger'>You feel like your insides are burning!</span>", "<span class='danger'>You feel like your insides are on fire!</span>", "<span class='danger'>You feel like your belly is full of lava!</span>"))
 	holder.remove_reagent("frostoil", 5)
 
 /datum/reagent/condensedcapsaicin


### PR DESCRIPTION
- Spice Resistance traits in the same flavor as Booze traits. 
- 3x, 2x, 1.5x, 0.75x, 0.5x, 0.25x resistance to the effects of capsaicin and frost oil.
- Frost Oil and Capsaicin will now **lower/increase your body temperature by a random amount** during the ingest step if you're over the danger threshold.
- var/spice_mod is added to the species datums, much like alcohol mod.
- Frost Oil will now remove 5 capsaicin on affect_ingest much like capsaicin would remove 5 frostoil.

Not much else to say.
I got tired of keeling over in agony after eating spicy food, and frankly, this is an RP server, so mechanical hardlimits on characters that canonically power down spicy food without giving a shit is frustrating to say the least.

Earlyport of: https://github.com/VOREStation/VOREStation/pull/8726
