### PR TITLE
Prevent proteans from eating metals they can't process anymore

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -301,7 +301,7 @@
 	if(refactory && istype(O,/obj/item/stack/material))
 		var/obj/item/stack/material/S = O
 		var/substance = S.material.name
-		var/list/edible_materials = list("steel", "plasteel", "diamond", "mhydrogen") //Can't eat all materials, just useful ones.
+		var/list/edible_materials = list("steel") //Can't eat all materials, just useful ones. CHOMP EDIT: Only steel
 		var/allowed = FALSE //CHOMP Edit
 		for(var/material in edible_materials)
 			if(material == substance) allowed = TRUE

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_powers.dm
@@ -296,7 +296,7 @@
 
 	var/obj/item/stack/material/matstack = held
 	var/substance = matstack.material.name
-	var/list/edible_materials = list(MAT_STEEL, MAT_SILVER, MAT_GOLD, MAT_URANIUM, MAT_METALHYDROGEN) //Can't eat all materials, just useful ones.
+	var/list/edible_materials = list(MAT_STEEL) //Can't eat all materials, just useful ones. CHOMP EDIT: Only steel
 	var allowed = FALSE
 	for(var/material in edible_materials)
 		if(material == substance) allowed = TRUE


### PR DESCRIPTION
Couple overlooked spots where proteans could eat metals other than steel.
Actually the abilities were disabled but they could eat the metals which was a waste.