### PR TITLE
Hides Borers from Health HUDs

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1754,6 +1754,7 @@
 			holder2.icon_state = "huddead"
 		else if(foundVirus)
 			holder.icon_state = "hudill"
+/* Start Chomp edit
 		else if(has_brain_worms())
 			var/mob/living/simple_mob/animal/borer/B = has_brain_worms()
 			if(B.controlling)
@@ -1761,13 +1762,13 @@
 			else
 				holder.icon_state = "hudhealthy"
 			holder2.icon_state = "hudbrainworm"
+End Chomp edit */
 		else
 			holder.icon_state = "hudhealthy"
 			if(virus2.len)
 				holder2.icon_state = "hudill"
 			else
 				holder2.icon_state = "hudhealthy"
-
 		apply_hud(STATUS_HUD, holder)
 		apply_hud(STATUS_HUD_OOC, holder2)
 


### PR DESCRIPTION
Borers, when in control, have a thing where on health HUDs it shows up an icon that says that the person has borers. This normally would be alright if it was just for medical, but it turns out Civ HUDs given by NIFs and normal AR glasses count as health huds too, meaning that you can't simply avoid medical when the borer is in control and going near any person while controlling the person is a risk as they might have a HUD that shows that they're sus. This simply comments out that portion of code so that going near literally anyone isn't a possible risk of blowing your cover. Health scanners throwing up "Aberrant brain activity" and body scanners are entirely unaffected.