### PR TITLE
Disables animation on growing/shrinking traits

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -968,10 +968,10 @@
 		//CHOMPEdit Begin
 		if(nutrition > 1000 && species.grows && size_multiplier < RESIZE_HUGE)
 			nutrition_reduction *= 5
-			resize(min(size_multiplier+0.004,RESIZE_HUGE))
+			resize(min(size_multiplier+0.004,RESIZE_HUGE), animate = FALSE)
 		if(nutrition < 200 && species.shrinks && size_multiplier > RESIZE_TINY)
 			nutrition_reduction *= 0.3
-			resize(max(size_multiplier-0.004,RESIZE_TINY))
+			resize(max(size_multiplier-0.004,RESIZE_TINY), animate = FALSE)
 		//CHOMPEdit End
 		adjust_nutrition(-nutrition_reduction)
 


### PR DESCRIPTION
Makes the use of growing/shrinking traits not cause performance chugging from trying to animate the aura effect on every life tick.