### PR TITLE
Make synths able to take the Photosynthesis trait.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
@@ -34,4 +34,4 @@
 	desc = "Your body is able to produce nutrition from being in light."
 	cost = 3
 	var_changes = list("photosynthesizing" = TRUE)
-	not_for_synths = 1 //Synths don't use nutrition.
+	not_for_synths = 0 //Synths actually use nutrition, just with a fancy covering.


### PR DESCRIPTION
So, turns out that synths also use nutrition, it is simply renamed 'power' in the UI, you can see that by the Expansive Taste & Growing trait working desipte synth use 'power' instead of nutrition, and that they gain power from churning people as well as gaining the nutrition descriptions when the power is at certain levels.

So since the Photosynthesis trait added by https://github.com/CHOMPStation2/CHOMPStation2/pull/749 actually work on synths, I see no reason for the 'not_for_synth' var to be there, even though I was the one that suggested it to be added. I didn't know how much of the code was lazy at the time.