### PR TITLE
Remove transit from SC extra_z_levels

### DIFF
--- a/maps/southern_cross/overmap/sectors.dm
+++ b/maps/southern_cross/overmap/sectors.dm
@@ -43,7 +43,7 @@
 	start_y =  10
 	known = 1 // lets Sectors appear on shuttle navigation for easy finding.
 	map_z = list(Z_LEVEL_STATION_ONE, Z_LEVEL_STATION_TWO, Z_LEVEL_STATION_THREE)
-	extra_z_levels = list(Z_LEVEL_TRANSIT, Z_LEVEL_MISC) // Hopefully temporary, so arrivals announcements work. //CHOMPedit: adds Z_LEVEL_MISC to connect the exploration carrier with the station
+	extra_z_levels = list(Z_LEVEL_MISC) // Hopefully temporary, so arrivals announcements work. //CHOMPedit: adds Z_LEVEL_MISC to connect the exploration carrier with the station
 	initial_generic_waypoints = list(
 		"d1_aux_a",
 		"d1_aux_b",


### PR DESCRIPTION
This is somehow causing people to drift into the transit level. I guess initially this was done so that radio comms can make it to the transit level. I don't know how to test that on a private server, so I am putting it to main and hopping for the best, heheh.

:cl:
bugfix: players should no longer reach the transit z-level
/:cl: