### PR TITLE
Add some missing modules to the medihound

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station_ch.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_ch.dm
@@ -20,3 +20,6 @@
 	src.modules += new /obj/item/weapon/surgical/bonesetter/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/circular_saw/cyborg(src)
 	src.modules += new /obj/item/weapon/surgical/surgicaldrill/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bioregen(src)
+	src.modules += new /obj/item/weapon/gripper/no_use/organ(src)
+	src.modules += new /obj/item/weapon/reagent_containers/dropper(src)


### PR DESCRIPTION
Adds the bioregenerator, organ gripper, and a dropper to the medihound, which should be the last few modules they were missing.
The bioregenerator because it's provided in the operating rooms by default, so... would make sense that the medihound also gets it.
Organ gripper because without it there is literally no way for a medihound to replace lost limbs. The research hound, on the other hand, has the robotics organ gripper, so...
Dropper because otherwise you have no way of fixing necrosis, besides amputation.