### PR TITLE
Webedit ore spawning fix

### DIFF
--- a/code/_global_vars/lists/mapping.dm
+++ b/code/_global_vars/lists/mapping.dm
@@ -30,20 +30,3 @@ GLOBAL_LIST_INIT(cww_dir, list( // cww_dir[dir] = counter-clockwise rotation of 
 	32, 40, 36, 44, 33, 41, 37, 45, 34, 42, 38, 46, 35, 43, 39, 47, // DOWN - Same as first line but +32
 	48, 56, 52, 60, 49, 57, 53, 61, 50, 58, 54, 62, 51, 59, 55, 63  // UP+DOWN - Same as first line but +48
 ))
-
-GLOBAL_LIST_INIT(ore_types, list(
-	"hematite" = /obj/item/weapon/ore/iron,
-	"uranium" = /obj/item/weapon/ore/uranium,
-	"gold" = /obj/item/weapon/ore/gold,
-	"silver" = /obj/item/weapon/ore/silver,
-	"diamond" = /obj/item/weapon/ore/diamond,
-	"phoron" = /obj/item/weapon/ore/phoron,
-	"osmium" = /obj/item/weapon/ore/osmium,
-	"hydrogen" = /obj/item/weapon/ore/hydrogen,
-	"silicates" = /obj/item/weapon/ore/glass,
-	"carbon" = /obj/item/weapon/ore/coal,
-	"verdantium" = /obj/item/weapon/ore/verdantium,
-	"marble" = /obj/item/weapon/ore/marble,
-	"lead" = /obj/item/weapon/ore/lead,
-	"rutile" = /obj/item/weapon/ore/rutile //VOREStation Add
-))

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -117,7 +117,7 @@
 		var/total_harvest = harvest_speed //Ore harvest-per-tick.
 		var/found_resource = 0 //If this doesn't get set, the area is depleted and the drill errors out.
 
-		for(var/metal in GLOB.ore_types)
+		for(var/metal in ore_types)
 
 			if(contents.len >= capacity)
 				system_error("Insufficient storage space.")
@@ -145,7 +145,7 @@
 					harvesting.resources[metal] = 0
 
 				for(var/i=1, i <= create_ore, i++)
-					var/oretype = GLOB.ore_types[metal]
+					var/oretype = ore_types[metal]
 					new oretype(src)
 
 		if(!found_resource)	// If a drill can't see an advanced material, it will destroy it while going through.

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -250,7 +250,7 @@ turf/simulated/mineral/floor/light_corner
 			for(var/ore in resources)
 				var/amount_to_give = rand(CEILING(resources[ore]/2, 1), resources[ore])  // Should result in at least one piece of ore.
 				for(var/i=1, i <= amount_to_give, i++)
-					var/oretype = GLOB.ore_types[ore]
+					var/oretype = ore_types[ore]
 					new oretype(src)
 				resources[ore] = 0
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -8,13 +8,13 @@ var/list/mining_overlay_cache = list()
 	density = 1
 	opacity = 1 // YW edit. Stops all my unsimulated tiles from being seethrough.
 
+//YW add start
 /turf/unsimulated/mineral/ice
 	name = "Ice wall"
 	desc = "Frigid Ice that seems to be stronger than most manmade structures."
 	icon = 'icons/turf/snow_new.dmi'
 	icon_state = "Icerock"
-
-
+//YW add end
 
 /turf/simulated/mineral //wall piece
 	name = "rock"


### PR DESCRIPTION
So #1863 converted ore lists to a static list. Problem is we already have a global list defined for ore_types which was never updated for new ores and seems to override the new, updated list. This PR deletes the now unneeded list, hopefully fixing the bug.

Webedit PR so untested/etc. 