### PR TITLE
Carbon shadekin fixes and balancing

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -626,6 +626,14 @@
 	if(usr.stat || usr.restrained() || usr.incapacitated())
 		return
 
+	//CHOMPEdit begin
+	if(istype(usr, /mob/living/carbon/human))
+		var/mob/living/carbon/human/H = usr
+		if(H.ability_flags & 0x1)
+			to_chat(usr, "<span class='warning'>You cannot do that while phase shifted.</span>")
+			return
+	//CHOMPEdit end
+
 	holding.forceMove(get_turf(usr))
 
 	if(usr.put_in_hands(holding))

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -126,6 +126,19 @@
 	if(usr.stat)
 		return
 
+	// CHOMPEdit begin
+	if(iscarbon(usr))
+		var/mob/living/carbon/C = usr
+		if(C.handcuffed)
+			to_chat(C, "<span class='warning'>You cannot remove accessories while handcuffed!</span>")
+			return
+		else if(istype(C, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = C
+			if(H.ability_flags & 0x1)
+				to_chat(H, "<span class='warning'>You cannot remove accessories while phase shifted!</span>")
+				return
+	//CHOMPEdit end
+
 	var/obj/item/clothing/accessory/A
 	var/accessory_amount = LAZYLEN(accessories)
 	if(accessory_amount)

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -49,6 +49,18 @@
 	if(istype(user.get_active_hand(),/obj) && istype(user.get_inactive_hand(),/obj))
 		to_chat(user, "<span class='warning'>You need an empty hand to draw \the [holstered]!</span>")
 	else
+		// CHOMPEdit begin
+		if(iscarbon(user))
+			var/mob/living/carbon/C = user
+			if(C.handcuffed)
+				to_chat(C, "<span class='warning'>You cannot draw \the [holstered] while handcuffed!</span>")
+				return
+			else if(istype(C, /mob/living/carbon/human))
+				var/mob/living/carbon/human/H = C
+				if(H.ability_flags & 0x1)
+					to_chat(H, "<span class='warning'>You cannot draw \the [holstered] while phase shifted!</span>")
+					return
+		//CHOMPEdit end
 		var/sound_vol = 25
 		if(user.a_intent == I_HURT)
 			sound_vol = 50

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -100,8 +100,10 @@
 		incorporeal_move = initial(incorporeal_move)
 		density = initial(density)
 		force_max_speed = initial(force_max_speed)
+		//CHOMPEdit begin - resetting pull ability after phasing back in
 		can_pull_size = initial(can_pull_size)
 		can_pull_mobs = initial(can_pull_mobs)
+		//CHOMPEdit end
 		update_icon()
 
 		//Cosmetics mostly
@@ -141,6 +143,7 @@
 		custom_emote(1,"phases out!")
 		name = "Something"
 
+		//CHOMPEdit begin - Unequipping slots when phasing in, and preventing pulling stuff while phased.
 		if(l_hand)
 			unEquip(l_hand)
 		if(r_hand)
@@ -150,6 +153,7 @@
 
 		can_pull_size = 0
 		can_pull_mobs = MOB_PULL_NONE
+		//CHOMPEdit end
 
 		for(var/obj/belly/B as anything in vore_organs)
 			B.escapable = FALSE

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -100,6 +100,8 @@
 		incorporeal_move = initial(incorporeal_move)
 		density = initial(density)
 		force_max_speed = initial(force_max_speed)
+		can_pull_size = initial(can_pull_size)
+		can_pull_mobs = initial(can_pull_mobs)
 		update_icon()
 
 		//Cosmetics mostly
@@ -138,6 +140,16 @@
 		mouse_opacity = 0
 		custom_emote(1,"phases out!")
 		name = "Something"
+
+		if(l_hand)
+			unEquip(l_hand)
+		if(r_hand)
+			unEquip(r_hand)
+		if(back)
+			unEquip(back)
+
+		can_pull_size = 0
+		can_pull_mobs = MOB_PULL_NONE
 
 		for(var/obj/belly/B as anything in vore_organs)
 			B.escapable = FALSE


### PR DESCRIPTION
Drop items in hand and back slot when phasing out, and fix pulling items and mobs while phased.
Other bugs will be fixed later, this just puts carbon shadekin in a state where they aren't as easily abusable.