### PR TITLE
Fixes tiny oversight on the language fix

### DIFF
--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -235,7 +235,7 @@
 		var/choice = tgui_alert(usr, "Remove [initial(trait.name)] and regain [initial(trait.cost)] points?","Remove Trait",list("Remove","Cancel"))
 		if(choice == "Remove")
 			if(traitpath == /datum/trait/positive/linguist)					//CHOMPEdit
-				pref.num_languages = 0								//CHOMPEdit
+				pref.num_languages = null								//CHOMPEdit
 			pref.pos_traits -= trait
 		return TOPIC_REFRESH
 


### PR DESCRIPTION
Fixes the removal of linguist trait slapping that returnable number 0 that likes to override the species value in prefs numlanguage()