### PR TITLE
A couple more vore tweaks.

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -895,6 +895,7 @@
 	dispvoreprefs += "<b>Spontaneous transformation:</b> [allow_spontaneous_tf ? "Enabled" : "Disabled"]<br>"
 	dispvoreprefs += "<b>Can be stepped on/over:</b> [step_mechanics_pref ? "Allowed" : "Disallowed"]<br>"
 	dispvoreprefs += "<b>Can be picked up:</b> [pickup_pref ? "Allowed" : "Disallowed"]<br>"
+	dispvoreprefs += "<b>Current active belly:</b> [vore_selected ? vore_selected.name : "None"]<br>"
 	user << browse("<html><head><title>Vore prefs: [src]</title></head><body><center>[dispvoreprefs]</center></body></html>", "window=[name]mvp;size=300x400;can_resize=1;can_minimize=0")
 	onclose(user, "[name]")
 	return

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -42,6 +42,7 @@
 	var/mob/living/host // Note, we do this in case we ever want to allow people to view others vore panels
 	var/unsaved_changes = FALSE
 	var/show_pictures = TRUE
+	var/max_icon_content = 21 //CHOMPedit: Contents above this disable icon mode. 21 for nice 3 rows to fill the default panel window.
 
 /datum/vore_look/New(mob/living/new_host)
 	if(istype(new_host))
@@ -83,7 +84,11 @@
 		key = "[target.type]"
 	else if(ismob(target))
 		var/mob/M = target
-		key = "\ref[target][M.real_name]"
+		if(istype(M,/mob/living/simple_mob)) //CHOMPedit: not generating unique icons for every simplemob(number)
+			var/mob/living/simple_mob/S = M
+			key = "[S.icon_living]"
+		else
+			key = "\ref[target][M.real_name]"
 	if(nom_icons[key])
 		. = nom_icons[key]
 	else
@@ -127,8 +132,11 @@
 				"ref" = "\ref[O]",
 				"outside" = FALSE,
 			)
-			if(show_pictures)
-				info["icon"] = cached_nom_icon(O)
+			if(show_pictures) //CHOMPedit: disables icon mode
+				if(inside_belly.contents.len <= max_icon_content)
+					info["icon"] = cached_nom_icon(O)
+				else
+					show_pictures = !show_pictures
 			if(isliving(O))
 				var/mob/living/M = O
 				info["stat"] = M.stat
@@ -224,8 +232,11 @@
 				"ref" = "\ref[O]",
 				"outside" = TRUE,
 			)
-			if(show_pictures)
-				info["icon"] = cached_nom_icon(O)
+			if(show_pictures) //CHOMPedit: disables icon mode
+				if(selected.contents.len <= max_icon_content)
+					info["icon"] = cached_nom_icon(O)
+				else
+					show_pictures = !show_pictures
 			if(isliving(O))
 				var/mob/living/M = O
 				info["stat"] = M.stat


### PR DESCRIPTION
-Makes the mechanical pref popup show the target's selected vorgan.
-Makes the vorepanel content tab automatically switch off icon mode after reaching a certain amount of items inside the vorgan, whether the one belonging to the person or the one they're inside. Current limit 21, which is just enough to fill up the vorepanel window in its default size.
-Makes the icon stuff not cache unique icons for every simplemob to avoid ending up filling the cache with hundreds of identical images of mice and such during the round.