### PR TITLE
Vox Don't Breath Spicy Air Here

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -618,7 +618,7 @@
 /datum/gas_mixture/belly_air/vox/New()
     . = ..()
     gas = list(
-        "phoron" = 100)
+        "nitrogen" = 100) // Chomp edit
 
 /datum/gas_mixture/belly_air/zaddat
     volume = 2500


### PR DESCRIPTION
Fixes oversight where bellies were filling with phoron for Vox when they don't breath that here. Should be filled with pure nitrogen instead. Note, didn't test this so let someone know if it goes tits up.