### PR TITLE
Adds RPD to Normal Engineering Module

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station_ch.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_ch.dm
@@ -2,3 +2,7 @@
 /obj/item/weapon/robot_module/drone/mining/New()
 	..()
 	src.modules += new /obj/item/weapon/mining_scanner(src)
+
+/obj/item/weapon/robot_module/robot/engineering/New()
+	..()
+	src.modules += new /obj/item/weapon/pipe_dispenser(src)


### PR DESCRIPTION
Hound engineering modules have the RPD but the normal engineering module does not. This adds the RPD to the normal engineering module as well.