### PR TITLE
Nitrogen vox pr

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -210,7 +210,7 @@
 
 /obj/item/weapon/tank/nitrogen/Initialize()
 	. = ..()
-	src.air_contents.adjust_gas("nitrogen", (3*ONE_ATMOSPHERE)*70/(R_IDEAL_GAS_EQUATION*T20C))
+	src.air_contents.adjust_gas("nitrogen", (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
 
 /obj/item/weapon/tank/nitrogen/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -210,7 +210,7 @@
 
 /obj/item/weapon/tank/nitrogen/Initialize()
 	. = ..()
-	src.air_contents.adjust_gas("nitrogen", (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
+	src.air_contents.adjust_gas("nitrogen", (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C)) //CHOMPedit
 
 /obj/item/weapon/tank/nitrogen/examine(mob/user)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -44,7 +44,7 @@
 
 	gluttonous = 1
 
-	breath_type = "phoron"
+	breath_type = "nitrogen"
 	poison_type = "oxygen"
 	siemens_coefficient = 0.2
 
@@ -102,10 +102,10 @@
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath(H), slot_wear_mask)
 	if(H.backbag == 1)
-		H.equip_to_slot_or_del(new /obj/item/weapon/tank/vox(H), slot_back)
+		H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(H), slot_back)
 		H.internal = H.back
 	else
-		H.equip_to_slot_or_del(new /obj/item/weapon/tank/vox(H), slot_r_hand)
+		H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(H), slot_r_hand)
 		H.internal = H.r_hand
 	H.internal = locate(/obj/item/weapon/tank) in H.contents
 	if(istype(H.internal,/obj/item/weapon/tank) && H.internals)

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -44,7 +44,7 @@
 
 	gluttonous = 1
 
-	breath_type = "nitrogen"
+	breath_type = "nitrogen" //CHOMPedit
 	poison_type = "oxygen"
 	siemens_coefficient = 0.2
 
@@ -102,10 +102,10 @@
 
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/breath(H), slot_wear_mask)
 	if(H.backbag == 1)
-		H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(H), slot_back)
+		H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(H), slot_back) //CHOMPedit
 		H.internal = H.back
 	else
-		H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(H), slot_r_hand)
+		H.equip_to_slot_or_del(new /obj/item/weapon/tank/nitrogen(H), slot_r_hand) //CHOMPedit
 		H.internal = H.r_hand
 	H.internal = locate(/obj/item/weapon/tank) in H.contents
 	if(istype(H.internal,/obj/item/weapon/tank) && H.internals)


### PR DESCRIPTION
What does this pr do?
change three lines of code to make vox breathe and spawn with N2 (nitrogen) tanks.

Why does this pr do that?
To start, vox breathing nitrogen is an extremely common thing in most other servers nowadays, and for good reason, as having a race breath something extremely combustible and toxic in a station where people eat and go inside each other while not breathing literal engine fuel is ridiculous, and a level of unrealistic I can't quite ignore super well.

Second off, one must ask why a vox _should_ breathe phoron. An answer like 'to make them special' or 'because they can process anything' may come up, but in and of itself both these things are already said and done by the rest of vox' whole existance.

Third, this is basically an ERP/vore server, this is no point in denying that. Mechanically the only difference that will be apparent here to most vox players is likely they will 1. have to ask for a nitrogen refill (if even that) every round. and 2. will notice when they ERP in a single spot for a while, the tank will leak neutral and breathable N2, 'causing a slight air mix imbalance, instead of bleeding toxic and extremely deadly phoron in, eventually killing their partner or interrupting the scene with evacuation.

Fourth, though the most minor reason to change this, this makes making and maintaining vox boxes much much easier, and might even incline some folks to try making one themselves, or even playing vox (probably not).