### PR TITLE
Fix traits thinking non-synths are synths because their other character was a synth or whatever

### DIFF
--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -86,6 +86,8 @@
 
 	if(character.isSynthetic())	//Checking if we have a synth on our hands, boys.
 		pref.dirty_synth = 1
+	else				//CHOMPEdit
+		pref.dirty_synth = 0	//CHOMPEdit
 
 	if(selected_species.selects_bodytype)
 		var/datum/species/custom/CS = character.species


### PR DESCRIPTION
:brain:
