### PR TITLE
Disable telekinesis

### DIFF
--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -34,7 +34,7 @@
 	BLINDBLOCK         = getAssignedBlock("BLIND",         numsToAssign)
 	DEAFBLOCK          = getAssignedBlock("DEAF",          numsToAssign)
 	HULKBLOCK          = getAssignedBlock("HULK",          numsToAssign, DNA_HARD_BOUNDS)
-	TELEBLOCK          = getAssignedBlock("TELE",          numsToAssign, DNA_HARD_BOUNDS)
+	//TELEBLOCK          = getAssignedBlock("TELE",          numsToAssign, DNA_HARD_BOUNDS)
 	FIREBLOCK          = getAssignedBlock("FIRE",          numsToAssign, DNA_HARDER_BOUNDS)
 	XRAYBLOCK          = getAssignedBlock("XRAY",          numsToAssign, DNA_HARDER_BOUNDS)
 	CLUMSYBLOCK        = getAssignedBlock("CLUMSY",        numsToAssign)


### PR DESCRIPTION
Been meaning to do this for a while. Telekinesis can be a nifty-ish mechanic, problem comes when people either just straight up use it to be annoying (which is more rare, but still a problem) and when people use it to cheese mechanics (I.e. people will get this and X-ray and just hide behind a wall and throw objects at a mob repeatedly to kill it), which is pretty much unacceptable because of how overpowered it is. 