### PR TITLE
Synx runtime, parasitic variable

### DIFF
--- a/code/modules/mob/living/simple_animal/aliens/synx.dm
+++ b/code/modules/mob/living/simple_animal/aliens/synx.dm
@@ -14,6 +14,7 @@
 	icon_living = "synx_living"
 	icon_dead = "synx_dead"
 	mob_bump_flag = SIMPLE_ANIMAL //This not existing was breaking vore bump for some reason.
+	parasitic = TRUE //Digestion immunity var
 
 	var/list/speak = list()
 	var/speak_chance = 1 //MAy have forgotten to readd that.
@@ -350,7 +351,7 @@
 
 /mob/living/simple_mob/animal/synx/hear_say(message,verb,language,fakename,isItalics,var/mob/living/speaker)
 	. = ..()
-	if(!message)    return
+	if(!message || !speaker)    return
 	if (speaker == src) return
 	speaker = speaker.GetVoice()
 	speak += message

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -35,16 +35,17 @@ GLOBAL_LIST_INIT(digest_modes, list())
 			return list("to_update" = TRUE, "soundToPlay" = sound(get_sfx("classic_death_sounds")))
 		return list("to_update" = TRUE, "soundToPlay" = sound(get_sfx("fancy_death_pred")))
 
-		//CHOMPEDIT: Snowflake synx hook. Hypothetically this could be expanded to any mob by, say, giving them a parasite variable and a check for it here.
-	if(istype(L,/mob/living/simple_mob/animal/synx))
-		var/syntox = B.digest_brute+B.digest_burn
-		B.owner.adjust_nutrition(-syntox)
-		L.adjust_nutrition(syntox)
-		L.adjustBruteLoss(-syntox*2) //Should automaticaly clamp to 0
-		L.adjustFireLoss(-syntox*2) //Should automaticaly clamp to 0
-		return
+		//CHOMPEDIT: Parasitic digestion immunity hook, used to be a synx istype check but this is more optimized.
+	if(L.parasitic)
+		if(isliving(L))
+			var/paratox = B.digest_brute+B.digest_burn
+			B.owner.adjust_nutrition(-paratox)
+			L.adjust_nutrition(paratox)
+			L.adjustBruteLoss(-paratox*2) //Should automaticaly clamp to 0
+			L.adjustFireLoss(-paratox*2) //Should automaticaly clamp to 0
+			return
 
- 		//END SYNX hook.
+ 		//CHOMPedit end
 
 	// Deal digestion damage (and feed the pred)
 	var/old_brute = L.getBruteLoss()

--- a/code/modules/vore/eating/living_ch.dm
+++ b/code/modules/vore/eating/living_ch.dm
@@ -7,7 +7,7 @@
 	var/vore_footstep_chance = 0
 	var/vore_footstep_volume_cooldown = 0	//goes up each time a step isnt heard, and will proc update of list of viable bellies to determine the most filled and loudest one to base audio on.
 
-
+	var/parasitic = FALSE //Digestion immunity and nutrition leeching variable 
 
 
 mob/living/proc/check_vorefootstep(var/m_intent, var/turf/T)


### PR DESCRIPTION
Cannot execute null.GetVoice()
Cannot execute null.GetVoice()
Cannot execute null.GetVoice()
Cannot execute null.GetVoice()
Cannot execute null.GetVoice()
Cannot execute null.GetVoice()
Cannot execute null.GetVoice()
Cannot execute null.GetVoice()

Kills a runtime which has been driving me mad. Also adds a parasitic variable for digestion immunity and changes the snowflake synx digestion hook to a check for the parasitic variable which is modular and should be more optimized than an istype() check. Kinda want digestion procs to stay optimized, yeah?