### PR TITLE
Allow Phase Weaponry to be printed again.

### DIFF
--- a/code/modules/research/designs/weapons.dm
+++ b/code/modules/research/designs/weapons.dm
@@ -123,7 +123,7 @@
 	..()
 	name = "Phase weapon prototype ([item_name])"
 
-/* //VOREStation Removal Start
+/**/ //VOREStation Removal Start // Chomp Edit : uncomment those weapons
 /datum/design/item/weapon/phase/phase_pistol
 	id = "phasepistol"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_POWER = 2)
@@ -151,7 +151,7 @@
 	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 2000, "silver" = 1000, "diamond" = 750)
 	build_path = /obj/item/weapon/gun/energy/phasegun/cannon
 	sort_string = "MACAD"
-*/ //VOREStation Removal End
+/**/ //VOREStation Removal End // Chomp Edit : uncomment those weapons
 
 // Other weapons
 


### PR DESCRIPTION
This pr simply allow R&D's protolathe to print the phase weaponry, which do 5 damages on everything that aren't animals simple mobs, while dealing more damage to them, making it useful for self-defense against wild-life and other mobs.

They all deal 5 damage by default, but when hitting simple mobs : 
The Pistol do 40
The Carbine do 50
The Rifle do 60
The Cannon do 75