### PR TITLE
Earlyports mob ID fix.

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -166,15 +166,17 @@
 	var/limb_icon_key
 	var/understands_common = TRUE 		//VOREStation Edit - Makes it so that simplemobs can understand galcomm without being able to speak it.
 	var/heal_countdown = 5				//VOREStation Edit - A cooldown ticker for passive healing
-	var/obj/item/weapon/card/id/mobcard = null
-	var/list/mobcard_access = list()
+	var/obj/item/weapon/card/id/mobcard = null //VOREStation Edit
+	var/list/mobcard_access = list() //VOREStation Edit
+	var/mobcard_provided = FALSE //VOREStation Edit
 
 /mob/living/simple_mob/Initialize()
 	verbs -= /mob/verb/observe
 	health = maxHealth
 
-	mobcard = new /obj/item/weapon/card/id(src)
-	mobcard.access = mobcard_access.Copy()
+	if(mobcard_provided) //VOREStation Edit
+		mobcard = new /obj/item/weapon/card/id(src)
+		mobcard.access = mobcard_access.Copy()
 
 	for(var/L in has_langs)
 		languages |= GLOB.all_languages[L]

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/catslug.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/catslug.dm
@@ -44,6 +44,8 @@
 	friendly = list("hugs")
 	see_in_dark = 8
 
+	mobcard_provided = TRUE
+
 	catalogue_data = list(/datum/category_item/catalogue/fauna/catslug)
 	ai_holder_type = /datum/ai_holder/simple_mob/melee/evasive/catslug
 	say_list_type = /datum/say_list/catslug


### PR DESCRIPTION
Makes mob ids only spawn on mobs that should come with them rather than jamming one into every single mouse and cockroach and so on.