### PR TITLE
Make the Synth Medichine be more like the organic version

### DIFF
--- a/code/modules/nifsoft/software/05_health.dm
+++ b/code/modules/nifsoft/software/05_health.dm
@@ -134,9 +134,8 @@
 					if(!isbelly(H.loc)) //Not notified in case of vore, for gameplay purposes.
 						var/turf/T = get_turf(H)
 						var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset/heads/captain(null)
-						a.autosay("[H.real_name] has been put in emergency stasis, located at ([T.x],[T.y],[T.z])!", "[H.real_name]'s NIF", "Medical")
+						a.autosay("[H.real_name] is in critical condition, located at ([T.x],[T.y],[T.z])!", "[H.real_name]'s NIF", "Medical")
 						qdel(a)
-
 
 		return TRUE
 

--- a/code/modules/nifsoft/software/05_health.dm
+++ b/code/modules/nifsoft/software/05_health.dm
@@ -117,7 +117,7 @@
 			var/obj/item/organ/external/EO = eo
 			for(var/w in EO.wounds)
 				var/datum/wound/W = w
-				if(W.damage <= 5)
+				if(W.damage <= 25)
 					W.heal_damage(0.1)
 					EO.update_damages()
 					if(EO.update_icon())
@@ -127,6 +127,16 @@
 				else if(mode == 1)
 					mode = 2
 					nif.notify("Medichines unable to repair all damage. Perform manual repairs.",TRUE)
+				else if(mode == 2 && HP_percent < -0.4)
+					nif.notify("User Status: CRITICAL. Notifying medical, and starting emergency stasis!",TRUE)
+					H << 'sound/voice/nifmed_critical.ogg' //CHOMP Add
+					mode = 0
+					if(!isbelly(H.loc)) //Not notified in case of vore, for gameplay purposes.
+						var/turf/T = get_turf(H)
+						var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset/heads/captain(null)
+						a.autosay("[H.real_name] has been put in emergency stasis, located at ([T.x],[T.y],[T.z])!", "[H.real_name]'s NIF", "Medical")
+						qdel(a)
+
 
 		return TRUE
 

--- a/code/modules/nifsoft/software/05_health.dm
+++ b/code/modules/nifsoft/software/05_health.dm
@@ -119,7 +119,7 @@
 			var/obj/item/organ/external/EO = eo
 			for(var/w in EO.wounds)
 				var/datum/wound/W = w
-				if(W.damage <= 25)
+				if(W.damage <= 30)
 					W.heal_damage(0.1)
 					EO.update_damages()
 					if(EO.update_icon())

--- a/code/modules/nifsoft/software/05_health.dm
+++ b/code/modules/nifsoft/software/05_health.dm
@@ -128,7 +128,7 @@
 					mode = 2
 					nif.notify("Medichines unable to repair all damage. Perform manual repairs.",TRUE)
 				else if(mode == 2 && HP_percent < -0.4)
-					nif.notify("User Status: CRITICAL. Notifying medical, and starting emergency stasis!",TRUE)
+					nif.notify("User Status: CRITICAL. Notifying medical!",TRUE)
 					H << 'sound/voice/nifmed_critical.ogg' //CHOMP Add
 					mode = 0
 					if(!isbelly(H.loc)) //Not notified in case of vore, for gameplay purposes.

--- a/code/modules/nifsoft/software/05_health.dm
+++ b/code/modules/nifsoft/software/05_health.dm
@@ -100,6 +100,8 @@
 
 /datum/nifsoft/medichines_syn/life()
 	if((. = ..()))
+		var/mob/living/carbon/human/H = nif.human
+		var/HP_percent = H.health/H.getMaxHealth()
 		//We're good!
 		if(!nif.human.bad_external_organs.len)
 			if(mode || active)

--- a/code/modules/nifsoft/software/05_health.dm
+++ b/code/modules/nifsoft/software/05_health.dm
@@ -100,8 +100,8 @@
 
 /datum/nifsoft/medichines_syn/life()
 	if((. = ..()))
-		var/mob/living/carbon/human/H = nif.human
-		var/HP_percent = H.health/H.getMaxHealth()
+		var/mob/living/carbon/human/H = nif.human // Chomp Edit
+		var/HP_percent = H.health/H.getMaxHealth() // Chomp Edit
 		//We're good!
 		if(!nif.human.bad_external_organs.len)
 			if(mode || active)
@@ -119,7 +119,7 @@
 			var/obj/item/organ/external/EO = eo
 			for(var/w in EO.wounds)
 				var/datum/wound/W = w
-				if(W.damage <= 30)
+				if(W.damage <= 30) // Chomp Edit // The current limb break threshold.
 					W.heal_damage(0.1)
 					EO.update_damages()
 					if(EO.update_icon())
@@ -129,6 +129,7 @@
 				else if(mode == 1)
 					mode = 2
 					nif.notify("Medichines unable to repair all damage. Perform manual repairs.",TRUE)
+				// Chomp Edit Start //
 				else if(mode == 2 && HP_percent < -0.4)
 					nif.notify("User Status: CRITICAL. Notifying medical!",TRUE)
 					H << 'sound/voice/nifmed_critical.ogg' //CHOMP Add
@@ -138,6 +139,7 @@
 						var/obj/item/device/radio/headset/a = new /obj/item/device/radio/headset/heads/captain(null)
 						a.autosay("[H.real_name] is in critical condition, located at ([T.x],[T.y],[T.z])!", "[H.real_name]'s NIF", "Medical")
 						qdel(a)
+				// Chomp Edit End //
 
 		return TRUE
 


### PR DESCRIPTION
If you compare the Organic Medichine to the Synth version, you would immediately see how much the synth version suck compared to the organic version, despite them costing the same price.

Here is what the Organic Medichine do : 
- Start healing as soon as under 80% health.
- Heal faster when under 20% health and notify the user to go get healed.
- When at -40% health, heal even faster and notify the medical department (Unless in a belly) and put the user in stasis until he is above 20% health.
- Heal Brute, Burn and Toxin at the same time at the rate of 0.1 each healed at the same time.

Here is what the Synthetic Medichine do : 
- Start healing as soon as there is damage.
- Heal 0.1 damage individually.
- Stop healing as soon as the damage is over 5 (Looks like total damage too). Which, from what I was told, is half the damage of a screwdriver stab.
- Does **not** warn Medical if the user is in critical.

As you can see, despite both of them costing 1250 Thalers, the synthetic version of the medichine clearly got the very short end of the stick. So in order to make it a little better for its cost, here is what this PR changed about the Synth Medichine : 
- Stop healing when over 30 combined damage, aka the threshold where the synth need someone else to fix them.
- Make it notify medical when under -40% health, but do not put them in stasis (Synths can't bleedout and I'm not sure if stasis protect against vacuum).

So, while it **does** still suck compared to its organic counterpart, it suck a lot less.