### PR TITLE
[WIP] Trait Tweaks - Heavyweight Changes + Stubborn trait, etc

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -302,6 +302,32 @@
 		halloss = 0
 	else
 		..()
+		
+/mob/living/carbon/human/Stun(var/amount)
+	if(amount > 0)	//only multiply it by the mod if it's positive, or else it takes longer to fade too!
+		amount = amount*species.stun_mod
+	..(amount)
+
+/mob/living/carbon/human/SetStunned(var/amount)
+	..()
+	
+/mob/living/carbon/human/AdjustStunned(var/amount)
+	if(amount > 0) // Only multiply it if positive.
+		amount = amount*species.stun_mod
+	..(amount)
+	
+/mob/living/carbon/human/Weaken(var/amount)
+	if(amount > 0)	//only multiply it by the mod if it's positive, or else it takes longer to fade too!
+		amount = amount*species.weaken_mod
+	..(amount)
+
+/mob/living/carbon/human/SetWeakened(var/amount)
+	..()
+	
+/mob/living/carbon/human/AdjustWeakened(var/amount)
+	if(amount > 0) // Only multiply it if positive.
+		amount = amount*species.weaken_mod
+	..(amount)
 
 /mob/living/carbon/human/getToxLoss()
 	if(species.flags & NO_POISON)

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -109,6 +109,9 @@
 	var/chemOD_mod =		1						// Damage modifier for overdose; higher = more damage from ODs
 	var/alcohol_mod =		1						// Multiplier to alcohol strength; 0.5 = half, 0 = no effect at all, 2 = double, etc.
 	var/pain_mod =			1						// Multiplier to pain effects; 0.5 = half, 0 = no effect (equal to NO_PAIN, really), 2 = double, etc.
+	var/stun_mod =			1						// Multiplier to stun effects; 0.5 = half, - = no effect (immune), 2 = double, etc.
+	var/weaken_mod =		1						// Multiplier to weakness effects; 0.5 = half, - = no effect (immune), 2 = double, etc.
+													// Stuns + Weakens will be rounded to the nearest whole #. If you set 0.5 mod, on a base stun of 3, the return will be 1.5, which rounds to 1. Be careful.
 	var/spice_mod =			1						// Multiplier to spice/capsaicin/frostoil effects; 0.5 = half, 0 = no effect (immunity), 2 = double, etc.
 	var/trauma_mod = 		1						// Affects traumatic shock (how fast pain crit happens). 0 = no effect (immunity to pain crit), 2 = double etc.Overriden by "can_feel_pain" var
 	// set below is EMP interactivity for nonsynth carbons

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -103,14 +103,14 @@
 /datum/trait/negative/pain_intolerance_basic
 	name = "Pain Intolerant"
 	desc = "You are frail and sensitive to pain. You experience 25% more pain from all sources." 
-	cost = -1
-	var_changes = list("pain_mod" = 1.25)
+	cost = -2
+	var_changes = list("pain_mod" = 1.2) // CHOMPEdit: Makes this exact opposite of Pain Tolerance Basic.
 
 /datum/trait/negative/pain_intolerance_advanced
 	name = "High Pain Intolerance"
 	desc = "You are highly sensitive to all sources of pain, and experience 50% more pain."
-	cost = -2
-	var_changes = list("pain_mod" = 1.5) //this makes you extremely vulnerable to most sources of pain, a stunbaton bop or shotgun beanbag will do around 90 agony, almost enough to drop you in one hit
+	cost = -3
+	var_changes = list("pain_mod" = 1.5) //this makes you extremely vulnerable to most sources of pain, a stunbaton bop or shotgun beanbag will do around 90 agony, almost enough to drop you in one hit. CHOMPEdit: This really should cost more if it's this bad.
 //YW ADDITIONS END
 
 /datum/trait/negative/conductive

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
@@ -40,3 +40,27 @@
 	cost = 0
 	var_changes = list("metabolic_rate" = 2, "hunger_factor" = 1.6, "metabolism" = 0.012)	//2x metabolism speed, 32x hunger speed
 	custom_only = FALSE
+
+/datum/trait/neutral/big_mouth
+	name = "Big mouth"
+	desc = "It takes half as many bites to finish food as it does for most people."
+	cost = 0
+	var_changes = list("bite_mod" = 2)
+	custom_only = FALSE
+	
+/datum/trait/neutral/big_mouth_extreme
+	name = "Giant mouth"
+	desc = "It takes a quarter as many bites to finish food as it does for most people."
+	cost = 0
+	var_changes = list("bite_mod" = 4)
+	custom_only = FALSE
+	
+/datum/trait/neutral/heavyweight
+	name = "Heavyweight"
+	desc = "You are harder to move out of the way due to your sturdiness or frame, and neither players nor mobs can trade places with you."
+	cost = 0
+	custom_only = FALSE
+	
+/datum/trait/neutral/heavyweight/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	H.mob_bump_flag = HEAVY

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
@@ -61,6 +61,6 @@
 	cost = 0
 	custom_only = FALSE
 	
-/datum/trait/neutral/heavyweight/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+/datum/trait/neutral/stubborn/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.mob_bump_flag = HEAVY

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
@@ -55,9 +55,9 @@
 	var_changes = list("bite_mod" = 4)
 	custom_only = FALSE
 	
-/datum/trait/neutral/heavyweight
-	name = "Heavyweight"
-	desc = "You are harder to move out of the way due to your sturdiness or frame, and neither players nor mobs can trade places with you."
+/datum/trait/neutral/stubborn
+	name = "Stubborn"
+	desc = "You are harder to move out of the way due to your sturdiness, frame, or just sheer stubbornness, and neither players nor mobs can trade places with you or bump you out of the way."
 	cost = 0
 	custom_only = FALSE
 	

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
@@ -76,16 +76,15 @@
 	excludes = list(/datum/trait/positive/more_blood,/datum/trait/negative/less_blood,/datum/trait/negative/less_blood_extreme)
 	can_take = ORGANICS
 
-/datum/trait/positive/heavyweight_combat
-	name = "Combat Heavyweight"
+/datum/trait/positive/heavyweight
+	name = "Heavyweight"
 	desc = "You are more heavyweight or otherwise more sturdy than most species, and as such, more resistant to knockdown effects and stuns. Stuns are only half as effective on you."
 	cost = 2
+	var_changes = list("stun_mod" = 0.75, "weaken_mod" = 0.75) // Stuns are 75% as effective - a stun of 3 seconds will be 2 seconds after rounding. Set to 0.75 to make a 3 second stun 2 seconds.(Weaken is used alongside stun to prevent aiming.)
 
 /datum/trait/positive/heavyweight/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.mob_size = MOB_LARGE
-	H.stun_mod = 0.5 // Stuns are 1/3 as effective - a stun of 3 seconds will be 1 second after rounding. Set to 0.75 to make a 3 second stun 2 seconds.
-	H.weaken_mod = 0.5 // Stuns are 1/3 as effective - a stun of 3 seconds will be 1 second after rounding. (Weaken is used alongside stun to prevent aiming.)
 
 /datum/trait/positive/table_passer
 	name = "Table passer"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
@@ -76,14 +76,16 @@
 	excludes = list(/datum/trait/positive/more_blood,/datum/trait/negative/less_blood,/datum/trait/negative/less_blood_extreme)
 	can_take = ORGANICS
 
-/datum/trait/positive/heavyweight
-	name = "Heavyweight"
-	desc = "You are more heavyweight or otherwise more sturdy than most species, and as such, it's much more difficult to move you."
+/datum/trait/positive/heavyweight_combat
+	name = "Combat Heavyweight"
+	desc = "You are more heavyweight or otherwise more sturdy than most species, and as such, more resistant to knockdown effects and stuns. Stuns are only half as effective on you."
 	cost = 2
 
 /datum/trait/positive/heavyweight/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
-	H.mob_bump_flag = HEAVY
+	H.mob_size = MOB_LARGE
+	H.stun_mod = 0.5 // Stuns are 1/3 as effective - a stun of 3 seconds will be 1 second after rounding. Set to 0.75 to make a 3 second stun 2 seconds.
+	H.weaken_mod = 0.5 // Stuns are 1/3 as effective - a stun of 3 seconds will be 1 second after rounding. (Weaken is used alongside stun to prevent aiming.)
 
 /datum/trait/positive/table_passer
 	name = "Table passer"
@@ -94,24 +96,11 @@
 	..()
 	H.pass_flags = PASSTABLE
 
-
-/datum/trait/positive/big_mouth
-	name = "Big mouth"
-	desc = "It takes half as many bites to finish food as it does for most people."
-	cost = 0  //This doesn't deserve a cost.
-	var_changes = list("bite_mod" = 2)
-
 /datum/trait/positive/grappling_expert
 	name = "Grappling expert"
 	desc = "Your grabs are much harder to escape from, and you are better at escaping from other's grabs!"
 	cost = 3
 	var_changes = list("grab_resist_divisor_victims" = 1.5, "grab_resist_divisor_self" = 0.5, "grab_power_victims" = -1, "grab_power_self" = 1)
-
-/datum/trait/positive/big_mouth_extreme
-	name = "Giant mouth"
-	desc = "It takes a quarter as many bites to finish food as it does for most people."
-	cost = 0  //This also doesn't deserve a cost.
-	var_changes = list("bite_mod" = 4)
 
 /datum/trait/positive/absorbent
 	name = "Absorbent"

--- a/code/modules/mob/living/simple_mob/subtypes/mechanical/mecha/combat_mecha.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/mechanical/mecha/combat_mecha.dm
@@ -36,3 +36,5 @@
 			L.throw_at(get_edge_target_turf(L, throw_dir), throw_dist, 1, src)
 		else
 			to_chat(L, span("warning", "\The [src] punches you with incredible force, but you remain in place."))
+			visible_message(span("danger", "\The [src] slams it's mechanized fist into \the [L] with incredible force, to no visible effect!")) // CHOMPEdit: Mechpunch visible/audible feedback for *resisting* the punch.
+			playsound(src, "punch", 50, 1) // CHOMPEdit: Mechpunch visible/audible feedback for *resisting* the punch.

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/subtypes.dm
@@ -417,6 +417,8 @@
 			L.throw_at(get_edge_target_turf(L, throwdir), 3, 1, src)
 		else
 			to_chat(L, span("warning", "\The [src] hits you with incredible force, but you remain in place."))
+			visible_message(span("danger", "\The [src] hits \the [L] with incredible force, to no visible effect!")) // CHOMPEdit: Visible/audible feedback for *resisting* the slam.
+			playsound(src, "punch", 50, 1) // CHOMPEdit: Visible/audible feedback for *resisting* the slam.
 
 
 /mob/living/simple_mob/slime/xenobio/amber


### PR DESCRIPTION
Heavyweight's effect has been moved to a neutral trait of the same name.
Combat Heavyweight replaces Heavyweight, offers reduction on all incoming stuns + resistance to knockdown effects.

Trait Changes requested by Cyrus:
Pain Intolerance + Intolerance High changed to cost 2 + 3 respectively.
Big + Giant Mouth are now neutral. They're literally just "I can eat food faster haha."

Other Changes:
Adds a visible message + sound to the else effect of the throwpunch - if you're punched, your friends are now aware of if you got yeeted or not yeeted, and it plays a sound so players are aware the special attack was just used.

This **does not mechanically change the punch.**
It is simply additional feedback to the player(s).

More TBD.
