### PR TITLE
add a method of limiting areas shadekin can phase in/out of

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -1819,6 +1819,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "\improper Vault"
 	icon_state = "nuke_storage"
 	ambience = AMBIENCE_HIGHSEC
+	limit_shadekin_phasing = TRUE // CHOMPEdit
 
 /area/security/checkpoint
 	name = "\improper Security Checkpoint"

--- a/code/game/area/areas_ch.dm
+++ b/code/game/area/areas_ch.dm
@@ -1,0 +1,2 @@
+/area
+    var/limit_shadekin_phasing = FALSE //Allows setting areas where shadekin cannot phase in/out

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -67,6 +67,13 @@
 		to_chat(src, "<span class='warning'>Not enough energy for that ability!</span>")
 		return FALSE
 
+	//CHOMPEdit begin - restricting areas where you can phase shift
+	var/area/A = T.loc
+	if(A?.limit_shadekin_phasing)
+		to_chat(src, "<span class='warning'>You can't use that here!</span>")
+		return FALSE
+	//CHOMPEdit end
+
 	if(!(ability_flags & AB_PHASE_SHIFTED))
 		shadekin_adjust_energy(-ability_cost)
 	playsound(src, 'sound/effects/stealthoff.ogg', 75, 1)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -599,6 +599,7 @@
 #include "code\game\antagonist\station\traitor.dm"
 #include "code\game\area\ai_monitored.dm"
 #include "code\game\area\areas.dm"
+#include "code\game\area\areas_ch.dm"
 #include "code\game\area\areas_vr.dm"
 #include "code\game\area\asteroid_areas.dm"
 #include "code\game\area\Away Mission areas.dm"


### PR DESCRIPTION
Currently only the vault has this enabled, but this could be applied other places, including live during rounds via variable editing.