### PR TITLE
Adds a new experimental item digestion mode

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -46,6 +46,7 @@
 	var/emote_time = 60						// How long between stomach emotes at prey (in seconds)
 	var/emote_active = TRUE					// Are we even giving emotes out at all or not?
 	var/next_emote = 0						// When we're supposed to print our next emote, as a world.time
+	var/item_mode_serial = TRUE				// Serial/parallel item digestion mode. Affect one item at a time or all of them with damage divided between contents. CHOMPEdit
 
 	//I don't think we've ever altered these lists. making them static until someone actually overrides them somewhere.
 	//Actual full digest modes
@@ -651,15 +652,16 @@
 //Digest a single item
 //Receives a return value from digest_act that's how much nutrition
 //the item should be worth
-/obj/belly/proc/digest_item(obj/item/item)
-	var/digested = item.digest_act(src, owner)
-	if(!digested)
+/obj/belly/proc/digest_item(obj/item/item, /var/touchable_amount) //CHOMPEdit
+	var/digested = item.digest_act(src, touchable_amount) //CHOMPEdit
+	if(!digested > 0) //CHOMPEdit
 		items_preserved |= item
 	else
 		owner.adjust_nutrition((nutrition_percent / 100) * 5 * digested)
 		if(isrobot(owner))
 			var/mob/living/silicon/robot/R = owner
 			R.cell.charge += ((nutrition_percent / 100) * 50 * digested)
+		digested = TRUE //CHOMPEdit
 	return digested
 
 //Determine where items should fall out of us into.

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -654,7 +654,7 @@
 //the item should be worth
 /obj/belly/proc/digest_item(obj/item/item, /var/touchable_amount) //CHOMPEdit
 	var/digested = item.digest_act(src, touchable_amount) //CHOMPEdit
-	if(!digested > 0) //CHOMPEdit
+	if(digested == FALSE) //CHOMPEdit
 		items_preserved |= item
 	else
 		owner.adjust_nutrition((nutrition_percent / 100) * 5 * digested)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -135,10 +135,14 @@
 
 	for(var/A in touchable_atoms)
 		//Handle stray items
-		if(isitem(A) && !did_an_item)
-			did_an_item = handle_digesting_item(A)
+		if(isitem(A)) //CHOMPEdit start
+			if(!item_mode_serial)
+				var/touchable_amount = touchable_atoms.len
+				did_an_item = handle_digesting_item(A, touchable_amount)
+			else if(!did_an_item)
+				did_an_item = handle_digesting_item(A, 1)
 			if(did_an_item)
-				to_update = TRUE
+				to_update = TRUE //CHOMPEdit end
 
 			//Less often than with normal digestion
 			if((item_digest_mode == IM_DIGEST_FOOD || item_digest_mode == IM_DIGEST) && prob(25))
@@ -213,7 +217,7 @@
 			M.playsound_local(get_turf(src), preyloop, 80, 0, channel = CHANNEL_PREYLOOP)
 			M.next_preyloop = (world.time + (52 SECONDS))
 
-/obj/belly/proc/handle_digesting_item(obj/item/I)
+/obj/belly/proc/handle_digesting_item(obj/item/I, var/touchable_amount = 1) //CHOMPEdit
 	var/did_an_item = FALSE
 	// We always contaminate IDs.
 	if(contaminates || istype(I, /obj/item/weapon/card/id))
@@ -224,11 +228,11 @@
 			items_preserved |= I
 		if(IM_DIGEST_FOOD)
 			if(istype(I,/obj/item/weapon/reagent_containers/food) || istype(I, /obj/item/organ))
-				did_an_item = digest_item(I)
+				did_an_item = digest_item(I, touchable_amount) //CHOMPEdit
 			else
 				items_preserved |= I
 		if(IM_DIGEST)
-			did_an_item = digest_item(I)
+			did_an_item = digest_item(I, touchable_amount) //CHOMPEdit
 	return did_an_item
 
 /obj/belly/proc/handle_digestion_death(mob/living/M)

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -3,7 +3,7 @@
 //return non-negative integer: Amount of nutrition/charge gained (scaled to nutrition, other end can multiply for charge scale).
 
 // Ye default implementation.
-/obj/item/proc/digest_act(atom/movable/item_storage = null)
+/obj/item/proc/digest_act(atom/movable/item_storage = null, var/touchable_amount = 1) //CHOMPEdit
 	if(istype(item_storage, /obj/item/device/dogborg/sleeper))
 		if(istype(src, /obj/item/device/pda))
 			var/obj/item/device/pda/P = src
@@ -26,7 +26,7 @@
 
 	if(isbelly(item_storage))
 		var/obj/belly/B = item_storage
-		g_damage = 0.25 * (B.digest_brute + B.digest_burn)
+		g_damage = 0.25 * (B.digest_brute + B.digest_burn) / touchable_amount //CHOMPEdit
 
 	if(digest_stage > 0)
 		if(g_damage > digest_stage)

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -27,6 +27,8 @@
 	if(isbelly(item_storage))
 		var/obj/belly/B = item_storage
 		g_damage = 0.25 * (B.digest_brute + B.digest_burn) / touchable_amount //CHOMPEdit
+	if(g_damage <= 0) //CHOMPEdit
+		return FALSE //CHOMPEdit
 
 	if(digest_stage > 0)
 		if(g_damage > digest_stage)


### PR DESCRIPTION
Adds a new experimental item digestion mode that divides the digestion damage between all items within the gut instead of going through one item at a time. Disabled by default.
Experimental because I don't know how badly it affects performance and because I'm feeling too lazy to make a vorepanel button for it rn, so it's a varedit toggle for now.