### PR TITLE
Fixes Only One Accessory Equipped at Spawn & in Character Preview

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -387,7 +387,7 @@ var/global/datum/controller/occupations/job_master
 		if(job)
 
 			//Equip custom gear loadout.
-			var/list/custom_equip_slots = list() //If more than one item takes the same slot, all after the first one spawn in storage.
+			var/list/custom_equip_slots = list()
 			var/list/custom_equip_leftovers = list()
 			if(H.client.prefs.gear && H.client.prefs.gear.len && !(job.mob_type & JOB_SILICON))
 				for(var/thing in H.client.prefs.gear)
@@ -420,14 +420,15 @@ var/global/datum/controller/occupations/job_master
 						I.implant_loadout(H)
 						continue
 
-					// Try desperately (and sorta poorly) to equip the item
+					// Try desperately (and sorta poorly) to equip the item. Now with increased desperation!
 					if(G.slot && !(G.slot in custom_equip_slots))
 						var/metadata = H.client.prefs.gear[G.display_name]
 						if(G.slot == slot_wear_mask || G.slot == slot_wear_suit || G.slot == slot_head)
 							custom_equip_leftovers += thing
 						else if(H.equip_to_slot_or_del(G.spawn_item(H, metadata), G.slot))
 							to_chat(H, "<span class='notice'>Equipping you with \the [thing]!</span>")
-							custom_equip_slots.Add(G.slot)
+							if(G.slot != slot_tie)
+								custom_equip_slots.Add(G.slot)
 						else
 							custom_equip_leftovers.Add(thing)
 					else

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -220,7 +220,7 @@
 				break
 
 	if((equip_preview_mob & EQUIP_PREVIEW_LOADOUT) && !(previewJob && (equip_preview_mob & EQUIP_PREVIEW_JOB) && (previewJob.type == /datum/job/ai || previewJob.type == /datum/job/cyborg)))
-		var/list/equipped_slots = list() //If more than one item takes the same slot only spawn the first
+		var/list/equipped_slots = list()
 		for(var/thing in gear)
 			var/datum/gear/G = gear_datums[thing]
 			if(G)
@@ -243,7 +243,8 @@
 				if(G.slot && !(G.slot in equipped_slots))
 					var/metadata = gear[G.display_name]
 					if(mannequin.equip_to_slot_or_del(G.spawn_item(mannequin, metadata), G.slot))
-						equipped_slots += G.slot
+						if(G.slot != slot_tie)
+							equipped_slots += G.slot
 
 	if((equip_preview_mob & EQUIP_PREVIEW_JOB) && previewJob)
 		mannequin.job = previewJob.title


### PR DESCRIPTION
## About The Pull Request
Ported from https://github.com/Aurorastation/Aurora.3/pull/10205, credit to fernerr

Now you can see all the accessories (within standard equipping logic) you've selected in the character preview.

Additionally, these accessories will now all be equipped when you spawn instead of filling your backpack unless it's actually necessary.

## Why It's Good For The Game
Fixes a long-standing issue where only one accessory is shown in character preview or equipped at spawn.

## Changelog
:cl:
fix: Character preview will now show all loadout accessories (within usual logic) in the order you selected them.
fix: All loadout accessories will be equipped to your character when you spawn (within usual logic) in the order you selected them.
/:cl:


_Example from Virgo character preview.
Order of Accessories: Brown webbing vest, drop straps, metal necklace, striped blue scarf._
![virgo ss13 yaro sargarra multiple accessories 20201008](https://user-images.githubusercontent.com/12377767/95519058-e292ce80-09b3-11eb-993d-54e2cf8ac8eb.png)