### PR TITLE
Remove shit opinion

### DIFF
--- a/code/modules/vore/eating/simple_animal_vr.dm
+++ b/code/modules/vore/eating/simple_animal_vr.dm
@@ -39,9 +39,12 @@
 	if(!vore_selected)
 		to_chat(user, "<span class='warning'>[src] isn't planning on eating anything much less digesting it.</span>")
 		return
+/*ChompStation edit: This prevented some flexibility with mob vore and the returned message was highly unprofessional.
+
 	if(ai_holder.retaliate || (ai_holder.hostile && faction != user.faction))
 		to_chat(user, "<span class='warning'>This predator isn't friendly, and doesn't give a shit about your opinions of it digesting you.</span>")
 		return
+*/
 	if(vore_selected.digest_mode == DM_HOLD)
 		var/confirm = alert(user, "Enabling digestion on [name] will cause it to digest all stomach contents. Using this to break OOC prefs is against the rules. Digestion will reset after 20 minutes.", "Enabling [name]'s Digestion", "Enable", "Cancel")
 		if(confirm == "Enable")


### PR DESCRIPTION
Removed a stanza that prevented some flexibility with the digestion for mobs, and also the returned comment was highly unprofessional.
You can now toggle the digestion mode on simple animals. You will be warned that using this to break OOC prefs is against the rules before doing so. Right click the mob and toggle their digestion.

It's VORE it's not meant to be balanced anyway.

Ports https://github.com/CHOMPstation/CHOMPstation/pull/836