### PR TITLE
Adds bellyrub mechanics

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -431,7 +431,7 @@
 		H.visible_message( \
 			"<span class='notice'>[H] boops [target]'s nose.</span>", \
 			"<span class='notice'>You boop [target] on the nose.</span>", )
-	else if(H.zone_sel.selecting == "groin") //CHOMPEdit
+	else if(H.zone_sel.selecting == BP_GROIN) //CHOMPEdit
 		H.vore_bellyrub(target)
 	//VOREStation Edit End
 	else

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -110,7 +110,7 @@
 	var/alcohol_mod =		1						// Multiplier to alcohol strength; 0.5 = half, 0 = no effect at all, 2 = double, etc.
 	var/pain_mod =			1						// Multiplier to pain effects; 0.5 = half, 0 = no effect (equal to NO_PAIN, really), 2 = double, etc.
 	var/spice_mod =			1						// Multiplier to spice/capsaicin/frostoil effects; 0.5 = half, 0 = no effect (immunity), 2 = double, etc.
-	var/trauma_mod = 		1						// Affects traumatic shock (how fast pain crit happens). 0 = no effect (immunity to pain crit), 2 = double etc.Overriden by "can_feel_pain" var	
+	var/trauma_mod = 		1						// Affects traumatic shock (how fast pain crit happens). 0 = no effect (immunity to pain crit), 2 = double etc.Overriden by "can_feel_pain" var
 	// set below is EMP interactivity for nonsynth carbons
 	var/emp_sensitivity =		0			// bitflag. valid flags are: EMP_PAIN, EMP_BLIND, EMP_DEAFEN, EMP_CONFUSE, EMP_STUN, and EMP_(BRUTE/BURN/TOX/OXY)_DMG
 	var/emp_dmg_mod =		1			// Multiplier to all EMP damage sustained by the mob, if it's EMP-sensitive
@@ -431,6 +431,8 @@
 		H.visible_message( \
 			"<span class='notice'>[H] boops [target]'s nose.</span>", \
 			"<span class='notice'>You boop [target] on the nose.</span>", )
+	else if(H.zone_sel.selecting == "groin") //CHOMPEdit
+		H.vore_bellyrub(target)
 	//VOREStation Edit End
 	else
 		H.visible_message("<span class='notice'>[H] hugs [target] to make [t_him] feel better!</span>", \

--- a/code/modules/mob/living/simple_mob/defense.dm
+++ b/code/modules/mob/living/simple_mob/defense.dm
@@ -16,6 +16,9 @@
 	switch(L.a_intent)
 		if(I_HELP)
 			if(health > 0)
+				if(L.zone_sel.selecting == "groin") //CHOMPEdit
+					if(L.vore_bellyrub(src))
+						return
 				L.visible_message("<span class='notice'>\The [L] [response_help] \the [src].</span>")
 
 		if(I_DISARM)

--- a/code/modules/mob/living/simple_mob/defense.dm
+++ b/code/modules/mob/living/simple_mob/defense.dm
@@ -16,7 +16,7 @@
 	switch(L.a_intent)
 		if(I_HELP)
 			if(health > 0)
-				if(L.zone_sel.selecting == "groin") //CHOMPEdit
+				if(L.zone_sel.selecting == BP_GROIN) //CHOMPEdit
 					if(L.vore_bellyrub(src))
 						return
 				L.visible_message("<span class='notice'>\The [L] [response_help] \the [src].</span>")

--- a/code/modules/mob/living/simple_mob/on_click.dm
+++ b/code/modules/mob/living/simple_mob/on_click.dm
@@ -14,7 +14,7 @@
 	switch(a_intent)
 		if(I_HELP)
 			if(isliving(A))
-				if(src.zone_sel.selecting == "groin") //CHOMPEdit
+				if(src.zone_sel.selecting == BP_GROIN) //CHOMPEdit
 					if(src.vore_bellyrub(A))
 						return
 				custom_emote(1,"[pick(friendly)] \the [A]!")

--- a/code/modules/mob/living/simple_mob/on_click.dm
+++ b/code/modules/mob/living/simple_mob/on_click.dm
@@ -14,6 +14,9 @@
 	switch(a_intent)
 		if(I_HELP)
 			if(isliving(A))
+				if(src.zone_sel.selecting == "groin") //CHOMPEdit
+					if(src.vore_bellyrub(A))
+						return
 				custom_emote(1,"[pick(friendly)] \the [A]!")
 
 		if(I_HURT)

--- a/code/modules/mob/living/simple_mob/subtypes/vore/otie.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/otie.dm
@@ -274,7 +274,7 @@
 	switch(M.a_intent)
 		if(I_HELP)
 			if(health > 0)
-				if(M.zone_sel.selecting == "groin") //CHOMPEdit
+				if(M.zone_sel.selecting == BP_GROIN) //CHOMPEdit
 					if(M.vore_bellyrub(src))
 						return
 				M.visible_message("<span class='notice'>[M] [response_help] \the [src].</span>")

--- a/code/modules/mob/living/simple_mob/subtypes/vore/otie.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/otie.dm
@@ -274,11 +274,15 @@
 	switch(M.a_intent)
 		if(I_HELP)
 			if(health > 0)
+				if(M.zone_sel.selecting == "groin") //CHOMPEdit
+					if(M.vore_bellyrub(src))
+						return
 				M.visible_message("<span class='notice'>[M] [response_help] \the [src].</span>")
 				if(has_AI())
 					var/datum/ai_holder/AI = ai_holder
 					AI.set_stance(STANCE_IDLE)
 					if(prob(tame_chance))
+						AI.violent_breakthrough = FALSE
 						AI.hostile = FALSE
 						friend = M
 						AI.set_follow(friend)

--- a/code/modules/vore/eating/living_ch.dm
+++ b/code/modules/vore/eating/living_ch.dm
@@ -219,3 +219,21 @@ mob/living/proc/check_vorefootstep(var/m_intent, var/turf/T)
 				soundfile = fancy_release_sounds[RTB.release_sound]
 			if(soundfile)
 				playsound(src, soundfile, vol = 100, vary = 1, falloff = VORE_SOUND_FALLOFF, preference = /datum/client_preference/eating_noises)
+
+/mob/living/proc/vore_bellyrub(var/mob/living/T)
+	set name = "Give Bellyrubs"
+	set category = "Abilities"
+	set desc = "Provide bellyrubs to either yourself or another mob with a belly."
+
+	if(!T)
+		T = input("Choose whose belly to rub") as null| mob in view(src.loc,1)
+		if(!T)
+			return FALSE
+	if(T.vore_selected)
+		var/obj/belly/B = T.vore_selected
+		if(istype(B))
+			custom_emote_vr(1, "gives some rubs over [T]'s [B].")
+			B.quick_cycle()
+			return TRUE
+	to_chat(src, "<span class='warning'>There is no suitable belly for rubs.</span>")
+	return FALSE

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -52,6 +52,7 @@
 	M.verbs += /mob/living/proc/insidePanel
 	M.verbs += /mob/living/proc/vore_transfer_reagents //CHOMP If mob doesnt have bellies it cant use this verb for anything
 	M.verbs += /mob/living/proc/vore_check_reagents //CHOMP If mob doesnt have bellies it cant use this verb for anything
+	M.verbs += /mob/living/proc/vore_bellyrub //CHOMP If mob doesnt have bellies it probably won't be needing this anyway
 
 	//Tries to load prefs if a client is present otherwise gives freebie stomach
 	spawn(2 SECONDS)
@@ -544,7 +545,7 @@
 
 	// Their AI should get notified so they can stab us
 	prey.ai_holder?.react_to_attack(user)
-	
+
 	//Timer and progress bar
 	if(!do_after(user, swallow_time, prey, exclusive = TASK_USER_EXCLUSIVE))
 		return FALSE // Prey escpaed (or user disabled) before timer expired.


### PR DESCRIPTION
Adds a bellyrub verb to manually trigger a belly processing cycle for the target's selected vorgan to help it process its contents faster using a lighter version of the regular belly cycle to avoid straining the subsystem. The bellyrubs can be accessed via an ability tab verb, and can also be easily applied by targeting groin for a hug alternative. This also works on simplemobs and simplemobs can also target groin on help intent to provide rubs.
Also fixes tamed oties smashing through shit that gets in their way.