### PR TITLE
Fixes wrong damage overlay on uncontaminable items

### DIFF
--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -56,6 +56,7 @@
 				if(d_stage_name)
 					cleanname = "[d_stage_name] [initial(name)]"
 					decontaminate()
+					gurgled_color = B.contamination_color //Apply the correct color setting so uncontaminable things can still have the right overlay.
 					gurgle_contaminate(B, B.contamination_flavor, B.contamination_color) //CHOMPEdit End
 	if(digest_stage <= 0)
 		if(istype(src, /obj/item/device/pda))


### PR DESCRIPTION
Fixes partially digested uncontaminable items not getting the correct belly setting color for their damage overlay.