### PR TITLE
Give HoS and CMO Teleport Access

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -16,10 +16,10 @@
 	req_admin_notify = 1
 	economic_modifier = 10
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
-			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
+			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce, access_teleporter,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
-			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
+			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce, access_teleporter,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
 
 	minimum_character_age = 25

--- a/code/game/jobs/job/security_vr.dm
+++ b/code/game/jobs/job/security_vr.dm
@@ -3,11 +3,11 @@
 	pto_type = PTO_SECURITY
 	dept_time_required = 60
 
-	access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory,
+	access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory, access_teleporter,
 						access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
 						access_research, access_engine, access_mining, access_construction, access_mailsorting,
 						access_heads, access_hos, access_RC_announce, access_keycard_auth, access_external_airlocks)
-	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory,
+	minimal_access = list(access_security, access_eva, access_sec_doors, access_brig, access_armory, access_teleporter,
 						access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
 						access_research, access_engine, access_mining, access_construction, access_mailsorting,
 						access_heads, access_hos, access_RC_announce, access_keycard_auth, access_external_airlocks)


### PR DESCRIPTION
I can understand why RD and CE have teleport access, but I feel like if we're gonna give it to two heads we might as well just give it to all of them. Would make a lot of people's jobs easier as well, especially CMO for surface rescues.