### PR TITLE
Fixes dogbase cleanbot faction

### DIFF
--- a/maps/submaps/surface_submaps/wilderness/dogbase.dmm
+++ b/maps/submaps/surface_submaps/wilderness/dogbase.dmm
@@ -33,7 +33,7 @@
 "lr" = (/obj/effect/floor_decal/industrial/danger{dir = 1},/turf/simulated/floor,/area/submap/DogBase)
 "lN" = (/obj/machinery/porta_turret/poi{faction = "syndicate"},/turf/simulated/floor,/area/submap/DogBase)
 "lX" = (/obj/effect/floor_decal/borderfloor,/turf/simulated/floor/tiled/dark,/area/submap/DogBase)
-"ng" = (/mob/living/bot/cleanbot{faction = "malf_drone"},/obj/effect/floor_decal/corner/purple/diagonal,/turf/simulated/floor/tiled/dark,/area/submap/DogBase)
+"ng" = (/mob/living/bot/cleanbot{faction = "syndicate"},/obj/effect/floor_decal/corner/purple/diagonal,/turf/simulated/floor/tiled/dark,/area/submap/DogBase)
 "np" = (/obj/structure/table/woodentable,/obj/item/weapon/gun/projectile/pistol,/turf/simulated/floor/tiled/dark,/area/submap/DogBase)
 "oW" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/outdoors/dirt,/area/template_noop)
 "pR" = (/obj/structure/bed,/obj/item/weapon/bedsheet,/obj/effect/floor_decal/borderfloor{dir = 9},/turf/simulated/floor/tiled/dark,/area/submap/DogBase)


### PR DESCRIPTION
Makes dogbase cleanbot same faction as the dogbase crew to avoid a hostile interaction leading to the entire poi mobs bugging out in an endless missed attack spam loop once the targeted bucket bot has been blown apart.

![kuva](https://user-images.githubusercontent.com/13697337/158407938-fba4433f-c5da-460b-a207-b82797073dca.png)
