### PR TITLE
Gives Medihound borg module surgery Tools

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station_ch.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_ch.dm
@@ -6,3 +6,17 @@
 /obj/item/weapon/robot_module/robot/engineering/New()
 	..()
 	src.modules += new /obj/item/weapon/pipe_dispenser(src)
+
+
+/obj/item/weapon/robot_module/robot/medihound/New()
+	..()
+	src.modules += new /obj/item/weapon/autopsy_scanner(src)
+	src.modules += new /obj/item/weapon/surgical/scalpel/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/hemostat/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/retractor/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/cautery/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bonegel/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/FixOVein/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bonesetter/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/circular_saw/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/surgicaldrill/cyborg(src)


### PR DESCRIPTION
This PR gives Medihound borgs the following surgery tools

- Scalpel
- Hemostat
- Retractor
- Hemostat
- Cautery
- FixOvien
- Bone setter
- Circular Saw
- Bone Gel
- Surgical Drill

The medihound module often has nothing to do, and since the medical system here has a decently high chance of broken bones and they can't perform surgery often times this module feels useless. Since I would like to play medihound more I made this PR hoping it would help me feel less like a third wheel. 

There are still some operations they can't do, I left out the organ gripper so transplants are not possible, neither are NIF installs.
