### PR TITLE
Remove Borg and pAI from whitelist

### DIFF
--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -144,9 +144,7 @@ var/list/whitelisted_positions = list(
 	"Chief Medical Officer",
 	"Command Secretary",
 	"Warden",
-	"AI",
-	"Cyborg",
-	"pAI"
+	"AI"
 )
 
 


### PR DESCRIPTION
-Removes Borg and pAI from whitelist requirement.

I'm assuming Kassc and Nadyr wouldn't mind if the pAI was removed from the list because pAIs are like, diet borg or something.