### PR TITLE
Belly overlay fix attempt 2

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -179,7 +179,6 @@
 			"belly_fullscreen" = selected.belly_fullscreen,
 			"belly_fullscreen_color" = selected.belly_fullscreen_color,	//CHOMPEdit
 			"mapRef" = map_name,	//CHOMPEdit
-			"possible_fullscreens" = icon_states('icons/mob/screen_full_vore_ch.dmi'), //CHOMPedit
 			"vorespawn_blacklist" = selected.vorespawn_blacklist
 		) //CHOMP Addition: vorespawn blacklist
 


### PR DESCRIPTION
I can't even reproduce the bug on local anymore but suspecting this part here was what made me try the previous fix in the first place since everything else pre-defined on this list is just singular vars while this part is a proccall for a generated list. Perhaps the old line was still getting to haunt the new sensitive tgui enough to have it randomly override the fixed part but only rngesus knows. Anyway, tested to work fine without the old line here and since I couldn't reproduce the bug anymore, there's a 50% chance it might actually work on live too.