### PR TITLE
Give the Roboticist access to the rest of Science.

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -129,7 +129,7 @@ VR edit end*/
 	supervisors = "the Research Director"
 	selection_color = "#633D63"
 	economic_modifier = 5
-	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
+	access = list(access_robotics, access_tox, access_tox_storage, access_tech_storage, access_morgue, access_research, access_xenobiology, access_hydroponics) //As a job that handles so many corpses, it makes sense for them to have morgue access. // Chomp Edit : Give roboticists additionnal access.
 	minimal_access = list(access_robotics, access_tech_storage, access_morgue, access_research) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 	minimal_player_age = 3
 


### PR DESCRIPTION
This PR give the roboticist job access to Xenobiology and Xenobotany. Mainly for two reason : 
1. So the roboticist don't have to beg for a plant analyzer each time he's asked to make a farmbot.
2. Literally every other job in Science has access to everywhere in Science (except the RD's office, of course), so Roboticists feel a bit left out, being unable to access those locations while those working there can freely access robotics.