### PR TITLE
Fixes small bug in Xenochimera Regen timer text

### DIFF
--- a/code/_onclick/hud/screen_objects_vr.dm
+++ b/code/_onclick/hud/screen_objects_vr.dm
@@ -56,7 +56,7 @@
 			var/mob/living/carbon/human/H = usr
 			if(istype(H) && istype(H.species, /datum/species/xenochimera)) // If you're somehow able to click this while not a chimera, this should prevent weird runtimes. Will need changing if regeneration is ever opened to non-chimera using the same alert.
 				if(H.revive_ready == REVIVING_NOW)
-					to_chat(usr, "<span class='notice'>We are currently reviving, and will be done in [round((H.revive_finished - world.time) / 10)] seconds, or [round((H.revive_finished - world.time) / 60)] minutes.</span>")
+					to_chat(usr, "<span class='notice'>We are currently reviving, and will be done in [round((H.revive_finished - world.time) / 10)] seconds, or [round(((H.revive_finished - world.time) * 0.1) / 60)] minutes.</span>")
 				else if(H.revive_ready == REVIVING_DONE)
 					to_chat(usr, "<span class='warning'>You should have a notification + alert for this! Bug report that this is still here!</span>")
 					


### PR DESCRIPTION
For minutes, I gotta remember:
input should be ((deciseconds * 0.1) / 60). Oops.

Fixes
![](https://cdn.discordapp.com/attachments/950612251088408596/956981439545639002/unknown.png)