### PR TITLE
Removes Baymiss

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -404,11 +404,15 @@ emp_act
 			zone = ran_zone(BP_TORSO,75)	//Hits a random part of the body, geared towards the chest
 
 		//check if we hit
+		/*
 		var/miss_chance = 15
 		if (O.throw_source)
 			var/distance = get_dist(O.throw_source, loc)
 			miss_chance = max(15*(distance-2), 0)
+
 		zone = get_zone_with_miss_chance(zone, src, miss_chance, ranged_attack=1)
+		*/
+		//CHOMPEDIT - removing baymiss
 
 		if(zone && O.thrower != src)
 			var/shield_check = check_shields(throw_damage, O, thrower, zone, "[O]")
@@ -418,6 +422,7 @@ emp_act
 				return
 
 		if(!zone)
+			message_admins("WE FOUND THE BITCH")
 			visible_message("<b>\The [O]</b> misses [src] narrowly!")
 			return
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -422,7 +422,6 @@ emp_act
 				return
 
 		if(!zone)
-			message_admins("WE FOUND THE BITCH")
 			visible_message("<b>\The [O]</b> misses [src] narrowly!")
 			return
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -268,15 +268,15 @@
 		var/dtype = O.damtype
 		var/throw_damage = O.throwforce*(speed/THROWFORCE_SPEED_DIVISOR)
 
-		var/miss_chance = 15
+		/*var/miss_chance = 15
 		if (O.throw_source)
 			var/distance = get_dist(O.throw_source, loc)
 			miss_chance = max(15*(distance-2), 0)
 
 		if (prob(miss_chance))
 			visible_message("<font color='blue'>\The [O] misses [src] narrowly!</font>")
-			return
-
+			return*/
+		//CHOMPEDIT - removing baymiss
 		src.visible_message("<font color='red'>[src] has been hit by [O].</font>")
 		var/armor = run_armor_check(null, "melee")
 		var/soaked = get_armor_soak(null, "melee")

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -149,10 +149,12 @@
 		miss_chance = base_miss_chance[zone]
 	if (zone == "eyes" || zone == "mouth")
 		miss_chance = base_miss_chance["head"]
-	miss_chance = max(miss_chance + miss_chance_mod, 0)
+	// miss_chance = max(miss_chance + miss_chance_mod, 0) CHOMPEDIT - removing baymiss
+	if(prob(miss_chance_mod)) //CHOMPADD - removing baymiss. Checking the miss chance for legacy. This should only be affected by special cases and evasion.
+		return null
 	if(prob(miss_chance))
-		if(prob(70))
-			return null
+		//if(prob(70))
+		//	return null	CHOMPEDIT - removing baymiss
 		return pick(base_miss_chance)
 	return zone
 
@@ -603,7 +605,7 @@ var/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 //The base miss chance for the different defence zones
 var/list/global/base_miss_chance = list(
 	"head" = 40,
-	"chest" = 10,
+	"torso" = 10,
 	"groin" = 20,
 	"l_leg" = 20,
 	"r_leg" = 20,
@@ -613,7 +615,7 @@ var/list/global/base_miss_chance = list(
 	"r_hand" = 50,
 	"l_foot" = 50,
 	"r_foot" = 50,
-)
+) //CHOMPEDIT - Changed "chest" to "torso", as chest is a typo. How long has this bug been here?
 
 //Used to weight organs when an organ is hit randomly (i.e. not a directed, aimed attack).
 //Also used to weight the protection value that armour provides for covering that body part when calculating protection from full-body effects.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -591,7 +591,7 @@
 		if(!this.velocity)
 			passthrough = FALSE
 			penetrating = 0
-	//CHOMPEdit End 
+	//CHOMPEdit End
 	*/
 
 	if(passthrough)
@@ -658,7 +658,7 @@
 		return
 
 	//roll to-hit
-	miss_modifier = max(15*(distance-2) - accuracy + miss_modifier + target_mob.get_evasion(), -100)
+	miss_modifier = max(miss_modifier + target_mob.get_evasion(), -100) //CHOMPEDIT - removing baymiss
 	var/hit_zone = get_zone_with_miss_chance(def_zone, target_mob, miss_modifier, ranged_attack=(distance > 1 || original != target_mob)) //if the projectile hits a target we weren't originally aiming at then retain the chance to miss
 
 	var/result = PROJECTILE_FORCE_MISS

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -16,7 +16,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/bullet
 
 /obj/item/projectile/bullet/on_hit(var/atom/target, var/blocked = 0)
-	//if (..(target, blocked))
+	..(target, blocked)
 		//var/mob/living/L = target
 		//shake_camera(L, 3, 2) CHOMPEDIT - "Muh realism". The screenshake is obnoxious for gameplay. TODO: Replace with blood splatter indicator.
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -16,9 +16,9 @@
 	muzzle_type = /obj/effect/projectile/muzzle/bullet
 
 /obj/item/projectile/bullet/on_hit(var/atom/target, var/blocked = 0)
-	if (..(target, blocked))
-		var/mob/living/L = target
-		shake_camera(L, 3, 2)
+	//if (..(target, blocked))
+		//var/mob/living/L = target
+		//shake_camera(L, 3, 2) CHOMPEDIT - "Muh realism". The screenshake is obnoxious for gameplay. TODO: Replace with blood splatter indicator.
 
 /obj/item/projectile/bullet/attack_mob(var/mob/living/target_mob, var/distance, var/miss_modifier)
 	if(penetrating > 0 && damage > 20 && prob(damage))
@@ -333,7 +333,7 @@
 	agony = 0
 	embed_chance = 0
 	sharp = FALSE
-	silenced = TRUE	
+	silenced = TRUE
 
 /obj/item/projectile/bullet/pellet/shotgun/bb // Shotgun
 	name = "BB"


### PR DESCRIPTION
Does exactly what it says in the title.
I have not adjusted any damage values. So yes, buckshot shotguns are the most damaging weapon class because of this.
Damage balance can come in later. Removing misschance is a big change to ranged combat and I'd rather not run guesses about what needs changing without useable data first.

Removes the layers upon layers of RnG fiasco for making bullets sometimes miss.
Seriously it was like four layers deep what the hell, there was even a bug in there about it, evasion as a stat didn't work either.

But hey that's fixed now.
By default, all projectiles / thrown items (crossbows) have a 100% hit chance.


I've also removed the obnoxious screenshake that occurs when getting hit by a bullet. Yeah, sure, you'd reasonably jump when being shot, but showering your screen with earthquakes is just destroying your agency.