### PR TITLE
Fixes Teshari Sneeze Sound and Scream

### DIFF
--- a/code/modules/emotes/definitions/audible_scream_ch.dm
+++ b/code/modules/emotes/definitions/audible_scream_ch.dm
@@ -1,0 +1,13 @@
+/decl/emote/audible/scream/get_emote_sound(var/atom/user)
+	var/mob/living/carbon/human/H = user
+	if(H.get_gender() == FEMALE)
+		return list(
+			"sound" = H.species.female_scream_sound,
+			"vol" = emote_volume
+		)
+	else
+		return list(
+			"sound" = H.species.male_scream_sound,
+			"vol" = emote_volume
+		)
+	return ..()

--- a/code/modules/mob/living/carbon/human/species/station/teshari_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari_vr.dm
@@ -13,10 +13,10 @@
 	descriptors = list()
 	wikilink="https://wiki.chompstation13.net/index.php?title=Teshari" //CHOMPedit: link to our wiki
 	agility = 90
-
+/* Begin Chomp edit
 	male_sneeze_sound = list('sound/effects/mob_effects/tesharisneeze.ogg','sound/effects/mob_effects/tesharisneezeb.ogg')
 	female_sneeze_sound = list('sound/effects/mob_effects/tesharisneeze.ogg','sound/effects/mob_effects/tesharisneezeb.ogg')
-
+End Chomp Edit */
 	inherent_verbs = list(
 		/mob/living/carbon/human/proc/sonar_ping,
 		/mob/living/proc/hide,

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2221,6 +2221,7 @@
 #include "code\modules\emotes\definitions\audible.dm"
 #include "code\modules\emotes\definitions\audible_cough.dm"
 #include "code\modules\emotes\definitions\audible_scream.dm"
+#include "code\modules\emotes\definitions\audible_scream_ch.dm"
 #include "code\modules\emotes\definitions\audible_slap.dm"
 #include "code\modules\emotes\definitions\audible_snap.dm"
 #include "code\modules\emotes\definitions\audible_sneeze.dm"


### PR DESCRIPTION
Also as a side effect adds sounds for any species that has a species scream defined. This was 'broken' in the emote refactor.

Commented out the sneeze stuff for teshari in the _vr file because the second sneeze sound file was identical to the first, but had white noise and was also super clipped.

Closes #1917 