### PR TITLE
De-crappifies Biofuel Processor

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -150,7 +150,7 @@
 	cost = 0
 	custom_only = FALSE
 	can_take = SYNTHETICS
-	var_changes = list("organic_food_coeff" = 0.75, "synthetic_food_coeff" = 1)
+	var_changes = list("organic_food_coeff" = 0.75, "synthetic_food_coeff" = 1) //CHOMPEdit: Increase values
 
 /datum/trait/neutral/glowing_eyes
 	name = "Glowing Eyes"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -150,7 +150,7 @@
 	cost = 0
 	custom_only = FALSE
 	can_take = SYNTHETICS
-	var_changes = list("organic_food_coeff" = 0, "synthetic_food_coeff" = 0.25)
+	var_changes = list("organic_food_coeff" = 0.75, "synthetic_food_coeff" = 1)
 
 /datum/trait/neutral/glowing_eyes
 	name = "Glowing Eyes"


### PR DESCRIPTION
THE CHANGES:
'Organic' food nutrient gain multiplier: 0% -> 75%
'Synthetic' food nutrient gain multiplier: 25% -> 100%

WHY:
With biofuel processors previous values I could have eaten a chef's entire spread and gained anywhere from NOTHING to a quarter of what it was actually worth through normal eaten. WHEREAS I could've used trash eat to do the same and gained more, despite the fact that trash eat gives less nutrition to discourage EXACTLY THAT.
With these new value there will be literally no balance change because there's public chargers scattered around the station anyway, all this will do is enable FBP synths to properly partake in foodplay as a fetish.

Why the fuck did a fetish station decide to arbitrarily bar a subset of species from a fetish?