### PR TITLE
Temporary bandaid fix for comms lag

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -1,4 +1,5 @@
 /obj/item/device/radio/intercom
+	listening = 0 //CHOMP Edit: Temporary bandaid fix for comms lag.
 	name = "station intercom (General)"
 	desc = "Talk through this."
 	icon = 'icons/obj/radio_vr.dmi' //VOREStation Edit - New Icon


### PR DESCRIPTION
Turns off the wall comms to stop listening for everything. If you want to use a wall comm, turn it on manually.