### PR TITLE
FIX WHITELIST AGAIN

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -60,6 +60,8 @@ var/global/datum/controller/occupations/job_master
 				return 0
 			if(!job.player_old_enough(player.client))
 				return 0
+			if(!check_whitelist(player)) // Yeah no, no more hardcoded whitelisting. Ree. - Jon. //CHOMPStation code.
+				return 0
 			//VOREStation Add
 			if(!job.player_has_enough_playtime(player.client))
 				return 0


### PR DESCRIPTION
:cl:
bugfix: Restores some mysteriously missing code...
/:cl:

WHY THE FUCK DID THIS DISAPPEAR AND HOW??? I literally cannot find it in gitblame or history. It was originally implemented in #59