### PR TITLE
Making radios even more optimized

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -239,7 +239,7 @@ var/mobs_radio_range_fired = 1					//CHOMPEdit
 				T.temp_check[our_iter] = TRUE	//CHOMPEdit
 				speaker_coverage[T] = R
 
-
+	CHECK_TICK	//CHOMPEdit
 	// Try to find all the players who can hear the message
 	//CHOMPEdit Begin
 	//So, to explain a bit here: The old code that used to be here was pretty slow for a few reasons, most of which have been addressed now.
@@ -251,6 +251,7 @@ var/mobs_radio_range_fired = 1					//CHOMPEdit
 		var/turf/T = get_turf(M)
 		if(istype(T) && T.temp_check[our_iter])
 			. += M
+	CHECK_TICK
 	for(var/turf/T in speaker_coverage)
 		T.temp_check -= our_iter //Freeing up the memory.
 	//CHOMPEdit End

--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -121,7 +121,6 @@ SUBSYSTEM_DEF(machines)
 	while(current_run.len)
 		var/obj/machinery/M = current_run[current_run.len]
 		current_run.len--
-		var/q = QDELETED(M) //CHOMPStation edit
 		if(!istype(M) || QDELETED(M) || (M.process(wait) == PROCESS_KILL))
 			global.processing_machines.Remove(M)
 			if(!QDELETED(M))

--- a/code/game/objects/items/devices/radio/radio_ch.dm
+++ b/code/game/objects/items/devices/radio/radio_ch.dm
@@ -37,6 +37,10 @@
                 continue
     broadcast_tiles = output
 
+/obj/item/device/radio/intercom/forceMove(atom/destination)
+    . = ..()
+    update_broadcast_tiles()
+
 /obj/item/device/radio/intercom/Initialize()
     update_broadcast_tiles()
 

--- a/code/game/objects/items/devices/radio/radio_ch.dm
+++ b/code/game/objects/items/devices/radio/radio_ch.dm
@@ -15,4 +15,33 @@
                 output += cand_turf
                 continue
     return output
+/obj/item/device/radio/intercom
+    var/list/broadcast_tiles
+
+/obj/item/device/radio/intercom/proc/update_broadcast_tiles()
+    var/list/output = list()
+    var/turf/T = get_turf(src)
+    if(!T)
+        return
+    var/dnumber = canhear_range*CANBROADCAST_INNERBOX
+    for(var/cand_x = max(0, T.x - canhear_range), cand_x <= T.x + canhear_range, cand_x++)
+        for(var/cand_y = max(0, T.y - canhear_range), cand_y <= T.y + canhear_range, cand_y++)
+            var/turf/cand_turf = locate(cand_x,cand_y,T.z)
+            if(!cand_turf) 
+                continue
+            if((abs(T.x - cand_x) < dnumber) || (abs(T.y - cand_y) < dnumber))
+                output += cand_turf
+                continue
+            if(sqrt((T.x - cand_x)**2 + (T.y - cand_y)**2) <= canhear_range) 
+                output += cand_turf
+                continue
+    broadcast_tiles = output
+
+/obj/item/device/radio/intercom/Initialize()
+    update_broadcast_tiles()
+
+/obj/item/device/radio/intercom/can_broadcast_to()
+    if(!broadcast_tiles)
+        update_broadcast_tiles()
+    return broadcast_tiles
 #undef CANBROADCAST_INNERBOX

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -317,7 +317,7 @@
 					bug.gib()
 				else
 					qdel(AM) //it just gets atomized I guess? TODO throw it into space somewhere, prevents people from using shuttles as an atom-smasher
-
+	var/list/radios = list()	//CHOMPEdit
 	var/list/powernets = list()
 	for(var/area/A in shuttle_area)
 		// If there was a zlevel above our origin and we own the ceiling, erase our ceiling now we're leaving
@@ -347,6 +347,10 @@
 		// We only need to rebuild powernets for our cables.  No need to check machines because they are on top of cables.
 		for(var/obj/structure/cable/C in A)
 			powernets |= C.powernet
+		//CHOMPEdit Begin
+		for(var/obj/item/device/radio/intercom/I in A)
+			radios |= I
+		//CHOMPEdit End
 
 	// Actually do the movement of everything - This replaces origin.move_contents_to(destination)
 	translate_turfs(turf_translation, current_location.base_area, current_location.base_turf)
@@ -370,7 +374,11 @@
 		cables |= P.cables
 		qdel(P)
 	SSmachines.setup_powernets_for_cables(cables)
-
+	//CHOMPEdit Begin
+	for(var/obj/item/device/radio/intercom/I in radios)
+		if(istype(I))
+			I.update_broadcast_tiles()
+	//CHOMPEdit End
 	// Adjust areas of mothershuttle so it doesn't try and bring us with it if it jumps while we aren't on it.
 	if(mothershuttle)
 		var/datum/shuttle/MS = SSshuttles.shuttles[mothershuttle]


### PR DESCRIPTION
had a big :brain: moment and realized that we can make this even faster by not calculating intercoms' broadcast tiles every time someone uses a radio, since they literally can't move at all except with shuttles, and just pray that whatever niche case that might move them involves using forceMove 👍 