### PR TITLE
Fix loading admin ranks if NOT using legacy system

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -68,9 +68,9 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 		C.remove_admin_verbs()
 		C.holder = null
 	GLOB.admins.Cut()
-
+	load_admin_ranks() //CHOMP Edit: moved this from "f(config.admin_legacy_system)" and put it here instead, literally just moved it 3 lines.
+	
 	if(config.admin_legacy_system)
-		load_admin_ranks()
 		//Clear profile access
 		for(var/A in world.GetConfig("admin"))
 			world.SetConfig("APP/admin", A, null)


### PR DESCRIPTION
Error found by Cadyn. We're using a database to keep track of admins, so we are using the database system, but the database system does not load from the admin_ranks file, so no admin ranks are being loaded at all.

Decided to move it out of the legacy system if statement and just force it to load before deciding if its legacy or database.