### PR TITLE
Another language loss fix attempt

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -164,7 +164,7 @@ var/list/preferences_datums = list()
 //CHOMPEdit Begin
 /datum/preferences/proc/numlanguage()
 	var/datum/species/S = GLOB.all_species[species]
-	return num_languages ? num_languages : S.num_alternate_languages
+	return max(num_languages, S.num_alternate_languages)
 //CHOMPEdit End
 
 /datum/preferences/New(client/C)


### PR DESCRIPTION
Ensures the lack of linguist trait won't somehow make the numlanguage proc return with less than the species default.