### PR TITLE
Revert "Tweaks Field Medic, Pilot, Paramedic, and CMO access"

### DIFF
--- a/code/game/jobs/job/exploration_vr.dm
+++ b/code/game/jobs/job/exploration_vr.dm
@@ -69,8 +69,8 @@
 	economic_modifier = 5
 	minimal_player_age = 3
 	pto_type = PTO_EXPLORATION
-	access = list(access_pilot)
-	minimal_access = list(access_pilot)
+	access = list(access_pilot, access_external_airlocks, access_eva) //CHOMPedit gave pilot a little more access
+	minimal_access = list(access_pilot, access_external_airlocks, access_eva) //CHOMPedit gave pilot a little more access
 	outfit_type = /decl/hierarchy/outfit/job/pilot
 	job_description = "A Pilot flies the various shuttles in the Vir System." //CHOMPedit: Replaces Virgo reference with Vir.
 	alt_titles = list("Co-Pilot" = /datum/alt_title/co_pilot, "Navigator" = /datum/alt_title/navigator, "Helmsman" = /datum/alt_title/helmsman)

--- a/code/game/jobs/job/exploration_vr.dm
+++ b/code/game/jobs/job/exploration_vr.dm
@@ -69,8 +69,8 @@
 	economic_modifier = 5
 	minimal_player_age = 3
 	pto_type = PTO_EXPLORATION
-	access = list(access_pilot, access_external_airlocks, access_eva) //CHOMPedit gave pilot a little more access
-	minimal_access = list(access_pilot, access_external_airlocks, access_eva) //CHOMPedit gave pilot a little more access
+	access = list(access_pilot)
+	minimal_access = list(access_pilot)
 	outfit_type = /decl/hierarchy/outfit/job/pilot
 	job_description = "A Pilot flies the various shuttles in the Vir System." //CHOMPedit: Replaces Virgo reference with Vir.
 	alt_titles = list("Co-Pilot" = /datum/alt_title/co_pilot, "Navigator" = /datum/alt_title/navigator, "Helmsman" = /datum/alt_title/helmsman)
@@ -124,8 +124,8 @@
 	economic_modifier = 6
 	minimal_player_age = 3
 	pto_type = PTO_EXPLORATION
-	access = list(access_medical, access_medical_equip, access_morgue, access_eva, access_maint_tunnels, access_external_airlocks) //CHOMPedit removed some FM access to restrict powergaming
-	minimal_access = list(access_medical, access_medical_equip, access_morgue) //CHOMPedit removed some FM access to restrict powergaming
+	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_eva, access_maint_tunnels, access_external_airlocks, access_pilot)
+	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_pilot)
 	outfit_type = /decl/hierarchy/outfit/job/medical/sar
 	job_description = "A Field medic works as the field doctor of expedition teams."
 	alt_titles = list("Expedition Medic" = /datum/alt_title/expedition_medic, "Offsite Medic" = /datum/alt_title/offsite_medic)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -17,7 +17,7 @@
 	economic_modifier = 10
 	access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce, access_teleporter,
-			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels, access_pilot) //CHOMPedit gave CMO pilot access for emergencies
+			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce, access_teleporter,
 			access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_external_airlocks, access_maint_tunnels)
@@ -177,7 +177,7 @@
 	supervisors = "the Chief Medical Officer"
 	selection_color = "#013D3B"
 	economic_modifier = 4
-	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_eva, access_maint_tunnels, access_external_airlocks, access_psychiatrist, access_pilot) //CHOMPedit gives paramedic pilot access for emergencies
+	access = list(access_medical, access_medical_equip, access_morgue, access_surgery, access_chemistry, access_virology, access_eva, access_maint_tunnels, access_external_airlocks, access_psychiatrist)
 	minimal_access = list(access_medical, access_medical_equip, access_morgue, access_eva, access_maint_tunnels, access_external_airlocks)
 	outfit_type = /decl/hierarchy/outfit/job/medical/paramedic
 	job_description = "A Paramedic is primarily concerned with the recovery of patients who are unable to make it to the Medical Department on their own. \

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -80,7 +80,8 @@ var/list/medical_positions = list(
 	"Geneticist",
 	"Psychiatrist",
 	"Chemist",
-	"Paramedic"
+	"Paramedic",
+	"Field Medic" //ywedit
 )
 
 
@@ -109,7 +110,8 @@ var/list/civilian_positions = list(
 	"Lawyer",
 	"Chaplain",
 	USELESS_JOB, //VOREStation Edit - Visitor not Assistant
-	"Intern" //VOREStation Edit - Intern
+	"Intern", //VOREStation Edit - Intern
+	"Pilot" //YWedit
 )
 
 
@@ -123,9 +125,9 @@ var/list/security_positions = list(
 
 var/list/planet_positions = list(
 	"Pathfinder", // VOREStation Edit - Added Pathfinder
-	"Explorer",
-	"Pilot", //CHOMPedit fixes YW nonsense
-	"Field Medic" //CHOMPedit fixes YW nonsense
+	"Explorer"
+	//YWmoved to civilian"Pilot",
+	//YWmoved to medical"Field Medic"  // VOREStation Edit - Field Medic
 )
 
 

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -123,7 +123,7 @@ var/list/security_positions = list(
 
 var/list/planet_positions = list(
 	"Pathfinder", // VOREStation Edit - Added Pathfinder
-	"Explorer"
+	"Explorer",
 	"Pilot",
 	"Field Medic" // VOREStation Edit - Field Medic
 )

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -80,8 +80,7 @@ var/list/medical_positions = list(
 	"Geneticist",
 	"Psychiatrist",
 	"Chemist",
-	"Paramedic",
-	"Field Medic" //ywedit
+	"Paramedic"
 )
 
 
@@ -110,8 +109,7 @@ var/list/civilian_positions = list(
 	"Lawyer",
 	"Chaplain",
 	USELESS_JOB, //VOREStation Edit - Visitor not Assistant
-	"Intern", //VOREStation Edit - Intern
-	"Pilot" //YWedit
+	"Intern" //VOREStation Edit - Intern
 )
 
 
@@ -126,8 +124,8 @@ var/list/security_positions = list(
 var/list/planet_positions = list(
 	"Pathfinder", // VOREStation Edit - Added Pathfinder
 	"Explorer"
-	//YWmoved to civilian"Pilot",
-	//YWmoved to medical"Field Medic"  // VOREStation Edit - Field Medic
+	"Pilot",
+	"Field Medic" // VOREStation Edit - Field Medic
 )
 
 


### PR DESCRIPTION
Reverts CHOMPStation2/CHOMPStation2#2321

Needs further assessment as to how widespread the issue is.

Also we don't want the paramedic and CMO access to the shuttles. I'll slightly modify this and leave the pilot access to airlocks. Also leaving FM and Pilot to explo manifest.