### PR TITLE
Remove micro recoil for more guns

### DIFF
--- a/code/modules/projectiles/guns/energy/laser_vr.dm
+++ b/code/modules/projectiles/guns/energy/laser_vr.dm
@@ -213,6 +213,7 @@
 		list(mode_name="lethal", fire_delay=12, projectile_type=/obj/item/projectile/beam/phaser, charge_cost = 300),
 		list(mode_name="low-power", fire_delay=8, projectile_type=/obj/item/projectile/beam/phaser/light, charge_cost = 60),
 	)
+	recoil_mode = 0 //CHOMP Addition: Removes recoil for micros.
 
 /obj/item/weapon/gun/energy/locked/frontier/unload_ammo(var/mob/user)
 	if(recharging)

--- a/code/modules/projectiles/guns/energy/particle.dm
+++ b/code/modules/projectiles/guns/energy/particle.dm
@@ -23,6 +23,7 @@
 	charge_cost = 200	//slightly more shots than lasers
 	var/safetycatch = 0 //if 1, won't let you fire in pressurised environment, rather than malfunctioning
 	var/obj/item/pressurelock/attached_safety
+	recoil_mode = 0 //CHOMP Addition: Removes recoil for micros.
 
 
 /obj/item/weapon/gun/energy/particle/advanced //particle equivalent of AEG

--- a/code/modules/projectiles/guns/energy/phase.dm
+++ b/code/modules/projectiles/guns/energy/phase.dm
@@ -11,6 +11,7 @@
 	charge_cost = 240
 	projectile_type = /obj/item/projectile/energy/phase
 	one_handed_penalty = 15
+	recoil_mode = 0 //CHOMP Addition: Removes recoil for micros.
 
 /obj/item/weapon/gun/energy/phasegun/pistol
 	name = "phase pistol"


### PR DESCRIPTION
Micro recoil removed from frontier phasers, the OG phaser, and the anti-particle projector guns.