### PR TITLE
Fix debug spam?

### DIFF
--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -200,7 +200,10 @@ GLOBAL_LIST_INIT(digest_modes, list())
 			if(isliving(C))
 				var/mob/living/M = C
 				B.ownegg.w_class = M.size_multiplier * 4 //Egg size and weight scaled to match occupant.
-				var/obj/item/weapon/holder/H = new M.holder_type(B.ownegg, M)
+				var/obj/item/weapon/holder/H = new M.holder_type(B.ownegg)
+				H.held_mob = M
+				M.forceMove(H)
+				H.sync(M)
 				B.ownegg.max_storage_space = H.w_class
 				B.ownegg.icon_scale_x = 0.25 * B.ownegg.w_class
 				B.ownegg.icon_scale_y = 0.25 * B.ownegg.w_class


### PR DESCRIPTION
We are getting spammed with "DEBUG: Digest mode Hold didn't exist in the digest_modes list!!"

This debug message comes from an old egg PR #1221

I am spitballing because I cannot replicate the problem on a test server.

Undoing a change in #2381