### PR TITLE
Removes pAI Construction Drone option

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -49,9 +49,6 @@
 		"Rat" = "rat",
 		"Panther" = "panther",
 		//VOREStation Addition End
-		//Chompstation Addition Start
-		"Construction Drone" = "pai-bigdrone"
-		//Chompstation Addition End
 		)
 
 	var/global/list/possible_say_verbs = list(


### PR DESCRIPTION
No such sprite exists in the .dmi, and people were using it to go invisible.
