### PR TITLE
Alters the server tick_lag from 1ds to 0.5ds (10tick to 20tick) 

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -288,7 +288,7 @@
 					direct = turn(direct, pick(90, -90))
 					n = get_step(my_mob, direct)
 
-	total_delay = DS2NEARESTTICK(total_delay) //Rounded to the next tick in equivalent ds
+	//total_delay = DS2NEARESTTICK(total_delay) //Rounded to the next tick in equivalent ds // CHOMPEdit - commented out.
 	my_mob.setMoveCooldown(total_delay)
 
 	if(istype(my_mob.pulledby, /obj/structure/bed/chair/wheelchair))

--- a/code/world.dm
+++ b/code/world.dm
@@ -6,3 +6,4 @@
 	view = "15x15"
 	cache_lifespan = 7
 	fps = 20 // If this isnt hard-defined, anything relying on this variable before world load will cry a lot
+	tick_lag = 0.5 // CHOMPEdit


### PR DESCRIPTION
To allow more granular movement control

Standard tick rate is 10, or one tick per 100ms. This allows a movement speed granularity MAXIMUM of 0.1s delay per step.

this is an OPTIONAL resolution to the haste/trait tweaks, because you cannot alter your slowdown currently at a resolution below 1/10th of a second.

This change will increase the server's tickrate to 20, to allow a doubling of the minimum resolution from 0.1 to 0.05. that -0.5 --> -0.45 change should be possible.

This is a fundamental change in how the server works, which COULD increase server load and cause other unknown problems.

Tested:
Mob AI, seems fine.
Atmos, seems fine.

MC Functions appear to be on a timebased tick, so tick rate changes "shouldn't" alter the MC

***TESTMERGE ONLY*** to check for unexpected consequences.

Alternatively, you can live with a maximum movement speed delay adjustment of 0.1s / 100ms steps instead.