### PR TITLE
Traits balancing changes

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -106,24 +106,26 @@
 	cost = -1
 	var_changes = list("pain_mod" = 1.25)
 
+//CHOMPEdit Begin
 /datum/trait/negative/pain_intolerance_advanced
 	name = "High Pain Intolerance"
-	desc = "You are highly sensitive to all sources of pain, and experience 50% more pain."
+	desc = "You are highly sensitive to all sources of pain, and experience 100% more pain."
 	cost = -2
-	var_changes = list("pain_mod" = 1.5) //this makes you extremely vulnerable to most sources of pain, a stunbaton bop or shotgun beanbag will do around 90 agony, almost enough to drop you in one hit
+	var_changes = list("pain_mod" = 2) //most things should down you in 1 or 2 hits
+//CHOMPEdit end
 //YW ADDITIONS END
 
 /datum/trait/negative/conductive
 	name = "Conductive"
-	desc = "Increases your susceptibility to electric shocks by 25%"
-	cost = -2 //CHOMPEdit
-	var_changes = list("siemens_coefficient" = 1.25) //This makes you a lot weaker to tasers.
+	desc = "Increases your susceptibility to electric shocks by 75%"
+	cost = -1 //CHOMPEdit What the fuck this is not worth 2 points.
+	var_changes = list("siemens_coefficient" = 1.75) //This makes you a lot weaker to tasers.
 
-/datum/trait/negative/conductive_plus
+/*/datum/trait/negative/conductive_plus //CHOMP Removal No we are not giving people a free 3 points with this trait.
 	name = "Conductive, Major"
 	desc = "Increases your susceptibility to electric shocks by 100%"
 	cost = -3 //CHOMPEdit
-	var_changes = list("siemens_coefficient" = 2.0) //This makes you extremely weak to tasers.
+	var_changes = list("siemens_coefficient" = 2.0)*/ //This makes you extremely weak to tasers.
 
 /datum/trait/negative/haemophilia
 	name = "Haemophilia - Organics only"
@@ -146,7 +148,7 @@
 /datum/trait/negative/lightweight
 	name = "Lightweight"
 	desc = "Your light weight and poor balance make you very susceptible to unhelpful bumping. Think of it like a bowling ball versus a pin. (STOP TAKING THIS AS SECURITY! We're MRP, so expect to lose your junk immediately, especially in events. - Love, Admins)" //CHOMP Edit btw
-	cost = -2
+	cost = -1 //CHOMPEdit Another source of free points. Being on the ground for a few seconds is not worth 2 points.
 	var_changes = list("lightweight" = 1)
 
 // YW Addition

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_ch.dm
@@ -15,7 +15,7 @@
 /datum/trait/negative/less_blood
 	name = "Low blood volume"
 	desc = "You have 33.3% less blood volume compared to most species, making you more prone to blood loss issues."
-	cost = -3
+	cost = -2
 	var_changes = list("blood_volume" = 375)
 	excludes = list(/datum/trait/negative/less_blood_extreme,/datum/trait/positive/more_blood,/datum/trait/positive/more_blood_extreme)
 	can_take = ORGANICS
@@ -23,7 +23,7 @@
 /datum/trait/negative/less_blood_extreme
 	name = "Extremely low blood volume"
 	desc = "You have 60% less blood volume compared to most species, making you much more prone to blood loss issues."
-	cost = -5
+	cost = -3
 	var_changes = list("blood_volume" = 224)
 	excludes = list(/datum/trait/negative/less_blood,/datum/trait/positive/more_blood,/datum/trait/positive/more_blood_extreme)
 	can_take = ORGANICS

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -160,7 +160,7 @@
 /datum/trait/positive/traceur
 	name = "Traceur"
 	desc = "You're capable of parkour and can *flip over low objects (most of the time)."
-	cost = 2
+	cost = 1 //CHOMPEdit this is not worth 2 points
 	var_changes = list("agility" = 90)
 
 // YW Addition
@@ -194,7 +194,7 @@
 /datum/trait/positive/weaver
 	name = "Weaver"
 	desc = "You can produce silk and create various articles of clothing and objects."
-	cost = 2
+	cost = 1 //Also not worth 2 points, wtf, this is literally just fluff
 	var_changes = list("is_weaver" = 1)
 
 /datum/trait/positive/weaver/apply(var/datum/species/S,var/mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
@@ -51,19 +51,19 @@
 /datum/trait/positive/rad_resistance
 	name = "Radiation Resistance"
 	desc = "You are generally more resistant to radiation, and it dissipates faster from your body."
-	cost = 2
+	cost = 1
 	var_changes = list("radiation_mod" = 0.65, "rad_removal_mod" = 3.5, "rad_levels" = list("safe" = 20, "danger_1" = 75, "danger_2" = 100, "danger_3" = 200))
 
 /datum/trait/positive/rad_resistance_extreme
 	name = "Extreme Radiation Resistance"
 	desc = "You are much more resistant to radiation, and it dissipates much faster from your body."
-	cost = 4
+	cost = 2
 	var_changes = list("radiation_mod" = 0.5, "rad_removal_mod" = 5, "rad_levels" = list("safe" = 40, "danger_1" = 100, "danger_2" = 150, "danger_3" = 250))
 
 /datum/trait/positive/more_blood
 	name = "High blood volume"
 	desc = "You have much 50% more blood than most other people"
-	cost = 3
+	cost = 2
 	var_changes = list("blood_volume" = 840)
 	excludes = list(/datum/trait/positive/more_blood_extreme,/datum/trait/negative/less_blood,/datum/trait/negative/less_blood_extreme)
 	can_take = ORGANICS
@@ -71,7 +71,7 @@
 /datum/trait/positive/more_blood_extreme
 	name = "Very high blood volume"
 	desc = "You have much 150% more blood than most other people"
-	cost = 6
+	cost = 4
 	var_changes = list("blood_volume" = 1400)
 	excludes = list(/datum/trait/positive/more_blood,/datum/trait/negative/less_blood,/datum/trait/negative/less_blood_extreme)
 	can_take = ORGANICS
@@ -105,18 +105,18 @@
 	name = "Grappling expert"
 	desc = "Your grabs are much harder to escape from, and you are better at escaping from other's grabs!"
 	cost = 3
-	var_changes = list("grab_resist_divisor_victims" = 3, "grab_resist_divisor_self" = 0.5, "grab_power_victims" = -1, "grab_power_self" = 1)
+	var_changes = list("grab_resist_divisor_victims" = 1.5, "grab_resist_divisor_self" = 0.5, "grab_power_victims" = -1, "grab_power_self" = 1)
 
 /datum/trait/positive/big_mouth_extreme
 	name = "Giant mouth"
 	desc = "It takes a quarter as many bites to finish food as it does for most people."
-	cost = 3
+	cost = 2
 	var_changes = list("bite_mod" = 4)
 
 /datum/trait/positive/absorbent
 	name = "Absorbent"
 	desc = "You are able to clean messes just by walking over them, and gain nutrition from doing so!"
-	cost = 2
+	cost = 1
 	special_env = TRUE
 	excludes = list(/datum/trait/negative/slipperydirt)
 


### PR DESCRIPTION
So, I kinda realized that traits needed to be fixed a bit after I found myself with a few grievances about the balance of certain traits. I'm 100% open to feedback on these changes, but I'm feeling pretty confident about the changes I want to make. This is isn't entirely a nerf, but will likely feel like it, because I'm specifically going after traits that I consider to be "free points" and that I know lots of people use as such.

Changes and why:
Negative traits:
High pain intolerance: Now 100% more pain instead of 50% to push it over the boundary of actually making a significant and noticeable difference in gameplay.

Conductive: Now -1 point instead of -2 points and 75% instead of 25% increase. Even still this is going to make a pretty negligible difference in gameplay, hence -1 point.

Lightweight: Now -1 point instead of -2. Having lightweight trait will not change the outcome of a combat situation 99/100 times. Only way that somebody could take advantage is if they even knew, it occured to them, and they could get close enough. All this trait really does is provide a minor annoyance.

Less blood: Now -2 points instead of -3. Less blood is impactful, but not that impactful. When I was originally making this I overestimated how much of a part blood plays.

Less blood extreme: Now -3 instead of -5. Again with above, the thing is despite being 40% the amount of blood, it only affects you if you start bleeding and can be fairly easily combatted.

Positive:

Traceur: Now 1 point instead of 2. It's my opinion that all "fluff" traits, and being able to flip more reliably is a fluff trait in my book, should be 1 point.

Weaver: Now 1 point instead of 2. Same as above, this constitutes a fluff trait, therefore only 1 point.

Rad resistance: Now 1 point instead of 2. Having to deal with radiation is pretty rare, and this doesn't provide that much of a buff against it.

Extreme rad resistance: Now 2 points instead of 4. Same with above, although this one does provide a more substantial buff, radiation remains something that just doesn't impact gameplay often enough to justify 4 points.

More blood: Now 2 points instead of 3. Same argument with negative blood traits, they just don't impact the game enough to have this much cost.

More blood extreme: Now 4 points instead of 6. I would have gone with 3, but this trait does give you a lot of blood, making you almost immune to blood loss. Reason for decreasing it is similar to decreasing negative blood traits.

Grappling expert: Now ~2x harder to escape instead of ~4-6x, this is just something that I didn't test enough originally. I discovered only on the server that it is pretty much if not entirely impossible to escape a level 3 grab with this trait.

Giant mouth: Now 2 points instead of 3. This is another fluff trait, really. I would leave it at 1 point, but wanting it to still be more expensive than big mouth, I'll settle it at 2.

Absorbent: Now 1 point instead of 2. This is yet another fluff trait. Neither nutrition nor dirt play a major part in gameplay.