### PR TITLE
Vore optimization and some

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -175,6 +175,10 @@
 	if(has_eye_glow)
 		add_eyes()
 
+	if(!IsAdvancedToolUser())	//CHOMPSTATION edit: Moved here so the verb is useable before initialising vorgans.
+		verbs |= /mob/living/simple_mob/proc/animal_nom
+		verbs |= /mob/living/proc/shred_limb
+
 	return ..()
 
 /mob/living/simple_mob/Destroy()

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -86,6 +86,8 @@
 			icon_state = "[icon_rest]-[vore_fullness]"
 
 /mob/living/simple_mob/proc/will_eat(var/mob/living/M)
+	M.init_vore()
+	init_vore()
 	if(client) //You do this yourself, dick!
 		//ai_log("vr/wont eat [M] because we're player-controlled", 3) //VORESTATION AI TEMPORARY REMOVAL
 		return 0
@@ -193,10 +195,6 @@
 /mob/living/simple_mob/init_vore()
 	if(!vore_active || no_vore)
 		return
-
-	if(!IsAdvancedToolUser())
-		verbs |= /mob/living/simple_mob/proc/animal_nom
-		verbs |= /mob/living/proc/shred_limb
 
 	if(LAZYLEN(vore_organs))
 		return

--- a/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander_ch.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander_ch.dm
@@ -64,11 +64,11 @@
 	movement_cooldown = 2
 
 /mob/living/simple_mob/vore/leopardmander/New() //Set to max nutrition on spawn since heal belly drains nutrition to work.
-	..() 
+	..()
 	src.adjust_nutrition(src.max_nutrition)
 
 /mob/living/simple_mob/vore/leopardmander/Initialize()
-	..() 
+	..()
 	src.adjust_nutrition(src.max_nutrition)
 
 /mob/living/simple_mob/vore/leopardmander/apply_melee_effects(atom/A)
@@ -78,6 +78,7 @@
 			var/target_zone = pick(BP_TORSO,BP_TORSO,BP_TORSO,BP_L_LEG,BP_R_LEG,BP_L_ARM,BP_R_ARM,BP_HEAD)
 			if(L.can_inject(src, null, target_zone))
 				last_inject = world.time
+				L.init_vore()
 				if(!L.allowmobvore) //If we can't eat them, stop mauling them.
 					ai_holder.lose_target() //Call this first so the attacks stop if the reagent proc runtimes.
 					L.reagents.add_reagent("bicaridine", venom_dose) //If we can't eat them, give them some bicar to compensate for no heal belly.
@@ -86,7 +87,7 @@
 				L.reagents.add_reagent("myelamine", venom_dose)
 				L.reagents.add_reagent("osteodaxon", venom_dose)
 
-	
+
 
 /mob/living/simple_mob/vore/leopardmander
 
@@ -160,7 +161,7 @@
 
 	glow_toggle = TRUE //Glow!
 	glow_range = 2
-	glow_color = "#FF006E" 
+	glow_color = "#FF006E"
 	glow_intensity = 1.5
 
 /mob/living/simple_mob/vore/leopardmander/exotic/proc/toggle_glow()
@@ -171,7 +172,7 @@
 	glow_toggle = !glow_toggle
 
 /mob/living/simple_mob/vore/leopardmander/exotic/New()
-	..() 
+	..()
 	verbs |= /mob/living/simple_mob/vore/leopardmander/exotic/proc/toggle_glow
 
 /mob/living/simple_mob/vore/leopardmander/exotic/init_vore()
@@ -205,4 +206,4 @@
 /obj/random/mob/leopardmander/item_to_spawn() //Random map spawner
 	return pick(prob(89);/mob/living/simple_mob/vore/leopardmander,
 		prob(10);/mob/living/simple_mob/vore/leopardmander/blue,
-		prob(1);/mob/living/simple_mob/vore/leopardmander/exotic,) 
+		prob(1);/mob/living/simple_mob/vore/leopardmander/exotic,)

--- a/code/modules/multiz/movement_vr.dm
+++ b/code/modules/multiz/movement_vr.dm
@@ -77,6 +77,8 @@
 	pred.Weaken(8)
 	var/mob/living/prey = src
 	var/fallloc = prey.loc
+	pred.init_vore()
+	prey.init_vore()
 	if(pred.can_be_drop_pred && prey.can_be_drop_prey)
 		pred.feed_grabbed_to_self_falling_nom(pred,prey)
 		pred.loc = fallloc

--- a/code/modules/vore/eating/human_ch.dm
+++ b/code/modules/vore/eating/human_ch.dm
@@ -1,0 +1,19 @@
+/*
+init_vore() was moved to only be called when vore organs are needed. This is also responsible for loading vore prefs.
+This file is here to make vore prefs default to off so that someone who hasn't opened their vore panel during a round
+won't accidentally be prefbroken.
+
+Also, these should've been defaulted to off in the first place.
+*/
+/mob/living/carbon/human
+	digestable = FALSE
+	devourable = FALSE
+	feeding = FALSE
+	absorbable = FALSE
+	digest_leave_remains = FALSE
+	allowmobvore = FALSE
+	showvoreprefs = FALSE
+	permit_healbelly = FALSE
+	can_be_drop_prey = FALSE
+	can_be_drop_pred = FALSE
+	show_vore_fx = FALSE

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -49,11 +49,6 @@
 	M.verbs += /mob/living/proc/insidePanel
 	M.verbs += /mob/living/proc/vore_transfer_reagents //CHOMP If mob doesnt have bellies it cant use this verb for anything
 
-	//Tries to load prefs if a client is present otherwise gives freebie stomach
-	spawn(2 SECONDS)
-		if(M)
-			M.init_vore()
-
 	//return TRUE to hook-caller
 	return TRUE
 
@@ -102,6 +97,7 @@
 		//Has to be aggressive grab, has to be living click-er and non-silicon grabbed
 		if(G.state >= GRAB_AGGRESSIVE && (isliving(user) && !issilicon(G.affecting)))
 			var/mob/living/attacker = user  // Typecast to living
+			G.affecting.init_vore()
 
 			// src is the mob clicked on and attempted predator
 
@@ -157,6 +153,10 @@
 		var/mob/living/attacker = user  // Typecast to living
 		if(is_vore_predator(src))
 			for(var/mob/living/M in H.contents)
+				M.init_vore()
+				if(!M.devourable)
+					to_chat(user, "<span class='notice'>[M] isn't able to be devoured.</span>")
+					return FALSE
 				if(attacker.eat_held_mob(attacker, M, src))
 					if(H.held_mob == M)
 						H.held_mob = null

--- a/code/modules/vore/eating/simple_animal_vr.dm
+++ b/code/modules/vore/eating/simple_animal_vr.dm
@@ -13,6 +13,8 @@
 
 	if(stat != CONSCIOUS)
 		return
+	init_vore()
+	T.init_vore()
 	// Verbs are horrifying. They don't call overrides. So we're stuck with this.
 	if(istype(src, /mob/living/simple_mob/animal/passive/mouse) && !T.ckey)
 		// Mice can't eat logged out players!

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -80,6 +80,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 //	Check if an object is capable of eating things, based on vore_organs
 //
 /proc/is_vore_predator(mob/living/O)
+	O.init_vore()
 	if(istype(O,/mob/living))
 		if(O.vore_organs.len > 0)
 			return TRUE

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -930,7 +930,6 @@
 			qdel(host.vore_selected)
 			host.vore_selected = host.vore_organs[1]
 			. = TRUE
-
 		if("b_vorespawn_blacklist") //CHOMP Addition
 			host.vore_selected.vorespawn_blacklist = !host.vore_selected.vorespawn_blacklist
 			. = TRUE

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -18,6 +18,7 @@
 	if(!vorePanel)
 		log_debug("[src] ([type], \ref[src]) didn't have a vorePanel and tried to use the verb.")
 		vorePanel = new(src)
+	init_vore()	//Returns if the organs already exist anyway.
 
 	vorePanel.tgui_interact(src)
 
@@ -929,7 +930,7 @@
 			qdel(host.vore_selected)
 			host.vore_selected = host.vore_organs[1]
 			. = TRUE
-			
+
 		if("b_vorespawn_blacklist") //CHOMP Addition
 			host.vore_selected.vorespawn_blacklist = !host.vore_selected.vorespawn_blacklist
 			. = TRUE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -3958,6 +3958,7 @@
 #include "code\modules\vore\eating\bellymodes_vr.dm"
 #include "code\modules\vore\eating\contaminate_vr.dm"
 #include "code\modules\vore\eating\digest_act_vr.dm"
+#include "code\modules\vore\eating\human_ch.dm"
 #include "code\modules\vore\eating\leave_remains_vr.dm"
 #include "code\modules\vore\eating\living_ch.dm"
 #include "code\modules\vore\eating\living_vr.dm"


### PR DESCRIPTION
Primary thing this PR does is make it so vore organs do not generate until after someone has attempted to do something vorish by moving init_vore() into instances where vore happens.

Preeeeeetty sure I hit up every instance where vore can occur. Let me know if I missed one.

Also sets carbon mob vore prefs to off by default.

Also makes picking up and nomming micros respect vore prefs... because it didn't, for some reason.