### PR TITLE
Fix size gun settings in station/outpost dorms

### DIFF
--- a/code/game/area/Space Station 13 areas_ch.dm
+++ b/code/game/area/Space Station 13 areas_ch.dm
@@ -30,21 +30,27 @@
 
 /area/surface/outpost/main/dorms/dorm_1
 	name = "\improper Main Outpost Dorm One"
+	limit_mob_size = FALSE
 
 /area/surface/outpost/main/dorms/dorm_2
 	name = "\improper Main Outpost Dorm Two"
+	limit_mob_size = FALSE
 
 /area/surface/outpost/main/dorms/dorm_3
 	name = "\improper Main Outpost Dorm Three"
+	limit_mob_size = FALSE
 
 /area/surface/outpost/main/dorms/dorm_4
 	name = "\improper Main Outpost Dorm Four"
+	limit_mob_size = FALSE
 
 /area/surface/outpost/main/dorms/dorm_5
 	name = "\improper Main Outpost Dorm Five"
+	limit_mob_size = FALSE
 
 /area/surface/outpost/main/dorms/dorm_6
 	name = "\improper Main Outpost Dorm Six"
+	limit_mob_size = FALSE
 
 //TFF 5/5/20 - make rad protection great again!
 /area/crew_quarters/cafeteria
@@ -61,3 +67,39 @@
 
 /area/crew_quarters/barrestroom
 	flags = RAD_SHIELDED
+
+/area/crew_quarters/sleep/vistor_room_1
+	limit_mob_size = FALSE
+
+/area/crew_quarters/sleep/vistor_room_2
+	limit_mob_size = FALSE
+
+/area/crew_quarters/sleep/vistor_room_3
+	limit_mob_size = FALSE
+
+/area/crew_quarters/sleep/vistor_room_4
+	limit_mob_size = FALSE
+
+/area/crew_quarters/sleep/vistor_room_5
+	limit_mob_size = FALSE
+
+/area/crew_quarters/sleep/vistor_room_6
+	limit_mob_size = FALSE
+
+/area/crew_quarters/sleep/vistor_room_7
+	limit_mob_size = FALSE
+
+/area/crew_quarters/sleep/vistor_room_8
+	limit_mob_size = FALSE
+
+/area/crew_quarters/sleep/vistor_room_9
+	limit_mob_size = FALSE
+
+/area/crew_quarters/sleep/vistor_room_10
+	limit_mob_size = FALSE
+
+/area/crew_quarters/sleep/vistor_room_11
+	limit_mob_size = FALSE
+
+/area/crew_quarters/sleep/vistor_room_12
+	limit_mob_size = FALSE


### PR DESCRIPTION
Just for the dorms, not going to touch any other areas at the moment. (But for context, walking out of these areas will return you to 25% or 200% if you were set below/above those limits by non-admin means.)