### PR TITLE
Removes Command Secretary from whitelisted jobs

### DIFF
--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -155,10 +155,9 @@ var/list/whitelisted_positions = list(
 	"Chief Engineer",
 	"Research Director",
 	"Chief Medical Officer",
-	"Command Secretary",
 	"Warden",
 	"AI"
-)
+) //CHOMPEdit: Removed Command Secretary from whitelisted jobs.
 
 /proc/guest_jobbans(var/job)
 	return ((job in whitelisted_positions))


### PR DESCRIPTION
It's just assistant with bridge access, made for ~~being ploughed~~ intermingling with the command staff.

This doesn't need to be whitelisted.