### PR TITLE
Changing shadekin to RESTRICTED from WHITELISTED

### DIFF
--- a/code/modules/mob/language/station_vr.dm
+++ b/code/modules/mob/language/station_vr.dm
@@ -101,7 +101,7 @@
 	colour = "changeling"
 	key = "M"
 	machine_understands = FALSE
-	flags = WHITELISTED | HIVEMIND
+	flags = RESTRICTED | HIVEMIND //CHOMPstation Edit: Changining from WHITELISTED to RESTRICTED | Empathy should be shadekin exclusive. This probably breaks carbon shadekins ability to use emptathy, we dont use them and if it does it should be implemented like DIONA root talk. -shark
 
 /datum/language/slavic
 	name = LANGUAGE_SLAVIC


### PR DESCRIPTION
This makes it so shadekin is never a selectable language but rather has to be assigned by the game automatically, similar to how root talk on diona behaves. 

This may break carbon shadekin from selecting this language if they dont assign it the same way diona do.
Howevcer we don't plan to use Shadekin carbons soooooo, yeah.