### PR TITLE
Energy Weapons Rebalance and Misc Fixes

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -159,7 +159,7 @@
 	w_class = ITEMSIZE_HUGE //CHOMP Edit. Lol a cannon used to be just large size? Are you kidding me? A CANNON.
 	one_handed_penalty = 90 // The thing's heavy and huge.
 	accuracy = 45
-	charge_cost = 600
+	charge_cost = 400 //CHOMP Edit. Let's give this thing some more shots, seeing as it needs to be recharged at a charger.
 
 /obj/item/weapon/gun/energy/lasercannon/mounted
 	name = "mounted laser cannon"
@@ -196,14 +196,16 @@
 	projectile_type = /obj/item/projectile/beam/sniper
 	slot_flags = SLOT_BACK
 	action_button_name = "Use Scope"
-	battery_lock = 1
-	charge_cost = 600
-	fire_delay = 35
+	//Begin CHOMPstation Edit for making this thing not trash
+	//battery_lock = 0
+	charge_cost = 360 
+	fire_delay = 40
 	force = 10
 	w_class = ITEMSIZE_HUGE // So it can't fit in a backpack.
-	accuracy = -45 //shooting at the hip
-	scoped_accuracy = 50
+	accuracy = -30 //shooting at the hip
+	scoped_accuracy = 100
 	one_handed_penalty = 60 // The weapon itself is heavy, and the long barrel makes it hard to hold steady with just one hand.
+	//End CHOMP Edit.
 
 /obj/item/weapon/gun/energy/sniperrifle/ui_action_click()
 	scope()
@@ -303,3 +305,4 @@
 
 	projectile_type = /obj/item/projectile/scatter/laser
 	w_class = ITEMSIZE_HUGE //CHOMP Edit.
+	slot_flags = SLOT_BELT|SLOT_BACK //CHOMP Edit because you can still holster it despite it not fitting in a backpack.

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -31,6 +31,7 @@
 	charge_cost = 100
 	force = 8
 	w_class = ITEMSIZE_HUGE		//Probably gonna make it a rifle sooner or later //CHOMP Edit, and so I did.
+	slot_flags = SLOT_BELT|SLOT_BACK //CHOMP Edit. Let's make it so that if it doesn't fit in a backpack, it doesn't fit in a holster either.
 	fire_delay = 6
 
 	projectile_type = /obj/item/projectile/beam/stun/weak

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -15,10 +15,10 @@
 	load_type = /obj/item/weapon/rcd_ammo
 	projectile_type = /obj/item/projectile/bullet/magnetic/slug
 
-	cell = /obj/item/weapon/cell/hyper
+	cell = /obj/item/weapon/cell/device/weapon //CHOMP Edit.
 	capacitor = /obj/item/weapon/stock_parts/capacitor/adv
 	loaded = /obj/item/weapon/rcd_ammo/large
-	removable_components = FALSE
+	removable_components = TRUE //CHOMP Edit.
 
 	var/slowdown_held = 2
 	var/slowdown_worn = 1
@@ -83,11 +83,13 @@
 	icon_state = "flechette_gun"
 	item_state = "z8carbine"
 
-	cell = /obj/item/weapon/cell/hyper
+	cell = /obj/item/weapon/cell/device/weapon //CHOMP Edit.
 	capacitor = /obj/item/weapon/stock_parts/capacitor/adv
+	removable_components = TRUE //CHOMP Edit.
 
 	fire_delay = 0
 
+	w_class = ITEMSIZE_HUGE //CHOMP Edit.
 	slot_flags = SLOT_BACK
 
 	slowdown = 0
@@ -98,6 +100,7 @@
 	load_type = /obj/item/weapon/magnetic_ammo
 	projectile_type = /obj/item/projectile/bullet/magnetic/flechette
 	loaded = /obj/item/weapon/magnetic_ammo
+	removable_components = TRUE //CHOMP Edit.
 	empty_sound = 'sound/weapons/smg_empty_alarm.ogg'
 
 	firemodes = list(
@@ -114,8 +117,9 @@
 	item_state = "combatrevolver"
 	w_class = ITEMSIZE_SMALL
 
-	cell = /obj/item/weapon/cell/super
+	cell = /obj/item/weapon/cell/device/weapon //CHOMP Edit.
 	capacitor = /obj/item/weapon/stock_parts/capacitor
+	removable_components = TRUE //CHOMPstation Edit
 
 	fire_delay = 0
 
@@ -129,7 +133,6 @@
 	load_type = /obj/item/weapon/magnetic_ammo/pistol
 	projectile_type = /obj/item/projectile/bullet/magnetic/flechette/small
 	loaded = /obj/item/weapon/magnetic_ammo/pistol
-	removable_components = TRUE
 	empty_sound = 'sound/weapons/smg_empty_alarm.ogg'
 
 	firemodes = list(
@@ -145,14 +148,14 @@
 	icon_state = "railgun_sec"
 	item_state = "cshotgun"
 
-	removable_components = TRUE
-
 	cell = /obj/item/weapon/cell/device/weapon
 	capacitor = /obj/item/weapon/stock_parts/capacitor
+	removable_components = TRUE //CHOMPstation Edit
 
 	fire_delay = 8
 
 	slot_flags = SLOT_BACK
+	w_class = ITEMSIZE_HUGE //CHOMP Edit.
 
 	slowdown = 0
 	slowdown_held = 0.3
@@ -182,6 +185,7 @@
 
 	cell = /obj/item/weapon/cell/device/weapon
 	capacitor = /obj/item/weapon/stock_parts/capacitor
+	removable_components = TRUE //CHOMPstation Edit
 
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 
@@ -209,10 +213,11 @@
 	icon_state = "railgun_sifguard"
 	item_state = "z8carbine"
 
-	cell = /obj/item/weapon/cell/high
+	cell = /obj/item/weapon/cell/device/weapon //CHOMP Edit.
 	capacitor = /obj/item/weapon/stock_parts/capacitor/adv
+	removable_components = TRUE //CHOMPstation Edit.
 
-	slot_flags = SLOT_BACK
+	slot_flags = SLOT_BELT|SLOT_BACK //CHOMPstation Edit. This is a carbine.
 
 	slowdown_held = 0.3
 


### PR DESCRIPTION
Allows magnetics to be modified, adds more shots to Lasercannon and balances the laser sniper.

Magnetics can have their capacitors switched out and no longer use standard power cells by default.
Laser Cannon has been buffed to 6 shots.
Energy Sniper has increased effective range, less penalty for shooting without scoping, 6 shots by default, can switch the power cell and slightly increased cooldown between shots.

Laser Shotgun and Burst Laser are no longer holsterable.