### PR TITLE
SynxTweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/aliens/synx.dm
+++ b/code/modules/mob/living/simple_animal/aliens/synx.dm
@@ -1,4 +1,8 @@
-/mob/living/simple_mob/retaliate/synx
+#define SYNX_LOWER_DAMAGE 2 //Using defines to make damage easier to tweak for hacky burn attack code.
+#define SYNX_UPPER_DAMAGE 6
+
+
+/mob/living/simple_mob/retaliate/synx //Player controlled variant
 	//on inteligence https://synx.fandom.com/wiki/Behavior/Intelligence //keeping this here for player controlled synxes.
 	name = "Synx"
 	desc = "A cold blooded, genderless, parasitic eel from the more distant and stranger areas of the cosmos. Plain, white, perpetually grinning and possessing a hunger as enthusiastic and endless as humanity's sense of exploration."
@@ -16,14 +20,20 @@
 	//VAR$ SETUP
 	//annoying for player controlled synxes.
 	var/realname = null
-	var/poison_per_bite = 2
+	var/poison_per_bite = 1 //Even with 2 this was OP with a 99% injection chance
 	var/poison_chance = 99.666
 	var/poison_type = "synxchem"//inaprovalin, but evil
 	var/transformed_state = "synx_transformed"
+	var/stomach_distended_state = "synx_pet_rainbow" //Proof of concept for now until actual sprite exists
 	var/transformed = FALSE
 	var/memorysize = 50 //Var for how many messages synxes remember if they know speechcode
 	var/list/voices = list()
-	var/forcefeedchance = 20
+	var/acid_damage_lower = SYNX_LOWER_DAMAGE - 1 //Variables for a hacky way to change to burn damage when they vomit up their stomachs. Set to 1 less than melee damage because it takes a minimum of 1 brute damage for this to activate.
+	var/acid_damage_upper = SYNX_UPPER_DAMAGE - 1
+	var/stomach_distended = 0 //Check for whether or not the synx has vomitted up its stomach.
+	var/forcefeedchance = 20 //This needs to be defined in the parent because code.
+
+
 
 	faction = "Synx"
 
@@ -42,7 +52,7 @@
 				"energy" = 0,
 				"bomb" = 0, //Same as above. -LO
 				"bio" = 50, //Nerfed from 100. They should have some protection against these things, but 100 is pushing it. -Lo
-				"rad" = 50)
+				"rad" = 100) //Keeping 100 rad armor as mobs cannot easily get radiation storm announcements. If this is reduced it'd be a good idea to make it 100 for the ai types.
 	has_hands = 1
 
 	response_help  = "pokes the synx, shifting the fur-like bristles on its body."
@@ -50,13 +60,16 @@
 	response_harm   = "tries to hit the synx. This tears out an area of fur which firmly melts upon contact, covering you in something sticky."
 
 
-	melee_damage_lower = 2 //Massive damage reduction, will be balanced with toxin injection/ //LO-  Made up for in skills. Toxin injection does not technically cause damage with these guys. Stomach acid does when they disegage their stomach from their mouths does, but that could be done differently.
-	melee_damage_upper = 6
+	melee_damage_lower = SYNX_LOWER_DAMAGE //Massive damage reduction, will be balanced with toxin injection/ //LO-  Made up for in skills. Toxin injection does not technically cause damage with these guys. Stomach acid does when they disegage their stomach from their mouths does, but that could be done differently.
+	melee_damage_upper = SYNX_UPPER_DAMAGE
 	attacktext = list("clawed") // "You are [attacktext] by the mob!"
+	var/distend_attacktext = list("smacked")
+	var/initial_attacktext = list("clawed") //I hate needing to do it this way.
 	friendly = list("prods") // "The mob [friendly] the person."
 	attack_armor_pen = 0			// How much armor pen this attack has. //Changed from 40. -Lo
 	attack_sharp = 1
 	attack_edge = 1
+	attack_armor_type = "melee" //Default is melee but I'm stating this explicitly to make it more obvious to anybody reading this
 
 //Vore stuff//leaving most of this here even though its no going to be an AI controlled variant.
 	vore_active = 1
@@ -87,6 +100,11 @@
 	max_n2 = 0 //Maybe add a max
 	// TODO: Set a max temperature of about 20-30 above room temperatures. Synx don't like the heat.
 
+/mob/living/simple_mob/retaliate/synx/ai //AI controlled variant
+
+	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+
+
 /mob/living/simple_mob/retaliate/synx/init_vore()
 	..()
 	var/obj/belly/B = vore_selected
@@ -114,8 +132,9 @@
 	"The acids and fluids rise up above your head, quickly putting an end to your squirming and conciousness.. the stomach eager to break you down completely.",
 	"The synx lets out an audible belch, the last of your air going with it, and with a few audible crunches from the outside, the stomach claims you as food for the parasite."
 	)
+	B.mode_flags = DM_FLAG_NUMBING	//Prey are more docile when it doesn't hurt.
 
-/mob/living/simple_mob/retaliate/synx/pet/asteri/init_vore()
+/mob/living/simple_mob/retaliate/synx/ai/pet/asteri/init_vore()
 	..()
 	var/obj/belly/B = vore_selected
 	B.desc    = "The synx eagerly swallows you, taking you from its gullet into its long, serpentine stomach. The internals around you greedily press into your from all sides, keeping you coated in a slick coat of numbing fluids..."
@@ -143,7 +162,7 @@
 //some things should be here that arent tho.
 	..()
 	verbs |= /mob/living/proc/ventcrawl
-	//verbs |= /mob/living/proc/disendstomach //to do later: add disendstomach verb and flag to check, also sprites of stomach outside the body.
+	verbs |= /mob/living/simple_mob/retaliate/synx/proc/distend_stomach //to do later: sprites of stomach outside the body.
 	verbs |= /mob/living/simple_mob/proc/contort
 	verbs |= /mob/living/simple_mob/retaliate/synx/proc/sonar_ping
 	verbs |= /mob/living/proc/shred_limb
@@ -185,7 +204,7 @@
 	name = "hardlightseedsx"
 	seed_name = "hardlightseedsx"
 	display_name = "Biomechanical Hardlight Generator SX"//PLant that is part mechanical part biological
-	has_mob_product = /mob/living/simple_mob/retaliate/synx/pet/holo
+	has_mob_product = /mob/living/simple_mob/retaliate/synx/ai/pet/holo
 
 /obj/item/seeds/hardlightseed/typesx
 	seed_type = "hardlightseedsx"
@@ -201,9 +220,9 @@
 /datum/reagent/inaprovaline/synxchem/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
 		if(prob(8))
-			M.custom_pain("You feel no pain despite the clear signs of damage to your body!", "You feel numb!", "You feel dizzy and heavy.", "You feel strange!",60)
+			M.custom_pain("You [pick("feel numb!","feel dizzy and heavy.","feel strange!")]",60)
 		if(prob(2))
-			M.custom_pain("You suddenly lose control over your body!", "You feel paralyzed!", "You can't move!", "You are frozen in place.", "Your muscles do not respond!", "You can't struggle!",60)
+			M.custom_pain("You [pick("suddenly lose control over your body!", "can't move!", "are frozen in place.", "can't struggle!")]",60)
 			M.AdjustParalysis(1)
 //		M.add_chemical_effect(CE_STABLE, 15)
 		M.add_chemical_effect(CE_PAINKILLER, 60)
@@ -230,7 +249,7 @@
 		M.adjustBruteLoss(-0.2)//Made to simulate combat, also useful as very odd healer.
 		M.adjustToxLoss(-0.2) //HELP ITS MAULING ME!
 		M.adjustFireLoss(-0.2) //huh this mauling aint so bad
-		M.adjustHalLoss(10) //OH MY GOD END MY PAIN NOW WHO MADE THIS SIMULATION
+		//M.adjustHalLoss(10) //OH MY GOD END MY PAIN NOW WHO MADE THIS SIMULATION //Removing because this is spammy and stunlocks for absurd durations
 
 /datum/reagent/inaprovaline/synxchem/clown
 	name = "HONK"
@@ -245,7 +264,7 @@
 	playsound(M.loc, 'sound/items/bikehorn.ogg', 50, 1)
 	M.adjustBruteLoss(-2)//healing brute
 	if(prob(1))
-		M.custom_pain("I have no horn but i must honk!",40)
+		M.custom_pain("I have no horn but i must honk!",60)
 	if(prob(2))
 		var/location = get_turf(M)
 		new /obj/item/weapon/bikehorn(location)
@@ -255,9 +274,9 @@
 	/datum/reagent/inaprovaline/synxchem/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 		if(alien != IS_DIONA)
 		if(prob(5))
-			M.custom_pain("You feel no pain despite the clear signs of damage to your body!",60)
+			M.custom_pain("You feel no pain despite the clear signs of damage to your body!",0)
 		if(prob(2))
-			M.custom_pain("You suddenly lose control over your body!",60)
+			M.custom_pain("You suddenly lose control over your body!",0)
 			M.AdjustParalysis(1)
 		M.add_chemical_effect(CE_STABLE, 15)
 		M.add_chemical_effect(CE_PAINKILLER, 50)
@@ -291,24 +310,39 @@
 //////////////////////////////////////////////////////////////////////////////////////
 // nevermind. I added any roleplay flavor weird fur mechanics to happen when you touch or attack the synx.
 
-/* /mob/living/simple_mob/retaliate/synx/DoPunch(var/atom/A)
-	. = ..()
-	if(.) // If we succeeded in hitting.
-		if(isliving(A))
+/mob/living/simple_mob/retaliate/synx/apply_melee_effects(var/atom/A) //Re-adding this for AI synx
+	if(stomach_distended) //Hacky burn damage code
+		if(isliving(A)) //Only affect living mobs, should include silicons. This could be expanded to deal special effects to acid-vulnerable objects.
 			var/mob/living/L = A
+			var/armor_modifier = abs((L.getarmor(null, "bio") / 100) - 1) //Factor in victim bio armor
+			var/amount = rand(acid_damage_lower, acid_damage_upper) //Select a damage value
+			var/damage_done = amount * armor_modifier
+			if(damage_done > 0) //sanity check, no healing the victim if somehow this is a negative value.
+				L.adjustFireLoss(damage_done)
+				return
+			else
+				to_chat(src,"<span class='notice'>Your stomach bounces off of the victim's armor!</span>")
+				return
+		return //If stomach is distended, return here to perform no forcefeeding or poison injecton.
 
-			if(prob(forcefeedchance))//Forcefeeding code
-				L.Weaken(2)
-				update_icon()
+	if(isliving(A))
+		var/mob/living/L = A
 
-			if(L.reagents)
-				var/target_zone = pick(BP_TORSO,BP_TORSO,BP_TORSO,BP_L_LEG,BP_R_LEG,BP_L_ARM,BP_R_ARM,BP_HEAD)
-				if(L.can_inject(src, null, target_zone))
-					L.reagents.add_reagent(poison_type, poison_per_bite)
-					if(prob(poison_chance))
-						to_chat(L, "<span class='warning'>You feel a strange substance on you.</span>")
-						L.reagents.add_reagent(poison_type, poison_per_bite)
+/*		if(prob(forcefeedchance) && !ckey)//Forcefeeding code //Only triggers if not player-controlled //This does not currently work
+			L.Weaken(2)
+			update_icon()
+			set_AI_busy(TRUE)
+			src.feed_self_to_grabbed(src,L)
+			update_icon()
+			set_AI_busy(FALSE)
 */
+		if(L.reagents)
+			var/target_zone = pick(BP_TORSO,BP_TORSO,BP_TORSO,BP_L_LEG,BP_R_LEG,BP_L_ARM,BP_R_ARM,BP_HEAD)
+			if(L.can_inject(src, null, target_zone))
+				if(prob(poison_chance))
+					to_chat(L, "<span class='warning'>You feel a strange substance on you.</span>")
+					L.reagents.add_reagent(poison_type, poison_per_bite)
+
 
 
 /mob/living/simple_mob/retaliate/synx/hear_say(message,verb,language,fakename,isItalics,var/mob/living/speaker)
@@ -327,7 +361,7 @@
 	if(message=="Honk!")
 		bikehorn()
 
-/mob/living/simple_mob/retaliate/synx/pet/clown/Life()
+/mob/living/simple_mob/retaliate/synx/ai/pet/clown/Life()
 	..()
 	if(vore_fullness)
 		size_multiplier = 1+(0.5*vore_fullness)
@@ -337,9 +371,16 @@
 		update_icons()
 /mob/living/simple_mob/retaliate/synx/Life()
 	..()
-///mob/living/simple_mob/retaliate/synx/handle_idle_speaking()
+//mob/living/simple_mob/retaliate/synx/ai/handle_idle_speaking() //Only ai-controlled synx will randomly speak
 	if(voices && prob(speak_chance/2))
 		randomspeech()
+
+/mob/living/simple_mob/retaliate/synx/perform_the_nom() //Synx can only eat people if their organs are on the inside.
+	if(stomach_distended)
+		to_chat(src,"<span class='notice'>You can't eat people without your stomach inside of you!</span>")
+		return
+	else
+		..()
 
 //////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////// POWERS!!!! /////////////////////////////////////
@@ -374,6 +415,9 @@
 		return
 
 	// If transform isn't true
+	if(stomach_distended)
+		to_chat(src,"<span class='warning'>You can't disguise with your stomach outside of your body!</span>")
+		return
 	if(!transformed)
 		to_chat(src,"<span class='warning'>you changed back into your disguise.</span>")
 		icon_living = transformed_state //Switch state to transformed state
@@ -454,18 +498,46 @@
 
 
 
-///////TODO
 
-///mob/living/simple_mob/proc/disend_stomach()
-	//set name = "Disend Stomach"
-	//set desc = "Allows you to disend your stomach, giving your attacks burn damage at the cost of your stomach contents going everywhere. Yuck."
-	//set category = "Abilities"
+/mob/living/simple_mob/retaliate/synx/proc/distend_stomach()
+	set name = "Distend Stomach"
+	set desc = "Allows you to throw up your stomach, giving your attacks burn damage at the cost of your stomach contents going everywhere. Yuck."
+	set category = "Abilities"
 
+	if(!stomach_distended) //true if stomach distended is null, 0, or ""
+		stomach_distended = !stomach_distended //switch statement
+		to_chat (src, "<span class='notice'>You disgorge your stomach, spilling its contents!</span>")
+		melee_damage_lower = 1 //Hopefully this will make all brute damage not apply while stomach is distended. I don't see a better way to do this.
+		melee_damage_upper = 1
+		icon_living = stomach_distended_state
+		attack_armor_type = "bio" //apply_melee_effects should handle all burn damage code so this might not be necessary.
+		attacktext += distend_attacktext
+		attacktext -= initial_attacktext
+
+		for(var/belly in src.vore_organs) //Spit out all contents because our insides are now outsides
+			var/obj/belly/B = belly
+			for(var/atom/movable/A in B)
+				playsound(src, 'sound/effects/splat.ogg', 50, 1)
+				B.release_specific_contents(A)
+		update_icons()
+		return
+
+	if(stomach_distended) //If our stomach has been vomitted
+		stomach_distended = !stomach_distended
+		to_chat (src, "<span class='notice'>You swallow your insides!</span>")
+		melee_damage_lower = SYNX_LOWER_DAMAGE //This is why I'm using a define
+		melee_damage_upper = SYNX_UPPER_DAMAGE
+		icon_living = initial(icon_living)
+		attack_armor_type = "melee"
+		attacktext += initial_attacktext
+		attacktext -= distend_attacktext
+		update_icons()
+		return
 
 ////////////////////////////////////////
 ////////////////PET VERSION/////////////
 ////////////////////////////////////////
-/mob/living/simple_mob/retaliate/synx/pet
+/mob/living/simple_mob/retaliate/synx/ai/pet
 	faction = "Cargonia" //Should not share a faction with those pesky non station synxes.//This is so newspaper has a failchance
 	name = "Bob"
 	desc = "A very regular pet."
@@ -474,21 +546,21 @@
 	glow_toggle = 1
 	player_msg = "You aren't supposed to be in this. Wrong mob."
 
-/mob/living/simple_mob/retaliate/synx/pet/init_vore()
+/mob/living/simple_mob/retaliate/synx/ai/pet/init_vore()
     ..()
     var/obj/belly/B = vore_selected
     B.vore_verb = "swallow"
     B.digest_burn = 1
     B.digest_brute = 0
 
-/mob/living/simple_mob/retaliate/synx/pet/holo/init_vore()
+/mob/living/simple_mob/retaliate/synx/ai/pet/holo/init_vore()
 	..()
 	var/obj/belly/B = vore_selected
 	B.vore_verb = "swallow"
 	B.digest_burn = 5
 	B.digest_brute = 5
 
-/mob/living/simple_mob/retaliate/synx/pet
+/mob/living/simple_mob/retaliate/synx/ai/pet
 	speak_chance = 2.0666
 
 //HONKMOTHER Code.
@@ -504,14 +576,14 @@
 	playsound(src.loc, 'sound/items/bikehorn.ogg', 50, 1)
 
 //HOLOSEEDSPAWNCODE
-/mob/living/simple_mob/retaliate/synx/pet/holo/death()
+/mob/living/simple_mob/retaliate/synx/ai/pet/holo/death()
 	..()
 	visible_message("<span class='notice'>\The [src] fades away!</span>")
 	var/location = get_turf(src)
 	new /obj/item/seeds/hardlightseed/typesx(location)
 	qdel(src)
 
-/mob/living/simple_mob/retaliate/synx/pet/holo/gib()
+/mob/living/simple_mob/retaliate/synx/ai/pet/holo/gib()
 	visible_message("<span class='notice'>\The [src] fades away!</span>")
 	var/location = get_turf(src)
 	new /obj/item/seeds/hardlightseed/typesx(location)
@@ -520,7 +592,7 @@
 ////////////////////////////////////////
 ////////////////SYNX VARIATIONS/////////
 ////////////////////////////////////////
-/mob/living/simple_mob/retaliate/synx/pet/holo
+/mob/living/simple_mob/retaliate/synx/ai/pet/holo
 	poison_chance = 100
 	poison_type = "fakesynxchem" //unlike synxchem this one heals!
 	name = "Hardlight synx"
@@ -545,7 +617,7 @@
 	vore_escape_chance = 30 //Much higher escape chance.. it's a hologram.
 	swallowTime = 10 SECONDS //Much more time to run
 
-/mob/living/simple_mob/retaliate/synx/pet/greed
+/mob/living/simple_mob/retaliate/synx/ai/pet/greed
 	name = "Greed"
 	desc = "A cold blooded, genderless, parasitic eel from the more distant and stranger areas of the cosmos. black, perpetually grinning and possessing a hunger as enthusiastic and endless as humanity's sense of exploration.. This one has the name Greed burnt into its back, the burnt in name seems to be luminescent making it harder for it to blend into the dark."
 	//icon= //icon= would just set what DMI we are using, we already have our special one set.
@@ -563,7 +635,7 @@
 	vore_bump_chance = 2 //lowered bump chance
 	vore_escape_chance = 5 //Multivore allows for people to shove eachother out so lower normal escape chance.
 
-/mob/living/simple_mob/retaliate/synx/pet/greed/synth
+/mob/living/simple_mob/retaliate/synx/ai/pet/greed/synth
 /*
 ▓███▓     ▓▓▓     ▓▓▓     ▓▓▓     ▓▓▓     ▓███▓
  ▓▓   ▓▓▓█ ▓▓  ▓▓█ ▓▓  ▓▓█ ▓▓  ▓▓█ ▓▓  ▓▓█ ▓▓   ▓▓▓█
@@ -619,11 +691,11 @@
 		..()
 		name = "SYN-KinC-([rand(100,999)])"
 
-/mob/living/simple_mob/retaliate/synx/pet/greed/synth/goodboy
+/mob/living/simple_mob/retaliate/synx/ai/pet/greed/synth/goodboy
 	//hostile = 0
 	faction = "neutral"
 
-/mob/living/simple_mob/retaliate/synx/pet/diablo
+/mob/living/simple_mob/retaliate/synx/ai/pet/diablo
 	//var/diablo_LIVING = "synx_diablo_living"
 	//var/diablo_DEAD = "synx_diablo_dead"
 	name = "diablo"
@@ -635,7 +707,7 @@
 	//Vore Section
 	vore_capacity = 2
 
-/mob/living/simple_mob/retaliate/synx/pet/asteri
+/mob/living/simple_mob/retaliate/synx/ai/pet/asteri
 	name = "Asteri"
 	desc = "A cold blooded, genderless, parasitic eel from the more distant and stranger areas of the cosmos. Bleak white, perpetually grinning and possessing a hunger as enthusiastic and endless as humanity's sense of exploration.. This one has distinctive markings over its face forming the shape of a star, and its back holds a sizeable scar leading up to a small implanted device just above its waist, the name 'Asteri' scribed across the metal."
 	//icon= //icon= would just set what DMI we are using, we already have our special one set.
@@ -654,7 +726,7 @@
 	vore_bump_chance = 2
 	vore_escape_chance = 5
 
-/mob/living/simple_mob/retaliate/synx/pet/clown
+/mob/living/simple_mob/retaliate/synx/ai/pet/clown
 	//hostile = 1
 	poison_chance = 100
 	poison_type = "clownsynxchem" //unlike synxchem this one HONKS
@@ -680,32 +752,32 @@
 ////////////////////////////////////////
 ////////////////SYNX DEBUG//////////////
 ////////////////////////////////////////
-/mob/living/simple_mob/retaliate/synx/pet/debug
+/mob/living/simple_mob/retaliate/synx/ai/pet/debug
 	name = "Syntox"
 	desc = "ERROR Connection to translation server could not be established!"
 
-/mob/living/simple_mob/retaliate/synx/pet/debug/proc/rename()
+/mob/living/simple_mob/retaliate/synx/ai/pet/debug/proc/rename()
 	set name = "rename"
 	set desc = "Renames the synx"
 	set category = "DEBUG"
 	name = input(usr, "What would you like to change name to?", "Renaming", null)
 
-/mob/living/simple_mob/retaliate/synx/pet/debug/proc/redesc()
+/mob/living/simple_mob/retaliate/synx/ai/pet/debug/proc/redesc()
 	set name = "redesc"
 	set desc = "Redescribes the synx"
 	set category = "DEBUG"
 	desc = input(usr, "What would you like to change desc to?", "Redescribing", null)
 
-/mob/living/simple_mob/retaliate/synx/pet/debug/proc/resprite()
+/mob/living/simple_mob/retaliate/synx/ai/pet/debug/proc/resprite()
 	set name = "resprite"
 	set desc = "Resprite the synx"
 	set category = "DEBUG"
 	icon_state = input(usr, "What would you like to change icon_state to?", "Respriting", null)
 
-/mob/living/simple_mob/retaliate/synx/pet/debug/New()
-	verbs |= /mob/living/simple_mob/retaliate/synx/pet/debug/proc/rename
-	verbs |= /mob/living/simple_mob/retaliate/synx/pet/debug/proc/resprite
-	verbs |= /mob/living/simple_mob/retaliate/synx/pet/debug/proc/redesc
+/mob/living/simple_mob/retaliate/synx/ai/pet/debug/New()
+	verbs |= /mob/living/simple_mob/retaliate/synx/ai/pet/debug/proc/rename
+	verbs |= /mob/living/simple_mob/retaliate/synx/ai/pet/debug/proc/resprite
+	verbs |= /mob/living/simple_mob/retaliate/synx/ai/pet/debug/proc/redesc
 
 ////////////////////////////////////////
 ////////////////SYNX SPAWNER////////////
@@ -714,10 +786,10 @@
 	name = "This is synxes"
 
 /obj/random/mob/synx/item_to_spawn()
-	return pick(prob(66);/mob/living/simple_mob/retaliate/synx/pet/greed,
+	return pick(prob(66);/mob/living/simple_mob/retaliate/synx/ai/pet/greed,
 		//prob(50);/mob/living/simple_mob/retaliate/synx/pet/asteri,//He's crew so let's remove this
-		prob(33);/mob/living/simple_mob/retaliate/synx/pet/holo,
-		prob(50);/mob/living/simple_mob/retaliate/synx,) //normal eel boyo.
+		prob(33);/mob/living/simple_mob/retaliate/synx/ai/pet/holo,
+		prob(50);/mob/living/simple_mob/retaliate/synx/ai,) //normal eel boyo.
 
 ////////////////////////////////////////////////////////////////////////////
 //////////////////////////NOT A SYNX///////but looks kinda like one/////////
@@ -758,3 +830,6 @@ This includes the sprites of the below Mob which are based upon SCP 939 and spri
 	//icon_state = "scp_living"
 	//icon_living = "scp_living"
 	//icon_dead = "scp_dead"
+
+#undef SYNX_LOWER_DAMAGE
+#undef SYNX_UPPER_DAMAGE

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -35,6 +35,17 @@ GLOBAL_LIST_INIT(digest_modes, list())
 			return list("to_update" = TRUE, "soundToPlay" = sound(get_sfx("classic_death_sounds")))
 		return list("to_update" = TRUE, "soundToPlay" = sound(get_sfx("fancy_death_pred")))
 
+		//CHOMPEDIT: Snowflake synx hook. Hypothetically this could be expanded to any mob by, say, giving them a parasite variable and a check for it here.
+	if(istype(L,/mob/living/simple_mob/retaliate/synx))
+		var/syntox = B.digest_brute+B.digest_burn
+		B.owner.adjust_nutrition(-syntox)
+		L.adjust_nutrition(syntox)
+		L.adjustBruteLoss(-syntox*2) //Should automaticaly clamp to 0
+		L.adjustFireLoss(-syntox*2) //Should automaticaly clamp to 0
+		return
+
+ 		//END SYNX hook.
+
 	// Deal digestion damage (and feed the pred)
 	var/old_brute = L.getBruteLoss()
 	var/old_burn = L.getFireLoss()


### PR DESCRIPTION
Partly by request, partly me fixing things.
-Adds requested "Distend Stomach" ability for player-controlled synxes. Vomit out your stomach (and its contents) to deal burn damage instead of brute. Stomach attacks are mitigated by bio armor instead of brute armor.
-Fixes synx chem messages to work instead of cause debugs.
-Fixes synx venom injection.
-Makes synxes parasites again. If you attempt to digest them they will drain your nutrition.
-Various balancing tweaks. 