### PR TITLE
Possibly fixes the language reset bug

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -82,6 +82,7 @@
 		player_setup.load_character(S)
 		S.cd = "/character[default_slot]"
 		player_setup.save_character(S)
+		sanitize_preferences() //CHOMPEdit
 
 	clear_character_previews() // VOREStation Edit
 	return 1


### PR DESCRIPTION
I managed to trigger the most likely circumstances leading to the loss of languages on character and found out it happens whenever you join the game without manually loading a character from your roster. Looking into this, I found a recent-ish change that looks like it removed a key line required in language preservation from the automatic character loading (such as what happens when you join the game without opening the char setup), and that very same line was still present in the manual character slot loading code, which would explain why it isn't always broken, and why it in my case was broken exceptionally rarely due to my indecisiveness and full roster usually taking up its sweet time before I hit the join button.