### PR TITLE
Making Gravekeeper Drone Viable

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -53,17 +53,10 @@
 	src.modules += new /obj/item/weapon/melee/baton/shocker/robot(src)
 	src.modules += new /obj/item/borg/combat/shield(src)
 
-	// For repairing gravemarkers and expanding the gravesite
+	// For repairing gravemarkers
 	src.modules += new /obj/item/weapon/weldingtool/electric/mounted(src)
 	src.modules += new /obj/item/weapon/tool/screwdriver/cyborg(src)
 	src.modules += new /obj/item/weapon/tool/wrench/cyborg(src)
-	src.modules += new /obj/item/weapon/tool/wirecutters/cyborg(src) //Gotta clear those pesky landmines somehow. Also allows for deconstruction of things in the way!
-	src.modules += new /obj/item/device/multitool(src)
-	src.modules += new /obj/item/device/lightreplacer(src)
-	src.modules += new /obj/item/weapon/gripper/no_use/loader(src)
-	src.modules += new /obj/item/weapon/gripper(src)
-	src.modules += new /obj/item/weapon/pickaxe(src)
-	src.modules += new /obj/item/device/floor_painter(src)
 
 	// For growing flowers
 	src.modules += new /obj/item/weapon/material/minihoe(src)
@@ -75,8 +68,25 @@
 	// For digging and beautifying graves
 	src.modules += new /obj/item/weapon/shovel(src)
 	src.modules += new /obj/item/weapon/gripper/gravekeeper(src)
+
+	// For really persistent looters
+	src.emag = new /obj/item/weapon/gun/energy/retro/mounted(src)
+
+	var/datum/matter_synth/wood = new /datum/matter_synth/wood(50000) //CHOMPEdit - "Buffing this to 50k on account of broken code not letting us pick up more stacks. Wee."
+	synths += wood
+
+	var/obj/item/stack/material/cyborg/wood/W = new (src)
+	W.synths = list(wood)
+	src.modules += W
 	
-	// For honoring the dead.
+	//CHOMPEdit - "Giving the gravekeeper drone more modules to allow it to actually do it's job."
+	src.modules += new /obj/item/weapon/tool/wirecutters/cyborg(src) //Gotta clear those pesky landmines somehow. Also allows for deconstruction of things in the way!
+	src.modules += new /obj/item/device/multitool(src)
+	src.modules += new /obj/item/device/lightreplacer(src)
+	src.modules += new /obj/item/weapon/gripper/no_use/loader(src)
+	src.modules += new /obj/item/weapon/gripper(src)
+	src.modules += new /obj/item/weapon/pickaxe(src)
+	src.modules += new /obj/item/device/floor_painter(src)
 	src.modules += new /obj/item/weapon/pen/robopen(src)
 	src.modules += new /obj/item/weapon/form_printer(src)
 	src.modules += new /obj/item/weapon/gripper/paperwork(src)
@@ -84,31 +94,23 @@
 	src.modules += new /obj/item/weapon/stamp(src)
 	src.modules += new /obj/item/weapon/stamp/denied(src)
 	
-	// Candles!
 	var/obj/item/weapon/flame/lighter/zippo/L = new /obj/item/weapon/flame/lighter/zippo(src)
 	L.lit = 1
 	src.modules += L
-
-	// For really persistent looters
-	src.emag = new /obj/item/weapon/gun/energy/retro/mounted(src)
+	
 	src.emag = new /obj/item/weapon/stamp/chameleon(src)
 	src.emag = new /obj/item/weapon/pen/chameleon(src)
-	
-	
-	// Giving it all the construction drone stuff. How else is is supposed to "expand the gravesite" without construction equipment?
 	var/datum/matter_synth/metal = new /datum/matter_synth/metal(50000)
 	var/datum/matter_synth/glass = new /datum/matter_synth/glass(50000)
 	var/datum/matter_synth/plasteel = new /datum/matter_synth/plasteel(20000)
 	var/datum/matter_synth/plastic = new /datum/matter_synth/plastic(50000)
-	var/datum/matter_synth/wood = new /datum/matter_synth/wood(50000) //Buffing this on account of broken code not letting us pick up more stacks. Wee.
 	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
 	synths += metal
 	synths += glass
 	synths += plasteel
-	synths += wood
 	synths += plastic
 	synths += wire
-	
+
 	var/obj/item/weapon/matter_decompiler/MD = new /obj/item/weapon/matter_decompiler(src)
 	MD.metal = metal
 	MD.glass = glass
@@ -133,15 +135,11 @@
 	var/obj/item/stack/material/cyborg/plasteel/PS = new (src)
 	PS.synths = list(plasteel)
 	src.modules += PS
-
-	var/obj/item/stack/material/cyborg/wood/W = new (src)
-	W.synths = list(wood)
-	src.modules += W	
 	
 	var/obj/item/stack/tile/wood/cyborg/WT = new /obj/item/stack/tile/wood/cyborg(src)
 	WT.synths = list(wood)
 	src.modules += WT
-	
+
 	var/obj/item/stack/tile/floor/cyborg/S = new /obj/item/stack/tile/floor/cyborg(src)
 	S.synths = list(metal)
 	src.modules += S
@@ -153,7 +151,7 @@
 	var/obj/item/stack/material/cyborg/glass/reinforced/RG = new (src)
 	RG.synths = list(metal, glass)
 	src.modules += RG
-	
+
 	var/obj/item/stack/material/cyborg/plastic/PL = new (src)
 	PL.synths = list(plastic)
-	src.modules += PL
+	src.modules += PL //CHOMEdit End

--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -47,7 +47,7 @@
 					"Sleek" = "sleek-gravekeeper"
 				)
 
-/obj/item/weapon/robot_module/robot/gravekeeper/New(var/mob/living/silicon/robot/R)
+/obj/item/weapon/robot_module/robot/gravekeeper/
 	..()
 	// For fending off animals and looters
 	src.modules += new /obj/item/weapon/melee/baton/shocker/robot(src)
@@ -106,10 +106,6 @@
 	var/obj/item/stack/material/cyborg/glass/G = new (src)
 	G.synths = list(glass)
 	src.modules += G
-
-	var/obj/item/stack/rods/cyborg/R = new (src)
-	R.synths = list(metal)
-	src.modules += R
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
 	C.synths = list(wire)

--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -90,8 +90,8 @@
 	synths += metal
 	synths += glass
 	synths += plasteel
-	synths += plastic
 	synths += wood
+	synths += plastic
 	synths += wire
 	
 	var/obj/item/weapon/matter_decompiler/MD = new /obj/item/weapon/matter_decompiler(src)
@@ -107,7 +107,7 @@
 	G.synths = list(glass)
 	src.modules += G
 
-	var/obj/item/stack/rods/cyborg/R = new (src)
+	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
 	R.synths = list(metal)
 	src.modules += R
 

--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -75,9 +75,19 @@
 	// For digging and beautifying graves
 	src.modules += new /obj/item/weapon/shovel(src)
 	src.modules += new /obj/item/weapon/gripper/gravekeeper(src)
+	
+	// For honoring the dead.
+	src.modules += new /obj/item/weapon/pen/robopen(src)
+	src.modules += new /obj/item/weapon/form_printer(src)
+	src.modules += new /obj/item/weapon/gripper/paperwork(src)
+	src.modules += new /obj/item/weapon/hand_labeler(src)
+	src.modules += new /obj/item/weapon/stamp(src)
+	src.modules += new /obj/item/weapon/stamp/denied(src)
 
 	// For really persistent looters
 	src.emag = new /obj/item/weapon/gun/energy/retro/mounted(src)
+	src.emag = new /obj/item/weapon/stamp/chameleon(src)
+	src.emag = new /obj/item/weapon/pen/chameleon(src)
 	
 	
 	// Giving it all the construction drone stuff. How else is is supposed to "expand the gravesite" without construction equipment?

--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -47,7 +47,7 @@
 					"Sleek" = "sleek-gravekeeper"
 				)
 
-/obj/item/weapon/robot_module/robot/gravekeeper/
+/obj/item/weapon/robot_module/robot/gravekeeper/New(var/mob/living/silicon/robot/R)
 	..()
 	// For fending off animals and looters
 	src.modules += new /obj/item/weapon/melee/baton/shocker/robot(src)
@@ -106,6 +106,10 @@
 	var/obj/item/stack/material/cyborg/glass/G = new (src)
 	G.synths = list(glass)
 	src.modules += G
+
+	var/obj/item/stack/rods/cyborg/R = new (src)
+	R.synths = list(metal)
+	src.modules += R
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
 	C.synths = list(wire)

--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -90,8 +90,8 @@
 	synths += metal
 	synths += glass
 	synths += plasteel
-	synths += wood
 	synths += plastic
+	synths += wood
 	synths += wire
 	
 	var/obj/item/weapon/matter_decompiler/MD = new /obj/item/weapon/matter_decompiler(src)
@@ -107,7 +107,7 @@
 	G.synths = list(glass)
 	src.modules += G
 
-	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
+	var/obj/item/stack/rods/cyborg/R = new (src)
 	R.synths = list(metal)
 	src.modules += R
 

--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -107,9 +107,9 @@
 	G.synths = list(glass)
 	src.modules += G
 
-	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
-	R.synths = list(metal)
-	src.modules += R
+	var/obj/item/stack/rods/cyborg/rods = new /obj/item/stack/rods/cyborg(src)
+	rods.synths = list(metal)
+	src.modules += rods
 
 	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
 	C.synths = list(wire)

--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -83,6 +83,11 @@
 	src.modules += new /obj/item/weapon/hand_labeler(src)
 	src.modules += new /obj/item/weapon/stamp(src)
 	src.modules += new /obj/item/weapon/stamp/denied(src)
+	
+	// Candles!
+	var/obj/item/weapon/flame/lighter/zippo/L = new /obj/item/weapon/flame/lighter/zippo(src)
+	L.lit = 1
+	src.modules += L
 
 	// For really persistent looters
 	src.emag = new /obj/item/weapon/gun/energy/retro/mounted(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -53,10 +53,17 @@
 	src.modules += new /obj/item/weapon/melee/baton/shocker/robot(src)
 	src.modules += new /obj/item/borg/combat/shield(src)
 
-	// For repairing gravemarkers
+	// For repairing gravemarkers and expanding the gravesite
 	src.modules += new /obj/item/weapon/weldingtool/electric/mounted(src)
 	src.modules += new /obj/item/weapon/tool/screwdriver/cyborg(src)
 	src.modules += new /obj/item/weapon/tool/wrench/cyborg(src)
+	src.modules += new /obj/item/weapon/tool/wirecutters/cyborg(src) //Gotta clear those pesky landmines somehow. Also allows for deconstruction of things in the way!
+	src.modules += new /obj/item/device/multitool(src)
+	src.modules += new /obj/item/device/lightreplacer(src)
+	src.modules += new /obj/item/weapon/gripper/no_use/loader(src)
+	src.modules += new /obj/item/weapon/gripper(src)
+	src.modules += new /obj/item/weapon/pickaxe(src)
+	src.modules += new /obj/item/device/floor_painter(src)
 
 	// For growing flowers
 	src.modules += new /obj/item/weapon/material/minihoe(src)
@@ -71,10 +78,67 @@
 
 	// For really persistent looters
 	src.emag = new /obj/item/weapon/gun/energy/retro/mounted(src)
-
-	var/datum/matter_synth/wood = new /datum/matter_synth/wood(25000)
+	
+	
+	// Giving it all the construction drone stuff. How else is is supposed to "expand the gravesite" without construction equipment?
+	var/datum/matter_synth/metal = new /datum/matter_synth/metal(50000)
+	var/datum/matter_synth/glass = new /datum/matter_synth/glass(50000)
+	var/datum/matter_synth/plasteel = new /datum/matter_synth/plasteel(20000)
+	var/datum/matter_synth/plastic = new /datum/matter_synth/plastic(50000)
+	var/datum/matter_synth/wood = new /datum/matter_synth/wood(50000) //Buffing this on account of broken code not letting us pick up more stacks. Wee.
+	var/datum/matter_synth/wire = new /datum/matter_synth/wire()
+	synths += metal
+	synths += glass
+	synths += plasteel
 	synths += wood
+	synths += plastic
+	synths += wire
+	
+	var/obj/item/weapon/matter_decompiler/MD = new /obj/item/weapon/matter_decompiler(src)
+	MD.metal = metal
+	MD.glass = glass
+	src.modules += MD
+
+	var/obj/item/stack/material/cyborg/steel/M = new (src)
+	M.synths = list(metal)
+	src.modules += M
+
+	var/obj/item/stack/material/cyborg/glass/G = new (src)
+	G.synths = list(glass)
+	src.modules += G
+
+	var/obj/item/stack/rods/cyborg/R = new /obj/item/stack/rods/cyborg(src)
+	R.synths = list(metal)
+	src.modules += R
+
+	var/obj/item/stack/cable_coil/cyborg/C = new /obj/item/stack/cable_coil/cyborg(src)
+	C.synths = list(wire)
+	src.modules += C
+
+	var/obj/item/stack/material/cyborg/plasteel/PS = new (src)
+	PS.synths = list(plasteel)
+	src.modules += PS
 
 	var/obj/item/stack/material/cyborg/wood/W = new (src)
 	W.synths = list(wood)
-	src.modules += W
+	src.modules += W	
+	
+	var/obj/item/stack/tile/wood/cyborg/WT = new /obj/item/stack/tile/wood/cyborg(src)
+	WT.synths = list(wood)
+	src.modules += WT
+	
+	var/obj/item/stack/tile/floor/cyborg/S = new /obj/item/stack/tile/floor/cyborg(src)
+	S.synths = list(metal)
+	src.modules += S
+
+	var/obj/item/stack/tile/roofing/cyborg/CT = new /obj/item/stack/tile/roofing/cyborg(src)
+	CT.synths = list(metal)
+	src.modules += CT
+
+	var/obj/item/stack/material/cyborg/glass/reinforced/RG = new (src)
+	RG.synths = list(metal, glass)
+	src.modules += RG
+	
+	var/obj/item/stack/material/cyborg/plastic/PL = new (src)
+	PL.synths = list(plastic)
+	src.modules += PL

--- a/maps/submaps/surface_submaps/wilderness/Chapel.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Chapel.dmm
@@ -126,6 +126,10 @@
 /area/submap/Chapel1)
 "aD" = (
 /obj/structure/ghost_pod/automatic/gravekeeper_drone,
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "aE" = (
@@ -394,6 +398,68 @@
 /obj/random/cash,
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"cQ" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"qO" = (
+/obj/machinery/power/rtg/advanced{
+	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/hyper = 1,/obj/item/weapon/stock_parts/micro_laser/hyper = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"rm" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"sH" = (
+/obj/vehicle/boat/dragon/sifwood,
+/obj/item/weapon/oar/sifwood,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/Chapel1)
+"Eq" = (
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/rtg/advanced{
+	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/hyper = 1,/obj/item/weapon/stock_parts/micro_laser/hyper = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"TH" = (
+/obj/machinery/power/apc/high{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood/sif/broken,
 /area/submap/Chapel1)
 
 (1,1,1) = {"
@@ -1196,8 +1262,8 @@ aa
 ab
 aa
 ac
-aB
-aB
+qO
+Eq
 ac
 ac
 ac
@@ -1229,8 +1295,8 @@ aa
 ab
 aa
 ac
-aC
-al
+TH
+cQ
 al
 al
 aW
@@ -1238,8 +1304,8 @@ al
 aW
 al
 aA
-aC
-al
+sH
+aB
 ac
 ah
 aj
@@ -1263,7 +1329,7 @@ aa
 aa
 ac
 aD
-al
+rm
 al
 aA
 al


### PR DESCRIPTION
Prior to this patch the poor thing wasn't able to do construction. This should fix that. Expand that gravesite until every simple mob is laid to rest properly!

Added some construction drone and clerical drone equipment. A zippo lighter too. Maximum gravekeeping.