### PR TITLE
Resolves #1081 Teleporter Hub Rebalance

### DIFF
--- a/code/game/objects/items/weapons/circuitboards/frame.dm
+++ b/code/game/objects/items/weapons/circuitboards/frame.dm
@@ -174,10 +174,14 @@
 	build_path = /obj/machinery/teleport/hub
 	board_type = new /datum/frame/frame_types/machine //YWEdit makes buildable
 //	origin_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 4)
+//CHOMPedit Balance
 	req_components = list(
-							/obj/item/weapon/stock_parts/scanning_module = 4,
-							/obj/item/weapon/stock_parts/micro_laser = 4,
-							/obj/item/stack/cable_coil = 10)
+							/obj/item/weapon/ore/bluespace_crystal = 2,
+							/obj/item/weapon/stock_parts/capacitor = 2,
+							/obj/item/weapon/stock_parts/scanning_module = 2,
+							/obj/item/weapon/stock_parts/micro_laser =2,
+							/obj/item/stack/cable_coil = 5)
+//End CHOMPedit
 
 /obj/item/weapon/circuitboard/teleporter_station
 	name = T_BOARD("teleporter station")


### PR DESCRIPTION
Adds bluespace crystals to the required materials to build a teleporter hub, bringing it in line with the rest of telesci.