### PR TITLE
Nerfs ranch dimension

### DIFF
--- a/maps/southern_cross/overmap/sectors.dm
+++ b/maps/southern_cross/overmap/sectors.dm
@@ -36,7 +36,7 @@
 	start_x =  10
 	start_y =  10
 	map_z = list(Z_LEVEL_STATION_ONE, Z_LEVEL_STATION_TWO, Z_LEVEL_STATION_THREE)
-	extra_z_levels = list(Z_LEVEL_TRANSIT) // Hopefully temporary, so arrivals announcements work.
+	extra_z_levels = list(Z_LEVEL_TRANSIT, Z_LEVEL_MISC) // Hopefully temporary, so arrivals announcements work. //CHOMPedit: adds Z_LEVEL_MISC to connect the exploration carrier with the station
 
 /obj/effect/overmap/visitable/planet/Sif/Initialize()
 	. = ..()

--- a/maps/southern_cross/southern_cross.dm
+++ b/maps/southern_cross/southern_cross.dm
@@ -40,7 +40,7 @@
 	#include "southern_cross-1.dmm"
 	#include "southern_cross-2.dmm"
 	#include "southern_cross-3.dmm"
-	#include "southern_cross-4.dmm"
+//	#include "southern_cross-4.dmm" CHOMPedit: Disabling empty space map because the overmap now generates empty space on its own for space transit.7
 	#include "southern_cross-5.dmm"
 	#include "southern_cross-6.dmm"
 	#include "southern_cross-7.dmm"

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -3,16 +3,14 @@
 #define Z_LEVEL_STATION_ONE				1
 #define Z_LEVEL_STATION_TWO				2
 #define Z_LEVEL_STATION_THREE			3
-#define Z_LEVEL_EMPTY_SPACE				4
-#define Z_LEVEL_SURFACE					5
-#define Z_LEVEL_SURFACE_MINE			6
-#define Z_LEVEL_MISC					7
-#define Z_LEVEL_CENTCOM					8
-#define Z_LEVEL_TRANSIT					9
-#define Z_LEVEL_SURFACE_WILD			10
-//Comment out Z_LEVEL_BELT temporarily - TFF 15/2/20
-//#define Z_LEVEL_BELT					11
-#define Z_LEVEL_GATEWAY					11
+//#define Z_LEVEL_EMPTY_SPACE				4 //CHOMPedit: Disabling empty space as now the overmap generates empty space on demand. Z_LEVEL_SURFACE and below have been decreased by 1 because byond fucks things if you don't do that.
+#define Z_LEVEL_SURFACE					4
+#define Z_LEVEL_SURFACE_MINE			5
+#define Z_LEVEL_MISC					6
+#define Z_LEVEL_CENTCOM					7
+#define Z_LEVEL_TRANSIT					8
+#define Z_LEVEL_SURFACE_WILD			9
+#define Z_LEVEL_GATEWAY					10
 
 /datum/map/southern_cross
 	name = "Southern Cross"
@@ -198,12 +196,13 @@
 	holomap_offset_x = HOLOMAP_ICON_SIZE - SOUTHERN_CROSS_HOLOMAP_MARGIN_X - SOUTHERN_CROSS_MAP_SIZE - 40
 	holomap_offset_y = SOUTHERN_CROSS_HOLOMAP_MARGIN_Y + SOUTHERN_CROSS_MAP_SIZE*1
 
+/* //CHOMPedit: Disabling empty space map level as overmap generation now generates this as needed.
 /datum/map_z_level/southern_cross/empty_space
 	z = Z_LEVEL_EMPTY_SPACE
 	name = "Empty"
 	flags = MAP_LEVEL_PLAYER
 	transit_chance = 76
-
+*/
 /datum/map_z_level/southern_cross/surface
 	z = Z_LEVEL_SURFACE
 	name = "Plains"


### PR DESCRIPTION
#502 fixed issues with space transit at the boundaries of a space z-level but introduced a new problem where you may drift into southern_cross-4.dmm without the ability to leave without admin intervention (or a teleporter). This PR fixes that and also allows the exploration carrier to get suit sensors, wifi, and the other fixes from #502 .
-Connects Z_LEVEL_MISC (the exploration carrier) to Southern Cross' overmap landmark, allowing cross z-level code to work within it.
-Comments out southern_cross-4.dmm (empty space) as it turns out the overmap dynamically creates and removes an empty space level (z-level 13) when somebody drifts through space, making southern_cross-4.dmm obsolete.
-Decreases all z-levels except 1, 2, and 3 by 1 because byond will not allow you to skip z-levels. Somebody else can rename the .dmm files if this causes too many aneurysms. 
-Removes comments about the belt miner as its removal is permanent.
-Removes herobrine