### PR TITLE
ranged_cooldown_time variable for mobs

### DIFF
--- a/code/modules/mob/living/simple_mob/combat.dm
+++ b/code/modules/mob/living/simple_mob/combat.dm
@@ -98,6 +98,16 @@
 		if(reload_count >= reload_max)
 			try_reload()
 			return FALSE
+			
+	//CHOMP Addition: This section here is special snowflake code for metroids only, or for whatever else in the future that you want to have move and shoot at the same time. Basically, this is a non-stupid version of the above intended for ranged vore mobs i.e. metroids. ranged_attack_delay is stupid because it sleeps the entire mob. This new ranged_cooldown_time is smarter in the sense that it is an internalized timer. Try not to confuse the names.
+	if(ranged_cooldown_time) //If you have a non-zero number in a mob's variables, this pattern begins.
+		if(ranged_cooldown <= world.time) //Further down, a timer keeps adding to the ranged_cooldown variable automatically.
+			visible_message("<span class='danger'><b>\The [src]</b> fires at \the [A]!</span>") //Leave notice of shooting.
+			shoot(A) //Perform the shoot action
+			if(casingtype) //If the mob is designated to leave casings...
+				new casingtype(loc) //... leave the casing.
+			ranged_cooldown = world.time + ranged_cooldown_time //Special addition here. This is a timer. Keeping updating the time after shooting. Add that ranged cooldown time specified in the mob to the world time.
+		return TRUE	//End these commands here.
 
 	visible_message("<span class='danger'><b>\The [src]</b> fires at \the [A]!</span>")
 	shoot(A)
@@ -106,9 +116,8 @@
 
 	if(ranged_attack_delay)
 		ranged_post_animation(A)
-
+	
 	return TRUE
-
 
 // Shoot a bullet at something.
 /mob/living/simple_mob/proc/shoot(atom/A)
@@ -133,6 +142,7 @@
 	P.launch_projectile(target = A, target_zone = null, user = src, params = null, angle_override = null, forced_spread = 0)
 	if(needs_reload)
 		reload_count++
+
 
 //	if(distance >= special_attack_min_range && distance <= special_attack_max_range)
 //		return TRUE
@@ -239,7 +249,6 @@
 	sleep(true_attack_delay)
 
 	set_AI_busy(FALSE)
-
 
 // Override these four for special custom animations (like the GOLEM).
 /mob/living/simple_mob/proc/melee_pre_animation(atom/A)

--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -175,29 +175,6 @@
 	if(has_eye_glow)
 		add_eyes()
 
-	if(LAZYLEN(organs))
-		for(var/path in organs)
-			if(ispath(path))
-				var/obj/item/organ/external/neworg = new path(src)
-				neworg.name = "[name] [neworg.name]"
-				neworg.meat_type = meat_type
-
-				if(limb_icon)
-					neworg.force_icon = limb_icon
-					neworg.force_icon_key = limb_icon_key
-
-				organs |= neworg
-				organs -= path
-
-	if(LAZYLEN(internal_organs))
-		for(var/path in internal_organs)
-			if(ispath(path))
-				var/obj/item/organ/neworg = new path(src)
-				neworg.name = "[name] [neworg.name]"
-				neworg.meat_type = meat_type
-				internal_organs |= neworg
-				internal_organs -= path
-
 	return ..()
 
 /mob/living/simple_mob/Destroy()

--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -108,6 +108,8 @@
 	var/melee_attack_delay = 2			// If set, the mob will do a windup animation and can miss if the target moves out of the way.
 	var/ranged_attack_delay = null
 	var/special_attack_delay = null
+	var/ranged_cooldown = 0 //CHOMP Addition. This is part of a timer in combat.dm.
+	var/ranged_cooldown_time = 0 //CHOMP Addition: This variable can be thrown into mob variables in order to allow the mob to move AND shoot at the same time. The previous "ranged_attack_delay" is a dumb way of handling ranged attacks because it sleeps the entire mob - this one uses an internalized timer so it is slightly smarter.
 
 	//Special attacks
 //	var/special_attack_prob = 0				// The chance to ATTEMPT a special_attack_target(). If it fails, it will do a regular attack instead.
@@ -172,6 +174,29 @@
 
 	if(has_eye_glow)
 		add_eyes()
+
+	if(LAZYLEN(organs))
+		for(var/path in organs)
+			if(ispath(path))
+				var/obj/item/organ/external/neworg = new path(src)
+				neworg.name = "[name] [neworg.name]"
+				neworg.meat_type = meat_type
+
+				if(limb_icon)
+					neworg.force_icon = limb_icon
+					neworg.force_icon_key = limb_icon_key
+
+				organs |= neworg
+				organs -= path
+
+	if(LAZYLEN(internal_organs))
+		for(var/path in internal_organs)
+			if(ispath(path))
+				var/obj/item/organ/neworg = new path(src)
+				neworg.name = "[name] [neworg.name]"
+				neworg.meat_type = meat_type
+				internal_organs |= neworg
+				internal_organs -= path
 
 	return ..()
 


### PR DESCRIPTION
This is the addition of a new mob variable that will allow mobs to move and shoot at the same time. This section here is special snowflake code for metroids only, or for whatever else in the future that you want to have move and shoot at the same time. Basically, this is a non-stupid version of "ranged_attack_delay." "ranged_attack_delay" is stupid because it sleeps the entire mob. This new ranged_cooldown_time is smarter in the sense that it is an internalized timer. Try not to confuse the names.