### PR TITLE
Fixes partial item digestion erasing custom names

### DIFF
--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -54,7 +54,9 @@
 					if(0)
 						d_stage_name = "ruined"
 				if(d_stage_name)
-					cleanname = "[d_stage_name] [initial(name)]"
+					if(!cleanname)
+						cleanname = name
+					cleanname = "[d_stage_name] [initial(cleanname)]"
 					decontaminate()
 					gurgled_color = B.contamination_color //Apply the correct color setting so uncontaminable things can still have the right overlay.
 					gurgle_contaminate(B, B.contamination_flavor, B.contamination_color) //CHOMPEdit End


### PR DESCRIPTION
Fixes the damaged item descriptions erasing non-initial item names, such as loadout customizations, named PDAs, labeled things, cash wad values etc.