### PR TITLE
Fix shuttle flooring generating insane lag

### DIFF
--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -112,7 +112,7 @@
 /turf/simulated/shuttle/proc/underlay_update()
 	if(!takes_underlays)
 		//Basically, if it's not forced, and we don't care, don't do it.
-		return 0
+		return //CHOMP Edit removed 0. Sarcastically quoting the above comment ^ "Basically, if it's not stupposed to store a fucking value, don't store a fucking value."
 
 	var/turf/under //May be a path or a turf
 	var/mutable_appearance/us = new(src) //We'll use this for changes later


### PR DESCRIPTION
/turf/simulated/shuttle/proc/underlay_update() had a "return 0" for it. Return 0 would add a blank value to a LIST and there was no GC for it. Nothing else seems adversely affected by this change to remove the 0 and just have it return.