### PR TITLE
Nerfs space vine pitcher plants

### DIFF
--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -130,12 +130,10 @@
 		//CHOMPedit start: Pitcher plant spawning
 		if((seed.get_trait(TRAIT_POTENCY)) >= 70) //Random event spacevines have 70 potency minimum. Should guarantee this always triggers on spacevines.
 			var/mob/living/pitcher
-			if(seed.get_trait(TRAIT_CARNIVOROUS) && prob(10))
+			if(!seed.get_trait(TRAIT_CARNIVOROUS) && prob(2)) //Check for canivorous or this could call if prob(10) above fails.
 				pitcher = new /mob/living/simple_mob/vore/pitcher_plant(src.loc)
-				pitcher.nutrition = 0
-			if(!seed.get_trait(TRAIT_CARNIVOROUS) && prob(5)) //Check for canivorous or this could call if prob(10) above fails.
-				pitcher = new /mob/living/simple_mob/vore/pitcher_plant(src.loc)
-				pitcher.nutrition = 100
+				pitcher.nutrition = 0 //With 0 nutrition, vine-spawned pitchers should die after ~10 minutes
+				pitcher.adjustToxLoss(170) //Reduce health, 200 is excessive when a lot of these are spawning.
 		//CHOMPedit end
 
 		//see if anything is there

--- a/code/modules/mob/living/simple_mob/subtypes/vore/plants_ch/pitcher.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/plants_ch/pitcher.dm
@@ -141,8 +141,12 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 	
 
 /mob/living/simple_mob/vore/pitcher_plant/death()
-	anchored = 0
 	..()
+	anchored = 0
+	if(fruit)
+		new /obj/item/weapon/reagent_containers/food/snacks/pitcher_fruit(get_turf(src))
+		fruit = 0
+
 	
 
 /mob/living/simple_mob/vore/pitcher_plant/proc/grow_fruit() //This proc handles the pitcher turning nutrition into fruit (and new pitchers).


### PR DESCRIPTION
-Pitcher plants will no longer spawn from carnivorous space vines
-Spawn chance of pitcher plants from vines reduced
-Pitcher plants from vines will spawn with 30 health and 0 nutrition, effectively starving to death ~10 minutes if ignored

Additionally,
-Pitcher plants should now unanchor properly on death
-Pitcher plants with fruit will drop the fruit on death