### PR TITLE
Earlyports fix for inactive vr pod traps

### DIFF
--- a/code/game/machinery/virtual_reality/vr_console.dm
+++ b/code/game/machinery/virtual_reality/vr_console.dm
@@ -185,7 +185,8 @@
 	if(!forced && avatar && tgui_alert(avatar, "Someone wants to remove you from virtual reality. Do you want to leave?", "Leave VR?", list("Yes", "No")) == "No")
 		return
 
-	avatar.exit_vr()
+	if(avatar)
+		avatar.exit_vr()
 	avatar = null
 
 	if(occupant.client)


### PR DESCRIPTION
Fixes inactive vr pods trapping the occupant due to a runtime error preventing the code from releasing the occupant.