### PR TITLE
Add hovering to shadekin when phased

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -103,6 +103,7 @@
 		//CHOMPEdit begin - resetting pull ability after phasing back in
 		can_pull_size = initial(can_pull_size)
 		can_pull_mobs = initial(can_pull_mobs)
+		hovering = initial(hovering)
 		//CHOMPEdit end
 		update_icon()
 
@@ -153,6 +154,7 @@
 
 		can_pull_size = 0
 		can_pull_mobs = MOB_PULL_NONE
+		hovering = TRUE
 		//CHOMPEdit end
 
 		for(var/obj/belly/B as anything in vore_organs)


### PR DESCRIPTION
Fixes leaving footprints in snow, burning from lava, slowdown in water, and probably falling off cliffs while phased out.