### PR TITLE
Mobvore verb QOL (makes player voremobs op again)

### DIFF
--- a/code/modules/vore/eating/simple_animal_vr.dm
+++ b/code/modules/vore/eating/simple_animal_vr.dm
@@ -26,9 +26,10 @@
 	if(istype(src, /mob/living/simple_mob/animal/passive/mouse) && !T.ckey)
 		// Mice can't eat logged out players!
 		return
-	if(client && IsAdvancedToolUser())
+	/*if(client && IsAdvancedToolUser()) //CHOMPedit: Mob QOL, not everything can be grabbed and nobody wants wiseguy gotchas for trying.
 		to_chat(src, "<span class='warning'>Put your hands to good use instead!</span>")
 		return
+	*/
 	feed_grabbed_to_self(src,T)
 	update_icon()
 


### PR DESCRIPTION
Lets simplemobs use their nom verb even if they do have hands enabled. Not everything can be grabbed and quirky gotcha policing by code kinda gives off an immature vibe.