### PR TITLE
Removes eguns_vr.dm

### DIFF
--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4010,7 +4010,6 @@
 #include "code\modules\xenoarcheaology\effects\teleport.dm"
 #include "code\modules\xenoarcheaology\effects\vampire.dm"
 #include "code\modules\xenoarcheaology\finds\eguns.dm"
-#include "code\modules\xenoarcheaology\finds\eguns_vr.dm"
 #include "code\modules\xenoarcheaology\finds\find_spawning.dm"
 #include "code\modules\xenoarcheaology\finds\finds.dm"
 #include "code\modules\xenoarcheaology\finds\finds_defines.dm"


### PR DESCRIPTION
Eguns VR.dm this means instead of the 6 virgos specific eguns we will now havve the 12 stock egun variants.

Future suggestion is to add a _ch DMI including all 18 unique guns this is just a hotfix