### PR TITLE
Revert "FIX WHITELIST AGAIN"

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -60,8 +60,6 @@ var/global/datum/controller/occupations/job_master
 				return 0
 			if(!job.player_old_enough(player.client))
 				return 0
-			if(!check_whitelist(player)) // Yeah no, no more hardcoded whitelisting. Ree. - Jon. //CHOMPStation code.
-				return 0
 			//VOREStation Add
 			if(!job.player_has_enough_playtime(player.client))
 				return 0


### PR DESCRIPTION
Reverts CHOMPStation2/CHOMPStation2#1242

Now I remember why this was removed. It just broke things. But why were whitelists allowing everyone a few weeks ago???