### PR TITLE
Fixes improper plating type on arrival shuttle

### DIFF
--- a/maps/southern_cross/southern_cross-9.dmm
+++ b/maps/southern_cross/southern_cross-9.dmm
@@ -654,7 +654,7 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/shuttle/plating/airless,
 /area/shuttle/arrival/pre_game)
 "Hw" = (
 /turf/simulated/shuttle/floor,
@@ -725,7 +725,7 @@
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/shuttle/plating/airless,
 /area/shuttle/arrival/pre_game)
 "SE" = (
 /obj/structure/bed/chair/shuttle,


### PR DESCRIPTION
Fixes a couple tiles on the arrival shuttle being wrong type and causing improper turf qdel runtimes.