### PR TITLE
Enables all metabolism types for all species

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -6,6 +6,7 @@
 	cost = 0
 	var_changes = list("metabolic_rate" = 1.2, "hunger_factor" = 0.2, "metabolism" = 0.06) // +20% rate and 4x hunger (Teshari level)
 	excludes = list(/datum/trait/neutral/metabolism_down, /datum/trait/neutral/metabolism_apex)
+	custom_only = FALSE
 
 /datum/trait/neutral/metabolism_down
 	name = "Metabolism, Slow"
@@ -13,6 +14,7 @@
 	cost = 0
 	var_changes = list("metabolic_rate" = 0.8, "hunger_factor" = 0.04, "metabolism" = 0.0012) // -20% of default.
 	excludes = list(/datum/trait/neutral/metabolism_up, /datum/trait/neutral/metabolism_apex)
+	custom_only = FALSE
 
 /datum/trait/neutral/metabolism_apex
 	name = "Metabolism, Apex"
@@ -20,6 +22,7 @@
 	cost = 0
 	var_changes = list("metabolic_rate" = 1.4, "hunger_factor" = 0.4, "metabolism" = 0.012) // +40% rate and 8x hunger (Double Teshari)
 	excludes = list(/datum/trait/neutral/metabolism_up, /datum/trait/neutral/metabolism_down)
+	custom_only = FALSE
 
 /datum/trait/neutral/coldadapt
 	name = "Temp. Adapted, Cold"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -6,7 +6,7 @@
 	cost = 0
 	var_changes = list("metabolic_rate" = 1.2, "hunger_factor" = 0.2, "metabolism" = 0.06) // +20% rate and 4x hunger (Teshari level)
 	excludes = list(/datum/trait/neutral/metabolism_down, /datum/trait/neutral/metabolism_apex)
-	custom_only = FALSE
+	custom_only = FALSE // CHOMPEdit
 
 /datum/trait/neutral/metabolism_down
 	name = "Metabolism, Slow"
@@ -14,7 +14,7 @@
 	cost = 0
 	var_changes = list("metabolic_rate" = 0.8, "hunger_factor" = 0.04, "metabolism" = 0.0012) // -20% of default.
 	excludes = list(/datum/trait/neutral/metabolism_up, /datum/trait/neutral/metabolism_apex)
-	custom_only = FALSE
+	custom_only = FALSE // CHOMPEdit
 
 /datum/trait/neutral/metabolism_apex
 	name = "Metabolism, Apex"
@@ -22,7 +22,7 @@
 	cost = 0
 	var_changes = list("metabolic_rate" = 1.4, "hunger_factor" = 0.4, "metabolism" = 0.012) // +40% rate and 8x hunger (Double Teshari)
 	excludes = list(/datum/trait/neutral/metabolism_up, /datum/trait/neutral/metabolism_down)
-	custom_only = FALSE
+	custom_only = FALSE // CHOMPEdit
 
 /datum/trait/neutral/coldadapt
 	name = "Temp. Adapted, Cold"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
@@ -35,7 +35,8 @@
 	var_changes = list("mudking" = TRUE)
 
 /datum/trait/neutral/singularity_metabolism
-	name = "Singularity Metabolism"
+	name = "Metabolism, Singularity"
 	desc = "You are insanely hungry. You can seemingly never get enough to eat. Perhaps you had a singularity as an ancestor, or maybe one is currently living inside of your gut."
 	cost = 0
 	var_changes = list("metabolic_rate" = 2, "hunger_factor" = 1.6, "metabolism" = 0.012)	//2x metabolism speed, 32x hunger speed
+	custom_only = FALSE


### PR DESCRIPTION
Fast, Slow, Apex, and Singularity metabolisms are now available for all species/characters irregardless of if custom species or not.

This shouldn't affect gameplay balance in any way, EXCEPT potentially on 'chimera - therefore it's advised that, as with the Neural Hypersensitivity trait for Xenochimera, you do not take it unless you understand what you're doing and WILL play around it.

Singularity Metabolism was renamed Metabolism, Singularity in the trait display list to line up better with the other metabolism traits.

I will admit I made this partly because I wanted my xenochimera to have apex metabolism because she eats a LOT, and I wanted to reflect that in-game - but after conferring with others, it was discovered that no species outside custom had access to metabolism traits, hence this PR.