### PR TITLE
Adds cable coil printing to all autolathes with basic material usage

### DIFF
--- a/code/datums/autolathe/tools.dm
+++ b/code/datums/autolathe/tools.dm
@@ -64,6 +64,6 @@
 	name = "rapid service fabricator"
 	path = /obj/item/weapon/rsf
 	
-/datum/category_item/autolathe/tools/cable_coil //Psik - defaults to 1,5,10x with a 30x stack max, need to figure out 30x eventually
+/datum/category_item/autolathe/tools/cable_coil //CHOMPEdit  -- defaults to 1,5,10x with a 30x stack max, need to figure out 30x eventually
 	name = "cable coil"
 	path =/obj/item/stack/cable_coil

--- a/code/datums/autolathe/tools.dm
+++ b/code/datums/autolathe/tools.dm
@@ -63,3 +63,7 @@
 /datum/category_item/autolathe/tools/rsf
 	name = "rapid service fabricator"
 	path = /obj/item/weapon/rsf
+	
+/datum/category_item/autolathe/tools/cable_coil //Psik - defaults to 1,5,10x with a 30x stack max, need to figure out 30x eventually
+	name = "cable coil"
+	path =/obj/item/stack/cable_coil


### PR DESCRIPTION
Adding cable coil to autolathe under the tools category
Default additions just have 1x, 5x, 10x print options.
Looking into a 30x print option to get a max stack, but need to dig through more code to figure out how this is done.