### PR TITLE
Citadel Mirror: fixes a pretty horrific memory leak

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -21,7 +21,6 @@ var/global/list/joblist = list()					//list of all jobstypes, minus borg and AI
 #define all_genders_define_list list(MALE,FEMALE,PLURAL,NEUTER,HERM) //VOREStaton Edit
 #define all_genders_text_list list("Male","Female","Plural","Neuter","Herm") //VOREStation Edit
 
-var/list/mannequins_
 
 // Times that players are allowed to respawn ("ckey" = world.time)
 GLOBAL_LIST_EMPTY(respawn_timers)
@@ -94,13 +93,14 @@ var/global/list/string_slot_flags = list(
 	"holster" = SLOT_HOLSTER
 )
 
-/proc/get_mannequin(var/ckey)
-	if(!mannequins_)
-		mannequins_ = new()
- 	. = mannequins_[ckey]
-	if(!.)
-		. = new/mob/living/carbon/human/dummy/mannequin()
-		mannequins_[ckey] = .
+//CHOMP Edit: This fix is taken from citadel station pr #2779. Fixes a "pretty horrific memory leak" that is called any time someone opens character creator.
+GLOBAL_LIST_EMPTY(mannequins)
+/proc/get_mannequin(var/ckey = "NULL")
+	var/mob/living/carbon/human/dummy/mannequin/M = GLOB.mannequins[ckey]
+	if(!istype(M))
+		GLOB.mannequins[ckey] = new /mob/living/carbon/human/dummy/mannequin(null)
+		M = GLOB.mannequins[ckey]
+	return M
 
 //////////////////////////
 /////Initial Building/////


### PR DESCRIPTION
This fix is taken from citadel station pr #2779. Fixes a "pretty horrific memory leak" that is called any time someone opens character creator.