### PR TITLE
Pos/neg traits for everyone

### DIFF
--- a/code/__defines/trait_defines_ch.dm
+++ b/code/__defines/trait_defines_ch.dm
@@ -1,0 +1,9 @@
+#define NO_TRAIT_FLAGS 0
+#define NO_DISALLOWED_TRAITS 0
+#define TRAITS_HEALTH (1<<0)
+#define TRAITS_SPEED (1<<1)
+#define TRAITS_HARDY (1<<2)
+#define TRAITS_ATTACK (1<<3)
+#define TRAITS_BLOOD (1<<4)
+#define TRAITS_BREATH (1<<5)
+#define TRAITS_FLASHMOD (1<<6)

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -84,7 +84,8 @@
 			pref.pos_traits -= path
 			continue
 		//CHOMPEdit Begin
-		if(!all_traits[path].can_take_trait(pref.species))
+		var/datum/trait/instance = all_traits[path]
+		if(!instance.can_take_trait(pref.species))
 			pref.pos_traits -= path
 			continue
 		//CHOMPEdit End
@@ -96,7 +97,8 @@
 		if(!(path in neutral_traits))
 			pref.neu_traits -= path
 			continue
-		if(!all_traits[path].can_take_trait(pref.species)) //CHOMPEdit
+		var/datum/trait/instance = all_traits[path] //CHOMPEdit
+		if(!instance.can_take_trait(pref.species)) //CHOMPEdit
 			pref.neu_traits -= path
 			continue
 		var/take_flags = initial(path.can_take)
@@ -108,8 +110,9 @@
 			pref.neg_traits -= path
 			continue
 		//CHOMPEdit Begin
-		if(!all_traits[path].can_take_trait(pref.species))
-			pref.neu_traits -= path
+		var/datum/trait/instance = all_traits[path]
+		if(!instance.can_take_trait(pref.species))
+			pref.neg_traits -= path
 			continue
 		//CHOMPEdit End
 		var/take_flags = initial(path.can_take)
@@ -306,7 +309,12 @@
 				picklist = negative_traits.Copy() - pref.neg_traits
 				mylist = pref.neg_traits
 			else
-
+		//CHOMP Addition, only show traits that are able to be taken:
+		for(var/datum/trait/path as anything in picklist)
+			var/datum/trait/instance = all_traits[path]
+			if(!instance.can_take_trait(pref.species))
+				picklist -= path
+		//CHOMP Addition End
 		if(isnull(picklist))
 			return TOPIC_REFRESH
 

--- a/code/modules/mob/living/carbon/human/species/species_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/species_ch.dm
@@ -15,6 +15,7 @@
 	var/mudking = FALSE
 	var/icodigi = 'icons/mob/human_races/r_digi_ch.dmi'
 	var/digi_allowed = FALSE
+	var/disallowed_traits = NO_DISALLOWED_TRAITS
 	
 /datum/species/handle_environment_special(var/mob/living/carbon/human/H)
 	for(var/datum/trait/env_trait in env_traits)

--- a/code/modules/mob/living/carbon/human/species/station/alraune.dm
+++ b/code/modules/mob/living/carbon/human/species/station/alraune.dm
@@ -95,6 +95,7 @@
 
 
 /datum/species/alraune/handle_environment_special(var/mob/living/carbon/human/H)
+	. = ..() //CHOMPEdit compat with env traits
 	if(H.inStasisNow()) // if they're in stasis, they won't need this stuff.
 		return
 

--- a/code/modules/mob/living/carbon/human/species/station/prometheans.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prometheans.dm
@@ -183,6 +183,7 @@ var/datum/species/shapeshifter/promethean/prometheans
 			H.gib()
 
 /datum/species/shapeshifter/promethean/handle_environment_special(var/mob/living/carbon/human/H)
+	. = ..() //CHOMPEdit compat with env traits
 	var/healing = TRUE	// Switches to FALSE if healing is not possible at all.
 	var/regen_brute = TRUE
 	var/regen_burn = TRUE

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -462,7 +462,7 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/space/void/zaddat/(H), slot_wear_suit)
 
 /datum/species/zaddat/handle_environment_special(var/mob/living/carbon/human/H)
-
+	. = ..() //CHOMPEdit compat with env traits
 	if(H.inStasisNow())
 		return
 
@@ -622,6 +622,7 @@
 	H.visible_message("<span class='danger'>\The [H] splits apart with a wet slithering noise!</span>")
 
 /datum/species/diona/handle_environment_special(var/mob/living/carbon/human/H)
+	. = ..() //CHOMPEdit compat with env traits
 	if(H.inStasisNow())
 		return
 

--- a/code/modules/mob/living/carbon/human/species/station/station_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_ch.dm
@@ -40,6 +40,75 @@
 	spawn_flags = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_WHITELIST_SELECTABLE
 */
 
+//alraune.dm
+/datum/species/alraune
+	disallowed_traits = TRAITS_BREATH
+
+//prometheans.dm
+/datum/species/shapeshifter/promethean
+	disallowed_traits = TRAITS_ATTACK | TRAITS_BLOOD | TRAITS_BREATH
+
+//protean_species.dm
+/datum/species/protean
+	disallowed_traits = TRAITS_BREATH | TRAITS_HEALTH | TRAITS_BLOOD
+
+//station.dm
+/datum/species/diona
+	disallowed_traits = TRAITS_SPEED | TRAITS_HARDY | TRAITS_ATTACK
+
+/datum/species/unathi
+	disallowed_traits = TRAITS_HEALTH | TRAITS_BLOOD | TRAITS_HARDY | TRAITS_SPEED
+
+/datum/species/tajaran
+	disallowed_traits = TRAITS_ATTACK
+
+/datum/species/zaddat
+	disallowed_traits = TRAITS_HEALTH | TRAITS_FLASHMOD
+
+//station_vr.dm
+/datum/species/sergal
+	disallowed_traits = TRAITS_ATTACK
+
+/datum/species/akula
+	disallowed_traits = TRAITS_ATTACK
+
+/datum/species/nevrean
+	disallowed_traits = TRAITS_ATTACK
+
+/datum/species/hi_zoxxen
+	disallowed_traits = TRAITS_ATTACK
+
+/datum/species/vulpkanin
+	disallowed_traits = TRAITS_ATTACK
+
+/datum/species/crew_shadekin
+	disallowed_traits = TRAITS_ATTACK | TRAITS_BLOOD | TRAITS_HEALTH
+
+/datum/species/fl_zorren
+	disallowed_traits = TRAITS_ATTACK
+
+/datum/species/xenohybrid
+	disallowed_traits = TRAITS_ATTACK
+
+//station_special_vr.dm
+/datum/species/xenochimera
+	disallowed_traits = TRAITS_ATTACK | TRAITS_HEALTH
+
+/datum/species/spider
+	disallowed_traits = TRAITS_ATTACK | TRAITS_HEALTH
+
+/datum/species/werebeast
+	disallowed_traits = TRAITS_ATTACK | TRAITS_HEALTH | TRAITS_HARDY
+
+//teshari.dm
+/datum/species/teshari
+	disallowed_traits = TRAITS_SPEED | TRAITS_HARDY | TRAITS_HEALTH | TRAITS_BLOOD
+
+//species/outsider/ -- adding these in too for the sake of keeping all of these overrides in one place.
+
+/datum/species/vox
+	disallowed_traits = TRAITS_ATTACK | TRAITS_BREATH
+
 //Can use digitigrade flags
 /datum/species/custom
 	digi_allowed = TRUE

--- a/code/modules/mob/living/carbon/human/species/station/station_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_ch.dm
@@ -42,7 +42,7 @@
 
 //alraune.dm
 /datum/species/alraune
-	disallowed_traits = TRAITS_BREATH
+	disallowed_traits = TRAITS_BREATH | TRAITS_SPEED | TRAITS_HARDY | TRAITS_BLOOD
 
 //prometheans.dm
 /datum/species/shapeshifter/promethean
@@ -60,7 +60,10 @@
 	disallowed_traits = TRAITS_HEALTH | TRAITS_BLOOD | TRAITS_HARDY | TRAITS_SPEED
 
 /datum/species/tajaran
-	disallowed_traits = TRAITS_ATTACK
+	disallowed_traits = TRAITS_ATTACK | TRAITS_HEALTH | TRAITS_FLASHMOD
+
+/datum/species/skrell
+	disallowed_traits = TRAITS_FLASHMOD
 
 /datum/species/zaddat
 	disallowed_traits = TRAITS_HEALTH | TRAITS_FLASHMOD

--- a/code/modules/mob/living/carbon/human/species/station/station_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_ch.dm
@@ -60,7 +60,7 @@
 	disallowed_traits = TRAITS_HEALTH | TRAITS_BLOOD | TRAITS_HARDY | TRAITS_SPEED
 
 /datum/species/tajaran
-	disallowed_traits = TRAITS_ATTACK | TRAITS_HEALTH | TRAITS_FLASHMOD
+	disallowed_traits = TRAITS_HEALTH | TRAITS_FLASHMOD
 
 /datum/species/skrell
 	disallowed_traits = TRAITS_FLASHMOD
@@ -69,39 +69,19 @@
 	disallowed_traits = TRAITS_HEALTH | TRAITS_FLASHMOD
 
 //station_vr.dm
-/datum/species/sergal
-	disallowed_traits = TRAITS_ATTACK
-
-/datum/species/akula
-	disallowed_traits = TRAITS_ATTACK
-
-/datum/species/nevrean
-	disallowed_traits = TRAITS_ATTACK
-
-/datum/species/hi_zoxxen
-	disallowed_traits = TRAITS_ATTACK
-
-/datum/species/vulpkanin
-	disallowed_traits = TRAITS_ATTACK
 
 /datum/species/crew_shadekin
-	disallowed_traits = TRAITS_ATTACK | TRAITS_BLOOD | TRAITS_HEALTH
-
-/datum/species/fl_zorren
-	disallowed_traits = TRAITS_ATTACK
-
-/datum/species/xenohybrid
-	disallowed_traits = TRAITS_ATTACK
+	disallowed_traits = TRAITS_BLOOD | TRAITS_HEALTH
 
 //station_special_vr.dm
 /datum/species/xenochimera
-	disallowed_traits = TRAITS_ATTACK | TRAITS_HEALTH
+	disallowed_traits = TRAITS_HEALTH
 
 /datum/species/spider
-	disallowed_traits = TRAITS_ATTACK | TRAITS_HEALTH
+	disallowed_traits = TRAITS_HEALTH
 
 /datum/species/werebeast
-	disallowed_traits = TRAITS_ATTACK | TRAITS_HEALTH | TRAITS_HARDY
+	disallowed_traits = TRAITS_HEALTH | TRAITS_HARDY
 
 //teshari.dm
 /datum/species/teshari

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -77,6 +77,7 @@
 	reagent_tag = IS_CHIMERA
 
 /datum/species/xenochimera/handle_environment_special(var/mob/living/carbon/human/H)
+	. = ..() //CHOMPEdit compat with env traits
 	//If they're KO'd/dead, they're probably not thinking a lot about much of anything.
 	if(!H.stat)
 		handle_feralness(H)
@@ -380,6 +381,7 @@
 	silk_max_reserve = 1000
 
 /datum/species/spider/handle_environment_special(var/mob/living/carbon/human/H)
+	. = ..() //CHOMPEdit compat with env traits
 	if(H.stat == DEAD) // If they're dead they won't need anything.
 		return
 

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_ch.dm
@@ -3,12 +3,14 @@
 #endif
 
 /datum/trait/negative/hollow
+	trait_flags = TRAITS_HEALTH
 	excludes = list(/datum/trait/positive/densebones)
 
 /datum/trait/negative/slipperydirt
 	name = "Dirt Vulnerability"
 	desc = "Even the tiniest particles of dirt give you uneasy footing, even through several layers of footwear."
 	cost = -5
+	banned_species = list(SPECIES_PROMETHEAN)
 	var_changes = list("dirtslip" = TRUE)
 	excludes = list(/datum/trait/positive/absorbent)
 
@@ -16,6 +18,7 @@
 	name = "Low blood volume"
 	desc = "You have 33.3% less blood volume compared to most species, making you more prone to blood loss issues."
 	cost = -3
+	trait_flags = TRAITS_BLOOD
 	var_changes = list("blood_volume" = 375)
 	excludes = list(/datum/trait/negative/less_blood_extreme,/datum/trait/positive/more_blood,/datum/trait/positive/more_blood_extreme)
 	can_take = ORGANICS
@@ -24,6 +27,7 @@
 	name = "Extremely low blood volume"
 	desc = "You have 60% less blood volume compared to most species, making you much more prone to blood loss issues."
 	cost = -5
+	trait_flags = TRAITS_BLOOD
 	var_changes = list("blood_volume" = 224)
 	excludes = list(/datum/trait/negative/less_blood,/datum/trait/positive/more_blood,/datum/trait/positive/more_blood_extreme)
 	can_take = ORGANICS
@@ -38,6 +42,7 @@
 	name = "Extreme slowdown"
 	desc = "You move EXTREMELY slower than baseline"
 	cost = -8
+	trait_flags = TRAITS_SPEED
 	var_changes = list("slowdown" = 4.0)
 
 /datum/trait/negative/deep_sleeper
@@ -376,3 +381,56 @@
 	if(ms != "")
 		to_chat(H, ms)
 	H.next_loneliness_time = world.time+500
+
+//Traits defined in negative.dm, just adding variables here
+/datum/trait/negative/speed_slow
+	trait_flags = TRAITS_SPEED
+
+/datum/trait/negative/speed_slow_plus
+	trait_flags = TRAITS_SPEED
+
+/datum/trait/negative/weakling
+	trait_flags = TRAITS_HARDY
+
+/datum/trait/negative/weakling_plus
+	trait_flags = TRAITS_HARDY
+
+/datum/trait/negative/endurance_low
+	trait_flags = TRAITS_HEALTH
+
+/datum/trait/negative/endurance_very_low
+	trait_flags = TRAITS_HEALTH
+
+/datum/trait/negative/minor_brute_weak
+	trait_flags = TRAITS_HEALTH
+
+/datum/trait/negative/brute_weak
+	trait_flags = TRAITS_HEALTH
+
+/datum/trait/negative/brute_weak_plus
+	trait_flags = TRAITS_HEALTH
+
+/datum/trait/negative/minor_burn_weak
+	trait_flags = TRAITS_HEALTH
+
+/datum/trait/negative/burn_weak
+	trait_flags = TRAITS_HEALTH
+
+/datum/trait/negative/burn_weak_plus
+	trait_flags = TRAITS_HEALTH
+
+/datum/trait/negative/haemophilia
+	excludes = list(/datum/trait/positive/more_blood,/datum/trait/positive/more_blood_extreme) //These kinda cancel each other out, so not allowed.
+	custom_only = TRUE
+
+/datum/trait/negative/breathes/phoron
+	trait_flags = TRAITS_BREATH
+
+/datum/trait/negative/breathes/nitrogen
+	trait_flags = TRAITS_BREATH
+
+/datum/trait/negative/light_sensitivity
+	trait_flags = TRAITS_FLASHMOD
+
+/datum/trait/negative/light_sensitivity_plus
+	trait_flags = TRAITS_FLASHMOD

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
@@ -300,6 +300,10 @@
 	trait_flags = TRAITS_HARDY
 
 /datum/trait/positive/melee_attack
+	//All of the banned species here already have these exact attacks.
+	banned_species = list(/*station.dm*/SPECIES_TAJ, \
+	/*station_vr.dm*/SPECIES_SERGAL, SPECIES_AKULA, SPECIES_NEVREAN, SPECIES_ZORREN_HIGH, SPECIES_VULPKANIN, SPECIES_SHADEKIN_CREW, SPECIES_FENNEC, SPECIES_XENOHYBRID, \
+	/*station_special_vr.dm*/SPECIES_XENOCHIMERA, SPECIES_VASILISSAN, SPECIES_WEREBEAST)
 	trait_flags = TRAITS_ATTACK
 
 /datum/trait/positive/melee_attack_fangs

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
@@ -9,17 +9,26 @@
 	desc = "Allows you to see a short distance in the dark." 
 	cost = 1
 	var_changes = list("darksight" = 4)  //CHOMP Edit
+	//These species have same or higher darksight by default
+	banned_species = list( /*station.dm*/SPECIES_SKRELL, SPECIES_TAJ, \
+	/*station_vr.dm*/ SPECIES_SERGAL, SPECIES_VULPKANIN, SPECIES_SHADEKIN_CREW, SPECIES_XENOHYBRID, \
+	/*station_special_vr.dm*/ SPECIES_XENOCHIMERA, SPECIES_VASILISSAN, SPECIES_WEREBEAST)
 
 /datum/trait/positive/darksight_plus
 	name = "Darksight, Major"
 	desc = "Allows you to see in the dark for the whole screen." 
 	cost = 2
 	var_changes = list("darksight" = 8)
+	//These species have same or higher darksight by default
+	banned_species = list( /*station.dm*/ SPECIES_TAJ, \
+	/*station_vr.dm*/ SPECIES_SERGAL, SPECIES_SHADEKIN_CREW, \
+	/*station_special_vr.dm*/ SPECIES_XENOCHIMERA, SPECIES_VASILISSAN, SPECIES_WEREBEAST)
 	
 /datum/trait/positive/densebones
 	name = "Dense bones"
 	desc = "Your bones (or robotic limbs) are more dense or stronger then what is considered normal. It is much harder to fracture your bones, yet pain from fractures is much more intense."
 	cost = 3
+	trait_flags = TRAITS_HEALTH
 	excludes = list(/datum/trait/negative/hollow)
 
 /datum/trait/positive/densebones/apply(var/datum/species/S,var/mob/living/carbon/human/H)
@@ -45,6 +54,7 @@
 	name = "Photosynthesis"
 	desc = "Your body is able to produce nutrition from being in light."
 	cost = 3
+	custom_only = TRUE
 	var_changes = list("photosynthesizing" = TRUE)
 	can_take = ORGANICS|SYNTHETICS //Synths actually use nutrition, just with a fancy covering.
 
@@ -65,6 +75,7 @@
 	desc = "You have much 50% more blood than most other people"
 	cost = 3
 	var_changes = list("blood_volume" = 840)
+	trait_flags = TRAITS_BLOOD
 	excludes = list(/datum/trait/positive/more_blood_extreme,/datum/trait/negative/less_blood,/datum/trait/negative/less_blood_extreme)
 	can_take = ORGANICS
 
@@ -73,6 +84,7 @@
 	desc = "You have much 150% more blood than most other people"
 	cost = 6
 	var_changes = list("blood_volume" = 1400)
+	trait_flags = TRAITS_BLOOD
 	excludes = list(/datum/trait/positive/more_blood,/datum/trait/negative/less_blood,/datum/trait/negative/less_blood_extreme)
 	can_take = ORGANICS
 
@@ -117,24 +129,9 @@
 	name = "Absorbent"
 	desc = "You are able to clean messes just by walking over them, and gain nutrition from doing so!"
 	cost = 2
+	banned_species = list(SPECIES_PROMETHEAN)
 	special_env = TRUE
 	excludes = list(/datum/trait/negative/slipperydirt)
-
-/datum/trait/positive/endurance_high
-	cost = 3
-	excludes = list(/datum/trait/positive/brute_resist, /datum/trait/positive/minor_brute_resist, /datum/trait/positive/minor_burn_resist, /datum/trait/positive/burn_resist)
-
-/datum/trait/positive/brute_resist
-	excludes = list(/datum/trait/positive/minor_brute_resist, /datum/trait/positive/burn_resist, /datum/trait/positive/endurance_high)
-
-/datum/trait/positive/minor_brute_resist
-	excludes = list(/datum/trait/positive/brute_resist, /datum/trait/positive/endurance_high)
-
-/datum/trait/positive/burn_resist
-	excludes = list(/datum/trait/positive/minor_burn_resist, /datum/trait/positive/brute_resist, /datum/trait/positive/endurance_high)
-
-/datum/trait/positive/minor_burn_resist
-	excludes = list(/datum/trait/positive/burn_resist, /datum/trait/positive/endurance_high)
 
 /datum/trait/positive/absorbent/handle_environment_special(var/mob/living/carbon/human/H)
 	var/turf/T = get_turf(H)
@@ -260,4 +257,69 @@
 /datum/trait/positive/insect_sting/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
 	H.verbs |= /mob/living/proc/insect_sting
-	
+
+//Traits defined in positive.dm, just adding variables here
+/datum/trait/positive/hardfeet
+	species_flags = NO_MINOR_CUT
+	var_changes = list()
+
+/datum/trait/positive/speed_fast
+	trait_flags = TRAITS_SPEED
+
+/datum/trait/positive/endurance_high
+	cost = 3
+	trait_flags = TRAITS_HEALTH
+	excludes = list(/datum/trait/positive/brute_resist, /datum/trait/positive/minor_brute_resist, /datum/trait/positive/minor_burn_resist, /datum/trait/positive/burn_resist)
+
+/datum/trait/positive/brute_resist
+	trait_flags = TRAITS_HEALTH
+	excludes = list(/datum/trait/positive/minor_brute_resist, /datum/trait/positive/burn_resist, /datum/trait/positive/endurance_high)
+	banned_species = list(SPECIES_TAJ)
+
+/datum/trait/positive/minor_brute_resist
+	trait_flags = TRAITS_HEALTH
+	excludes = list(/datum/trait/positive/brute_resist, /datum/trait/positive/endurance_high)
+	banned_species = list(SPECIES_TAJ)
+
+/datum/trait/positive/burn_resist
+	trait_flags = TRAITS_HEALTH
+	excludes = list(/datum/trait/positive/minor_burn_resist, /datum/trait/positive/brute_resist, /datum/trait/positive/endurance_high)
+	banned_species = list(/*station.dm*/ SPECIES_TAJ, \
+	/*alraune.dm*/ SPECIES_ALRAUNE)
+
+/datum/trait/positive/minor_burn_resist
+	trait_flags = TRAITS_HEALTH
+	excludes = list(/datum/trait/positive/burn_resist, /datum/trait/positive/endurance_high)
+	banned_species = list(/*station.dm*/ SPECIES_TAJ, \
+	/*alraune.dm*/ SPECIES_ALRAUNE)
+
+/datum/trait/positive/hardy
+	trait_flags = TRAITS_HARDY
+
+/datum/trait/positive/hardy_plus
+	trait_flags = TRAITS_HARDY
+
+/datum/trait/positive/melee_attack
+	trait_flags = TRAITS_ATTACK
+
+/datum/trait/positive/melee_attack_fangs
+	trait_flags = TRAITS_ATTACK
+
+/datum/trait/positive/fangs
+	trait_flags = TRAITS_ATTACK
+
+/datum/trait/positive/snowwalker
+	banned_species = list(/*station.dm*/ SPECIES_DIONA, \
+	/*teshari.dm*/ SPECIES_TESHARI)
+
+/datum/trait/positive/winged_flight
+	banned_species = list(SPECIES_NEVREAN, SPECIES_RAPALA)
+
+/datum/trait/positive/weaver
+	banned_species = list(SPECIES_VASILISSAN)
+
+/datum/trait/positive/photoresistant
+	trait_flags = TRAITS_FLASHMOD
+
+/datum/trait/positive/photoresistant_plus
+	trait_flags = TRAITS_FLASHMOD

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/trait_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/trait_ch.dm
@@ -27,6 +27,8 @@
 		return FALSE
 	if(species in banned_species)
 		return FALSE
+	if(LAZYLEN(allowed_species) && !(species in allowed_species))
+		return FALSE
 	var/datum/species/S = GLOB.all_species[species]
 	if(S.disallowed_traits & trait_flags)
 		return FALSE

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/trait_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/trait_ch.dm
@@ -1,11 +1,15 @@
 /datum/trait
+	custom_only = FALSE
 	var/special_env = FALSE
+	var/trait_flags = NO_TRAIT_FLAGS
+	var/species_flags = 0
 
 /datum/trait/proc/handle_environment_special(var/mob/living/carbon/human/H)
 	return
 
 /datum/trait/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	ASSERT(S)
+	S.flags = S.flags | species_flags
 	if(var_changes)
 		for(var/V in var_changes)
 			S.vars[V] = var_changes[V]
@@ -17,3 +21,13 @@
 	if(special_env)
 		S.env_traits -= src
 	return
+
+/datum/trait/proc/can_take_trait(var/species)
+	if(custom_only && (species != SPECIES_CUSTOM))
+		return FALSE
+	if(species in banned_species)
+		return FALSE
+	var/datum/species/S = GLOB.all_species[species]
+	if(S.disallowed_traits & trait_flags)
+		return FALSE
+	return TRUE

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -79,6 +79,33 @@
 			else if(LAZYLEN(instance.allowed_species) && !(client.prefs.species in instance.allowed_species)) //We use else if here, so as to prevent getting two errors for one trait.
 				pass = FALSE
 				to_chat(src,"<span class='warning'>One of your traits, [instance.name], is not available for your species! Please fix this conflict and then try again.</span>")
+			else if(!instance.can_take_trait(client.prefs.species))
+				pass = FALSE
+				to_chat(src,"<span class='warning'>One of your traits, [instance.name], is not available for your species! Please fix this conflict and then try again.</span>")
+	if(client?.prefs?.neg_traits)
+		for(var/T in client.prefs.neg_traits)
+			var/datum/trait/instance = all_traits[T]
+			if(client.prefs.species in instance.banned_species)
+				pass = FALSE
+				to_chat(src,"<span class='warning'>One of your traits, [instance.name], is not available for your species! Please fix this conflict and then try again.</span>")
+			else if(LAZYLEN(instance.allowed_species) && !(client.prefs.species in instance.allowed_species)) //We use else if here, so as to prevent getting two errors for one trait.
+				pass = FALSE
+				to_chat(src,"<span class='warning'>One of your traits, [instance.name], is not available for your species! Please fix this conflict and then try again.</span>")
+			else if(!instance.can_take_trait(client.prefs.species))
+				pass = FALSE
+				to_chat(src,"<span class='warning'>One of your traits, [instance.name], is not available for your species! Please fix this conflict and then try again.</span>")
+	if(client?.prefs?.pos_traits)
+		for(var/T in client.prefs.pos_traits)
+			var/datum/trait/instance = all_traits[T]
+			if(client.prefs.species in instance.banned_species)
+				pass = FALSE
+				to_chat(src,"<span class='warning'>One of your traits, [instance.name], is not available for your species! Please fix this conflict and then try again.</span>")
+			else if(LAZYLEN(instance.allowed_species) && !(client.prefs.species in instance.allowed_species)) //We use else if here, so as to prevent getting two errors for one trait.
+				pass = FALSE
+				to_chat(src,"<span class='warning'>One of your traits, [instance.name], is not available for your species! Please fix this conflict and then try again.</span>")
+			else if(!instance.can_take_trait(client.prefs.species))
+				pass = FALSE
+				to_chat(src,"<span class='warning'>One of your traits, [instance.name], is not available for your species! Please fix this conflict and then try again.</span>")
 	//CHOMP Addition End
 
 	//Final popup notice

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -38,36 +38,37 @@
 		if(!client?.prefs?.custom_species)
 			pass = FALSE
 			to_chat(src,"<span class='warning'>You have to name your custom species. Do this on the VORE tab in character setup.</span>")
+	//CHOMPEdit Begin, Unindenting block
+	//Check traits/costs
+	var/list/megalist = client.prefs.pos_traits + client.prefs.neu_traits + client.prefs.neg_traits
+	var/points_left = client.prefs.starting_trait_points
+	var/traits_left = client.prefs.max_traits
+	var/pref_synth = client.prefs.dirty_synth
+	var/pref_meat = client.prefs.gross_meatbag
+	for(var/datum/trait/T as anything in megalist)
+		var/cost = traits_costs[T]
 
-		//Check traits/costs
-		var/list/megalist = client.prefs.pos_traits + client.prefs.neu_traits + client.prefs.neg_traits
-		var/points_left = client.prefs.starting_trait_points
-		var/traits_left = client.prefs.max_traits
-		var/pref_synth = client.prefs.dirty_synth
-		var/pref_meat = client.prefs.gross_meatbag
-		for(var/datum/trait/T as anything in megalist)
-			var/cost = traits_costs[T]
+		if(cost)
+			traits_left--
 
-			if(cost)
-				traits_left--
-
-			//A trait was removed from the game
-			if(isnull(cost))
-				pass = FALSE
-				to_chat(src,"<span class='warning'>Your custom species is not playable. One or more traits appear to have been removed from the game or renamed. Enter character setup to correct this.</span>")
-				break
-			else
-				points_left -= traits_costs[T]
-
-			var/take_flags = initial(T.can_take)
-			if((pref_synth && !(take_flags & SYNTHETICS)) || (pref_meat && !(take_flags & ORGANICS)))
-				pass = FALSE
-				to_chat(src, "<span class='warning'>Some of your traits are not usable by your character type (synthetic traits on organic, or vice versa).</span>")
-
-		//Went into negatives
-		if(points_left < 0 || traits_left < 0)
+		//A trait was removed from the game
+		if(isnull(cost))
 			pass = FALSE
-			to_chat(src,"<span class='warning'>Your custom species is not playable. Reconfigure your traits on the VORE tab.</span>")
+			to_chat(src,"<span class='warning'>Your custom species is not playable. One or more traits appear to have been removed from the game or renamed. Enter character setup to correct this.</span>")
+			break
+		else
+			points_left -= traits_costs[T]
+
+		var/take_flags = initial(T.can_take)
+		if((pref_synth && !(take_flags & SYNTHETICS)) || (pref_meat && !(take_flags & ORGANICS)))
+			pass = FALSE
+			to_chat(src, "<span class='warning'>Some of your traits are not usable by your character type (synthetic traits on organic, or vice versa).</span>")
+
+	//Went into negatives
+	if(points_left < 0 || traits_left < 0)
+		pass = FALSE
+		to_chat(src,"<span class='warning'>Your traits are not playable. Reconfigure your traits on the VORE tab.</span>") //CHOMPEdit
+	//CHOMPEdit End, Unindenting block
 
 	//CHOMP Addition Begin
 	if(client?.prefs?.neu_traits)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -101,6 +101,7 @@
 #include "code\__defines\tgs.dm"
 #include "code\__defines\tgui.dm"
 #include "code\__defines\tools.dm"
+#include "code\__defines\trait_defines_ch.dm"
 #include "code\__defines\turfs.dm"
 #include "code\__defines\typeids.dm"
 #include "code\__defines\unit_tests.dm"


### PR DESCRIPTION
Make positive and negative traits available for all species, add lots of restrictions to what species can take which traits.
Only custom species starts with 1 point, everyone else starts with 0.
The menu for traits will only show traits that the user's species is able to take.

Why should this be added?:
We've been talking about stuff like skill systems and other types of trait systems for a while now, but I had a realization that we can just use the one we already have and expand it so that it conforms with the all the special properties of the default species. This should also bring more motivation for new traits to fill gaps in both more generalized areas as well as even more specialized ones.

How was this balanced?:
1. If a species has a detrimental trait by default, they can't use custom traits to remove that or combat it. This would break species balancing.
2. If a species has bonuses in something like health, they shouldn't be able to take other bonuses, this could lead to them becoming too powerful.
3. If the trait had a possibility of breaking stuff by overriding values or what have you, it will be disabled for them.
4. Generally try to avoid giving a species a negative trait that will end up being pretty much ignorable because of other factors.

Current trait categories (traits can have no category as well. Categories are only used in code, they don't affect anything visually.):
TRAITS_HEALTH -- Traits that change maxhealth, damage percentages (brutemod, burnmod, etc.), and also dense/weak bones.
TRAITS_SPEED -- Traits that affect movement speed.
TRAITS_HARDY -- Traits that affect item slowdown
TRAITS_ATTACK -- Traits that give the user new melee attacks(sharp attack, numbing fangs)
TRAITS_BLOOD -- Traits that affect blood volume
TRAITS_BREATH -- Traits that change what gases the user breathes.
TRAITS_FLASHMOD -- Traits that change the user's sensitivity to flashes (light sensitivity)

The following are species restrictions(These are tied to the species datum, and are for categories of traits instead of single traits. And to be specific, these are the traits which are DISALLOWED for these species):
Alraune: TRAITS_BREATH, TRAITS_SPEED, TRAITS_HARDY, TRAITS_BLOOD
Promethean: TRAITS_ATTACK, TRAITS_BLOOD, TRAITS_BREATH
Protean: TRAITS_BREATH, TRAITS_HEALTH, TRAITS_BLOOD
Diona: TRAITS_SPEED, TRAITS_HARDY, TRAITS_ATTACK
Tajaran: TRAITS_HEALTH. TRAITS_FLASHMOD
Skrell: TRAITS_FLASHMOD
Zaddat: TRAITS_HEALTH, TRAITS_FLASHMOD
Crew Shadekin: TRAITS_BLOOD, TRAITS_HEALTH
Xenochimera: TRAITS_HEALTH
Vasilissan/Spiderfolk: TRAITS_HEALTH
Werebeast: TRAITS_HEALTH, TRAITS_HARDY
Teshari: TRAITS_SPEED, TRAITS_HARDY, TRAITS_HEALTH, TRAITS_BLOOD
Vox: TRAITS_ATTACK, TRAITS_BREATH

The following are trait species banlists, these are species that are banned for a specific trait, generally too specific for a category.
Positive:
Darksight(This is because these species already have higher or equal darksight): Skrell, Tajaran, Sergal, Vulpkanin, Crew Shadekin, Xenohybrid, Xenochimera, Vasilissan/Spiderfolk, Werebeast
Major Darksight(This is because these species already have higher or equal darksight): Tajaran, Sergal, Crew Shadekin, Xenochimera, Vasilissan/Spiderfolk, Werebeast
Absorbent: Prometheans (They already have it)
Minor burn resist: Alraune (They have burn weakness by default)
Burn resist: Alraune (They have burn weakness by default)
Snow walker: Diona, Teshari (They have it by default)
Winged Flight: Nevrean, Rapala (They have it by default)
Weaver: Vasilissan/Spiderfolk (They have it by default)
Sharp melee: Tajaran, Sergals, Akula, Nevrean, Zorren, Vulpkanin, Crew Shadekin, Fennec, Xenohybrid, Xenochimera, Vasilissan/Spiderfolk, Werebeast (They all have it by default.)

Negative:
Dirt Vulnerability: Promethean (conflicts with absorbent which they have by default)

Update 1:
Removed TRAITS_ATTACK from a lot of the species, and added them to a blacklist for the specific trait they start with as default.
