### PR TITLE
Adds damage descriptions and effects to partially digested stuff

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -279,6 +279,7 @@
 	if(isitem(thing) && !isbelly(thing.loc)) //CHOMPEdit: Digest stage effects. Don't bother adding overlays to stuff that won't make it back out.
 		var/obj/item/I = thing
 		if(I.gurgled)
+			cut_overlay(gurgled_overlays[gurgled_color]) //No double-overlay for worn items.
 			I.add_overlay(gurgled_overlays[I.gurgled_color])
 		if(I.d_mult < 1)
 			var/image/temp = new /image(gurgled_overlays[I.gurgled_color ? I.gurgled_color : "green"])

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -276,6 +276,16 @@
 				L.toggle_hud_vis()
 		if((L.stat != DEAD) && L.ai_holder)
 			L.ai_holder.go_wake()
+	if(isitem(thing) && !isbelly(thing.loc)) //CHOMPEdit: Digest stage effects. Don't bother adding overlays to stuff that won't make it back out.
+		var/obj/item/I = thing
+		if(I.gurgled)
+			I.add_overlay(gurgled_overlays[I.gurgled_color])
+		if(I.d_mult < 1)
+			var/image/temp = new /image(gurgled_overlays[I.gurgled_color ? I.gurgled_color : "green"])
+			temp.filters += filter(type = "alpha", icon = icon(I.icon, I.icon_state))
+			I.d_stage_overlay = temp
+			for(var/count in I.d_mult to 1 step 0.25)
+				I.add_overlay(I.d_stage_overlay, TRUE) //CHOMPEdit end
 
 /obj/belly/proc/vore_fx(mob/living/L)
 	if(!istype(L))

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -279,7 +279,7 @@
 	if(isitem(thing) && !isbelly(thing.loc)) //CHOMPEdit: Digest stage effects. Don't bother adding overlays to stuff that won't make it back out.
 		var/obj/item/I = thing
 		if(I.gurgled)
-			cut_overlay(gurgled_overlays[gurgled_color]) //No double-overlay for worn items.
+			I.cut_overlay(gurgled_overlays[I.gurgled_color]) //No double-overlay for worn items.
 			I.add_overlay(gurgled_overlays[I.gurgled_color])
 		if(I.d_mult < 1)
 			var/image/temp = new /image(gurgled_overlays[I.gurgled_color ? I.gurgled_color : "green"])

--- a/code/modules/vore/eating/contaminate_vr.dm
+++ b/code/modules/vore/eating/contaminate_vr.dm
@@ -32,7 +32,8 @@ var/list/gurgled_overlays = list(
 	if(!gurgled)
 		gurgled = TRUE
 		gurgled_color = contamination_color
-		//add_overlay(gurgled_overlays[gurgled_color]) //CHOMPEdit: Moved to belly_obj_vr.dm Exited proc. No need to add overlays to things that won't make it out.
+		if(ishuman(src.loc)) //CHOMPEdit: Moved non-worn overlay stuff to belly_obj_vr.dm Exited proc. No need to add overlays to things that won't make it out.
+			add_overlay(gurgled_overlays[gurgled_color])
 		var/list/pickfrom = contamination_flavors[contamination_flavor]
 		var/gurgleflavor = pick(pickfrom)
 		cleanname = src.name

--- a/code/modules/vore/eating/contaminate_vr.dm
+++ b/code/modules/vore/eating/contaminate_vr.dm
@@ -32,7 +32,7 @@ var/list/gurgled_overlays = list(
 	if(!gurgled)
 		gurgled = TRUE
 		gurgled_color = contamination_color
-		if(ishuman(src.loc)) //CHOMPEdit: Moved non-worn overlay stuff to belly_obj_vr.dm Exited proc. No need to add overlays to things that won't make it out.
+		if(!isbelly(src.loc)) //CHOMPEdit: Moved non-worn overlay stuff to belly_obj_vr.dm Exited proc. No need to add overlays to things that won't make it out.
 			add_overlay(gurgled_overlays[gurgled_color])
 		var/list/pickfrom = contamination_flavors[contamination_flavor]
 		var/gurgleflavor = pick(pickfrom)

--- a/code/modules/vore/eating/contaminate_vr.dm
+++ b/code/modules/vore/eating/contaminate_vr.dm
@@ -32,7 +32,7 @@ var/list/gurgled_overlays = list(
 	if(!gurgled)
 		gurgled = TRUE
 		gurgled_color = contamination_color
-		add_overlay(gurgled_overlays[gurgled_color])
+		//add_overlay(gurgled_overlays[gurgled_color]) //CHOMPEdit: Moved to belly_obj_vr.dm Exited proc. No need to add overlays to things that won't make it out.
 		var/list/pickfrom = contamination_flavors[contamination_flavor]
 		var/gurgleflavor = pick(pickfrom)
 		cleanname = src.name

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -29,13 +29,32 @@
 		if(!touchable_amount) //CHOMPEdit Start
 			touchable_amount = 1
 		g_damage = 0.25 * (B.digest_brute + B.digest_burn) / touchable_amount
-	if(g_damage <= 0)
-		return FALSE //CHOMPEdit End
-
-	if(digest_stage > 0)
+		if(g_damage <= 0)
+			return FALSE
 		if(g_damage > digest_stage)
 			g_damage = digest_stage
-		digest_stage -= g_damage
+			digest_stage = 0 //Don't bother with further math for 1 hit kills.
+		if(digest_stage > 0)
+			if(g_damage > digest_stage)
+				g_damage = digest_stage
+			digest_stage -= g_damage
+			d_mult = round(1 / w_class * digest_stage, 0.25)
+			if(d_mult < d_mult_old)
+				d_mult_old = d_mult
+				var/d_stage_name
+				switch(d_mult)
+					if(0.75)
+						d_stage_name = "blemished"
+					if(0.5)
+						d_stage_name = "disfigured"
+					if(0.25)
+						d_stage_name = "deteriorating"
+					if(0)
+						d_stage_name = "ruined"
+				if(d_stage_name)
+					cleanname = "[d_stage_name] [initial(name)]"
+					decontaminate()
+					gurgle_contaminate(B, B.contamination_flavor, B.contamination_color) //CHOMPEdit End
 	if(digest_stage <= 0)
 		if(istype(src, /obj/item/device/pda))
 			var/obj/item/device/pda/P = src
@@ -50,8 +69,6 @@
 			else if(item_storage)
 				O.forceMove(item_storage)
 		qdel(src)
-	if(g_damage > w_class)
-		return w_class
 	return g_damage
 
 /////////////
@@ -135,3 +152,6 @@
 // Gradual damage measurement
 /obj/item
 	var/digest_stage = null
+	var/d_mult_old = 1 //CHOMPEdit: digest stage descriptions
+	var/d_mult = 1 //CHOMPEdit: digest stage descriptions
+	var/d_stage_overlay //CHOMPEdit: digest stage effects


### PR DESCRIPTION
-Adds 4 stages of damage descriptions and overlays to indicate the "health" of partially digested (on non item-friendly modes of course) items that won't just wash off with the regular contamination.
-Also optimizes some stuff by moving damage and contamination overlays to only be applied on items upon vorgan release without slapping any of them on stuff that won't be coming out. (except for stuff worn by the prey if the belly is set to affect worn items)