### PR TITLE
Revert "[MIRROR] [MIRROR] Throw Mode QoL Tweaks"

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -84,10 +84,12 @@
 		RestrainedClickOn(A)
 		return 1
 
-	if(in_throw_mode && (isturf(A) || isturf(A.loc)) && throw_item(A))
-		trigger_aiming(TARGET_CAN_CLICK)
+	if(in_throw_mode)
+		if(isturf(A) || isturf(A.loc))
+			throw_item(A)
+			trigger_aiming(TARGET_CAN_CLICK)
+			return 1
 		throw_mode_off()
-		return TRUE
 
 	var/obj/item/W = get_active_hand()
 
@@ -284,7 +286,7 @@
 	if(T && user.TurfAdjacent(T))
 		user.ToggleTurfTab(T)
 	return 1
-
+	
 /mob/proc/ToggleTurfTab(var/turf/T)
 	if(listed_turf == T)
 		listed_turf = null

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -1,46 +1,42 @@
-/mob/living/verb/give(var/mob/living/target in living_mobs(1))
+/mob/living/carbon/human/verb/give(var/mob/living/carbon/target in living_mobs(1))
 	set category = "IC"
 	set name = "Give"
 
-	do_give(target)
-
-/mob/living/proc/do_give(var/mob/living/carbon/human/target)
-
-	if(src.incapacitated())
+	// TODO :  Change to incapacitated() on merge.
+	if(src.stat || src.lying || src.resting || src.handcuffed)
 		return
-	if(!istype(target) || target.incapacitated() || target.client == null)
+	if(!istype(target) || target.stat || target.lying || target.resting || target.handcuffed || target.client == null)
 		return
 
 	var/obj/item/I = src.get_active_hand()
 	if(!I)
 		I = src.get_inactive_hand()
 	if(!I)
-		to_chat(src, SPAN_WARNING("You don't have anything in your hands to give to \the [target]."))
+		to_chat(src, "<span class='warning'>You don't have anything in your hands to give to \the [target].</span>")
 		return
 
-	usr.visible_message(SPAN_NOTICE("\The [usr] holds out \the [I] to \the [target]."), SPAN_NOTICE("You hold out \the [I] to \the [target], waiting for them to accept it."))
-
-	if(tgui_alert(target,"[src] wants to give you \a [I]. Will you accept it?","Item Offer",list("No","Yes")) == "No")
-		target.visible_message(SPAN_NOTICE("\The [src] tried to hand \the [I] to \the [target], but \the [target] didn't want it."))
+	if(tgui_alert(target,"[src] wants to give you \a [I]. Will you accept it?","Item Offer",list("Yes","No")) == "No") //VOREStation Edit - make yes on the left to be consistent with other dialogs
+		target.visible_message("<span class='notice'>\The [src] tried to hand \the [I] to \the [target], \
+		but \the [target] didn't want it.</span>")
 		return
 
 	if(!I) return
 
 	if(!Adjacent(target))
-		to_chat(src, SPAN_WARNING("You need to stay in reaching distance while giving an object"))
-		to_chat(target, SPAN_WARNING("\The [src] moved too far away."))
+		to_chat(src, "<span class='warning'>You need to stay in reaching distance while giving an object.</span>")
+		to_chat(target, "<span class='warning'>\The [src] moved too far away.</span>")
 		return
 
 	if(I.loc != src || !src.item_is_in_hands(I))
-		to_chat(src, SPAN_WARNING("You need to keep the item in your hands."))
-		to_chat(target, SPAN_WARNING("\The [src] seems to have given up on passing \the [I] to you."))
+		to_chat(src, "<span class='warning'>You need to keep the item in your hands.</span>")
+		to_chat(target, "<span class='warning'>\The [src] seems to have given up on passing \the [I] to you.</span>")
 		return
 
 	if(target.hands_are_full())
-		to_chat(target, SPAN_WARNING("Your hands are full."))
-		to_chat(src, SPAN_WARNING("Their hands are full."))
+		to_chat(target, "<span class='warning'>Your hands are full.</span>")
+		to_chat(src, "<span class='warning'>Their hands are full.</span>")
 		return
 
 	if(src.unEquip(I))
 		target.put_in_hands(I) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
-		target.visible_message(SPAN_NOTICE("\The [src] handed \the [I] to \the [target]"))
+		target.visible_message("<span class='notice'>\The [src] handed \the [I] to \the [target].</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1004,13 +1004,14 @@
 		swap_hand()
 
 /mob/living/throw_item(atom/target)
-	if(incapacitated() || !target || istype(target, /obj/screen))
-		return FALSE
+	src.throw_mode_off()
+	if(usr.stat || !target)
+		return
+	if(target.type == /obj/screen) return
 
 	var/atom/movable/item = src.get_active_hand()
 
-	if(!item)
-		return FALSE
+	if(!item) return
 
 	var/throw_range = item.throw_range
 	if (istype(item, /obj/item/weapon/grab))
@@ -1030,32 +1031,10 @@
 				if((N.health + N.halloss) < config.health_threshold_crit || N.stat == DEAD)
 					N.adjustBruteLoss(rand(10,30))
 			src.drop_from_inventory(G)
-			return TRUE
-		else
-			return FALSE
 
-	if(!item)
-		return FALSE //Grab processing has a chance of returning null
-
-	if(a_intent == I_HELP && Adjacent(target) && isitem(item))
-		var/obj/item/I = item
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
-			if(H.in_throw_mode && H.a_intent == I_HELP && unEquip(I))
-				H.put_in_hands(I) // If this fails it will just end up on the floor, but that's fitting for things like dionaea.
-				visible_message("<b>[src]</b> hands \the [H] \a [I].", SPAN_NOTICE("You give \the [target] \a [I]."))
-			else
-				to_chat(src, SPAN_NOTICE("You offer \the [I] to \the [target]."))
-				do_give(H)
-			return TRUE
-		make_item_drop_sound(I)
-		I.forceMove(get_turf(target))
-		return TRUE
-
-	drop_from_inventory(item)
-
-	if(!item || QDELETED(item))
-		return TRUE //It may not have thrown, but it sure as hell left your hand successfully.
+	src.drop_from_inventory(item)
+	if(!item || !isturf(item.loc))
+		return
 
 	//actually throw it!
 	src.visible_message("<span class='warning'>[src] has thrown [item].</span>")
@@ -1076,7 +1055,6 @@
 
 
 	item.throw_at(target, throw_range, item.throw_speed, src)
-	return TRUE
 
 /mob/living/get_sound_env(var/pressure_factor)
 	if (hallucination)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1150,7 +1150,7 @@
 
 //Throwing stuff
 /mob/proc/throw_item(atom/target)
-	return FALSE
+	return
 
 /mob/proc/will_show_tooltip()
 	if(alpha <= EFFECTIVE_INVIS)


### PR DESCRIPTION
Reverts CHOMPStation2/CHOMPStation2#3047

This PR broke/caused the following issues:
Reinforced grabs will no longer allow you to throw people.
Placing items onto tables with or without throw mode on will dupe the item icon onto the table, and other players can interact with it, causing weird interactions like the item reappearing/disappearing from your hand based on if someone else is holding the item.
This bug ALSO will randomly take up a hand slot with an invisible item you CANNOT drop, and will only reappear once you "Reconnect", forcing the item to teleport to you wherever you are, irregardless of who else is holding it.
The "Give" menu is also now fucking reversed, as are some others, as "Yes" is now the right-hand option and "No" is the left-hand/default option, causing a LOT of sudden acceptances when you didn't want to.

Point is, I don't feel that this was tested properly - I literally discovered the first couple bugs within 30m.
And this change... doesn't really bring any positives, but it sure has downsides.