### PR TITLE
Fix runtime for mob headsets

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -62,9 +62,7 @@
 
 /obj/item/device/radio/headset/receive_range(freq, level, aiOverride = 0)
 	if(!ishuman(src.loc))				//CHOMP Addition, this IF block.
-		var/mob/living/carbon/human/H = src.loc
-		if(H.l_ear == src || H.r_ear == src)
-			return ..(freq, level)		//CHOMP Addition end
+		return ..(freq, level)		//CHOMP Addition end
 	if (aiOverride)
 		playsound(loc, 'sound/effects/radio_common.ogg', 20, 1, 1, preference = /datum/client_preference/radio_sounds)
 		return ..(freq, level)


### PR DESCRIPTION
Deleted two unnecessary lines because mobs don't have L and R ears.