### PR TITLE
[Manual MIRROR]Nerfs Item Slowdown

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -97,6 +97,7 @@
 			var/their_slowdown = max(H.calculate_item_encumbrance(), 1)
 			item_tally = max(item_tally, their_slowdown) // If our slowdown is less than theirs, then we become as slow as them (before species modifires).
 
+	item_tally /= 2 //VOREStation Add
 	item_tally *= species.item_slowdown_mod
 
 	. += item_tally


### PR DESCRIPTION
Ports https://github.com/VOREStation/VOREStation/pull/10093
"Time to start tackling the thing that made hasty/hardy meta necessary in the first place.

A kind of lazy fix but I would rather do this than do a 500-file refactor."


:cl:
tweak: Any worn item that slowed you down now slows you down less. Also, any worn item that speeds you up speeds you up less.
/:cl:

Chems and hardsuit modules should remain unaffected.