### PR TITLE
Trait Tweak - Positives capped at 6, Negatives Uncapped

### DIFF
--- a/code/__defines/misc_vr.dm
+++ b/code/__defines/misc_vr.dm
@@ -20,7 +20,7 @@
 
 //For custom species
 #define STARTING_SPECIES_POINTS 1 //CHOMPEdit
-#define MAX_SPECIES_TRAITS 8	//CHOMPEdit
+#define MAX_SPECIES_TRAITS 6	//CHOMPEdit - Cap positive traits at 6, given negatives are unlimited.
 
 // Xenochimera thing mostly
 #define REVIVING_NOW		-1

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -168,28 +168,29 @@
 	if(pref.species == SPECIES_CUSTOM)
 		var/points_left = pref.starting_trait_points
 
-		for(var/T in pref.pos_traits + pref.neg_traits)
+		for(var/T in pref.pos_traits + pref.neg_traits) // CHOMPEdit: Only Positive traits cost slots now.
 			points_left -= traits_costs[T]
+		for(var/T in pref.pos_traits)
 			traits_left--
 		. += "<b>Traits Left:</b> [traits_left]<br>"
 		. += "<b>Points Left:</b> [points_left]<br>"
 		if(points_left < 0 || traits_left < 0 || !pref.custom_species)
 			. += "<span style='color:red;'><b>^ Fix things! ^</b></span><br>"
 
-		. += "<a href='?src=\ref[src];add_trait=[POSITIVE_MODE]'>Positive Trait +</a><br>"
+		. += "<a href='?src=\ref[src];add_trait=[POSITIVE_MODE]'>Positive Trait(s) (Limited) +</a><br>" // CHOMPEdit: More obvious/clear to players.
 		. += "<ul>"
 		for(var/T in pref.pos_traits)
 			var/datum/trait/trait = positive_traits[T]
 			. += "<li>- <a href='?src=\ref[src];clicked_pos_trait=[T]'>[trait.name] ([trait.cost])</a></li>"
 		. += "</ul>"
 
-		. += "<a href='?src=\ref[src];add_trait=[NEGATIVE_MODE]'>Negative Trait +</a><br>"
+		. += "<a href='?src=\ref[src];add_trait=[NEGATIVE_MODE]'>Negative Trait(s) (No Limit) +</a><br>" // CHOMPEdit: More obvious/clear to players.
 		. += "<ul>"
 		for(var/T in pref.neg_traits)
 			var/datum/trait/trait = negative_traits[T]
 			. += "<li>- <a href='?src=\ref[src];clicked_neg_trait=[T]'>[trait.name] ([trait.cost])</a></li>"
 		. += "</ul>"
-	. += "<a href='?src=\ref[src];add_trait=[NEUTRAL_MODE]'>Neutral Trait +</a><br>"
+	. += "<a href='?src=\ref[src];add_trait=[NEUTRAL_MODE]'>Neutral Trait(s) (No Limit) +</a><br>" // CHOMPEdit: More obvious/clear to players.
 	. += "<ul>"
 	for(var/T in pref.neu_traits)
 		var/datum/trait/trait = neutral_traits[T]
@@ -324,7 +325,7 @@
 		for(var/T in pref.pos_traits + pref.neu_traits + pref.neg_traits)
 			points_left -= traits_costs[T]
 
-		var/traits_left = pref.max_traits - (pref.pos_traits.len + pref.neg_traits.len)
+		var/traits_left = pref.max_traits - pref.pos_traits.len // CHOMPEdit: Only positive traits have a slot limit, to prevent broken builds
 
 		var/message = "Select a trait to learn more."
 		if(mode != NEUTRAL_MODE)


### PR DESCRIPTION
As above.
Traits now have an unlimited amount for negatives, given they are intended to harm you.
Positives have a cap of 6 total.
Prior to this, one could do 6 positives and two extremely expensive negatives, but no other 'fun' negatives.

Now, one can still do 6 strong positives, but as many negatives as they like.
IDEALLY this will allow for custom setups with a lot of small-cost negatives for higher cost positives.

Assuming Tankiness PR comes in before this, it will need adjusting to account for this, but, assuming one powergames to get the ABSOLUTE best traits possible (using the tankiness PR):
```
Positive:
High Endurance - 3
Burn Resist, Major - 3
Brute Resist, Major - 3
Increased Pain Tolerance - 2
Extreme Hardy - 3
Sharp Melee - 1

Traits Left: 0
Points Left: -15

Negative:
Reduced Biocompatability, Major - -8
Conductive Major - -3
Haemophilia - -2
Extreme Photosensitivity - -2

Points Left: 0

Summary:
40% incoming reduction on Brute damage
40% incoming reduction on Burn damage
50 total HP, 25 'regular' HP (200 -> 250, but only 25 extra HP before you go into crit/pass out (100 -> 125))
20% incoming reduction on pain.
0 Slowdown on any item type.
Sharp unarmed attacks against carbonmobs.

Extremely low healing (30% effective heals, meaning a heal for 10 will only heal 3)
Double incoming taser/electrical damage
Bleed 2x as fast
Flashes stun 2x as long. (This trait in particular is badly in need of an overhaul so it's not free points on 99% of rounds).
```