### PR TITLE
Fix space transit, properly lists space station as space map

### DIFF
--- a/maps/southern_cross/overmap/sectors.dm
+++ b/maps/southern_cross/overmap/sectors.dm
@@ -42,8 +42,7 @@
 	start_x =  10
 	start_y =  10
 	known = 1 // lets Sectors appear on shuttle navigation for easy finding.
-	map_z = list(Z_LEVEL_STATION_ONE, Z_LEVEL_STATION_TWO, Z_LEVEL_STATION_THREE)
-	extra_z_levels = list(Z_LEVEL_MISC) // Hopefully temporary, so arrivals announcements work. //CHOMPedit: adds Z_LEVEL_MISC to connect the exploration carrier with the station
+	extra_z_levels = list(Z_LEVEL_TRANSIT, Z_LEVEL_MISC,Z_LEVEL_SURFACE, Z_LEVEL_SURFACE_MINE, Z_LEVEL_SURFACE_WILD) //This should allow for comms to reach people from the station. Basically this defines all the areas of Southern Cross and the Sif local system on the overmap.
 	initial_generic_waypoints = list(
 		"d1_aux_a",
 		"d1_aux_b",
@@ -69,6 +68,8 @@
 		"baby_mammoth_dock"
 		)
 
-/obj/effect/overmap/visitable/planet/Sif/Initialize()
-	. = ..()
-	docking_codes = null
+/obj/effect/overmap/visitable/sector/Southern_Cross/get_space_zlevels() //These are the primary levels that our space station resides in. This also indicates what levels astronauts can drift into.
+	return list(Z_LEVEL_STATION_ONE,
+			Z_LEVEL_STATION_TWO,
+			Z_LEVEL_STATION_THREE,
+			Z_LEVEL_MISC)


### PR DESCRIPTION
Now that our station is defined as space map and not just map, we now have established it as a "multi-z complex", I think.

Anyway it also means that I can add all the other levels as extra_z_levels and solidifies Vir as a fully functional overmap system.

🆑
bugfix: Players can hear from the Transit level over comms again
/🆑