### PR TITLE
Changing Sickshot desc and info_desc

### DIFF
--- a/code/modules/projectiles/guns/energy/sickshot_vr.dm
+++ b/code/modules/projectiles/guns/energy/sickshot_vr.dm
@@ -1,11 +1,11 @@
 // -------------- Sickshot -------------
 /obj/item/weapon/gun/energy/sickshot
 	name = "\'Sickshot\' revolver"
-	desc = "Need to stun someone? Don't mind having to clean up the mess afterwards? The MPA6 'Sickshot' is the answer to your prayers. \
-	Using a short-range concentrated blast of disruptive sound, the Sickshot will nauseate and confuse the target for several seconds. NOTE: Not suitable \
-	for use in vacuum. Usage on animals may cause panic and rage without stunning. May cause contraction and release of various 'things' from various 'orifices', even if the target is already dead."
-
-	description_info = "This gun causes nausea in targets, stunning them briefly and causing vomiting. It will also cause them to vomit up prey, sometimes. Repeated shots may help in that case."
+	desc = "Need to expel something? Don't mind having to clean up the mess afterwards? The MPA6 'Sickshot' is the answer to your prayers. \
+	Using a short-range concentrated blast of disruptive sound, the Sickshot will nauseate the target for several seconds. NOTE: Not suitable \
+	for use in vacuum. Usage on animals may cause panic and rage. May cause contraction and release of various 'things' from various 'orifices', even if the target is already dead."
+	//CHOMPedit , changed desc and description_info to make it not sound like a self defense weapon. Because its not, it only does 5 damage and some very minor confusion
+	description_info = "This gun causes nausea in targets, causing vomiting. It will also cause them to vomit up prey, sometimes. Repeated shots may help in that case."
 	description_fluff = ""
 	description_antag = ""
 


### PR DESCRIPTION
The Sickshot states in its description that it can stun, and because of that implies that it is a self defense weapon. It is not a self defense weapon, as it only does 5 burn damage and causes some very minor confusion, not stuns. Its true use is to forcibly expel the contents of stomachs, so the description has been changed to make that a bit more obvious.

Also for some silly reason the sickshot doesn't live in a normal weapon file, so I have to edit the sickshot_vr to make this work. Not much I can do about that.