### PR TITLE
Brings back pref ignoring micro stomps

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -112,14 +112,14 @@ default behaviour is:
 
 			//VOREstation Edit - End
 			forceMove(tmob.loc)
-			//VOREstation Edit - Begin
+			//CHOMPSTATION Edit - Making macro/micro step mechanics mandatory again for balance, but removing the fetish aspects if pref denied.
+			//There's nothing fetishistic about politely stepping past someone.
 			// In case of micros, we don't swap positions; instead occupying the same square!
-			if(step_mechanics_pref && tmob.step_mechanics_pref)
-				if(handle_micro_bump_helping(tmob))
-					now_pushing = 0
-					return
+			if(handle_micro_bump_helping(tmob))
+				now_pushing = 0
+				return
 			// TODO - Check if we need to do something about the slime.UpdateFeed() we are skipping below.
-			// VOREStation Edit - End
+			// CHOMPSTATION Edit - End
 			tmob.forceMove(oldloc)
 			now_pushing = 0
 			return
@@ -145,10 +145,13 @@ default behaviour is:
 				H.Weaken(5)
 				now_pushing = 0
 				return
+		//CHOMPSTATION edit - bringing back mandatory step mechanics, fetish stuff removed if no prefs
 		// Handle grabbing, stomping, and such of micros!
 		if(step_mechanics_pref && tmob.step_mechanics_pref)
 			if(handle_micro_bump_other(tmob)) return
-		// VOREStation Edit - End
+		else
+			if(handle_micro_bump_other(tmob,1)) return
+		// CHOMPSTATION edit end
 		if(istype(tmob, /mob/living/carbon/human) && (FAT in tmob.mutations))
 			if(prob(40) && !(FAT in src.mutations))
 				to_chat(src, "<span class='danger'>You fail to push [tmob]'s fat ass out of the way.</span>")

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -144,9 +144,7 @@
 	var/new_size = input(nagmessage, "Pick a Size") as num|null
 	if(size_range_check(new_size))
 		resize(new_size/100, uncapped = has_large_resize_bounds(), ignore_prefs = TRUE)
-		// I'm not entirely convinced that `src ? ADMIN_JMP(src) : "null"` here does anything
-		// but just in case it does, I'm leaving the null-src checking
-		message_admins("[key_name(src)] used the resize command in-game to be [new_size]% size. [src ? ADMIN_JMP(src) : "null"]")
+		//CHOMPEDIT - I don't need to be informed every time a prommie changes sizes
 
 /*
 //Add the set_size() proc to usable verbs. By commenting this out, we can leave the proc and hand it to species that need it.
@@ -241,7 +239,7 @@
  *
  * @return false if normal code should continue, 1 to prevent normal code.
  */
-/mob/living/proc/handle_micro_bump_other(mob/living/tmob)
+/mob/living/proc/handle_micro_bump_other(mob/living/tmob, nofetish = 0) //CHOMPEDIT - changed a lot in this whole proc tbh, to bring back micro combat balance
 	ASSERT(istype(tmob))
 	//If we're flying, don't do any special interactions.
 	if(flying)
@@ -271,25 +269,27 @@
 	// We need to be above a certain size ratio in order to do anything to the prey.
 	// For DISARM and HURT intent, this is >=0.75, for GRAB it is >=0.5
 	var/size_ratio = get_effective_size() - tmob.get_effective_size()
-	if(a_intent == I_GRAB && size_ratio < 0.5)
+	if((a_intent == I_GRAB || a_intent == I_DISARM) && size_ratio < 0.5) //CHOMPEDIT - more step changes
 		return FALSE
-	if((a_intent == I_DISARM || a_intent == I_HURT) && size_ratio < 0.75)
+	if(a_intent == I_HURT && size_ratio < 0.75)
 		return FALSE
 	if(a_intent == I_HELP) // Theoretically not possible, but just in case.
 		return FALSE
 
-	if(tmob.a_intent != I_HELP && prob(35))
-		to_chat(pred, "<span class='danger'>[prey] dodges out from under your foot!</span>")
-		to_chat(prey, "<span class='danger'>You narrowly avoid [pred]'s foot!</span>")
-		return FALSE
-
+	//CHOMPEdit - removed chance to dodge steppies. Get rng out of my combat.
 	now_pushing = 0
 	forceMove(tmob.loc)
-	if(a_intent == I_GRAB || a_intent == I_DISARM)
-		if(tmob.a_intent == I_HELP)
-			tmob.resting = 1
-		else
-			tmob.Weaken(1)
+	if(a_intent != I_HELP)
+		if(tmob.size_multiplier >= 1 && nofetish) //So we can stun micros with step mechanics off, but prevent macros from stunning regular heights
+			to_chat(pred, "<span class='danger'>You pass over [tmob.name].</span>")
+			to_chat(prey, "<span class='danger'>[src.name] passes over you.</span>")
+			return FALSE
+		tmob.resting = 1
+		tmob.Weaken(3)		//CHOMPEdit - do both regardless of intent, dummy
+		if(nofetish)
+			to_chat(pred, "<span class='danger'>You casually knock [tmob.name] over.</span>")
+			to_chat(prey, "<span class='danger'>[src.name] casually knocks you over.</span>")
+			return TRUE
 
 	var/size_damage_multiplier = size_multiplier - tmob.size_multiplier
 	// This technically means that I_GRAB will set this value to the same as I_HARM, but
@@ -306,71 +306,71 @@
 	var/datum/sprite_accessory/tail/taur/tail = null
 	if(istaurtail(pred.tail_style))
 		tail = pred.tail_style
+	if(!nofetish)	//CHOMPedit - Brings back mandatory step mechanics, circumvents the fetish stuff if no pref match
+		if(a_intent == I_GRAB)
+			// You can only grab prey if you have no shoes on. And both of you are cool with it.
+			if(pred.shoes || !(pred.pickup_pref && prey.pickup_pref))
+				message_pred = "You step down onto [prey], squishing them and forcing them down to the ground!"
+				message_prey = "[pred] steps down and squishes you with their foot, forcing you down to the ground!"
+				if(tail)
+					message_pred = STEP_TEXT_OWNER(tail.msg_owner_grab_fail)
+					message_prey = STEP_TEXT_PREY(tail.msg_prey_grab_fail)
+				add_attack_logs(pred, prey,"Grabbed underfoot ([tail ? "taur" : "nontaur"], shoes)")
+			else
+				message_pred = "You pin [prey] down onto the floor with your foot and curl your toes up around their body, trapping them inbetween them!"
+				message_prey = "[pred] pins you down to the floor with their foot and curls their toes up around your body, trapping you inbetween them!"
+				if(tail)
+					message_pred = STEP_TEXT_OWNER(tail.msg_owner_grab_success)
+					message_prey = STEP_TEXT_PREY(tail.msg_prey_grab_success)
+				equip_to_slot_if_possible(prey.get_scooped(pred), slot_shoes, 0, 1)
+				add_attack_logs(pred, prey, "Grabbed underfoot ([tail ? "taur" : "nontaur"], no shoes)")
 
-	if(a_intent == I_GRAB)
-		// You can only grab prey if you have no shoes on. And both of you are cool with it.
-		if(pred.shoes || !(pred.pickup_pref && prey.pickup_pref))
-			message_pred = "You step down onto [prey], squishing them and forcing them down to the ground!"
-			message_prey = "[pred] steps down and squishes you with their foot, forcing you down to the ground!"
-			if(tail)
-				message_pred = STEP_TEXT_OWNER(tail.msg_owner_grab_fail)
-				message_prey = STEP_TEXT_PREY(tail.msg_prey_grab_fail)
-			add_attack_logs(pred, prey,"Grabbed underfoot ([tail ? "taur" : "nontaur"], shoes)")
+		if(m_intent == "run")
+			switch(a_intent)
+				if(I_DISARM)
+					message_pred = "You quickly push [prey] to the ground with your foot!"
+					message_prey = "[pred] pushes you down to the ground with their foot!"
+					if(tail)
+						message_pred = STEP_TEXT_OWNER(tail.msg_owner_disarm_run)
+						message_prey = STEP_TEXT_PREY(tail.msg_prey_disarm_run)
+					add_attack_logs(pred, prey, "Pinned underfoot (run, no halloss)")
+				if(I_HURT)
+					message_pred = "You carelessly step down onto [prey], crushing them!"
+					message_prey = "[pred] steps carelessly on your body, crushing you!"
+					if(tail)
+						message_pred = STEP_TEXT_OWNER(tail.msg_owner_harm_run)
+						message_prey = STEP_TEXT_PREY(tail.msg_prey_harm_run)
+
+					for(var/obj/item/organ/external/I in prey.organs)
+						I.take_damage(calculated_damage, 0) // 5 damage min, 26.25 damage max, depending on size & RNG. If they're only stepped on once, the damage will (probably not...) heal over time.
+					prey.drip(0.1)
+					add_attack_logs(pred, prey, "Crushed underfoot (run, about [calculated_damage] damage)")
 		else
-			message_pred = "You pin [prey] down onto the floor with your foot and curl your toes up around their body, trapping them inbetween them!"
-			message_prey = "[pred] pins you down to the floor with their foot and curls their toes up around your body, trapping you inbetween them!"
-			if(tail)
-				message_pred = STEP_TEXT_OWNER(tail.msg_owner_grab_success)
-				message_prey = STEP_TEXT_PREY(tail.msg_prey_grab_success)
-			equip_to_slot_if_possible(prey.get_scooped(pred), slot_shoes, 0, 1)
-			add_attack_logs(pred, prey, "Grabbed underfoot ([tail ? "taur" : "nontaur"], no shoes)")
+			switch(a_intent)
+				if(I_DISARM)
+					message_pred = "You firmly push your foot down on [prey], painfully but harmlessly pinning them to the ground!"
+					message_prey = "[pred] firmly pushes their foot down on you, quite painfully but harmlessly pinning you to the ground!"
+					if(tail)
+						message_pred = STEP_TEXT_OWNER(tail.msg_owner_disarm_walk)
+						message_prey = STEP_TEXT_PREY(tail.msg_prey_disarm_walk)
+					add_attack_logs(pred, prey, "Pinned underfoot (walk, about [damage] halloss)")
+					tmob.Weaken(2) //Removed halloss because it was being abused
+				if(I_HURT)
+					message_pred = "You methodically place your foot down upon [prey]'s body, slowly applying pressure, crushing them against the floor below!"
+					message_prey = "[pred] methodically places their foot upon your body, slowly applying pressure, crushing you against the floor below!"
+					if(tail)
+						message_pred = STEP_TEXT_OWNER(tail.msg_owner_harm_walk)
+						message_prey = STEP_TEXT_PREY(tail.msg_prey_harm_walk)
+					// Multiplies the above damage by 3.5. This means a min of 1.75 damage, or a max of 9.1875. damage to each limb, depending on size and RNG.
+					calculated_damage *= 3.5
+					for(var/obj/item/organ/I in prey.organs)
+						I.take_damage(calculated_damage, 0)
+					prey.drip(3)
+					add_attack_logs(pred, prey, "Crushed underfoot (walk, about [calculated_damage] damage)")
 
-	if(m_intent == "run")
-		switch(a_intent)
-			if(I_DISARM)
-				message_pred = "You quickly push [prey] to the ground with your foot!"
-				message_prey = "[pred] pushes you down to the ground with their foot!"
-				if(tail)
-					message_pred = STEP_TEXT_OWNER(tail.msg_owner_disarm_run)
-					message_prey = STEP_TEXT_PREY(tail.msg_prey_disarm_run)
-				add_attack_logs(pred, prey, "Pinned underfoot (run, no halloss)")
-			if(I_HURT)
-				message_pred = "You carelessly step down onto [prey], crushing them!"
-				message_prey = "[pred] steps carelessly on your body, crushing you!"
-				if(tail)
-					message_pred = STEP_TEXT_OWNER(tail.msg_owner_harm_run)
-					message_prey = STEP_TEXT_PREY(tail.msg_prey_harm_run)
-
-				for(var/obj/item/organ/external/I in prey.organs)
-					I.take_damage(calculated_damage, 0) // 5 damage min, 26.25 damage max, depending on size & RNG. If they're only stepped on once, the damage will (probably not...) heal over time.
-				prey.drip(0.1)
-				add_attack_logs(pred, prey, "Crushed underfoot (run, about [calculated_damage] damage)")
-	else
-		switch(a_intent)
-			if(I_DISARM)
-				message_pred = "You firmly push your foot down on [prey], painfully but harmlessly pinning them to the ground!"
-				message_prey = "[pred] firmly pushes their foot down on you, quite painfully but harmlessly pinning you to the ground!"
-				if(tail)
-					message_pred = STEP_TEXT_OWNER(tail.msg_owner_disarm_walk)
-					message_prey = STEP_TEXT_PREY(tail.msg_prey_disarm_walk)
-				add_attack_logs(pred, prey, "Pinned underfoot (walk, about [damage] halloss)")
-				tmob.Weaken(2) //Removed halloss because it was being abused
-			if(I_HURT)
-				message_pred = "You methodically place your foot down upon [prey]'s body, slowly applying pressure, crushing them against the floor below!"
-				message_prey = "[pred] methodically places their foot upon your body, slowly applying pressure, crushing you against the floor below!"
-				if(tail)
-					message_pred = STEP_TEXT_OWNER(tail.msg_owner_harm_walk)
-					message_prey = STEP_TEXT_PREY(tail.msg_prey_harm_walk)
-				// Multiplies the above damage by 3.5. This means a min of 1.75 damage, or a max of 9.1875. damage to each limb, depending on size and RNG.
-				calculated_damage *= 3.5
-				for(var/obj/item/organ/I in prey.organs)
-					I.take_damage(calculated_damage, 0)
-				prey.drip(3)
-				add_attack_logs(pred, prey, "Crushed underfoot (walk, about [calculated_damage] damage)")
-
-	to_chat(pred, "<span class='danger'>[message_pred]</span>")
-	to_chat(prey, "<span class='danger'>[message_prey]</span>")
-	return TRUE
+		to_chat(pred, "<span class='danger'>[message_pred]</span>")
+		to_chat(prey, "<span class='danger'>[message_prey]</span>")
+		return TRUE
 
 /mob/living/verb/toggle_pickups()
 	set name = "Toggle Micro Pick-up"

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -280,7 +280,7 @@
 	now_pushing = 0
 	forceMove(tmob.loc)
 	if(a_intent != I_HELP)
-		if(tmob.size_multiplier >= 1 && nofetish) //So we can stun micros with step mechanics off, but prevent macros from stunning regular heights
+		if(tmob.size_multiplier > 0.75 && nofetish) //So we can stun micros with step mechanics off, but prevent macros from stunning regular heights
 			to_chat(pred, "<span class='danger'>You pass over [tmob.name].</span>")
 			to_chat(prey, "<span class='danger'>[src.name] passes over you.</span>")
 			return FALSE


### PR DESCRIPTION
Except I did it smartly.
See, stomping on someone was a mechanic to balance out people being two pixels tall and impossible to click in melee combat.

But then some genius made it a toggleable pref, so a cigarette with a fireaxe is the most dangerous thing to any sec team.

I'm bringing back no pref micro stomping in a smart way.

If you have step mechanics turned on, all the fetishistic messages about foot stuff, grabs and taking damage are included.

If you have step mechanics off, and are 100%+ scale, you cannot be stomp stunned. Macros can still walk over you and you can still walk under them, tho.

If you have step mechanics off, and are below 100% scale, anyone that's 50% or more scale above you can briefly stun you with a disarm/grab/harm step with a simple message of being knocked down. Nothing more, no foot stuff, no damage. Just a stun.

Hopefully, this should make micros non-threatening in melee combat, as intended, while also not being aggravating to people with step mechanics turned off.