### PR TITLE
Southern Cross STS shuttles reach max

### DIFF
--- a/maps/southern_cross/shuttles/crew_shuttles.dm
+++ b/maps/southern_cross/shuttles/crew_shuttles.dm
@@ -14,8 +14,10 @@
 	web_master_type = /datum/shuttle_web_master/shuttle1
 	autopilot = TRUE
 	can_autopilot = TRUE
-	autopilot_delay = 60
-	autopilot_first_delay = 150 // Five minutes at roundstart. Two minutes otherwise.
+	autopilot_delay = 30
+	autopilot_first_delay = 150 // Five minutes at roundstart. One minute otherwise.
+
+	flight_time_modifier = 0.25 // Speeding up Southern Cross auto shuttles because they're too slow.
 
 /datum/shuttle_web_master/shuttle1
 	destination_class = /datum/shuttle_destination/shuttle1
@@ -56,8 +58,10 @@
 	web_master_type = /datum/shuttle_web_master/shuttle2
 	autopilot = TRUE
 	can_autopilot = TRUE
-	autopilot_delay = 60
-	autopilot_first_delay = 270 // Nine minutes at roundstart. Two minutes otherwise. This should leave when the first shuttle departs the outpost.
+	autopilot_delay = 30
+	autopilot_first_delay = 210 // Seven minutes at roundstart. One minute otherwise. This should leave when the first shuttle departs the outpost.
+
+	flight_time_modifier = 0.25 // Speeding up Southern Cross auto shuttles because they're too slow.
 
 /datum/shuttle_web_master/shuttle2
 	destination_class = /datum/shuttle_destination/shuttle2


### PR DESCRIPTION
After a year and a half of nonstop grinding, Shuttles 1 and 2 have finally reached level 99 Sailing. As a result of finally maxing, shuttle transport speed is now 4 times faster. Transit between station and planet now takes 1 minute. As a result of this new speed, shuttles now wait only 1 minute for passengers to board.

WARNING: Attempting to pilot a level 99 vessel without maxed skill may result in spontaneous combustion, public lynching, code nerfs, passive-aggressive complaints, and/or death. Please drink responsibly. 