### PR TITLE
Buffs simplemob leap ability

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -440,5 +440,5 @@
 	var/armor_block = run_armor_check(T, "melee")
 	var/armor_soak = get_armor_soak(T, "melee")
 	T.apply_damage(20, HALLOSS,, armor_block, armor_soak)
-	if(prob(33))
+	if(prob(75)) //CHOMPEdit
 		T.apply_effect(3, WEAKEN, armor_block)


### PR DESCRIPTION
Makes the ability somewhat viable again by swapping the old virgo balance number to match the borgo leap chance. A hardly useful scene ability failing 8 times in a row is just cringe.