### PR TITLE
Disable Casino

### DIFF
--- a/maps/southern_cross/southern_cross.dm
+++ b/maps/southern_cross/southern_cross.dm
@@ -48,7 +48,7 @@
 	#include "southern_cross-9.dmm"
 	#include "southern_cross-10.dmm"
 	//CHOMPStation Edit End
-	#include "southern_cross-casino.dmm" //CHOMPedit: Disabled to save resources and loaded in during events - Jack
+//	#include "southern_cross-casino.dmm" //CHOMPedit: Disabled to save resources and loaded in during events - Jack
 
 	#include "submaps/_southern_cross_submaps.dm"
 


### PR DESCRIPTION
To save on memory and resources, we are disabling casino since we don't need it for a bit. But casino will be back!