### PR TITLE
Fix Dupe Research Design

### DIFF
--- a/code/modules/research/designs/mining_toys.dm
+++ b/code/modules/research/designs/mining_toys.dm
@@ -49,13 +49,3 @@
 	build_path = /obj/item/device/depth_scanner
 	sort_string = "FBAAA"
 
-// CHOMPstation addition
-/datum/design/item/weapon/mining/satchel_holding
-	name = "Satchel of Holding"
-	desc = "An ore satchel that opens into a localized pocket of bluespace."
-	id = "satchel_bspace"
-	req_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 6)
-	materials = list("gold" = 2500, "diamond" = 1000, "uranium" = 250)
-	build_path = /obj/item/weapon/storage/bag/ore/holding
-	sort_string = "FBAAC"
-// CHOMPstation addition end


### PR DESCRIPTION
Ore Bag of Holding was fixed upstream, as it was a duplicate define, so this fixes the compile error of dupe research design and uses the upstream ore bag of holding.

Small bonus, the upstream is 1500 gold cheaper, 500 diamond cheaper, and only costs 2 BLUESPACE and 2 TECH materials. <3
