### PR TITLE
Slightly lighter autotransfer system.

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -29,6 +29,7 @@
 
 	var/cloaked = FALSE //If we're cloaked or not
 	var/image/cloaked_selfimage //The image we use for our client to let them see where we are
+	var/belly_cycles = 0 //CHOMPEdit: Counting current belly process cycles for autotransfer.
 
 /atom/movable/Initialize(mapload)
 	. = ..()

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -231,6 +231,7 @@
 
 // Called whenever an atom enters this belly
 /obj/belly/Entered(atom/movable/thing, atom/OldLoc)
+	thing.belly_cycles = 0 //CHOMPEdit: reset cycle count
 	if(OldLoc in contents)
 		return //Someone dropping something (or being stripdigested)
 
@@ -261,9 +262,10 @@
 		if(M.ai_holder)
 			M.ai_holder.go_sleep()
 
-	// Intended for simple mobs
+	/*/ Intended for simple mobs //CHMOPEdit: Counting belly cycles now.
 	if((!owner.client || autotransfer_enabled) && autotransferlocation && autotransferchance > 0)
 		addtimer(CALLBACK(src, /obj/belly/.proc/check_autotransfer, thing, autotransferlocation), autotransferwait)
+	*/
 
 // Called whenever an atom leaves this belly
 /obj/belly/Exited(atom/movable/thing, atom/OldLoc)
@@ -857,7 +859,7 @@
 		M.updateVRPanel()
 
 //Autotransfer callback
-/obj/belly/proc/check_autotransfer(var/prey, var/autotransferlocation)
+/obj/belly/proc/check_autotransfer(var/atom/movable/prey, var/autotransferlocation)
 	if(autotransferlocation && (autotransferchance > 0) && (prey in contents))
 		if(prob(autotransferchance))
 			var/obj/belly/dest_belly
@@ -870,7 +872,7 @@
 		else
 			// Didn't transfer, so wait before retrying
 			// I feel like there's a way to make this timer looping using the normal looping thing, but pass in the ID and cancel it if we aren't looping again
-			addtimer(CALLBACK(src, .proc/check_autotransfer, prey, autotransferlocation), autotransferwait)
+			prey.belly_cycles = 0 //CHOMPEdit: reset cycle count
 
 // Belly copies and then returns the copy
 // Needs to be updated for any var changes

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -14,6 +14,17 @@
 	if(!contents.len)
 		return
 
+	//CHOMPEdit: Autotransfer count moved here.
+	if((!owner.client || autotransfer_enabled) && autotransferlocation && autotransferchance > 0)
+		for(var/atom/movable/M in contents)
+			if(isliving(M))
+				var/mob/living/L = M
+				if(L.absorbed)
+					continue
+			M.belly_cycles++
+			if(M.belly_cycles >= autotransferwait / 60)
+				check_autotransfer(M, autotransferlocation)
+
 	var/play_sound //Potential sound to play at the end to avoid code duplication.
 	var/to_update = FALSE //Did anything update worthy happen?
 

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -1062,7 +1062,7 @@
 				host.vore_selected.autotransferchance = sanitize_integer(autotransferchance_input, 0, 100, initial(host.vore_selected.autotransferchance))
 			. = TRUE
 		if("b_autotransferwait")
-			var/autotransferwait_input = input(user, "Set number of seconds for auto-transfer wait delay.", "Auto-Transfer Time") as num|null
+			var/autotransferwait_input = input(user, "Set minimum number of seconds for auto-transfer wait delay.", "Auto-Transfer Time") as num|null //CHOMPEdit: Wiggle room for rougher time resolution in process cycles.
 			if(!isnull(autotransferwait_input))
 				host.vore_selected.autotransferwait = sanitize_integer(autotransferwait_input*10, 10, 18000, initial(host.vore_selected.autotransferwait))
 			. = TRUE


### PR DESCRIPTION
Had a big brainfart in the shower and figured the belly autotransfer mechanics could just count belly processing cycles instead of juggling around a crapload of active timers which may often end up orphaned anyway with churned/moved/released things. This system just makes the bellies tally up processing cycles on their contents and hits that transfer chance check when the number reaches the setting. Also made absorbed prey immune to autotransfer while at it. Also fixed the mechanic completely ignoring dropped stuff.