### PR TITLE
Removes redundant timer from autotransfer

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -260,11 +260,6 @@
 		//Stop AI processing in bellies
 		if(M.ai_holder)
 			M.ai_holder.go_sleep()
-	//CHOMPStation edit start
-	if(!owner.client || autotransfer_enabled)	//Intended for simple mobs
-		if(autotransferlocation != null && autotransferchance > 0)
-			addtimer(CALLBACK(src, /obj/belly/.proc/check_autotransfer, thing, autotransferlocation), autotransferwait)
-	//CHOMPStation edit end
 
 	// Intended for simple mobs
 	if((!owner.client || autotransfer_enabled) && autotransferlocation && autotransferchance > 0)


### PR DESCRIPTION
Duplicated by upstream port.