### PR TITLE
Reduce Volume size for vials.

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -240,10 +240,10 @@
 	icon_state = "vial"
 	center_of_mass = list("x" = 15,"y" = 9)
 	matter = list("glass" = 250)
-	volume = 30
+	volume = 10 //CHOMPedit reduced volume size, because its stupid to give a tiny little vial 30 volume
 	w_class = ITEMSIZE_TINY
-	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,30)
+	amount_per_transfer_from_this = 5 //CHOMPedit edited default transfer amount so you don't dump everything in one go
+	possible_transfer_amounts = list(1,5,10) //CHOMPedit edited possible transfer amounts to work with volume
 	flags = OPENCONTAINER
 
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone


### PR DESCRIPTION
Vials are a mostly science/exploration, and sometimes medical beaker used to collect samples or hold small amounts of rare chemicals. This is just a simple fix that highlights that use, by reducing a 'balance' PR years back that changed all beakers to multiples of 30.

For all of the other beakers this makes perfect sense, as they are often used for mixing on chemistry machines. The vial however, is a different story. It is not intended to be used for mixing reasons, but rather small storage or sample collection. 

This PR changes the following :

- Reduces Volume size for Vials from 30 to 10, since it makes no sense to give them half the capacity of a beaker.

- Edit default transfer values, and transfer value options for vials. This is just so transfer works well with the new vial volume.