### PR TITLE
Fixes 6 year old bug with icon filepaths being override in update_icon

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -32,6 +32,8 @@ var/list/mining_overlay_cache = list()
 	var/rock_side_icon_state = "rock_side"
 	var/sand_icon_state = "asteroid"
 	var/rock_icon_state = "rock"
+	var/sand_icon_path = 'icons/turf/flooring/asteroid.dmi' // Override this on a subtype turf if you want a custom icon
+	var/rock_icon_path = 'icons/turf/walls.dmi' // Override this on a subtype turf if you want a custom icon
 	var/random_icon = 0
 
 	var/ore/mineral
@@ -39,6 +41,7 @@ var/list/mining_overlay_cache = list()
 	var/mined_ore = 0
 	var/last_act = 0
 	var/overlay_detail
+	var/overlay_detail_icon_path = 'icons/turf/flooring/decals.dmi' // Override this on a subtype turf if you want a custom icon
 
 	var/datum/geosample/geologic_data
 	var/excavation_level = 0
@@ -229,7 +232,7 @@ var/list/mining_overlay_cache = list()
 		else
 			name = "rock"
 
-		icon = 'icons/turf/walls.dmi'
+		icon = rock_icon_path
 		icon_state = rock_icon_state
 
 		//Apply overlays if we should have borders
@@ -247,7 +250,7 @@ var/list/mining_overlay_cache = list()
 	//We are a sand floor
 	else
 		name = floor_name
-		icon = 'icons/turf/flooring/asteroid.dmi'
+		icon = sand_icon_path
 		icon_state = sand_icon_state
 
 		if(sand_dug)
@@ -262,10 +265,10 @@ var/list/mining_overlay_cache = list()
 			else
 				var/turf/T = get_step(src, direction)
 				if(istype(T) && T.density)
-					add_overlay(get_cached_border(rock_side_icon_state,direction,'icons/turf/walls.dmi',rock_side_icon_state))
+					add_overlay(get_cached_border(rock_side_icon_state,direction,rock_icon_path,rock_side_icon_state))
 
 		if(overlay_detail)
-			add_overlay('icons/turf/flooring/decals.dmi',overlay_detail)
+			add_overlay(overlay_detail_icon_path,overlay_detail)
 
 		if(update_neighbors)
 			for(var/direction in alldirs)


### PR DESCRIPTION
Specific to mining turfs, but I imagine others might have this.
The reason we don't directly pull from 'icon' is to allow turf making folk to have some fun to play with it, make the icon change only on update, etc.

If preferred, icon_path var can just be set to grab the turf's base icon path, but I prefer the var imo.

This is not CHOMPEdit marked as this is a base Polaris error and will be PR'd momentarily there.