### PR TITLE
Updates evidencebag.dm

### DIFF
--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -2,7 +2,7 @@
 
 /obj/item/weapon/evidencebag
 	name = "evidence bag"
-	desc = "An empty evidence bag."
+	desc = "An empty evidence bag.  Use by clicking on the bag and dragging it to the item you want to bag."	//CHOMPstation edit-"Actually clarifies how to use the item in game"
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "evidenceobj"
 	item_state = null


### PR DESCRIPTION
Explains to the player how to use evidence bags since otherwise it's very unintuitive

Updates line 5 to actually explain to the user how to use evidence bags.