### PR TITLE
Makes heal belly work on synths/prosthetic limbs

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/bigdragon.dm
@@ -907,10 +907,7 @@ I think I covered everything.
 		if(H.will_eat(P))
 			if(issilicon(P))
 				return
-			if(iscarbon(P))
-				if(P.isSynthetic()) //Sorry robits
-					return
-			else
+			if(!iscarbon(P))	//CHOMPEdit. Makes healbelly mobs target synths now. Man.. feels weird writing chompedit on my own code from chomp.
 				if(!P.client)	//Don't target simple mobs that aren't player controlled
 					return
 			if(P.stat == DEAD)

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -147,8 +147,8 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	if(L.stat == DEAD)
 		return null // Can't heal the dead with healbelly
 	if(B.owner.nutrition > 90 && (L.health < L.maxHealth))
-		L.adjustBruteLoss(-2.5)
-		L.adjustFireLoss(-2.5)
+		L.adjustBruteLoss(-2.5,1)	//CHOMPEdit. Makes heal bellies work on synths
+		L.adjustFireLoss(-2.5,1)	//Ditto
 		L.adjustToxLoss(-5)
 		L.adjustOxyLoss(-5)
 		L.adjustCloneLoss(-1.25)


### PR DESCRIPTION
"Haha wow that's overpowered"
Yes. Healbelly is. The damn thing can heal genetic damage.
And it's still rarely used, since it's a scening tool.

I looked at it and tilted my head about why robots get shafted in regards to this.
So hey, figured I'd make it work for synths too.
Afterall, encouraging vore's a pretty good idea for this server.

(Yes I acknowledge that synth surgery is annoying enough that people might actually resort to using this due to synth surgery being as one dimensional as it is.)