### PR TITLE
Fix double comms?

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -142,7 +142,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	machinetype = 6
 	produces_heat = 0
 	var/intercept = 0 // if nonzero, broadcasts all messages to syndicate channel
-	var/overmap_range = 1 //Same turf
+	var/overmap_range = 0 //Same turf //CHOMP Edit: Reverted range from 1 to 0 because I think this is causing double speak somehow over comms.
 
 	var/list/linked_radios_weakrefs = list()
 


### PR DESCRIPTION
I honestly do not onkw what this does. overmap_range = 0 would definitely mean "same turf." But setting it to overmap_range = 1 should make it +/- one z-level IN THEORY. I am not sure.

DO IT LIVE!