### PR TITLE
Trait List Reorganization + Fixy, 2.0

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative.dm
@@ -81,38 +81,6 @@
 	cost = -3
 	var_changes = list("burn_mod" = 1.5)
 
-//YW ADDITIONS START
-/datum/trait/negative/reduced_biocompat_minor // CHOMPEdit: Changed name of trait + desc.
-	name = "Reduced Biocompatibility, Minor"
-	desc = "For whatever reason, you're one of the unlucky few who don't get as much benefit from modern-day chemicals. Remember to note this down in your medical records! Chems are only 80% as effective on you!"
-	cost = -1
-	var_changes = list("chem_strength_heal" = 0.8)
-
-/datum/trait/negative/sensitive_biochem
-	name = "Sensitive Biochemistry"
-	desc = "Your biochemistry is a little delicate, rendering you more susceptible to both deadly toxins and the more subtle ones. You'll probably want to list this in your medical records, and perhaps in your exploitable info as well."
-	cost = -1
-	var_changes = list("chem_strength_tox" = 1.25)
-
-/datum/trait/negative/alcohol_intolerance_advanced
-	name = "Liver of Air"
-	desc = "The only way you can hold a drink is if it's in your own two hands, and even then you'd best not inhale too deeply near it. Drinks hit thrice as hard. You may wish to note this down in your medical records, and perhaps your exploitable info as well."
-	cost = -1
-	var_changes = list("alcohol_mod" = 3)
-	
-/datum/trait/negative/pain_intolerance_basic
-	name = "Pain Intolerant"
-	desc = "You are frail and sensitive to pain. You experience 25% more pain from all sources." 
-	cost = -2
-	var_changes = list("pain_mod" = 1.2) // CHOMPEdit: Makes this exact opposite of Pain Tolerance Basic.
-
-/datum/trait/negative/pain_intolerance_advanced
-	name = "High Pain Intolerance"
-	desc = "You are highly sensitive to all sources of pain, and experience 50% more pain."
-	cost = -3
-	var_changes = list("pain_mod" = 1.5) //this makes you extremely vulnerable to most sources of pain, a stunbaton bop or shotgun beanbag will do around 90 agony, almost enough to drop you in one hit. CHOMPEdit: This really should cost more if it's this bad.
-//YW ADDITIONS END
-
 /datum/trait/negative/conductive
 	name = "Conductive"
 	desc = "Increases your susceptibility to electric shocks by 25%"
@@ -126,8 +94,8 @@
 	var_changes = list("siemens_coefficient" = 2.0) //This makes you extremely weak to tasers.
 
 /datum/trait/negative/haemophilia
-	name = "Haemophilia - Organics only"
-	desc = "When you bleed, you bleed a LOT."
+	name = "Haemophilia" // CHOMPEdit: Trait List Organization
+	desc = "When you bleed, you bleed a LOT. Double the bloodloss rate." // CHOMPEdit: More Trait Feedback for players.
 	cost = -2
 	var_changes = list("bloodloss_rate" = 2)
 	can_take = ORGANICS
@@ -148,30 +116,6 @@
 	desc = "Your light weight and poor balance make you very susceptible to unhelpful bumping. Think of it like a bowling ball versus a pin. (STOP TAKING THIS AS SECURITY! We're MRP, so expect to lose your junk immediately, especially in events. - Love, Admins)" //CHOMP Edit btw
 	cost = -2
 	var_changes = list("lightweight" = 1)
-
-// YW Addition
-/datum/trait/negative/light_sensitivity
-	name = "Photosensitivity"
-	desc = "You have trouble dealing with sudden flashes of light, taking some time for you to recover. The effects of flashes from cameras and security equipment leaves you stunned for some time."
-	cost = -1
-	var_changes = list("flash_mod" = 1.5)
-
-/datum/trait/negative/light_sensitivity_plus
-	name = "Extreme Photosensitivity"
-	desc = "You have trouble dealing with sudden flashes of light, taking quite a long time for you to be able to recover. The effects of flashes from cameras and security equipment leave you stunned for some time."
-	cost = -2
-	var_changes = list("flash_mod" = 2.0)
-
-
-/datum/trait/negative/haemophilia
-	name = "Haemophilia"
-	desc = "Some say that when it rains, it pours.  Unfortunately, this is also true for yourself if you get cut. You bleed much faster than average"
-	cost = -3
-
-/datum/trait/negative/haemophilia/apply(var/datum/species/S,var/mob/living/carbon/human/H)
-	..(S,H)
-	H.add_modifier(/datum/modifier/trait/haemophilia)
-// YW Addition End
 
 /datum/trait/negative/neural_hypersensitivity
 	name = "Neural Hypersensitivity"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/negative_ch.dm
@@ -387,6 +387,12 @@
 	..(S,H)
 	H.setMaxHealth(S.total_health)
 	
+/datum/trait/negative/reduced_biocompat_minor
+	name = "Reduced Biocompatibility, Minor"
+	desc = "For whatever reason, you're one of the unlucky few who don't get as much benefit from modern-day chemicals. Remember to note this down in your medical records! Chems are only 80% as effective on you!"
+	cost = -1
+	var_changes = list("chem_strength_heal" = 0.8)
+	
 /datum/trait/negative/reduced_biocompat
 	name = "Reduced Biocompatibility"
 	desc = "For whatever reason, you're one of the unlucky few who don't get as much benefit from modern-day chemicals. Remember to note this down in your medical records! Chems are only 60% as effective on you!"
@@ -398,3 +404,46 @@
 	desc = "For whatever reason, you're one of the unlucky few who don't get as much benefit from modern-day chemicals. Remember to note this down in your medical records! Chems are only 30% as effective on you!"
 	cost = -8
 	var_changes = list("chem_strength_heal" = 0.3)
+
+// Rykkanote: Relocated these here as we're no longer a YW downstream.
+/datum/trait/negative/light_sensitivity
+	name = "Photosensitivity"
+	desc = "You have trouble dealing with sudden flashes of light, taking some time for you to recover. The effects of flashes from cameras and security equipment leaves you stunned for some time. 50% increased stun duration from flashes."
+	cost = -1
+	var_changes = list("flash_mod" = 1.5)
+
+/datum/trait/negative/light_sensitivity_plus
+	name = "Photosensitivity, Major"
+	desc = "You have trouble dealing with sudden flashes of light, taking quite a long time for you to be able to recover. The effects of flashes from cameras and security equipment leave you stunned for some time. 100% (2x) stun duration from flashes."
+	cost = -2
+	var_changes = list("flash_mod" = 2.0)
+
+
+/datum/trait/negative/haemophilia_plus
+	name = "Haemophilia, Major"
+	desc = "Some say that when it rains, it pours.  Unfortunately, this is also true for yourself if you get cut. You bleed much faster than average, at 3x the normal rate." // CHOMPEdit: More Trait Feedback for players.
+	cost = -3
+	can_take = ORGANICS
+
+/datum/trait/negative/haemophilia/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.add_modifier(/datum/modifier/trait/haemophilia)
+	
+/datum/trait/negative/pain_intolerance_basic
+	name = "Pain Intolerance"
+	desc = "You are frail and sensitive to pain. You experience 25% more pain from all sources." 
+	cost = -2
+	var_changes = list("pain_mod" = 1.2) // CHOMPEdit: Makes this exact opposite of Pain Tolerance Basic.
+
+/datum/trait/negative/pain_intolerance_advanced
+	name = "Pain Intolerance, Major"
+	desc = "You are highly sensitive to all sources of pain, and experience 50% more pain."
+	cost = -3
+	var_changes = list("pain_mod" = 1.5) //this makes you extremely vulnerable to most sources of pain, a stunbaton bop or shotgun beanbag will do around 90 agony, almost enough to drop you in one hit. CHOMPEdit: This really should cost more if it's this bad.
+	
+
+/datum/trait/negative/sensitive_biochem
+	name = "Sensitive Biochemistry"
+	desc = "Your biochemistry is a little delicate, rendering you more susceptible to both deadly toxins and the more subtle ones. You'll probably want to list this in your medical records, and perhaps in your exploitable info as well. Toxin damages and knockout drugs are 25% stronger on you."
+	cost = -1
+	var_changes = list("chem_strength_tox" = 1.25)

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -54,7 +54,7 @@
 			"x" = list("ks", "kss", "ksss")
 		),
 	autohiss_exempt = list("Sinta'unathi"))
-	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_vassilian) //YW edit: exclude vassillian hiss
+	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_vassilian) // CHOMPEdit: exclude vassillian hiss
 
 /datum/trait/neutral/autohiss_tajaran
 	name = "Autohiss (Tajaran)"
@@ -65,28 +65,10 @@
 			"r" = list("rr", "rrr", "rrrr")
 		),
 	autohiss_exempt = list("Siik"))
-	excludes = list(/datum/trait/neutral/autohiss_unathi, /datum/trait/neutral/autohiss_vassilian) //YW edit: exclude vassillian hiss
-
-// YW addition
-/datum/trait/neutral/autohiss_vassilian
-	name = "Autohiss (Vassilian)"
-	desc = "You buzz your S's, F's, Th's, and R's."
-	cost = 0
-	var_changes = list(
-	autohiss_basic_map = list(
-        "s" = list("sz", "z", "zz"),
-        "f" = list("zk")
-		),
-	autohiss_extra_map = list(
-		"th" = list("zk", "szk"),
-        "r" = list("rk")
-	),
-	autohiss_exempt = list("Vespinae"))
-	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_unathi)
-// YW Addition end
+	excludes = list(/datum/trait/neutral/autohiss_unathi, /datum/trait/neutral/autohiss_vassilian) // CHOMPEdit: exclude vassillian hiss
 
 /datum/trait/neutral/bloodsucker
-	name = "Bloodsucker, Obligate" //YW edit
+	name = "Bloodsucker, Obligate"
 	desc = "Makes you unable to gain nutrition from anything but blood. To compensate, you get fangs that can be used to drain blood from prey."
 	cost = 0
 	custom_only = FALSE

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
@@ -42,16 +42,33 @@
 	custom_only = FALSE
 
 /datum/trait/neutral/big_mouth
-	name = "Big mouth"
+	name = "Mouth, Big"
 	desc = "It takes half as many bites to finish food as it does for most people."
 	cost = 0
 	var_changes = list("bite_mod" = 2)
 	custom_only = FALSE
 	
 /datum/trait/neutral/big_mouth_extreme
-	name = "Giant mouth"
+	name = "Mouth, Giant"
 	desc = "It takes a quarter as many bites to finish food as it does for most people."
 	cost = 0
 	var_changes = list("bite_mod" = 4)
 	custom_only = FALSE
+	
+// CHOMPNote: Moving YW additions here, to sync our files better with VORE in the event of edits.
+/datum/trait/neutral/autohiss_vassilian
+	name = "Autohiss (Vassilian)"
+	desc = "You buzz your S's, F's, Th's, and R's."
+	cost = 0
+	var_changes = list(
+	autohiss_basic_map = list(
+        "s" = list("sz", "z", "zz"),
+        "f" = list("zk")
+		),
+	autohiss_extra_map = list(
+		"th" = list("zk", "szk"),
+        "r" = list("rk")
+	),
+	autohiss_exempt = list("Vespinae"))
+	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_unathi)
 	

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -8,16 +8,6 @@
 	var_changes = list("slowdown" = -0.45)
 	excludes = list(/datum/trait/positive/hardy,/datum/trait/positive/hardy_extreme,/datum/trait/positive/hardy_plus,/datum/trait/positive/speed_fast_minor)
 	
-//ChompEdit
-
-/datum/trait/positive/speed_fast_minor
-	name = "Haste, minor"
-	desc = "Allows you to move a little bit faster on average than baseline."
-	cost = 2
-	var_changes = list("slowdown" = -0.25)
-	excludes = list(/datum/trait/positive/hardy_extreme,/datum/trait/positive/hardy_plus,/datum/trait/positive/speed_fast)
-
-//ChompEdit End
 
 /datum/trait/positive/hardy
 	name = "Hardy"
@@ -26,22 +16,13 @@
 	var_changes = list("item_slowdown_mod" = 0.5)
 	excludes = list(/datum/trait/positive/hardy_extreme,/datum/trait/positive/hardy_plus,/datum/trait/positive/speed_fast)
 
-//ChompEdit
 /datum/trait/positive/hardy_plus
 	name = "Hardy, Major"
 	desc = "Allows you to carry heavy equipment with almost no slowdown."
 	cost = 2
 	var_changes = list("item_slowdown_mod" = 0.25)
-	excludes = list(/datum/trait/positive/speed_fast,/datum/trait/positive/speed_fast_minor,/datum/trait/positive/hardy_extreme,/datum/trait/positive/hardy)
+	excludes = list(/datum/trait/positive/speed_fast,/datum/trait/positive/speed_fast_minor,/datum/trait/positive/hardy_extreme,/datum/trait/positive/hardy) // CHOMPEdit: Prevents Haste + Hardy being taken together.
 
-/datum/trait/positive/hardy_extreme
-	name = "Hardy, Extreme"
-	desc = "Allows you to carry heavy equipment with no slowdown at all."
-	cost = 3
-	var_changes = list("item_slowdown_mod" = 0.0)
-	excludes = list(/datum/trait/positive/speed_fast,/datum/trait/positive/speed_fast_minor,/datum/trait/positive/hardy,/datum/trait/positive/hardy_plus)
-	
-//ChompEdit End
 
 /datum/trait/positive/endurance_high
 	name = "High Endurance"
@@ -64,6 +45,7 @@
 	desc = "Decreases your susceptibility to electric shocks by 50%." //CHOMP Edit - GRAMMAR PLS.
 	cost = 3 //Let us not forget this effects tasers!
 	var_changes = list("siemens_coefficient" = 0.5) //CHOMP Edit
+	
 /*   //Chompedit, moving to Positive_ch.dm so it wont be messed with from upstream
 /datum/trait/positive/darksight
 	name = "Darksight"
@@ -121,20 +103,6 @@
 	var_changes = list("burn_mod" = 0.8) //CHOMP Edit
 	//excludes = list(/datum/trait/positive/minor_brute_resist,/datum/trait/positive/brute_resist) //CHOMP disable, this is already handled in positive_ch.dm
 	
-//YW ADDITIONS START
-/datum/trait/positive/improved_biocompat
-	name = "Improved Biocompatibility"
-	desc = "Your body is naturally (or artificially) more receptive to healing chemicals without being vulnerable to the 'bad stuff'. You heal more efficiently from most chemicals, with no other drawbacks. Remember to note this down in your medical records!"
-	cost = 2
-	var_changes = list("chem_strength_heal" = 1.2)
-
-/datum/trait/positive/pain_tolerance // CHOMPEdit: There is no "basic" pain tolerance, so I'm reducing this to regular pain tolerance.
-	name = "Pain Tolerance" // CHOMPEdit: Renamed for clarity
-	desc = "You are noticeably more resistant to pain than most, and experience 20% less pain from all sources."
-	cost = 2
-	var_changes = list("pain_mod" = 0.8)
-
-//YW ADDITIONS END
 
 
 /datum/trait/positive/photoresistant
@@ -142,14 +110,6 @@
 	desc = "Decreases stun duration from flashes and other light-based stuns and disabilities by 25%" //CHOMP Edit
 	cost = 1
 	var_changes = list("flash_mod" = 0.75) //CHOMP Edit
-
-//YW add
-/datum/trait/positive/photoresistant_plus
-	name = "Major Photoresistance"
-	desc = "Decreases stun duration from flashes and other light-based stuns and disabilities by 50%"
-	cost = 2
-	var_changes = list("flash_mod" = 0.5)
-//YW end
 
 /datum/trait/positive/winged_flight
 	name = "Winged Flight"
@@ -184,34 +144,11 @@
 	..()
 	H.verbs |= /mob/living/carbon/human/proc/lick_wounds
 
-
 /datum/trait/positive/traceur
 	name = "Traceur"
 	desc = "You're capable of parkour and can *flip over low objects (most of the time)."
 	cost = 1 //CHOMPEdit this is not worth 2 points
 	var_changes = list("agility" = 90)
-
-// YW Addition
-/datum/trait/positive/bloodsucker_plus
-	name = "Evolved Bloodsucker"
-	desc = "Makes you able to gain nutrition by draining blood as well as eating food. To compensate, you get fangs that can be used to drain blood from prey."
-	cost = 1
-	var_changes = list("organic_food_coeff" = 0.5) // Hopefully this works???
-	excludes = list(/datum/trait/neutral/bloodsucker)
-
-/datum/trait/positive/bloodsucker_plus/apply(var/datum/species/S,var/mob/living/carbon/human/H)
-	..(S,H)
-	H.verbs |= /mob/living/carbon/human/proc/bloodsuck
-
-/datum/trait/positive/sonar
-	name="Perceptive Hearing"
-	desc = "You can hear slight vibrations in the air very easily, if you focus."
-	cost = 1
-	
-/datum/trait/positive/sonar/apply(var/datum/species/S,var/mob/living/carbon/human/H)
-	..(S,H)
-	H.verbs |= /mob/living/carbon/human/proc/sonar_ping
-// YW Addition end
 
 /datum/trait/positive/snowwalker
 	name = "Snow Walker"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
@@ -1,12 +1,12 @@
 /datum/trait/positive/linguist
 	name = "Master Linguist"
-	desc = "You are a master of languages! For whatever reason you might have, you are able to learn many more languages than others."
+	desc = "You are a master of languages! For whatever reason you might have, you are able to learn many more languages than others. Your language cap is 12 slots."
 	cost = 2
 	var_changes = list("num_alternate_languages" = 12)
 
 /datum/trait/positive/darksight
 	name = "Darksight"
-	desc = "Allows you to see a short distance in the dark." 
+	desc = "Allows you to see a short distance in the dark. (Half the screen)." 
 	cost = 1
 	var_changes = list("darksight" = 4)  //CHOMP Edit
 
@@ -17,8 +17,8 @@
 	var_changes = list("darksight" = 8)
 	
 /datum/trait/positive/densebones
-	name = "Dense bones"
-	desc = "Your bones (or robotic limbs) are more dense or stronger then what is considered normal. It is much harder to fracture your bones, yet pain from fractures is much more intense."
+	name = "Dense Bones"
+	desc = "Your bones (or robotic limbs) are more dense or stronger then what is considered normal. It is much harder to fracture your bones, yet pain from fractures is much more intense. Bones require 50% more damage to break, and deal 2x pain on break."
 	cost = 3
 	excludes = list(/datum/trait/negative/hollow)
 
@@ -30,13 +30,13 @@
 			organ.brokenpain *= 2
 
 /datum/trait/positive/lowpressureres
-	name = "Low Pressure Resistance"
+	name = "Pressure Resistance, Low"
 	desc = "Your body is more resistant to low pressures. Pretty simple."
 	cost = 3
 	var_changes = list("hazard_low_pressure" = HAZARD_LOW_PRESSURE*0.66, "warning_low_pressure" = WARNING_LOW_PRESSURE*0.66, "minimum_breath_pressure" = 16*0.66)
 
 /datum/trait/positive/highpressureres
-	name = "High Pressure Resistance"
+	name = "Pressure Resistance, High"
 	desc = "Your body is more resistant to high pressures. Pretty simple."
 	cost = 3
 	var_changes = list("hazard_high_pressure" = HAZARD_HIGH_PRESSURE*1.5, "warning_high_pressure" = WARNING_HIGH_PRESSURE*1.5)
@@ -55,22 +55,22 @@
 	var_changes = list("radiation_mod" = 0.65, "rad_removal_mod" = 3.5, "rad_levels" = list("safe" = 20, "danger_1" = 75, "danger_2" = 100, "danger_3" = 200))
 
 /datum/trait/positive/rad_resistance_extreme
-	name = "Extreme Radiation Resistance"
+	name = "Radiation Resistance, Major"
 	desc = "You are much more resistant to radiation, and it dissipates much faster from your body."
 	cost = 2
 	var_changes = list("radiation_mod" = 0.5, "rad_removal_mod" = 5, "rad_levels" = list("safe" = 40, "danger_1" = 100, "danger_2" = 150, "danger_3" = 250))
 
 /datum/trait/positive/more_blood
-	name = "High blood volume"
-	desc = "You have much 50% more blood than most other people"
+	name = "Blood Volume, High"
+	desc = "You have 50% more blood."
 	cost = 2
 	var_changes = list("blood_volume" = 840)
 	excludes = list(/datum/trait/positive/more_blood_extreme,/datum/trait/negative/less_blood,/datum/trait/negative/less_blood_extreme)
 	can_take = ORGANICS
 
 /datum/trait/positive/more_blood_extreme
-	name = "Very high blood volume"
-	desc = "You have much 150% more blood than most other people"
+	name = "Blood Volume, Very High"
+	desc = "You have 150% more blood."
 	cost = 4
 	var_changes = list("blood_volume" = 1400)
 	excludes = list(/datum/trait/positive/more_blood,/datum/trait/negative/less_blood,/datum/trait/negative/less_blood_extreme)
@@ -88,7 +88,7 @@
 	H.mob_bump_flag = HEAVY
 
 /datum/trait/positive/table_passer
-	name = "Table passer"
+	name = "Table Passer"
 	desc = "You move over or under tables with ease of a Teshari."
 	cost = 2
 
@@ -97,7 +97,7 @@
 	H.pass_flags = PASSTABLE
 
 /datum/trait/positive/grappling_expert
-	name = "Grappling expert"
+	name = "Grappling Expert"
 	desc = "Your grabs are much harder to escape from, and you are better at escaping from other's grabs!"
 	cost = 3
 	var_changes = list("grab_resist_divisor_victims" = 1.5, "grab_resist_divisor_self" = 0.5, "grab_power_victims" = -1, "grab_power_self" = 1)
@@ -289,6 +289,19 @@
 /datum/trait/positive/endurance_extremely_high/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..(S,H)
 	H.setMaxHealth(S.total_health)
+	
+// CHOMPNote: Reshuffling traits to match our current upstream, VORE.
+/datum/trait/positive/pain_tolerance_minor // Minor Pain Tolerance, 10% reduced pain
+	name = "Pain Tolerance, Minor"
+	desc = "You are slightly more resistant to pain than most, and experience 10% less pain from all sources."
+	cost = 1
+	var_changes = list("pain_mod" = 0.9)
+	
+/datum/trait/positive/pain_tolerance 
+	name = "Pain Tolerance"
+	desc = "You are noticeably more resistant to pain than most, and experience 20% less pain from all sources."
+	cost = 2
+	var_changes = list("pain_mod" = 0.8)
 
 /datum/trait/positive/pain_tolerance_advanced // High Pain Intolerance is 50% incoming pain, but this is 40% reduced incoming pain.
 	name = "Pain Tolerance, Major"
@@ -296,8 +309,49 @@
 	cost = 3 // Equivalent to High Pain Intolerance, but less pain resisted for balance reasons.
 	var_changes = list("pain_mod" = 0.6)
 	
-/datum/trait/positive/pain_tolerance_minor // Minor Pain Tolerance, 10% reduced pain
-	name = "Pain Tolerance, Minor"
-	desc = "You are slightly more resistant to pain than most, and experience 10% less pain from all sources."
+	
+/datum/trait/positive/improved_biocompat
+	name = "Improved Biocompatibility"
+	desc = "Your body is naturally (or artificially) more receptive to healing chemicals without being vulnerable to the 'bad stuff'. You heal more efficiently from most chemicals, with no other drawbacks. Remember to note this down in your medical records! Chems heal for 20% more."
+	cost = 2
+	var_changes = list("chem_strength_heal" = 1.2)
+
+/datum/trait/positive/photoresistant_plus // YW added Trait
+	name = "Photoresistance, Major"
+	desc = "Decreases stun duration from flashes and other light-based stuns and disabilities by 50%."
+	cost = 2
+	var_changes = list("flash_mod" = 0.5)
+	
+/datum/trait/positive/speed_fast_minor
+	name = "Haste, Minor"
+	desc = "Allows you to move a little bit faster on average than baseline."
+	cost = 2
+	var_changes = list("slowdown" = -0.25)
+	excludes = list(/datum/trait/positive/hardy_extreme,/datum/trait/positive/hardy_plus,/datum/trait/positive/speed_fast)
+	
+/datum/trait/positive/hardy_extreme
+	name = "Hardy, Extreme"
+	desc = "Allows you to carry heavy equipment with no slowdown at all."
+	cost = 3
+	var_changes = list("item_slowdown_mod" = 0.0)
+	excludes = list(/datum/trait/positive/speed_fast,/datum/trait/positive/speed_fast_minor,/datum/trait/positive/hardy,/datum/trait/positive/hardy_plus)
+	
+/datum/trait/positive/bloodsucker_plus
+	name = "Evolved Bloodsucker"
+	desc = "Makes you able to gain nutrition by draining blood as well as eating food. To compensate, you get fangs that can be used to drain blood from prey."
 	cost = 1
-	var_changes = list("pain_mod" = 0.9)
+	var_changes = list("organic_food_coeff" = 0.5) // Hopefully this works???
+	excludes = list(/datum/trait/neutral/bloodsucker)
+
+/datum/trait/positive/bloodsucker_plus/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/carbon/human/proc/bloodsuck
+
+/datum/trait/positive/sonar
+	name="Perceptive Hearing"
+	desc = "You can hear slight vibrations in the air very easily, if you focus."
+	cost = 1
+	
+/datum/trait/positive/sonar/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..(S,H)
+	H.verbs |= /mob/living/carbon/human/proc/sonar_ping


### PR DESCRIPTION
The diff looks like a lot, but:
All YW Additions have been moved to positive/negative/neutral_ch.dm given YW refused to follow sanity policies of putting stuff in _yw files, and we're seemingly keeping these.

All BASE VOREStation files (negative, positive, neutral).dm have been synced with upstream, and any changes are appropriately labeled with CHOMPEdits and WHY they're edited, for future coders.
This will also make incoming PRs from VOREStation HOPEFULLY not conflict as much if they touch trait files.

Traits have been renamed to make for easier grouping.
Specifically:
Pain Intolerant -> Pain Intolerance
High Pain Intolerance -> Pain Intolerance, Major
Haemophilia (Organics Only) -> Haemophilia (2x bloodloss rate, 2 points)
Haemophilia (YW Added) -> Haemophilia, Major (This one was 3x bloodloss rate for 3 points)
Big mouth -> Mouth, Big (Yes, it reads weird, but makes it easier to see the traits in the list.)
Giant mouth -> Mouth, Giant (Yes, it reads weird, but makes it easier to see the traits in the list.)
Low/High Pressure Resistance -> Pressure Resistance, Low (or High)
Extreme Radiation Resistance -> Radiation Resistance, Major. (Standardizes names.)
High blood volume -> Blood Volume, High
Very high blood volume -> Blood Volume, Very High

A note on Haemophilia - Both traits shared the same name, so the YW version is what applied. This resolves that.

Multiple traits had description notes added to explain what they MECHANICALLY do. We're a server with more action than upstream, our traits need to be mechanically clear.
Species will be receiving a pass to give their description/readme info a mechanical summary later on.
