### PR TITLE
Reverts the latest language fix attempt

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -82,7 +82,6 @@
 		player_setup.load_character(S)
 		S.cd = "/character[default_slot]"
 		player_setup.save_character(S)
-		sanitize_preferences() //CHOMPEdit
 
 	clear_character_previews() // VOREStation Edit
 	return 1


### PR DESCRIPTION
Realized I didn't think this one through all too well after all since this would only affect actually hitting that reset slot button. Probably won't fix the connection issues due to being irrelevant outside slot resets, but you know how it is with spaghetti