### PR TITLE
Fixes a couple vorgan duping causes

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -281,11 +281,13 @@
 
 	if(bellies)
 		release_vore_contents(silent = TRUE)
-		vore_organs.Cut()
+		QDEL_LIST(vore_organs)
+		bellies_loaded = FALSE //CHOMPedit
 		for(var/entry in P.belly_prefs)
 			list_to_object(entry,src)
 			if(!full_vorgans) //CHOMPedit: full_vorgans var to bypass 1-belly load optimization.
 				break //CHOMPedit: Belly load optimization. Only load first belly, save the rest for vorepanel.
+			bellies_loaded = TRUE //CHOMPedit
 
 	return TRUE
 

--- a/code/modules/vore/eating/simple_animal_vr.dm
+++ b/code/modules/vore/eating/simple_animal_vr.dm
@@ -34,7 +34,7 @@
 
 //CHOMPedit: On-demand belly loading.
 /mob/living/simple_mob/perform_the_nom(mob/living/user, mob/living/prey, mob/living/pred, obj/belly/belly, delay)
-	if(vore_active && !voremob_loaded)
+	if(vore_active && !voremob_loaded && pred == src) //Only init your own bellies.
 		voremob_loaded = TRUE
 		init_vore()
 		belly = vore_selected


### PR DESCRIPTION
Adds a sanity check to simplemob perform_the_nom to ensure they only init their vore as the pred. (Feeding self to another pred calls the proc on the user with the target as pred)
Fixes another vorgan duping bug and optimizes the reload by getting rid of the old vorgans instead of keeping them in mob contents. (vorepanel reload loads the prefs with full_vorgans enabled, but wasn't marking the mob as loaded, so a fresh vorepanel from a relog thought the vorgans weren't loaded and loaded them again.)