### PR TITLE
Changes all pistols to move_delay = 0 via CHOMPEdits

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -125,6 +125,7 @@
 	origin_tech = list(TECH_COMBAT = 8, TECH_MAGNET = 7)
 	modifystate = "alienpistol"
 	battery_lock = 1 //CHOMPedit adds battery lock.
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 
 /obj/item/weapon/gun/energy/captain

--- a/code/modules/projectiles/guns/energy/laser_yw.dm
+++ b/code/modules/projectiles/guns/energy/laser_yw.dm
@@ -34,4 +34,5 @@
 	charge_meter = 1
 	recoil = 1
 	fire_delay = 27 //old technology
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 ///END OF GAUSS WEAPONRY///

--- a/code/modules/projectiles/guns/energy/phase.dm
+++ b/code/modules/projectiles/guns/energy/phase.dm
@@ -39,6 +39,7 @@
 	charge_cost = 300
 	projectile_type = /obj/item/projectile/energy/phase/light
 	one_handed_penalty = 0
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/energy/locked/phasegun/pistol/unlocked
 	desc = "The RayZar EW15 Apollo is an energy handgun, specifically designed for self-defense against aggressive wildlife."

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -27,6 +27,7 @@
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
 	charge_cost = 480
 	projectile_type = /obj/item/projectile/ion/pistol
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/energy/decloner
 	name = "biological demolecularisor"

--- a/code/modules/projectiles/guns/energy/special_vr.dm
+++ b/code/modules/projectiles/guns/energy/special_vr.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/gun/energy/ionrifle/pistol
 	projectile_type = /obj/item/projectile/ion/pistol // still packs a punch but no AoE
 	w_class = ITEMSIZE_NORMAL //CHOMP Edit.
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/energy/ionrifle/weak
 	projectile_type = /obj/item/projectile/ion/small

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -122,6 +122,7 @@
 	removable_components = TRUE //CHOMPstation Edit
 
 	fire_delay = 0
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 	slot_flags = SLOT_BELT
 
@@ -180,6 +181,7 @@
 	item_state = "revolver"
 
 	w_class = ITEMSIZE_NORMAL
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 	slowdown_held = 0.1
 

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun_vr.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun_vr.dm
@@ -1,6 +1,7 @@
 /obj/item/weapon/gun/magnetic/railgun/flechette/pistol/khi
 	name = "kitsuhana flechette pistol"
 	desc = "This rail pistol appears to have been 'tampered with', improving it's power storage and efficiency."
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 	cell = /obj/item/weapon/cell/hyper
 	capacitor = /obj/item/weapon/stock_parts/capacitor/hyper

--- a/code/modules/projectiles/guns/modular_guns.dm
+++ b/code/modules/projectiles/guns/modular_guns.dm
@@ -155,6 +155,7 @@
 	desc = "A bulky modular pistol frame. This only only accepts six parts."
 	origin_tech = list(TECH_COMBAT = 3, TECH_MAGNET = 3)
 	burst_delay = 2
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/energy/modular/carbine
 	name = "modular carbine"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -121,6 +121,7 @@
 	magazine_type = /obj/item/ammo_magazine/m9mmt/rubber
 	allowed_magazines = list(/obj/item/ammo_magazine/m9mmt)
 	projectile_type = /obj/item/projectile/bullet/pistol/medium
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/automatic/wt550/update_icon()
 	..()
@@ -335,6 +336,7 @@
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 2, TECH_ILLEGAL = 5)
 	magazine_type = /obj/item/ammo_magazine/m45uzi
 	allowed_magazines = list(/obj/item/ammo_magazine/m45uzi)
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 	firemodes = list(
 		list(mode_name="semiauto", burst=1, fire_delay=0),

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -9,6 +9,7 @@
 	caliber = ".45"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	load_method = MAGAZINE
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/colt/update_icon()
 	if(ammo_magazine)
@@ -87,6 +88,7 @@
 	caliber = ".45"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	load_method = MAGAZINE
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/sec/update_icon()
 	..()
@@ -98,6 +100,7 @@
 /obj/item/weapon/gun/projectile/sec/flash
 	name = ".45 signal pistol"
 	magazine_type = /obj/item/ammo_magazine/m45/flash
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/sec/wood
 	desc = "The MT Mk58 is a cheap, ubiquitous sidearm, produced by MarsTech. This one has a sweet wooden grip. Uses .45 rounds."
@@ -119,6 +122,7 @@
 	caliber = ".45"
 	silenced = 1
 	fire_delay = 1
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 	recoil = 0
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2, TECH_ILLEGAL = 8)
 	load_method = MAGAZINE
@@ -175,6 +179,7 @@
 	allowed_magazines = list(/obj/item/ammo_magazine/m75)
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/gyropistol/update_icon()
 	..()
@@ -196,6 +201,7 @@
 	magazine_type = /obj/item/ammo_magazine/m9mm/compact
 	allowed_magazines = list(/obj/item/ammo_magazine/m9mm/compact)
 	projectile_type = /obj/item/projectile/bullet/pistol
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/pistol/flash
 	name = "compact signal pistol"
@@ -327,6 +333,7 @@
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/m9mm
 	allowed_magazines = list(/obj/item/ammo_magazine/m9mm) // Can accept illegal large capacity magazines, or compact magazines.
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/p92x/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/pistol_vr.dm
+++ b/code/modules/projectiles/guns/projectile/pistol_vr.dm
@@ -26,6 +26,7 @@
 	auto_eject = 1
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'
 	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 4)
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/lamia/update_icon()
 	cut_overlays()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -131,6 +131,7 @@
 	caliber = ".38"
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	ammo_type = /obj/item/ammo_casing/a38
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/revolver/deckard/emp
 	ammo_type = /obj/item/ammo_casing/a38/emp

--- a/code/modules/projectiles/guns/projectile/zz_ballistics_ch.dm
+++ b/code/modules/projectiles/guns/projectile/zz_ballistics_ch.dm
@@ -13,6 +13,7 @@
 	icon_state = "fiveseven"
 	load_method = MAGAZINE
 	muzzle_velocity = 650
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/fiveseven/update_icon()
 	icon_state = ammo_magazine ? "[initial(icon_state)]" : "[initial(icon_state)]-e"
@@ -558,6 +559,7 @@
 	load_method = MAGAZINE
 	muzzle_velocity = 400
 	is_long = FALSE
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/automatic/serdy/vityaz
 	name = "WKHM 'Vityaz'"
@@ -577,6 +579,7 @@
 	muzzle_velocity = 430
 	is_long = FALSE
 	fire_sound = "sound/weapons/serdy/vityaz.ogg"
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 //LMGs
 
@@ -617,6 +620,7 @@
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	muzzle_velocity = 405
 	is_long = FALSE
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/automatic/serdy/ssp4/silenced
 	name = "WKHM SSP4-S"
@@ -630,6 +634,7 @@
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	load_method = MAGAZINE
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/serdy_pistols/makarov
 	name = "Makarov PM"
@@ -677,6 +682,7 @@
 	icon = 'icons/obj/gun_ch.dmi'
 	icon_state = "nagant"
 	max_shells = 7
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/revolver/nagant/skinned
 	name = "nagant revolver"
@@ -824,48 +830,57 @@
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	muzzle_velocity = 253	//M1911
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/silenced
 	bolt_name="slide"
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	muzzle_velocity = 240	//Guestimation, minus velocity for suppressor
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/deagle
 	bolt_name="slide"
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	muzzle_velocity = 430	//Guestimation, everyone uses .50AE lol
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/gyropistol
 	bolt_name="slide"
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/pistol
 	bolt_name="slide"
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	muzzle_velocity = 300	//P365
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/pirate
 	manual_chamber = FALSE
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/derringer
 	manual_chamber = FALSE
 	muzzle_velocity = 350	//Guestimation
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/luger
 	bolt_name="slide"
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	muzzle_velocity = 350	//Luger
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/p92x
 	bolt_name="slide"
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	muzzle_velocity = 370
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 //pistol_vr.dm
 /obj/item/weapon/gun/projectile/lamia
@@ -873,6 +888,7 @@
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	muzzle_velocity = 400	//Guestimation
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 
 /obj/item/weapon/gun/projectile/giskard	//To be updated to .380
@@ -880,6 +896,7 @@
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	muzzle_velocity = 300	//Guestimation
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 //pistol_yw.dm
 /obj/item/weapon/gun/projectile/automatic/glock
@@ -887,12 +904,14 @@
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	muzzle_velocity = 375	//Actual gun.
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/ppk
 	bolt_name="slide"
 	bolt_release = "slide release"
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY
 	muzzle_velocity = 310	//Guestimation since PPK doesn't fire 9mm
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/m2024
 	bolt_name="slide"
@@ -910,6 +929,7 @@
 /obj/item/weapon/gun/projectile/revolver 	//To be updated to use .375
 	manual_chamber = FALSE
 	muzzle_velocity = 330	//Guestimation
+	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
 
 /obj/item/weapon/gun/projectile/revolver/detective 		//To be updated to use .38
 	muzzle_velocity = 350	//Guestimation


### PR DESCRIPTION
Some of these are probably redundant, I did this quickly in response to a request so it could get in before an event.

I'll do a more thorough move_delay lookover later and determine what weapons should be fire-able on the move vs not.
