### PR TITLE
Autoresleeving PR Adaptations for CHOMPStation

### DIFF
--- a/code/controllers/subsystems/transcore_vr.dm
+++ b/code/controllers/subsystems/transcore_vr.dm
@@ -112,11 +112,11 @@ SUBSYSTEM_DEF(transcore)
 		if(since_backup < overdue_time)
 			curr_MR.dead_state = MR_NORMAL
 		else
-/*			if(curr_MR.dead_state != MR_DEAD) //First time switching to dead	//Remove auto notification! Ghosts have a button to notify, so no more false flags.
+			if(curr_MR.dead_state != MR_DEAD) //First time switching to dead	//Remove auto notification! Ghosts have a button to notify, so no more false flags. CHOMPEdit: Revert removal
 				if(curr_MR.do_notify)
 					db.notify(curr_MR)
 					curr_MR.last_notification = world.time
-*/
+
 			curr_MR.dead_state = MR_DEAD
 
 		if(MC_TICK_CHECK)

--- a/code/datums/mind_vr.dm
+++ b/code/datums/mind_vr.dm
@@ -1,3 +1,2 @@
-//CHOMPStation EDIT: This file has been disabled in the .dme.
 /datum/mind
 	var/vore_death = FALSE	// Was our last gasp a gurgle?

--- a/code/game/area/Space Station 13 areas_ch.dm
+++ b/code/game/area/Space Station 13 areas_ch.dm
@@ -108,3 +108,6 @@
 
 /area/crew_quarters/sleep/vistor_room_12
 	limit_mob_size = FALSE
+
+/area/medical/cryo/autoresleeve
+	name = "\improper Medical Autoresleeving"

--- a/code/modules/mob/dead/observer/observer_vr.dm
+++ b/code/modules/mob/dead/observer/observer_vr.dm
@@ -130,3 +130,31 @@
 			stop_following()
 		else
 			to_chat(src, "This ghost pod is not located in the game world.")
+			
+/mob/observer/dead/verb/findautoresleever()
+	set category = "Ghost"
+	set name = "Find Auto Resleever"
+	set desc = "Find a Auto Resleever"
+	set popup_menu = FALSE
+
+	if(!istype(usr, /mob/observer/dead)) //Make sure they're an observer!
+		return
+
+	var/list/ar = list()
+	for(var/obj/machinery/transhuman/autoresleever/A in world)
+		if(A.spawntype)
+			continue
+		else
+			ar |= A
+
+	var/obj/machinery/transhuman/autoresleever/thisone = pick(ar)
+
+	if(!thisone)
+		to_chat(src, "<span class='warning'>There appears to be no auto-resleevers available.</span>")
+		return
+	var/L = get_turf(thisone)
+	if(!L)
+		to_chat(src, "<span class='warning'>There appears to be something wrong with this auto-resleever, try again.</span>")
+		return
+
+	forceMove(L)

--- a/code/modules/mob/dead/observer/observer_vr.dm
+++ b/code/modules/mob/dead/observer/observer_vr.dm
@@ -84,7 +84,7 @@
 			to_chat(src, "<span class='notice'>New notification has been sent.</span>")
 	else
 		to_chat(src,"<span class='warning'>No backup record could be found, sorry.</span>")
-/*
+// CHOMPEdit: Revert Removal
 /mob/observer/dead/verb/backup_delay()
 	set category = "Ghost"
 	set name = "Cancel Transcore Notification"
@@ -103,7 +103,7 @@
 			to_chat(src, "<span class='notice'>Overdue mind backup notification delayed successfully.</span>")
 	else
 		to_chat(src,"<span class='warning'>No backup record could be found, sorry.</span>")
-*/
+
 /mob/observer/dead/verb/findghostpod() //Moves the ghost instead of just changing the ghosts's eye -Nodrak
 	set category = "Ghost"
 	set name = "Find Ghost Pod"

--- a/code/modules/mob/living/carbon/human/death_vr.dm
+++ b/code/modules/mob/living/carbon/human/death_vr.dm
@@ -12,7 +12,6 @@
 
 	. = ..()
 
-/* CHOMPEdit - Removed because we don't use resleeving sickness.
 //Surprisingly this is only called for humans, but whatever!
 /hook/death/proc/digestion_check(var/mob/living/carbon/human/H, var/gibbed)
 	//Not in a belly? Well, too bad!
@@ -31,7 +30,6 @@
 
 	//Hooks need to return true otherwise they're considered having failed
 	return TRUE
-*/
 
 //For making sure that if a mob is able to be joined by ghosts, that ghosts can't join it if it dies
 /mob/living/simple_mob/death()

--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -65,8 +65,14 @@
 		return
 	
 	if(ghost.mind && ghost.mind.current && ghost.mind.current.stat != DEAD)
-		to_chat(ghost, "<span class='warning'>Your body is still alive, you cannot be resleeved.</span>")
-		return
+		if(istype(ghost.mind.current.loc, /obj/item/device/mmi))
+			if(tgui_alert(ghost, "Your brain is still alive, using the auto-resleever will delete that brain. Are you sure?", "Delete Brain", list("No","Yes")) != "Yes")
+				return
+			if(istype(ghost.mind.current.loc, /obj/item/device/mmi))
+				qdel(ghost.mind.current.loc)
+		else
+			to_chat(ghost, "<span class='warning'>Your body is still alive, you cannot be resleeved.</span>")
+			return
 
 	var/client/ghost_client = ghost.client
 	

--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -8,7 +8,7 @@
 	var/equip_body = FALSE				//If true, this will spawn the person with equipment
 	var/default_job = USELESS_JOB		//The job that will be assigned if equip_body is true and the ghost doesn't have a job
 	var/ghost_spawns = FALSE			//If true, allows ghosts who haven't been spawned yet to spawn
-	var/vore_respawn = 15 MINUTES		//The time to wait if you died from vore
+	var/vore_respawn = 5 MINUTES		//The time to wait if you died from vore // CHOMPEdit: Faster respawn for vorni so ghosts don't go bug medical.
 	var/respawn = 30 MINUTES			//The time to wait if you didn't die from vore
 	var/spawn_slots = -1				//How many people can be spawned from this? If -1 it's unlimited
 	var/spawntype						//The kind of mob that will be spawned, if set.
@@ -70,6 +70,20 @@
 		return
 
 	var/client/ghost_client = ghost.client
+	
+	// CHOMPEdit Start: Add checks for Whitelist + Resleeving
+	if(!is_alien_whitelisted(ghost, GLOB.all_species[ghost_client?.prefs?.species]) && !check_rights(R_ADMIN, 0)) // Prevents a ghost somehow ghosting in on a slot and spawning via a resleever with race they're not whitelisted for, getting around normal joins.
+		to_chat(ghost, "<span class='warning'>You are not whitelisted to spawn as this species!</span>")
+		return
+	
+	var/datum/species/chosen_species
+	if(ghost.client.prefs.species) // In case we somehow don't have a species set here.
+		chosen_species = GLOB.all_species[ghost_client.prefs.species]
+		
+	if(chosen_species.flags && NO_SCAN)
+		to_chat(ghost, "<span class='warning'>This species cannot be resleeved!</span>")
+		return
+	// CHOMPEdit End: Add checks for Whitelist + Resleeving
 	
 	//Name matching is ugly but mind doesn't persist to look at.
 	var/charjob

--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -12,7 +12,6 @@
 	var/respawn = 30 MINUTES			//The time to wait if you didn't die from vore
 	var/spawn_slots = -1				//How many people can be spawned from this? If -1 it's unlimited
 	var/spawntype						//The kind of mob that will be spawned, if set.
-	var/update_i = FALSE
 
 /obj/machinery/transhuman/autoresleever/update_icon()
 	. = ..()
@@ -177,6 +176,12 @@
 
 	log_admin("[new_character.ckey]'s character [new_character.real_name] has been auto-resleeved.")
 	message_admins("[new_character.ckey]'s character [new_character.real_name] has been auto-resleeved.")
+	
+	var/datum/transcore_db/db = SStranscore.db_by_mind_name(new_character.mind.name)
+	if(db)
+		var/datum/transhuman/mind_record/record = db.backed_up[new_character.mind.name]
+		if((world.time - record.last_notification) < 30 MINUTES)
+			global_announcer.autosay("[new_character.name] has been resleeved by the automatic resleeving system.", "TransCore Oversight", new_character.isSynthetic() ? "Science" : "Medical")
 
 	if(spawn_slots == -1)
 		return

--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -183,11 +183,28 @@
 	log_admin("[new_character.ckey]'s character [new_character.real_name] has been auto-resleeved.")
 	message_admins("[new_character.ckey]'s character [new_character.real_name] has been auto-resleeved.")
 	
+	var/obj/item/weapon/implant/backup/imp = new(src)
+
+	if(imp.handle_implant(new_character,new_character.zone_sel.selecting))
+		imp.post_implant(new_character)
+	
 	var/datum/transcore_db/db = SStranscore.db_by_mind_name(new_character.mind.name)
 	if(db)
 		var/datum/transhuman/mind_record/record = db.backed_up[new_character.mind.name]
 		if((world.time - record.last_notification) < 30 MINUTES)
 			global_announcer.autosay("[new_character.name] has been resleeved by the automatic resleeving system.", "TransCore Oversight", new_character.isSynthetic() ? "Science" : "Medical")
+		spawn(0)	//Wait a second for nif to do its thing if there is one
+		if(record.nif_path)
+			var/obj/item/device/nif/nif
+			if(new_character.nif)
+				nif = new_character.nif
+			else
+				nif = new record.nif_path(new_character,null,record.nif_savedata)
+			spawn(0)	//Wait another second in case we just gave them a new nif
+			if(nif)	//Now restore the software
+				for(var/path in record.nif_software)
+					new path(nif)
+				nif.durability = record.nif_durability
 
 	if(spawn_slots == -1)
 		return

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -10556,6 +10556,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/engineering/workshop)
+"aIg" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/vending/loadout/overwear,
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "aIj" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/machinery/alarm{
@@ -43893,6 +43902,9 @@
 /obj/item/weapon/storage/box/monkeycubes,
 /turf/simulated/floor/tiled/white,
 /area/medical/genetics)
+"dqr" = (
+/turf/simulated/wall/r_wall,
+/area/medical/cryo/autoresleeve)
 "dqF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -51478,8 +51490,7 @@
 	dir = 8
 	},
 /obj/machinery/cryopod{
-	dir = 1;
-	time_till_despawn = 60
+	dir = 1
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/cryo/station)
@@ -52654,8 +52665,7 @@
 /area/rnd/misc_lab)
 "ihl" = (
 /obj/machinery/cryopod{
-	dir = 2;
-	time_till_despawn = 60
+	dir = 2
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -54650,6 +54660,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"jnL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/medical{
+	name = "Autoresleeving Bay";
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/seconddeck/research_medical)
 "jnX" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -54717,6 +54742,17 @@
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor,
 /area/engineering/engine_waste)
+"jqu" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "jqw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/ai_status_display{
@@ -56030,8 +56066,7 @@
 /area/assembly/robotics)
 "jZO" = (
 /obj/machinery/cryopod{
-	dir = 1;
-	time_till_despawn = 60
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -60312,6 +60347,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/teleporter)
+"mFk" = (
+/obj/machinery/vending/loadout,
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "mFN" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -63113,8 +63152,13 @@
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
 /obj/item/weapon/pen,
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/secondary/seconddeck/research_medical)
+/area/medical/cryo/autoresleeve)
 "onb" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -63136,10 +63180,14 @@
 /area/crew_quarters/seconddeck/gym)
 "ond" = (
 /obj/structure/table/glass,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/secondary/seconddeck/research_medical)
+/area/medical/cryo/autoresleeve)
 "ooC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/cable/yellow{
@@ -63150,9 +63198,9 @@
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "ooQ" = (
-/obj/random/obstruction,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/seconddeck/research_medical)
+/obj/machinery/vending/loadout/uniform,
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "ooT" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/seconddeck/research_medical)
@@ -64547,15 +64595,18 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "pfJ" = (
-/obj/item/stack/tile/floor/white,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/seconddeck/research_medical)
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Autoresleeving Bay";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "pfT" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/hallway/secondary/seconddeck/research_medical)
+/area/medical/cryo/autoresleeve)
 "pfY" = (
 /obj/structure/table/standard,
 /obj/item/weapon/soap/nanotrasen,
@@ -64644,6 +64695,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"pix" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/obj/machinery/newscaster{
+	pixel_x = -36
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "piE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -65613,8 +65680,11 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D2)
 "pMv" = (
-/turf/simulated/floor/plating,
-/area/hallway/secondary/seconddeck/research_medical)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "pMy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -65675,16 +65745,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/medical/cryo)
 "pNa" = (
-/obj/structure/closet,
-/obj/item/device/flashlight,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/item/weapon/storage/backpack/satchel/vir,
-/obj/item/weapon/storage/backpack/virology,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/seconddeck/research_medical)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "pNf" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave{
@@ -67399,6 +67464,12 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"qQJ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "qQL" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -67746,6 +67817,9 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D3)
+"rev" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "reH" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -68993,19 +69067,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/workshop)
 "rRk" = (
-/obj/item/frame/light,
-/turf/simulated/floor/plating,
-/area/hallway/secondary/seconddeck/research_medical)
-"rRD" = (
-/obj/structure/closet/crate/medical,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
-/obj/random/medical,
-/obj/random/medical/lite,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/vending/loadout/loadout_misc,
 /turf/simulated/floor/tiled/white,
-/area/hallway/secondary/seconddeck/research_medical)
+/area/medical/cryo/autoresleeve)
+"rRD" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/super{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "rSd" = (
 /obj/structure/reagent_dispensers/water_cooler/full,
 /obj/machinery/light{
@@ -69779,6 +69858,19 @@
 "sql" = (
 /turf/unsimulated/mask,
 /area/hallway/primary/seconddeck/starboard)
+"sqI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/vending/wallmed1{
+	name = "Emergency NanoMed";
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "sqJ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/disposalpipe/segment,
@@ -71345,6 +71437,13 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
 "toM" = (
@@ -72216,6 +72315,12 @@
 "tTx" = (
 /turf/space,
 /area/shuttle/arrival/station)
+"tUA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "tVa" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck - Port Hallway 4";
@@ -72906,6 +73011,10 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/cargo)
+"uoF" = (
+/obj/machinery/vending/loadout/gadget,
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "uoP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -73103,6 +73212,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medsci and Autoresleeving";
+	req_one_access = null
+	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
 "uwy" = (
@@ -73278,17 +73391,18 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
 "uAF" = (
@@ -74208,6 +74322,10 @@
 /obj/item/weapon/book/codex/lore/robutt,
 /turf/simulated/floor/wood,
 /area/library)
+"vhy" = (
+/obj/machinery/vending/loadout/accessory,
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "vhB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75203,6 +75321,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"vLw" = (
+/obj/machinery/vending/loadout/clothing,
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "vMl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 6
@@ -75830,8 +75952,7 @@
 	dir = 8
 	},
 /obj/machinery/cryopod{
-	dir = 2;
-	time_till_despawn = 60
+	dir = 2
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/cryo/station)
@@ -77685,6 +77806,12 @@
 /obj/structure/curtain/open/shower/medical,
 /turf/simulated/floor/tiled/freezer,
 /area/medical/medical_restroom)
+"xpf" = (
+/obj/machinery/transhuman/autoresleever{
+	ghost_spawns = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/cryo/autoresleeve)
 "xpv" = (
 /obj/machinery/conveyor{
 	id = "recycler"
@@ -129413,12 +129540,12 @@ kux
 lju
 mmq
 cXZ
-olj
+xpf
 pfJ
-pfJ
-pfJ
-pfJ
-ooQ
+sqI
+jqu
+pix
+jnL
 tos
 uAD
 vJq
@@ -129674,9 +129801,9 @@ cXZ
 omu
 pfT
 pMv
-pfJ
-pMv
-ooT
+tUA
+aIg
+dqr
 toU
 uAZ
 vJS
@@ -129930,9 +130057,9 @@ liq
 mnf
 cXZ
 ond
-olj
-olj
+rev
 pMv
+tUA
 rRk
 opM
 opM
@@ -130188,9 +130315,9 @@ ljU
 ljU
 cXZ
 ooQ
-ooQ
+rev
 pNa
-pMv
+qQJ
 rRD
 opM
 tpH
@@ -130445,11 +130572,11 @@ eTf
 ecy
 cXZ
 cXZ
-ooT
-ooQ
-ooQ
-ooQ
-ooQ
+dqr
+uoF
+vLw
+vhy
+mFk
 opM
 ttq
 uEc

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -335,6 +335,7 @@
 #include "code\datums\ghost_query_vr.dm"
 #include "code\datums\hierarchy.dm"
 #include "code\datums\mind.dm"
+#include "code\datums\mind_vr.dm"
 #include "code\datums\mixed.dm"
 #include "code\datums\modules.dm"
 #include "code\datums\mutable_appearance.dm"


### PR DESCRIPTION
Does the following:
1: Re-enables Automatic Notifications for Transcore. Ghosts can still delay these as per live, or cancel them entirely before they go off.
2: Autoresleever cannot print species with NO_SCAN, and cannot spawn you if you're whitelisted. Prevents exploits by loading a slot you're not whitelisted for and spawning as it. Incoming to resleever soon:tm:
3: Vore Deaths are reduced to only being a 5 minute wait, so as to prevent ghosts whining at medical "sleeve me now".
4: Autoresleever latejoin is enabled. This will spawn you as a VISITOR irregardless of occupation preferences.

Pretty screenshot of new autoresleeving bay, above Genetics and Viro, to the right of Circuits.
All doors out to maintenance have no access requirements.
![](https://i.imgur.com/kTXAusg.png)
