### PR TITLE
Earlyports fix for endless holocarps

### DIFF
--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -317,6 +317,9 @@
 	for(var/obj/effect/decal/cleanable/blood/B in linkedholodeck)
 		qdel(B)
 
+	for(var/obj/effect/landmark/L in linkedholodeck)
+		qdel(L)
+
 	holographic_objs = A.copy_contents_to(linkedholodeck , 1)
 	for(var/obj/holo_obj in holographic_objs)
 		holo_obj.alpha *= 0.8 //give holodeck objs a slight transparency

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -213,11 +213,10 @@
 		if(!(get_turf(item) in linkedholodeck))
 			derez(item, 0)
 
-	if (!safety_disabled)
-		for(var/mob/living/simple_mob/animal/space/carp/holodeck/C in holographic_mobs)
-			if (get_area(C.loc) != linkedholodeck)
-				holographic_mobs -= C
-				C.derez()
+	for(var/mob/living/simple_mob/animal/space/carp/holodeck/C in holographic_mobs) //CHOMPEdit
+		if (get_area(C.loc) != linkedholodeck)
+			holographic_mobs -= C
+			C.derez()
 
 	if(!..())
 		return


### PR DESCRIPTION
Fixes holodeck spawn landmarks (such as carps and "atmos test") not getting cleared when the program is unloaded and thus permanently leaving the holodeck to spawn endless carps and sparks on every simulation without any way to fix ingame.

Also makes emagged holocarps not be able to defy both science and god by having some shit meme excuse to wander out of holoprojector range. Just having them hostile and oofy for a victim on the holodeck is enough.