### PR TITLE
Delay Arrival Announcement for Join to Belly Until Released

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -749,7 +749,9 @@ var/global/datum/controller/occupations/job_master
 	else if(!fail_deadly)
 		var/spawning = pick(latejoin)
 		.["turf"] = get_turf(spawning)
-		.["msg"] = "has arrived on the station"
+		while (!isbelly(H.loc))
+		else ["msg"] = "has arrived on the station"
+			break
 
 /datum/controller/occupations/proc/m_backup_client(var/client/C)	//Same as m_backup, but takes a client entry. Used for vore late joining.
 	if(!ishuman(C.mob))

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -749,7 +749,7 @@ var/global/datum/controller/occupations/job_master
 	else if(!fail_deadly)
 		var/spawning = pick(latejoin)
 		.["turf"] = get_turf(spawning)
-		while (!isbelly(H.loc))
+		while (isbelly(H.loc))
 		else ["msg"] = "has arrived on the station"
 			break
 

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -749,9 +749,10 @@ var/global/datum/controller/occupations/job_master
 	else if(!fail_deadly)
 		var/spawning = pick(latejoin)
 		.["turf"] = get_turf(spawning)
-		while (isbelly(H.loc))
-		else ["msg"] = "has arrived on the station"
-			break
+		while(isbelly(H.loc))
+			Sleep(3000)
+		else 
+			["msg"] = "has arrived on the station"
 
 /datum/controller/occupations/proc/m_backup_client(var/client/C)	//Same as m_backup, but takes a client entry. Used for vore late joining.
 	if(!ishuman(C.mob))


### PR DESCRIPTION
No need to announce people who aren't actually going to be on shift.