### PR TITLE
Remove headset sound effect for simple_mob

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -61,10 +61,10 @@
 	return ..()
 
 /obj/item/device/radio/headset/receive_range(freq, level, aiOverride = 0)
-	if(!ishuman(src.loc))
+	if(!ishuman(src.loc))				//CHOMP Addition, this IF block.
 		var/mob/living/carbon/human/H = src.loc
 		if(H.l_ear == src || H.r_ear == src)
-			return ..(freq, level)
+			return ..(freq, level)		//CHOMP Addition end
 	if (aiOverride)
 		playsound(loc, 'sound/effects/radio_common.ogg', 20, 1, 1, preference = /datum/client_preference/radio_sounds)
 		return ..(freq, level)

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -61,6 +61,10 @@
 	return ..()
 
 /obj/item/device/radio/headset/receive_range(freq, level, aiOverride = 0)
+	if(!ishuman(src.loc))
+		var/mob/living/carbon/human/H = src.loc
+		if(H.l_ear == src || H.r_ear == src)
+			return ..(freq, level)
 	if (aiOverride)
 		playsound(loc, 'sound/effects/radio_common.ogg', 20, 1, 1, preference = /datum/client_preference/radio_sounds)
 		return ..(freq, level)


### PR DESCRIPTION
This will remove the headset sound effect for mobs, so that way if during an event, a stealthy mob has a mob_headset, it won't make any radio noise whenever a transmission occurs and so that other players won't hear it.

Tested for simple mobs and confirmed simple mobs will not make static noise while carbons will still hear it.