### PR TITLE
Revert "Revert "Add quick authentic nif""

### DIFF
--- a/code/modules/admin/admin_verb_lists.dm
+++ b/code/modules/admin/admin_verb_lists.dm
@@ -106,6 +106,7 @@ var/list/admin_verbs_admin = list(
 	/datum/admins/proc/paralyze_mob,
 	/client/proc/fixatmos,
 	/datum/admins/proc/quick_nif, //VOREStation Add,
+	/datum/admins/proc/quick_authentic_nif, //CHOMPStation add
 	/datum/admins/proc/sendFax,
 	/client/proc/despawn_player,
 	/datum/admins/proc/view_feedback,
@@ -368,6 +369,7 @@ var/list/admin_verbs_mod = list(
 	/datum/admins/proc/view_persistent_data,
 	/datum/admins/proc/view_txt_log,	//shows the server log (diary) for today,
 	/datum/admins/proc/quick_nif, //CHOMPEdit
+	/datum/admins/proc/quick_authentic_nif, //CHOMPEdit
 	/client/proc/admin_teleport,		//CHOMPEdit
 	/datum/admins/proc/view_atk_log		//shows the server combat-log, doesn't do anything presently,
 )

--- a/code/modules/admin/verbs/debug_ch.dm
+++ b/code/modules/admin/verbs/debug_ch.dm
@@ -1,0 +1,32 @@
+/datum/admins/proc/quick_authentic_nif()
+	set category = "Fun"
+	set name = "Quick Auth NIF"
+	set desc = "Spawns an authentic NIF into someone in quick-implant mode."
+
+	if(!check_rights(R_ADMIN|R_EVENT|R_DEBUG))	//CHOMPStation Edit TFF 24/4/19: Allow Devs to use Quick-NIF verb.
+		return
+
+	var/mob/living/carbon/human/H = input("Pick a mob with a player","Quick Authentic NIF") as null|anything in player_list
+
+	if(!H)
+		return
+
+	if(!istype(H))
+		to_chat(usr,"<span class='warning'>That mob type ([H.type]) doesn't support NIFs, sorry.</span>")
+		return
+
+	if(!H.get_organ(BP_HEAD))
+		to_chat(usr,"<span class='warning'>Target is unsuitable.</span>")
+		return
+
+	if(H.nif)
+		to_chat(usr,"<span class='warning'>Target already has a NIF.</span>")
+		return
+
+	if(H.species.flags & NO_SCAN)
+		new /obj/item/device/nif/authenticbio(H)
+	else
+		new /obj/item/device/nif/authentic(H)
+
+	log_and_message_admins("[key_name(src)] Quick Authentic NIF'd [H.real_name].")
+	feedback_add_details("admin_verb","QANIF") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1796,6 +1796,7 @@
 #include "code\modules\admin\verbs\custom_event.dm"
 #include "code\modules\admin\verbs\deadsay.dm"
 #include "code\modules\admin\verbs\debug.dm"
+#include "code\modules\admin\verbs\debug_ch.dm"
 #include "code\modules\admin\verbs\debug_vr.dm"
 #include "code\modules\admin\verbs\diagnostics.dm"
 #include "code\modules\admin\verbs\dice.dm"


### PR DESCRIPTION
Reverts CHOMPStation2/CHOMPStation2#1395

The normal quicknif command doesn't cover prometheans properly, and doesn't allow us to give them authentic bioadaptive NIFs, this one does.  I also lack the knowledge to adjust the other one properly.