### PR TITLE
Earlyports headset sound fix

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -62,12 +62,12 @@
 
 /obj/item/device/radio/headset/receive_range(freq, level, aiOverride = 0)
 	if (aiOverride)
-		playsound(loc, 'sound/effects/radio_common.ogg', 25, 1, 1)
+		playsound(loc, 'sound/effects/radio_common.ogg', 20, 1, 1, preference = /datum/client_preference/radio_sounds)
 		return ..(freq, level)
 	if(ishuman(src.loc))
 		var/mob/living/carbon/human/H = src.loc
 		if(H.l_ear == src || H.r_ear == src)
-			playsound(loc, 'sound/effects/radio_common.ogg', 25, 1, 1)
+			playsound(loc, 'sound/effects/radio_common.ogg', 20, 1, 1, preference = /datum/client_preference/radio_sounds)
 			return ..(freq, level)
 	return -1
 


### PR DESCRIPTION
Fixes the sound pref toggle not working and makes the sound a little bit less obnoxiously loud.

Fixes #2928