### PR TITLE
Adds a couple more experimental autotransfer features

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -52,6 +52,9 @@
 	var/autotransferwait = 10 				// Time between trying to transfer.
 	var/autotransferlocation				// Place to send them
 	var/autotransfer_enabled = FALSE		// Player toggle
+	var/autotransfer_min_amount = 0			// Minimum amount of things to pass at once. //CHOMPAdd
+	var/autotransfer_max_amount = 0			// Maximum amount of things to pass at once. //CHOMPAdd
+	var/tmp/list/autotransfer_queue = list()// Reserve for above things. //CHOMPAdd
 
 	//I don't think we've ever altered these lists. making them static until someone actually overrides them somewhere.
 	//Actual full digest modes
@@ -206,7 +209,9 @@
 		"autotransferchance",
 		"autotransferwait",
 		"autotransferlocation",
-		"autotransfer_enabled", //CHOMP end of variables from CHOMP
+		"autotransfer_enabled",
+		"autotransfer_min_amount",
+		"autotransfer_max_amount", //CHOMP end of variables from CHOMP
 		"egg_type"
 		)
 
@@ -868,11 +873,13 @@
 					dest_belly = B
 					break
 			if(dest_belly)
-				transfer_contents(prey, dest_belly)
+				if(autotransfer_min_amount > 0) //CHOMPEdit start
+					autotransfer_queue += prey
+				else
+					transfer_contents(prey, dest_belly)
 		else
 			// Didn't transfer, so wait before retrying
-			// I feel like there's a way to make this timer looping using the normal looping thing, but pass in the ID and cancel it if we aren't looping again
-			prey.belly_cycles = 0 //CHOMPEdit: reset cycle count
+			prey.belly_cycles = 0 //CHOMPEdit end
 
 // Belly copies and then returns the copy
 // Needs to be updated for any var changes
@@ -935,7 +942,9 @@
 	dupe.autotransferchance = autotransferchance
 	dupe.autotransferwait = autotransferwait
 	dupe.autotransferlocation = autotransferlocation
-	dupe.autotransfer_enabled = autotransfer_enabled //CHOMP end of variables from CHOMP
+	dupe.autotransfer_enabled = autotransfer_enabled
+	dupe.autotransfer_min_amount = autotransfer_min_amount
+	dupe.autotransfer_max_amount = autotransfer_max_amount //CHOMP end of variables from CHOMP
 
 	dupe.belly_fullscreen = belly_fullscreen
 	dupe.disable_hud = disable_hud

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -873,7 +873,7 @@
 					dest_belly = B
 					break
 			if(dest_belly)
-				if(autotransfer_min_amount > 0) //CHOMPEdit start
+				if(autotransfer_min_amount > 1) //CHOMPEdit start
 					autotransfer_queue += prey
 				else
 					transfer_contents(prey, dest_belly)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -16,12 +16,27 @@
 
 	//CHOMPEdit: Autotransfer count moved here.
 	if((!owner.client || autotransfer_enabled) && autotransferlocation && autotransferchance > 0)
-		for(var/atom/movable/M in contents)
+		var/list/autotransferables = contents - autotransfer_queue
+		if(LAZYLEN(autotransfer_queue) >= autotransfer_min_amount)
+			var/obj/belly/dest_belly
+			for(var/obj/belly/B in owner.vore_organs)
+				if(B.name == autotransferlocation)
+					dest_belly = B
+					break
+			if(dest_belly)
+				for(var/atom/movable/M in autotransfer_queue)
+					transfer_contents(M, dest_belly)
+				autotransfer_queue.Cut()
+		var/tally = 0
+		for(var/atom/movable/M in autotransferables)
 			if(isliving(M))
 				var/mob/living/L = M
 				if(L.absorbed)
 					continue
+			tally++
 			M.belly_cycles++
+			if(autotransfer_max_amount > 0 && tally >= autotransfer_max_amount)
+				continue
 			if(M.belly_cycles >= autotransferwait / 60)
 				check_autotransfer(M, autotransferlocation)
 


### PR DESCRIPTION
Makes it possible to set minimum and maximum number of things that can be autotransfered at once.
Currently experimental varedit setting only. Will need to wait for the vorepanel complexity fix update before these can have accessible UI buttons.