### PR TITLE
Some fixes for the experimental item gurgs

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -652,7 +652,7 @@
 //Digest a single item
 //Receives a return value from digest_act that's how much nutrition
 //the item should be worth
-/obj/belly/proc/digest_item(obj/item/item, /var/touchable_amount) //CHOMPEdit
+/obj/belly/proc/digest_item(obj/item/item, touchable_amount) //CHOMPEdit
 	var/digested = item.digest_act(src, touchable_amount) //CHOMPEdit
 	if(digested == FALSE) //CHOMPEdit
 		items_preserved |= item

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -132,17 +132,17 @@
 	var/to_update = FALSE
 	var/digestion_noise_chance = 0
 	var/list/touchable_mobs = list()
+	var/touchable_amount = touchable_atoms.len  //CHOMPEdit start
 
 	for(var/A in touchable_atoms)
 		//Handle stray items
-		if(isitem(A)) //CHOMPEdit start
+		if(isitem(A))
 			if(!item_mode_serial)
-				var/touchable_amount = touchable_atoms.len
 				did_an_item = handle_digesting_item(A, touchable_amount)
 			else if(!did_an_item)
 				did_an_item = handle_digesting_item(A, 1)
 			if(did_an_item)
-				to_update = TRUE //CHOMPEdit end
+				to_update = TRUE
 
 			//Less often than with normal digestion
 			if((item_digest_mode == IM_DIGEST_FOOD || item_digest_mode == IM_DIGEST) && prob(25))
@@ -150,6 +150,7 @@
 				// but we also want the prob(25) chance to run for -every- item we look at, not just once
 				// More gurgles the better~
 				digestion_noise_chance = 25
+			continue  //CHOMPEdit end
 
 		//Handle eaten mobs
 		else if(isliving(A))
@@ -217,7 +218,7 @@
 			M.playsound_local(get_turf(src), preyloop, 80, 0, channel = CHANNEL_PREYLOOP)
 			M.next_preyloop = (world.time + (52 SECONDS))
 
-/obj/belly/proc/handle_digesting_item(obj/item/I, var/touchable_amount = 1) //CHOMPEdit
+/obj/belly/proc/handle_digesting_item(obj/item/I, touchable_amount) //CHOMPEdit
 	var/did_an_item = FALSE
 	// We always contaminate IDs.
 	if(contaminates || istype(I, /obj/item/weapon/card/id))

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -3,7 +3,7 @@
 //return non-negative integer: Amount of nutrition/charge gained (scaled to nutrition, other end can multiply for charge scale).
 
 // Ye default implementation.
-/obj/item/proc/digest_act(atom/movable/item_storage = null, var/touchable_amount = 1) //CHOMPEdit
+/obj/item/proc/digest_act(atom/movable/item_storage = null, touchable_amount) //CHOMPEdit
 	if(istype(item_storage, /obj/item/device/dogborg/sleeper))
 		if(istype(src, /obj/item/device/pda))
 			var/obj/item/device/pda/P = src
@@ -26,9 +26,11 @@
 
 	if(isbelly(item_storage))
 		var/obj/belly/B = item_storage
-		g_damage = 0.25 * (B.digest_brute + B.digest_burn) / touchable_amount //CHOMPEdit
-	if(g_damage <= 0) //CHOMPEdit
-		return FALSE //CHOMPEdit
+		if(!touchable_amount) //CHOMPEdit Start
+			touchable_amount = 1
+		g_damage = 0.25 * (B.digest_brute + B.digest_burn) / touchable_amount
+	if(g_damage <= 0)
+		return FALSE //CHOMPEdit End
 
 	if(digest_stage > 0)
 		if(g_damage > digest_stage)


### PR DESCRIPTION
- Tested to have fairly little effect on performance even with a large amount of contents (tested up to 150)
- Fixed a bunch of jank revealed in a live test.
- Also maybe optimizes the belly code by making the "for" part for items to skip the rest of the non-item checks.