### PR TITLE
Enable reviving vox

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -271,11 +271,10 @@
 //Checks for various conditions to see if the mob is revivable
 /obj/item/weapon/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
 	//CHOMPEdit Begin - Vox can be revived with jumper cables
-	if(H.get_species() == SPECIES_VOX && use_on_synthetic && H.stat == DEAD && check_contact(H))
-		return null
-	//CHOMPEdit End
-
-	if((H.species.flags & NO_DEFIB))
+	if(H.get_species() == SPECIES_VOX && use_on_synthetic)
+		// Will silently continue to the other two checks.
+	//CHOMPEdit End - Edit included the else on the next line.
+	else if((H.species.flags & NO_DEFIB))
 		return "buzzes, \"Incompatible physiology. Operation aborted.\""
 	else if(H.isSynthetic() && !use_on_synthetic)
 		return "buzzes, \"Synthetic Body. Operation aborted.\""

--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -270,6 +270,11 @@
 
 //Checks for various conditions to see if the mob is revivable
 /obj/item/weapon/shockpaddles/proc/can_defib(mob/living/carbon/human/H) //This is checked before doing the defib operation
+	//CHOMPEdit Begin - Vox can be revived with jumper cables
+	if(H.get_species() == SPECIES_VOX && use_on_synthetic && H.stat == DEAD && check_contact(H))
+		return null
+	//CHOMPEdit End
+
 	if((H.species.flags & NO_DEFIB))
 		return "buzzes, \"Incompatible physiology. Operation aborted.\""
 	else if(H.isSynthetic() && !use_on_synthetic)


### PR DESCRIPTION
This enables reviving vox using jumper cables (Including the robotic variant). Idea for this was suggested by DustZMann/Nick on the Discord.