### PR TITLE
Makes toilets slightly more fun

### DIFF
--- a/code/game/objects/structures/watercloset_vr.dm
+++ b/code/game/objects/structures/watercloset_vr.dm
@@ -4,6 +4,8 @@
 /obj/structure/toilet
 	var/teleplumbed = FALSE
 	var/exit_landmark
+	var/refill_cooldown = 200
+	var/refilling = FALSE
 
 /obj/structure/toilet/Initialize()
 	if(z in global.using_map.map_levels)
@@ -14,20 +16,39 @@
 	return ..()
 
 /obj/structure/toilet/attack_hand(mob/living/user as mob)
-	if(open && teleplumbed && exit_landmark)
+	if(open && teleplumbed && exit_landmark && !refilling)
 		var/list/bowl_contents = list()
 		for(var/obj/item/I in loc.contents)
 			if(istype(I) && !I.anchored)
 				bowl_contents += I
 		if(bowl_contents.len)
+			refilling = TRUE
 			user.visible_message("<span class='notice'>[user] flushes the toilet.</span>", "<span class='notice'>You flush the toilet.</span>")
 			playsound(src, 'sound/vore/death7.ogg', 50, 1) //Got lazy about getting new sound files. Have a sick remix lmao.
 			playsound(src, 'sound/effects/bubbles.ogg', 50, 1)
 			playsound(src, 'sound/mecha/powerup.ogg', 30, 1)
+			var/bowl_conga = 0
 			for(var/obj/item/F in bowl_contents)
-				F.forceMove(get_turf(exit_landmark))
-				bowl_contents -= F
+				if(bowl_conga < 150)
+					bowl_conga += 2
+				spawn(3 + bowl_conga)
+					F.SpinAnimation(5,3)
+					spawn(15)
+						F.forceMove(src)
+			spawn(refill_cooldown)
+				for(var/obj/item/F in bowl_contents)
+					F.forceMove(get_turf(exit_landmark))
+				bowl_contents.Cut()
+				refilling = FALSE
 			return
+	if(refilling)
+		playsound(src, 'sound/machines/door_locked.ogg', 30, 1)
+		to_chat(user, "<span class='notice'>The toilet is still refilling its tank.</span>")
+	return ..()
+
+/obj/structure/toilet/attackby(obj/item/I as obj, mob/living/user as mob)
+	if(refilling) //No cistern interactions until bowl contents have been dealt with.
+		return
 	return ..()
 
 /obj/structure/toilet/attack_ai(mob/user as mob)


### PR DESCRIPTION
Instead of instantly just zapping the contents away, they now swirl the stuff around before making it vanish one item at a time, keeping the things contained for a 20 sec cooldown time before it gets zapped to the exit landmark, this serving as both, spam protection and a chance for the possible player victim to watch the action finish before they're bluespaced away.

Not even gonna bother marking as chompedit for now cause it was already all my code and I doubt anyone else up there's gonna be touching the file and might just end up porting it there anyway if I somehow get a charitable urge to provide them with non-critical funfeatures again :v