### PR TITLE
Probably fixes a little autotransfer bug

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -39,7 +39,7 @@
 					continue
 			tally++
 			M.belly_cycles++
-			if(autotransfer_max_amount > 0 && tally > autotransfer_max_amount)
+			if(autotransfer_max_amount > 1 && tally > autotransfer_max_amount)
 				continue
 			if(M.belly_cycles >= autotransferwait / 60)
 				check_autotransfer(M, autotransferlocation)

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -25,15 +25,13 @@
 					break
 			if(dest_belly)
 				for(var/atom/movable/M in autotransfer_queue)
-					if(!M.autotransferable)
-						autotransfer_queue -= M
+					if(!M || !M.autotransferable)
 						continue
 					transfer_contents(M, dest_belly)
 				autotransfer_queue.Cut()
 		var/tally = 0
 		for(var/atom/movable/M in autotransferables)
-			if(!M.autotransferable)
-				autotransferables -= M
+			if(!M || !M.autotransferable)
 				continue
 			if(isliving(M))
 				var/mob/living/L = M

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -37,12 +37,12 @@
 				var/mob/living/L = M
 				if(L.absorbed)
 					continue
-			tally++
 			M.belly_cycles++
-			if(autotransfer_max_amount > 1 && tally > autotransfer_max_amount)
-				continue
 			if(M.belly_cycles >= autotransferwait / 60)
 				check_autotransfer(M, autotransferlocation)
+				tally++
+			if(autotransfer_max_amount > 0 && tally >= autotransfer_max_amount)
+				break
 
 	var/play_sound //Potential sound to play at the end to avoid code duplication.
 	var/to_update = FALSE //Did anything update worthy happen?


### PR DESCRIPTION
Probably fixes a bug where a prey-ghost queued for single-slot autotransfer vanishes from existence, leaving their position on the queue as a null, which neither has the autotransferable var or a thing to remove from that now-occupied-by-a-null list, which basically broke both parts of the thing by having an already "full" queue that wasn't clearing itself and also a blank un-skipped null in the contents list bumping up the tally and hitting the max amount to skip further handling of the contents. Or something like that idk. Thinkmeat too depleted to ~~(legit so depleted i completely forgot the word that was upposed to go here smh. it started with c tho i think but even google ain't helping rn lmao)~~ **elaborate** further.