### PR TITLE
Adding the clown and mime but with a twist

### DIFF
--- a/code/game/jobs/job/civilian_vr.dm
+++ b/code/game/jobs/job/civilian_vr.dm
@@ -198,7 +198,9 @@
 	job_description = "An entertainer does just that, entertains! Put on plays, play music, sing songs, tell stories, or read your favorite fanfic."
 	alt_titles = list("Performer" = /datum/alt_title/performer, "Musician" = /datum/alt_title/musician, "Stagehand" = /datum/alt_title/stagehand,
 						"Actor" = /datum/alt_title/actor, "Dancer" = /datum/alt_title/dancer, "Singer" = /datum/alt_title/singer,
-						"Magician" = /datum/alt_title/magician, "Comedian" = /datum/alt_title/comedian, "Tragedian" = /datum/alt_title/tragedian)
+						"Magician" = /datum/alt_title/magician, "Comedian" = /datum/alt_title/comedian, "Tragedian" = /datum/alt_title/tragedian,
+						"Clown" = /datum/alt_title/clown, "Jester" = /datum/alt_title/clown/jester,"Fool" = /datum/alt_title/clown/fool,
+						"Mime"= /datum/alt_title/mime,"Poseur"= /datum/alt_title/mime/poseur) //CHOMPEDIT: Adding clown + mime and their alts as alts of entertainer
 
 // Entertainer Alt Titles
 /datum/alt_title/actor
@@ -236,3 +238,25 @@
 /datum/alt_title/tragedian
 	title = "Tragedian"
 	title_blurb = "A Tragedian will focus on making people think about life and world around them! Life is a tragedy, and who's better to convey its emotions than you?"
+
+//CHOMP ADDITION: Below, well sort off, these are the clown and mime returning! as entertainer alts
+//They even get their respective outfits.
+/datum/alt_title/clown
+	title = "Clown"
+	title_blurb = "A Clown is there to entertain the crew and keep high morale using various harmless pranks and ridiculous jokes!"
+	title_outfit = /decl/hierarchy/outfit/job/clown
+
+/datum/alt_title/clown/jester
+	title = "Jester"
+
+/datum/alt_title/clown/fool
+	title = "Fool"
+
+/datum/alt_title/mime
+	title = "Mime"
+	title_blurb = "A Mime is there to entertain the crew and keep high morale using unbelievable performances and acting skills!"
+	title_outfit = /decl/hierarchy/outfit/job/mime
+
+/datum/alt_title/mime/poseur
+	title = "Poseur"
+//CHOMP ADDITION END


### PR DESCRIPTION
So the clown and mime are commonly given their own slots on the job page,

I thought that`s kinda silly, both have as goal to ENTERTAIN the crew, so why not just make them ALT titles of the Entertainer.

They retain their unique outfits however.