### PR TITLE
Fixes vorgan duping on relog

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -36,6 +36,7 @@
 	var/show_vore_fx = TRUE				// Show belly fullscreens
 	var/latejoin_vore = FALSE			//CHOMPedit: If enabled, latejoiners can spawn into this, assuming they have a client
 	var/noisy_full = FALSE				//CHOMPEdit: Enables belching when a mob has overeaten
+	var/bellies_loaded = FALSE			//CHOMPedit: On-demand belly loading
 
 //
 // Hook for generic creation of stuff on new creatures

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -19,7 +19,7 @@
 		log_debug("[src] ([type], \ref[src]) didn't have a vorePanel and tried to use the verb.")
 		vorePanel = new(src)
 
-	if(!vorePanel.bellies_loaded) //CHOMPedit Start: On-demand belly loading
+	if(!bellies_loaded) //CHOMPedit Start: On-demand belly loading
 		var/datum/vore_preferences/P = client.prefs_vr
 		var/firstbelly = FALSE // First belly loaded on init_vore
 		for(var/entry in P.belly_prefs)
@@ -27,7 +27,7 @@
 				firstbelly = TRUE
 				continue
 			list_to_object(entry,src)
-		vorePanel.bellies_loaded = TRUE //CHOMPedit End
+		bellies_loaded = TRUE //CHOMPedit End
 
 	vorePanel.tgui_interact(src)
 
@@ -42,7 +42,6 @@
 	var/mob/living/host // Note, we do this in case we ever want to allow people to view others vore panels
 	var/unsaved_changes = FALSE
 	var/show_pictures = TRUE
-	var/bellies_loaded = FALSE //CHOMPedit: On-demand belly loading
 
 /datum/vore_look/New(mob/living/new_host)
 	if(istype(new_host))


### PR DESCRIPTION
A recent thing made vorepanel delete on logout and spawn a new one on login, which erased the var that was supposed to tell the panel the vorgans had been already loaded. Moved that var from the panel to the mob.