### PR TITLE
Fixes vorepanel hud button bypassing belly loading

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -985,7 +985,7 @@
 /datum/component/vore_panel/proc/vore_panel_click(source, location, control, params, user)
 	var/mob/living/owner = user
 	if(istype(owner) && owner.vorePanel)
-		INVOKE_ASYNC(owner.vorePanel, .proc/tgui_interact, user)
+		INVOKE_ASYNC(owner, .proc/insidePanel, user) //CHOMPEdit
 
 /**
  * Screen object for vore panel

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -985,7 +985,7 @@
 /datum/component/vore_panel/proc/vore_panel_click(source, location, control, params, user)
 	var/mob/living/owner = user
 	if(istype(owner) && owner.vorePanel)
-		INVOKE_ASYNC(owner, .proc/insidePanel, user) //CHOMPEdit
+		INVOKE_ASYNC(owner, /mob/living/proc/insidePanel, owner) //CHOMPEdit
 
 /**
  * Screen object for vore panel


### PR DESCRIPTION
Makes the button actually hit the vorepanel verb instead of just hitting tgui refresh on a never-opened panel