### PR TITLE
Earlyports vorepanel save check for non-slot chars

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -375,7 +375,7 @@
 			return set_attr(usr, params)
 
 		if("saveprefs")
-			if(!ishuman(host) && !issilicon(host))
+			if(host.real_name != host.client.prefs.real_name || !ishuman(host) && !issilicon(host))
 				var/choice = tgui_alert(usr, "Warning: Saving your vore panel while playing what is very-likely not your normal character will overwrite whatever character you have loaded in character setup. Maybe this is your 'playing a simple mob' slot, though. Are you SURE you want to overwrite your current slot with these vore bellies?", "WARNING!", list("No, abort!", "Yes, save."))
 				if(choice != "Yes, save.")
 					return TRUE


### PR DESCRIPTION
Makes the vorepanel save button also do the double check it gives for simplemobs when the user is playing a character whose real_name doesn't match their client prefs, such as during body swap shenanigans etc.