### PR TITLE
Add a verb to hide nutrition levels.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -177,7 +177,7 @@
 			message = "makes a weird noise!"
 			playsound(src.loc, 'sound/misc/ough.ogg', 50, 1, -1, preference = /datum/client_preference/emote_noises)
 			m_type = 2 //End of Yawn Addtion
-		*/ 
+		*/
 		if ("howl") // YW add begins
 			m_type = 2
 			message = "lets out a howl."
@@ -269,7 +269,7 @@
 	set desc = "Switch tail layer on top."
 	tail_alt = !tail_alt
 	update_tail_showing()
-	
+
 /mob/living/carbon/human/verb/hide_wings_vr()
 	set name = "Show/Hide wings"
 	set category = "IC"
@@ -282,4 +282,15 @@
 	else
 		message = "hides their wings."
 	visible_message("[src] [message]")
-	
+
+/mob/living/carbon/human/verb/hide_nutrition_vr()
+	set name = "Show/Hide Nutrition Levels"
+	set category = "IC"
+	set desc = "Allow other player to see your current nutrition level or not."
+	nutrition_hidden = !nutrition_hidden
+	var/message = ""
+	if(!nutrition_hidden)
+		message = "Players will now see your nutrition levels."
+	else
+		message = "Players will no longer see your nutrition levels."
+	to_chat(src, "[message]")

--- a/code/modules/mob/living/carbon/human/emote_vr.dm
+++ b/code/modules/mob/living/carbon/human/emote_vr.dm
@@ -283,14 +283,11 @@
 		message = "hides their wings."
 	visible_message("[src] [message]")
 
+// Chomp Edit Start
 /mob/living/carbon/human/verb/hide_nutrition_vr()
 	set name = "Show/Hide Nutrition Levels"
 	set category = "IC"
 	set desc = "Allow other player to see your current nutrition level or not."
 	nutrition_hidden = !nutrition_hidden
-	var/message = ""
-	if(!nutrition_hidden)
-		message = "Players will now see your nutrition levels."
-	else
-		message = "Players will no longer see your nutrition levels."
-	to_chat(src, "[message]")
+	to_chat(src, "Players will [nutrition_hidden ? "no longer" : "now"] see your nutrition levels.")
+// Chomp Edit End

--- a/code/modules/mob/living/carbon/human/examine_vr.dm
+++ b/code/modules/mob/living/carbon/human/examine_vr.dm
@@ -68,7 +68,7 @@
 /mob/living/carbon/human/proc/examine_nutrition()
 	if(!show_pudge()) //Some clothing or equipment can hide this.
 		return ""
-	if(nutrition_hidden)
+	if(nutrition_hidden) // Chomp Edit
 		return ""
 	var/message = ""
 	var/nutrition_examine = round(nutrition)

--- a/code/modules/mob/living/carbon/human/examine_vr.dm
+++ b/code/modules/mob/living/carbon/human/examine_vr.dm
@@ -68,6 +68,8 @@
 /mob/living/carbon/human/proc/examine_nutrition()
 	if(!show_pudge()) //Some clothing or equipment can hide this.
 		return ""
+	if(nutrition_hidden)
+		return ""
 	var/message = ""
 	var/nutrition_examine = round(nutrition)
 	var/t_He 	= "It" //capitalised for use at the start of each line.

--- a/code/modules/mob/living/carbon/human/human_defines_vr.dm
+++ b/code/modules/mob/living/carbon/human/human_defines_vr.dm
@@ -10,6 +10,7 @@
 	var/ability_flags = 0	//Shadekin abilities/potentially other species-based?
 	var/sensorpref = 5		//Suit sensor loadout pref
 	var/wings_hidden = FALSE
+	var/nutrition_hidden = FALSE
 
 /mob/living/carbon/human/proc/shadekin_get_energy()
 	var/datum/species/shadekin/SK = species

--- a/code/modules/mob/living/carbon/human/human_defines_vr.dm
+++ b/code/modules/mob/living/carbon/human/human_defines_vr.dm
@@ -10,7 +10,7 @@
 	var/ability_flags = 0	//Shadekin abilities/potentially other species-based?
 	var/sensorpref = 5		//Suit sensor loadout pref
 	var/wings_hidden = FALSE
-	var/nutrition_hidden = FALSE
+	var/nutrition_hidden = FALSE // Chomp Edit
 
 /mob/living/carbon/human/proc/shadekin_get_energy()
 	var/datum/species/shadekin/SK = species


### PR DESCRIPTION
This PR add the verb 'Show/Hide Nutrition Levels', similar to the 'Show/Hide wings' verb, but all it does is preventing (or not) players from seeing if you are starving or very full, based on your nutrition levels.

This does not affect the weight that players see on examination nor the actual nutrition levels, this is so that you can eat like 10 people and not appear as a whale that defy the laws of physics by being able to walk.