### PR TITLE
Xenochimera feral reduction while in darkness OR belly

### DIFF
--- a/code/_onclick/hud/screen_objects_vr.dm
+++ b/code/_onclick/hud/screen_objects_vr.dm
@@ -45,6 +45,8 @@
 						var/turf/T = get_turf(H)
 						if(T.get_lumcount() <= 0.1)
 							to_chat(usr, "<span class='notice'>You are slowly calming down in darkness' safety...</span>")
+						else if(isbelly(H.loc)) // CHOMPEdit: Safety message for if inside a belly.
+							to_chat(usr, "<span class='notice'>You are slowly calming down within the darkness of something's belly, listening to their body as it moves around you. ...safe...</span>")
 						else
 							to_chat(usr, "<span class='notice'>You are slowly calming down... But safety of darkness is much preferred.</span>")
 				else

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -205,6 +205,10 @@
 			feral++
 		else
 			feral = max(0,--feral)
+		
+		// Being in a belly decreases stress further. :9	
+		if(feral && isbelly(H.loc))
+			feral = max(0,--feral)
 
 		//Set our real mob's var to our temp var
 		H.feral = feral
@@ -233,8 +237,8 @@
 			//This is basically the 'lite' version of the below block.
 			var/list/nearby = H.living_mobs(world.view)
 
-			//Not in the dark and out in the open.
-			if(!darkish && isturf(H.loc))
+			//Not in the dark, or a belly, and out in the open.
+			if(!darkish && isturf(H.loc) && !isbelly(H.loc)) // CHOMPEdit: added specific check for if in belly
 
 				//Always handle feral if nobody's around and not in the dark.
 				if(!nearby.len)
@@ -248,8 +252,8 @@
 			update_xenochimera_hud(H, danger, feral_state)
 			return
 
-		// In the darkness or "hidden". No need for custom scene-protection checks as it's just an occational infomessage.
-		if(darkish || !isturf(H.loc))
+		// In the darkness, "hidden", or in a belly. No need for custom scene-protection checks as it's just an occational infomessage.
+		if(darkish || !isturf(H.loc) || isbelly(H.loc)) // CHOMPEdit: added specific check for if in belly
 			// If hurt, tell 'em to heal up
 			if (shock)
 				to_chat(H,"<span class='info'>This place seems safe, secure, hidden, a place to lick your wounds and recover...</span>")

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -226,7 +226,7 @@
 		H.shock_stage = max(H.shock_stage-(feral/20), 0)
 
 		//Handle light/dark areas
-		var/turf/T = get_turf(H)
+		// var/turf/T = get_turf(H) // CHOMPEdit: Moved up to before the in-belly/dark combined check, should still safely reach here just fine.
 		if(!T)
 			update_xenochimera_hud(H, danger, feral_state)
 			return //Nullspace

--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -206,8 +206,9 @@
 		else
 			feral = max(0,--feral)
 		
-		// Being in a belly decreases stress further. :9	
-		if(feral && isbelly(H.loc))
+		// Being in a belly or in the darkness decreases stress further. :9
+		var/turf/T = get_turf(H)
+		if(feral && (isbelly(H.loc) || T.get_lumcount() <= 0.1))
 			feral = max(0,--feral)
 
 		//Set our real mob's var to our temp var


### PR DESCRIPTION
Xenochimera will now reduce ferality at a tickrate of 1 per Life tick while inside a belly or in darkness, same as the hunger reduction if they're full.
They will not experience hallucinations and will get safety messages while inside a belly, as well as the status indicator confirming they're safe even in a lit environment.

In total:
If sated, feral will reduce by 1 per Life() tick.
If in darkness _or_ a belly, feral will reduce by 1 per Life() tick.
A feral of 220 will take 110 seconds to clear if satiated, not in a belly, and in light.
Alternatively, it will take 55 seconds to clear if satiated **and** either in a belly _or_ in the darkness.