### PR TITLE
Give carp event a 50% chance to even occur

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -6,6 +6,9 @@
 	var/list/spawned_carp = list()
 
 /datum/event/carp_migration/setup()
+	if(prob(50)
+		kill()
+		return
 	announceWhen = rand(30, 60) // 1 to 2 minutes
 	endWhen += severity * 25
 	carp_cap = 2 + 3 ** severity // No more than this many at once regardless of waves. (5, 11, 29)

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -6,7 +6,7 @@
 	var/list/spawned_carp = list()
 
 /datum/event/carp_migration/setup()
-	if(prob(50)
+	if(prob(50))
 		kill()
 		return
 	announceWhen = rand(30, 60) // 1 to 2 minutes


### PR DESCRIPTION
If the carp event procs, there is a 50% chance for it to not occur, giving a free moment of peace for that event timeslot.

There are a lot of security events already including the minor carp invasion, major carp invasion, drones, blob, spiders, and metroids. That is a lot to handle. So this is part of a slight effort to tone that down.