### PR TITLE
Use admin_verb_lists_vr instead

### DIFF
--- a/code/modules/admin/admin_verb_lists_vr.dm
+++ b/code/modules/admin/admin_verb_lists_vr.dm
@@ -118,6 +118,7 @@ var/list/admin_verbs_admin = list(
 	/datum/admins/proc/paralyze_mob,
 	/client/proc/fixatmos,
 	/datum/admins/proc/quick_nif, //VOREStation Add,
+	/datum/admins/proc/quick_authentic_nif, //CHOMPStation add
 	/datum/admins/proc/set_uplink, //VOREStation Add,
 	/datum/admins/proc/sendFax,
 	/client/proc/despawn_player,

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -1722,7 +1722,7 @@
 #include "code\modules\admin\admin_ranks.dm"
 #include "code\modules\admin\admin_secrets.dm"
 #include "code\modules\admin\admin_tools.dm"
-#include "code\modules\admin\admin_verb_lists.dm"
+#include "code\modules\admin\admin_verb_lists_vr.dm"
 #include "code\modules\admin\admin_verbs.dm"
 #include "code\modules\admin\admin_vr.dm"
 #include "code\modules\admin\banjob.dm"


### PR DESCRIPTION
-Switches us from using admin_verb_lists to admin_verb_lists_vr.
-Ports quick auth nif to admin_verb_lists_vr