### PR TITLE
Adds Liquid Copper/Aluminium to Sheets Reactions

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -731,21 +731,6 @@
 	required_reagents = list("frostoil" = 100, "hydrogen" = REAGENTS_PER_SHEET)
 	sheet_to_give = /obj/item/stack/material/mhydrogen
 
-
-// Chompstation addition
-/datum/chemical_reaction/solidification/aluminium
-	name = "Solid Aluminium"
-	id = "solidaluminium"
-	required_reagents = list("frostoil" = 5, "aluminum" = REAGENTS_PER_SHEET)
-	sheet_to_give = /obj/item/stack/material/aluminium
-
-/datum/chemical_reaction/solidification/copper
-	name = "Solid Copper"
-	id = "solidcopper"
-	required_reagents = list("frostoil" = 5, "copper" = REAGENTS_PER_SHEET)
-	sheet_to_give = /obj/item/stack/material/copper
-// Chompstation addition end
-
 // These are from Xenobio.
 /datum/chemical_reaction/solidification/steel
 	name = "Solid Steel"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -732,6 +732,20 @@
 	sheet_to_give = /obj/item/stack/material/mhydrogen
 
 
+// Chompstation addition
+/datum/chemical_reaction/solidification/aluminium
+	name = "Solid Aluminium"
+	id = "solidaluminium"
+	required_reagents = list("frostoil" = 5, "aluminum" = REAGENTS_PER_SHEET)
+	sheet_to_give = /obj/item/stack/material/aluminium
+
+/datum/chemical_reaction/solidification/copper
+	name = "Solid Copper"
+	id = "solidcopper"
+	required_reagents = list("frostoil" = 5, "copper" = REAGENTS_PER_SHEET)
+	sheet_to_give = /obj/item/stack/material/copper
+// Chompstation addition end
+
 // These are from Xenobio.
 /datum/chemical_reaction/solidification/steel
 	name = "Solid Steel"

--- a/code/modules/reagents/Chemistry-Recipes_ch.dm
+++ b/code/modules/reagents/Chemistry-Recipes_ch.dm
@@ -300,3 +300,16 @@
 	result = "hachi"
 	required_reagents = list("burbon" = 2, "sake" = 1, "lemonjuice" = 1, "mushroom" = 1)
 	result_amount = 5
+
+// Frost oil reactions for material sheets
+/datum/chemical_reaction/solidification/aluminium
+	name = "Solid Aluminium"
+	id = "solidaluminium"
+	required_reagents = list("frostoil" = 5, "aluminum" = REAGENTS_PER_SHEET)
+	sheet_to_give = /obj/item/stack/material/aluminium
+
+/datum/chemical_reaction/solidification/copper
+	name = "Solid Copper"
+	id = "solidcopper"
+	required_reagents = list("frostoil" = 5, "copper" = REAGENTS_PER_SHEET)
+	sheet_to_give = /obj/item/stack/material/copper


### PR DESCRIPTION
So first off the agony that is the reagent of aluminum being called 'aluminum' and the sheets being called 'aluminium'.

Second, you can now use xenobotany frost oil to make copper and aluminum sheets.