### PR TITLE
Fixes communicator watches breaking gun reloading

### DIFF
--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -347,6 +347,7 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	icon = 'icons/obj/device.dmi'
 	icon_state = "commwatch"
 	slot_flags = SLOT_GLOVES
+	var/gunshot_residue	//CHOMPEDIT - Fixes a bug where guns cannot be operated while wearing a watch
 
 /obj/item/device/communicator/watch/update_icon()
 	if(video_source)


### PR DESCRIPTION
Webedit PR moment
Yeah so anything in the "gloves" slot gets checked for bullet forensics.
Communicator watches aren't a /gloves subtype so they're not inheriting the correct vars.
Lazy fix, so I added one.
Complicated fix would be changing the watch into a gloves subtype.