### PR TITLE
Make max languages properly update

### DIFF
--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -12,7 +12,7 @@
 	for(var/trait in pref.pos_traits)
 		if(trait==/datum/trait/positive/linguist)
 			morelang = 1
-			pref.num_languages = morelang * 12
+	pref.num_languages = morelang * 12
 	//CHOMPEdit End
 
 /datum/category_item/player_setup_item/general/language/save_character(var/savefile/S)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -30,7 +30,7 @@ var/list/preferences_datums = list()
 	var/tgui_lock = FALSE
 
 	//character preferences
-	var/num_languages				//CHOMPEdit
+	var/num_languages = 0				//CHOMPEdit
 	var/real_name						//our character's name
 	var/be_random_name = 0				//whether we are a random name every round
 	var/nickname						//our character's nickname
@@ -164,7 +164,8 @@ var/list/preferences_datums = list()
 //CHOMPEdit Begin
 /datum/preferences/proc/numlanguage()
 	var/datum/species/S = GLOB.all_species[species]
-	return max(num_languages, S.num_alternate_languages)
+	var/num = max(num_languages, S.num_alternate_languages)
+	return (num == 0) ? 3 : num //Don't return 0
 //CHOMPEdit End
 
 /datum/preferences/New(client/C)


### PR DESCRIPTION
Seems this line was indented for some reason, which made the languages only update if they were increased. Fixes a bug where someone can get 12 languages without the trait by ghosting and then switching character slots.