### PR TITLE
Probably fixes the language loading bug

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -516,12 +516,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(new_character.mind)
 		new_character.mind.loaded_from_ckey = picked_ckey
 		new_character.mind.loaded_from_slot = picked_slot
-
-	for(var/lang in picked_client.prefs.alternate_languages)
-		var/datum/language/chosen_language = GLOB.all_languages[lang]
-		if(chosen_language)
-			if(is_lang_whitelisted(src,chosen_language) || (new_character.species && (chosen_language.name in new_character.species.secondary_langs)))
-				new_character.add_language(lang)
 	//VOREStation Add End
 
 	for(var/lang in picked_client.prefs.alternate_languages)

--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -33,7 +33,7 @@
 		// Sanitize illegal languages
 		for(var/language in pref.alternate_languages)
 			var/datum/language/L = GLOB.all_languages[language]
-			if(!istype(L) || (L.flags & RESTRICTED) || (!(language in S.secondary_langs) && pref.client && !is_lang_whitelisted(pref.client, L))) //CHOMPEdit: Testing before tossing upstream.
+			if(!istype(L) || (L.flags & RESTRICTED) || (!(language in S.secondary_langs) && pref.client && !is_lang_whitelisted(pref.client, L)))
 				pref.alternate_languages -= language
 
 	if(isnull(pref.language_prefixes) || !pref.language_prefixes.len)

--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -33,7 +33,7 @@
 		// Sanitize illegal languages
 		for(var/language in pref.alternate_languages)
 			var/datum/language/L = GLOB.all_languages[language]
-			if(!istype(L) || (L.flags & RESTRICTED) || (!(language in S.secondary_langs) && !is_lang_whitelisted(pref.client, L)))
+			if(!istype(L) || (L.flags & RESTRICTED) || (!(language in S.secondary_langs) && pref.client && !is_lang_whitelisted(pref.client, L))) //CHOMPEdit: Testing before tossing upstream.
 				pref.alternate_languages -= language
 
 	if(isnull(pref.language_prefixes) || !pref.language_prefixes.len)

--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -7,6 +7,7 @@
 	S["language"]			>> pref.alternate_languages
 	S["language_prefixes"]	>> pref.language_prefixes
 	//CHOMPEdit Begin
+	S["species"]			>> pref.species
 	S["pos_traits"]		>> pref.pos_traits
 	var/morelang = 0
 	for(var/trait in pref.pos_traits)


### PR DESCRIPTION
Got a very solid hunch this time. Seems like the bug is mainly triggered by the despawn persistence settings triggering character save procs, which on the language part, require client presence to pass at all, meaning a good way to reliably lose your languages is to hit cryo and close client without ghosting. Also slips a species load into the language load chomp additions because the other additions kind of rely on species presence, and the species would normally be loaded *after* the languages in 03_body.dm.
Also removes a duplicate chunk of code missed during some old conflict resolves.