### PR TITLE
Fix two mapping runtimes

### DIFF
--- a/maps/submaps/surface_submaps/mountains/deadspy.dmm
+++ b/maps/submaps/surface_submaps/mountains/deadspy.dmm
@@ -1,10 +1,10 @@
 "a" = (/obj/effect/decal/remains/xeno,/obj/item/clothing/mask/gas,/obj/item/clothing/suit/fire/firefighter,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
 "b" = (/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
-"c" = (/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel,/obj/effect/decal/cleanable/molten_item,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
-"d" = (/obj/item/weapon/flamethrower,/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
-"e" = (/obj/effect/decal/cleanable/liquid_fuel,/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
-"f" = (/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
-"g" = (/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel,/obj/effect/decal/cleanable/ash,/obj/random/landmine,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
+"c" = (/obj/effect/decal/cleanable/molten_item,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
+"d" = (/obj/item/weapon/flamethrower,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
+"e" = (/obj/effect/decal/cleanable/liquid_fuel,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
+"f" = (/obj/effect/decal/cleanable/ash,/obj/random/landmine,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
+"g" = (/obj/random/landmine,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
 "h" = (/obj/effect/decal/cleanable/liquid_fuel,/obj/random/landmine,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
 "i" = (/obj/effect/decal/cleanable/liquid_fuel,/obj/effect/decal/cleanable/molten_item,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
 "j" = (/obj/item/weapon/material/butterfly,/obj/effect/decal/cleanable/liquid_fuel,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
@@ -17,16 +17,15 @@
 "q" = (/obj/effect/decal/cleanable/liquid_fuel,/obj/effect/decal/cleanable/liquid_fuel,/obj/random/landmine,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
 "r" = (/obj/effect/decal/cleanable/liquid_fuel,/obj/item/weapon/storage/fancy/cigarettes/professionals,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
 "s" = (/obj/item/weapon/card/emag_broken,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
-"t" = (/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel,/obj/random/landmine,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
-"u" = (/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel,/obj/effect/decal/cleanable/ash,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
+"t" = (/obj/effect/decal/cleanable/ash,/turf/simulated/mineral/floor/ignore_mapgen,/area/submap/deadspy)
 "v" = (/turf/simulated/mineral,/area/submap/deadspy)
 
 (1,1,1) = {"
 abbbbvv
-bcdefgb
-bfhijfk
-bflmnfo
-vfpqrfs
-vtfuffb
+bcdebfb
+bbhijbk
+bblmnbo
+vbpqrbs
+vgbtbbb
 vvbbbvb
 "}

--- a/maps/submaps/surface_submaps/plains/oldhotel.dmm
+++ b/maps/submaps/surface_submaps/plains/oldhotel.dmm
@@ -1,3 +1,5 @@
+"aa" = (/obj/structure/table/woodentable,/obj/item/weapon/cell/hyper,/obj/random/single,/obj/random/single,/turf/simulated/floor/wood,/area/submap/oldhotel)
+"ab" = (/obj/structure/closet/crate,/obj/random/cash,/obj/random/single,/turf/simulated/floor/wood,/area/submap/oldhotel)
 "ai" = (/obj/random/trash,/turf/simulated/floor/carpet/purcarpet,/area/submap/oldhotel)
 "aJ" = (/obj/item/weapon/towel/random,/obj/item/weapon/towel/random,/obj/structure/table/standard,/obj/item/weapon/storage/firstaid,/turf/simulated/floor/tiled/asteroid_steel,/area/submap/oldhotel)
 "bb" = (/obj/machinery/light/small{dir = 4},/obj/item/device/multitool,/turf/simulated/floor/wood,/area/submap/oldhotel)
@@ -29,7 +31,6 @@
 "lj" = (/obj/structure/table/wooden_reinforced,/obj/item/weapon/material/kitchen/rollingpin,/turf/simulated/floor/tiled/asteroid_steel,/area/submap/oldhotel)
 "ly" = (/obj/structure/bed/double/padded,/obj/item/weapon/bedsheet/piratedouble,/turf/simulated/floor/wood,/area/submap/oldhotel)
 "lZ" = (/obj/structure/table/woodentable,/obj/item/trash/tray,/turf/simulated/floor/carpet/blue,/area/submap/oldhotel)
-"mr" = (/obj/structure/table/woodentable,/obj/random,/obj/random,/obj/item/weapon/cell/hyper,/turf/simulated/floor/wood,/area/submap/oldhotel)
 "mR" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt,/area/submap/oldhotel)
 "nD" = (/turf/simulated/floor,/area/submap/oldhotel)
 "nG" = (/obj/item/weapon/material/shard,/turf/simulated/floor/outdoors/dirt,/area/submap/oldhotel)
@@ -92,7 +93,6 @@
 "MD" = (/obj/effect/decal/cleanable/dirt,/obj/structure/simple_door/wood,/turf/simulated/floor/wood,/area/submap/oldhotel)
 "MU" = (/turf/template_noop,/area/submap/oldhotel)
 "Nu" = (/obj/random/soap,/turf/simulated/floor/tiled/asteroid_steel,/area/submap/oldhotel)
-"OQ" = (/obj/structure/closet/crate,/obj/random,/obj/random/cash,/turf/simulated/floor/wood,/area/submap/oldhotel)
 "Pd" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/carpet/sblucarpet,/area/submap/oldhotel)
 "PO" = (/obj/machinery/space_heater,/turf/simulated/floor/wood/broken,/area/submap/oldhotel)
 "Qv" = (/obj/structure/table/woodentable,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/obj/item/weapon/pen,/obj/item/weapon/pen,/turf/simulated/floor/wood,/area/submap/oldhotel)
@@ -124,7 +124,7 @@ gAgAgAgAgAgAgAgAgAgAgAgAgAgAgAgAgAgAgAgAgAgAgAgAgA
 gAMUMUMUmRMUMUMUMUMUMUMUMUMUMUMUMUMUMUMUMUMUMUMUgA
 gAMUkwhQmRhQnGMUbWZGnDMUnGMUhQZGhQMUMUMUMUGNMUMUgA
 gAMUhQhQgoztvMdLwKhQhQdLYQdLhQhQhQhQZGMUMUMUMUMUgA
-gAMUhQBtTUSZqgqYJTzPqgqgJTqgmrZGaJsdhQMUMUMUMUMUgA
+gAMUhQBtTUSZqgqYJTzPqgqgJTqgaaZGaJsdhQMUMUMUMUMUgA
 gAMUZGYITUQvrKUUAUTUqgdajOvhTUhQdzSyZGMUMUMUMUMUgA
 gAMUZGGVWHSZQwGrqgqgSZopvRQGhcMDSyNuSLbWMUMUMUMUgA
 gAMUhQhQhQhQhQZGnDhQqglZtEQGSZhQVfGzhQwXMUMUMUMUgA
@@ -136,7 +136,7 @@ gAMUMUnDZGnDhQhQhQhQhcDNhQrbCxmREsCxJqCxMUCxMUMUgA
 gAMUwXhQhQDNRMTUrKhQSZdnnDljJqEsCxCxCxMUMUCxMUGNgA
 gAMUMUCxIkiUaiSGSfZGqgkWZGAcCxmRyjMUMUCxMUMUMUMUgA
 gAMUbWpnYQGkjayMzEhQSZGkhQUwJqCxCxJVMUMUMUMUMUMUgA
-gAMUMUnDZGOQqgWySZtnRQbbhQWDSywmCxeKCxCxMUCxMUMUgA
+gAMUMUnDZGabqgWySZtnRQbbhQWDSywmCxeKCxCxMUCxMUMUgA
 gAMUMUhQZGhQhQZGhQhQSZDNhQwVJqCxCxJVMUMUMUMUMUMUgA
 gAMUMUhQhQMkPOTUqgtnSZkWhQDxmRmREsMUMUMUMUMUMUMUgA
 gAMUMUCxdLDNPdkISehQSZdnhQDiSyzsCxCxMUMUMUMUMUMUgA

--- a/maps/submaps/surface_submaps/plains/oldhotel.dmm
+++ b/maps/submaps/surface_submaps/plains/oldhotel.dmm
@@ -1,5 +1,5 @@
-"aa" = (/obj/structure/table/woodentable,/obj/item/weapon/cell/hyper,/obj/random/single,/obj/random/single,/turf/simulated/floor/wood,/area/submap/oldhotel)
-"ab" = (/obj/structure/closet/crate,/obj/random/cash,/obj/random/single,/turf/simulated/floor/wood,/area/submap/oldhotel)
+"aa" = (/obj/structure/table/woodentable,/obj/item/weapon/cell/hyper,/obj/random/coin,/obj/random/cash/huge,/turf/simulated/floor/wood,/area/submap/oldhotel)
+"ab" = (/obj/structure/closet/crate,/obj/random/cash,/obj/random/cigarettes,/turf/simulated/floor/wood,/area/submap/oldhotel)
 "ai" = (/obj/random/trash,/turf/simulated/floor/carpet/purcarpet,/area/submap/oldhotel)
 "aJ" = (/obj/item/weapon/towel/random,/obj/item/weapon/towel/random,/obj/structure/table/standard,/obj/item/weapon/storage/firstaid,/turf/simulated/floor/tiled/asteroid_steel,/area/submap/oldhotel)
 "bb" = (/obj/machinery/light/small{dir = 4},/obj/item/device/multitool,/turf/simulated/floor/wood,/area/submap/oldhotel)


### PR DESCRIPTION
This is so that runtimes will shut up about this runtime

```
[2021-09-21T00:58:51] Runtime in unsorted.dm,1447: Non movable passed to turf CanPass : 
  proc name: stack trace (/datum/proc/stack_trace)
  src: the rock (92,81,5) (/turf/simulated/mineral/sif)
  call stack:
  the rock (92,81,5) (/turf/simulated/mineral/sif): stack trace("Non movable passed to turf Can...")
  the rock (92,81,5) (/turf/simulated/mineral/sif): CanPass(null, the sand (91,81,5) (/turf/simulated/mineral/floor/ignore_mapgen), 0, 0)
  the flamethrower fuel (/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel): Spread()
  the flamethrower fuel (/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel): New(the sand (91,81,5) (/turf/simulated/mineral/floor/ignore_mapgen), 1, 0)
  the flamethrower fuel (/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel): New(the sand (91,81,5) (/turf/simulated/mineral/floor/ignore_mapgen), 1, 0)
  /dmm_suite (/dmm_suite): create atom(/obj/effect/decal/cleanable/li... (/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel), the sand (91,81,5) (/turf/simulated/mineral/floor/ignore_mapgen))
  /dmm_suite (/dmm_suite): instance atom(/obj/effect/decal/cleanable/li... (/obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel), /list (/list), the sand (91,81,5) (/turf/simulated/mineral/floor/ignore_mapgen), 0, 0)
  /dmm_suite (/dmm_suite): parse grid("/obj/effect/decal/cleanable/li...", "c", 91, 81, 5, 0, 0)
  /dmm_suite (/dmm_suite): load map impl('maps/submaps/surface_submaps/m...', 90, 76, 5, 1, null, null, 0)
  /dmm_suite (/dmm_suite): load map('maps/submaps/surface_submaps/m...', 90, 76, 5, 1, null, null, 0)
  Spy Remains (/datum/map_template/surface/mountains/normal/deadspy): load(the rock (90,76,5) (/turf/simulated/mineral/sif), 1, 0)
  seed submaps(/list (/list), 15, /area/surface/cave/unexplored/... (/area/surface/cave/unexplored/normal), /datum/map_template/surface/mo... (/datum/map_template/surface/mountains/normal))
  Southern Cross (/datum/map/southern_cross): perform map generation()
  Mapping (/datum/controller/subsystem/mapping): Initialize(35307)
  Master (/datum/controller/master): Initialize(10, 0, 1)
```