### PR TITLE
Tiny vorespawn fix

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -755,4 +755,4 @@ var/global/datum/controller/occupations/job_master
 	if(!ishuman(C.mob))
 		return
 	var/mob/living/carbon/human/CM = C.mob
-	SStranscore.m_backup(CM.mind, CM.nif)
+	SStranscore.m_backup(CM.mind, CM.nif, TRUE)

--- a/code/modules/client/preferences_spawnpoints_ch.dm
+++ b/code/modules/client/preferences_spawnpoints_ch.dm
@@ -8,7 +8,7 @@
 
 /datum/spawnpoint/vore
 	display_name = "Vore Belly"
-	msg = "has arrived on the station."
+	msg = "has arrived on the station"
 
 /datum/spawnpoint/vore/New()
 	..()


### PR DESCRIPTION
appends a "TRUE" to the vorespawn mind backup, so it doesn't ping transcore when you're alive.

Go get a full backup implant if you intend to get out of the gut and go die somewhere other than that belly.