### PR TITLE
Fix unityhound

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -910,6 +910,7 @@
 	src.modules += B
 
 	R.icon = 'icons/mob/widerobot_ch.dmi'
+	R.wideborg_dept = 'icons/mob/widerobot_ch.dmi'
 	R.hands.icon = 'icons/mob/screen1_robot_vr.dmi'
 	R.ui_style_vr = TRUE
 	R.pixel_x 	 = -16


### PR DESCRIPTION
Because of the icon split from upstream, but it is now widerobot_dept that defines where borg sprites come from. Although there seems to be a var called "custom sprite" that if true will ignore it> I think it's ridiculous and I would have to test, but I am gonna fix this unityhound now.