### PR TITLE
Add the protector energy gun to loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_utility_ch.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_ch.dm
@@ -16,3 +16,10 @@
 		var/obj/item/weapon/implant/reagent_generator/egg/implant_type = implant
 		implants[initial(implant_type.name)] = implant_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(implants))
+
+/datum/gear/utility/protector
+	display_name = "Protector Energy Gun"
+	description = "The WT-98a 'Protector' is a common sidearm developed by Ward-Takahashi GMC. It features a powerful stun mode, and \
+					an alert-level-locked lethal mode, only usable when the connected jurisdiction allows. It also features an integrated flashlight!"
+	path = /obj/item/weapon/gun/energy/gun/protector/loadout
+	cost = 5

--- a/code/modules/client/preference_setup/loadout/loadout_utility_ch.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_ch.dm
@@ -22,4 +22,5 @@
 	description = "The WT-98a 'Protector' is a common sidearm developed by Ward-Takahashi GMC. It features a powerful stun mode, and \
 					an alert-level-locked lethal mode, only usable when the connected jurisdiction allows. It also features an integrated flashlight!"
 	path = /obj/item/weapon/gun/energy/gun/protector/loadout
+	allowed_roles = list("Site Manager", "Head of Security","Warden","Detective","Security Officer")//YW ADDITIONS
 	cost = 5

--- a/code/modules/projectiles/guns/energy/protector_vr.dm
+++ b/code/modules/projectiles/guns/energy/protector_vr.dm
@@ -104,3 +104,7 @@
 	emagged = TRUE
 	name = "small energy gun"
 	desc = "The LAEP95 'Protector' is another firearm from Lawson Arms and "+TSC_HEPH+", unlike the Perun this is designed for issue to non-security staff. It contains a detachable cell. It also features an integrated flashlight!"
+
+// CHOMP EDIT : Add a version without tech levels for loadout.
+/obj/item/weapon/gun/energy/gun/protector/loadout
+	origin_tech = list(TECH_COMBAT = 0, TECH_MATERIAL = 0, TECH_MAGNET = 0)


### PR DESCRIPTION
This PR add the Small Energy Gun 'Protector' to the loadout.

Taken from the game : 

> The WT-98a 'Protector' is a common sidearm developed by Ward-Takahashi GMC. It features a powerful stun mode, and an alert-level-locked lethal mode, only usable when the connected jurisdiction allows.

It is a great Self-Defense gun that can only fire a few shots, 3 lethal and 6 stunning with a fully charged Advanced Device Power Cell
It can't fire lethal shots if the alert level is at Green.
It cost 5 points in the loadout (can be changed if people feel it need to cost even more).
It actually spawn a variation that does not give any tech level, so people can't get the gun just to speed research.
Can only be taken by the Site Manager and Security.