### PR TITLE
Tweaks leopardmander pref checks

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander_ch.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander_ch.dm
@@ -42,7 +42,6 @@
 	vore_icons = 4
 	vore_capacity = 4
 	swallowTime = 100
-	vore_ignores_undigestable = TRUE
 	vore_default_mode = DM_HEAL
 	vore_pounce_maxhealth = 125
 	vore_bump_emote = "tries to snap up"
@@ -173,4 +172,4 @@
 /obj/random/mob/leopardmander/item_to_spawn() //Random map spawner
 	return pick(prob(89);/mob/living/simple_mob/vore/leopardmander,
 		prob(10);/mob/living/simple_mob/vore/leopardmander/blue,
-		prob(1);/mob/living/simple_mob/vore/leopardmander/exotic,)
+		prob(1);/mob/living/simple_mob/vore/leopardmander/exotic)


### PR DESCRIPTION
I misread this var and did it backwards lmao.
Leopardmanders are supposed to target regardless of digestion pref. Since, y'know, healbelly.

Webedit PR.