### PR TITLE
Chapel POI edit + Gravekeeper Drone Bugfix

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/event.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/event.dm
@@ -82,6 +82,9 @@
 	//CHOMPEdit - "Giving the gravekeeper drone more modules to allow it to actually do it's job."
 	src.modules += new /obj/item/weapon/tool/wirecutters/cyborg(src) //Gotta clear those pesky landmines somehow. Also allows for deconstruction of things in the way!
 	src.modules += new /obj/item/device/multitool(src)
+	src.modules += new /obj/item/weapon/soap/nanotrasen(src)
+	src.modules += new /obj/item/weapon/storage/bag/trash(src)
+	src.modules += new /obj/item/weapon/mop(src)
 	src.modules += new /obj/item/device/lightreplacer(src)
 	src.modules += new /obj/item/weapon/gripper/no_use/loader(src)
 	src.modules += new /obj/item/weapon/gripper(src)
@@ -98,8 +101,6 @@
 	L.lit = 1
 	src.modules += L
 	
-	src.emag = new /obj/item/weapon/stamp/chameleon(src)
-	src.emag = new /obj/item/weapon/pen/chameleon(src)
 	var/datum/matter_synth/metal = new /datum/matter_synth/metal(50000)
 	var/datum/matter_synth/glass = new /datum/matter_synth/glass(50000)
 	var/datum/matter_synth/plasteel = new /datum/matter_synth/plasteel(20000)

--- a/maps/submaps/surface_submaps/wilderness/Chapel.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Chapel.dmm
@@ -17,6 +17,7 @@
 	pixel_y = 32
 	},
 /obj/item/weapon/book/tome,
+/obj/item/weapon/telecube,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "af" = (
@@ -97,38 +98,43 @@
 /obj/item/weapon/flame/candle/candelabra/everburn,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
-"ax" = (
-/obj/machinery/vending/sovietsoda,
-/turf/simulated/floor/wood/sif,
-/area/submap/Chapel1)
 "ay" = (
-/obj/random/junk,
-/obj/structure/table/sifwoodentable,
-/obj/random/soap,
+/obj/machinery/washing_machine,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "az" = (
-/obj/machinery/microwave,
-/obj/structure/table/sifwoodentable,
-/turf/simulated/floor/wood/sif,
+/obj/machinery/vending/event/uniform{
+	desc = "A vendor using compressed matter cartridges to store large amounts of clothing.";
+	name = "Morgue Wear";
+	product_ads = "...";
+	products = list(/obj/item/clothing/under/color/black = 50,/obj/item/clothing/under/gentlesuit = 50,/obj/item/clothing/under/color/blackjumpskirt = 50,/obj/item/clothing/under/gentlesuit/skirt = 50,/obj/item/clothing/shoes/black = 100,/obj/item/clothing/shoes/dress = 100)
+	},
+/turf/simulated/floor/wood/sif/broken,
 /area/submap/Chapel1)
 "aA" = (
 /obj/random/junk,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "aB" = (
-/obj/vehicle/boat/dragon/sifwood,
-/obj/item/weapon/oar/sifwood,
+/obj/machinery/vending/hydroseeds{
+	dir = 4
+	},
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "aC" = (
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/Chapel1)
 "aD" = (
-/obj/structure/ghost_pod/automatic/gravekeeper_drone,
 /obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 4;
+	dir = 1;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/rtg/advanced{
+	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/omni = 1,/obj/item/weapon/stock_parts/micro_laser/omni = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
 	},
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
@@ -151,7 +157,12 @@
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/Chapel1)
 "aI" = (
-/obj/machinery/floodlight,
+/obj/structure/ghost_pod/automatic/gravekeeper_drone,
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/item/device/gps/internal/poi{
+	desc = "A safe haven in a harsh place.";
+	gps_tag = "Wilderness Chapel Signal"
+	},
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "aJ" = (
@@ -187,8 +198,7 @@
 /area/submap/Chapel1)
 "aO" = (
 /obj/structure/table/sifwoodentable,
-/obj/item/weapon/chainsaw,
-/obj/random/tool/powermaint,
+/obj/machinery/recharger,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "aP" = (
@@ -198,7 +208,7 @@
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "aQ" = (
-/obj/item/weapon/oar/sifwood,
+/obj/random/junk,
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/Chapel1)
 "aR" = (
@@ -207,8 +217,7 @@
 /area/submap/Chapel1)
 "aS" = (
 /obj/structure/table/sifwoodentable,
-/obj/fiftyspawner/sifwood,
-/obj/fiftyspawner/sifwood,
+/obj/machinery/cell_charger,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "aT" = (
@@ -289,8 +298,10 @@
 /area/submap/Chapel1)
 "bh" = (
 /obj/structure/table/sifwoodentable,
-/obj/item/weapon/material/harpoon,
-/obj/item/weapon/material/harpoon,
+/obj/fiftyspawner/sifwood,
+/obj/fiftyspawner/sifwood,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/steel,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "bi" = (
@@ -307,7 +318,8 @@
 /area/submap/Chapel1)
 "bk" = (
 /obj/structure/table/sifwoodentable,
-/obj/item/weapon/material/fishing_net,
+/obj/item/weapon/chainsaw,
+/obj/random/tool/powermaint,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "bl" = (
@@ -331,7 +343,9 @@
 /turf/simulated/floor/outdoors/rocks,
 /area/template_noop)
 "bq" = (
-/obj/machinery/vending/hydroseeds,
+/obj/machinery/vending/food{
+	dir = 8
+	},
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "br" = (
@@ -354,14 +368,17 @@
 /obj/item/weapon/ore/coal,
 /obj/item/weapon/ore/coal,
 /obj/item/weapon/pickaxe/hand,
+/obj/structure/table/sifwoodentable,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "bt" = (
-/obj/machinery/vending/hydronutrients,
-/turf/simulated/floor/wood/sif/broken,
+/obj/machinery/vending/sovietsoda{
+	dir = 8
+	},
+/turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "bu" = (
-/obj/machinery/space_heater,
+/obj/machinery/autolathe,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "bv" = (
@@ -399,6 +416,16 @@
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
+"cA" = (
+/obj/random/mob/spider{
+	mob_faction = "neutral"
+	},
+/turf/simulated/floor/outdoors/rocks,
+/area/template_noop)
+"cD" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
 "cQ" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -406,34 +433,165 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/cyan{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	dir = 1;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
-"qO" = (
-/obj/machinery/power/rtg/advanced{
-	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/hyper = 1,/obj/item/weapon/stock_parts/micro_laser/hyper = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+"gk" = (
+/obj/structure/fence/door,
+/turf/simulated/floor/outdoors/grass/sif/forest,
+/area/submap/Chapel1)
+"ih" = (
+/obj/machinery/vending/hydronutrients{
+	dir = 4
 	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"iB" = (
+/obj/structure/sign/department/chapel,
+/turf/simulated/wall/log_sif,
+/area/submap/Chapel1)
+"mK" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"nu" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/fiftyspawner/phoron,
+/obj/fiftyspawner/phoron,
+/obj/item/weapon/storage/toolbox/syndicate/powertools,
+/obj/item/stack/cable_coil/cyan,
+/obj/item/stack/cable_coil/cyan,
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"om" = (
+/obj/random/junk,
+/obj/structure/table/sifwoodentable,
+/obj/random/soap,
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"oO" = (
+/obj/structure/table/sifwoodentable,
+/obj/item/weapon/material/fishing_net,
+/obj/item/weapon/material/harpoon,
+/obj/item/weapon/material/harpoon,
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"pp" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall/log_sif,
+/area/submap/Chapel1)
+"qt" = (
+/obj/effect/floor_decal/rust,
 /obj/structure/cable/cyan{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/plating/sif/planetuse,
+/area/submap/Chapel1)
+"qO" = (
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/rtg/advanced{
+	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/omni = 1,/obj/item/weapon/stock_parts/micro_laser/omni = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	dir = 1;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "rm" = (
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	dir = 1;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/rtg/advanced{
+	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/omni = 1,/obj/item/weapon/stock_parts/micro_laser/omni = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
 	},
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "sH" = (
+/obj/random/mob/spider{
+	mob_faction = "neutral"
+	},
+/obj/structure/closet/grave,
+/turf/simulated/floor/outdoors/rocks,
+/area/template_noop)
+"tu" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/closet/crate/trashcart{
+	starts_with = list(/obj/item/weapon/stock_parts/capacitor/omni = 5,/obj/item/weapon/stock_parts/manipulator/omni = 5,/obj/item/weapon/stock_parts/matter_bin/omni = 5,/obj/item/weapon/stock_parts/micro_laser/omni = 5,/obj/item/weapon/stock_parts/scanning_module/omni = 5)
+	},
+/turf/simulated/floor/plating/sif/planetuse,
+/area/submap/Chapel1)
+"uK" = (
+/obj/structure/closet/body_bag/large,
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"vU" = (
+/obj/structure/sign/electricshock,
+/turf/simulated/wall/log_sif,
+/area/submap/Chapel1)
+"yx" = (
+/obj/machinery/floodlight{
+	dir = 4
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"CX" = (
 /obj/vehicle/boat/dragon/sifwood,
 /obj/item/weapon/oar/sifwood,
-/turf/simulated/floor/wood/sif/broken,
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"Dz" = (
+/obj/structure/simple_door/sifwood,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 1
+	},
+/turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
 "Eq" = (
 /obj/structure/cable/cyan{
@@ -441,25 +599,98 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/rtg/advanced{
-	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/hyper = 1,/obj/item/weapon/stock_parts/micro_laser/hyper = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/omni = 1,/obj/item/weapon/stock_parts/micro_laser/omni = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 6
 	},
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
+"Gr" = (
+/obj/structure/closet/grave,
+/turf/simulated/floor/outdoors/rocks,
+/area/template_noop)
+"JO" = (
+/obj/machinery/microwave,
+/obj/structure/table/sifwoodentable,
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"Kb" = (
+/obj/structure/table/sifwoodentable,
+/obj/item/weapon/storage/firstaid,
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"OM" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/plating/sif/planetuse,
+/area/submap/Chapel1)
+"OZ" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	dir = 4;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/log_sif,
+/area/submap/Chapel1)
+"Rf" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/obj/machinery/power/smes/buildable/point_of_interest{
+	charge = 2e+006;
+	input_attempt = 1;
+	input_level = 250000;
+	input_level_max = 250000
+	},
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"Tv" = (
+/turf/simulated/floor/outdoors/grass/sif/forest,
+/area/submap/Chapel1)
+"TE" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass/sif/forest,
+/area/submap/Chapel1)
 "TH" = (
-/obj/machinery/power/apc/high{
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/power/apc/hyper{
 	dir = 1;
 	pixel_y = 24
 	},
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 8;
+	dir = 4;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/structure/cable/cyan,
 /turf/simulated/floor/wood/sif/broken,
+/area/submap/Chapel1)
+"UJ" = (
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/Chapel1)
 
 (1,1,1) = {"
@@ -598,11 +829,11 @@ aa
 aa
 aa
 aa
-ab
-ak
-aa
+sH
 ac
-ax
+ac
+ac
+ay
 al
 al
 aQ
@@ -612,7 +843,7 @@ al
 al
 aM
 al
-aA
+JO
 ac
 bl
 ah
@@ -632,8 +863,8 @@ aa
 aa
 aa
 ab
-ab
-aa
+ac
+nu
 ac
 ay
 aC
@@ -642,10 +873,10 @@ aR
 aV
 al
 bc
-al
-al
+mK
+mK
 aC
-al
+om
 ac
 ai
 ai
@@ -665,11 +896,11 @@ aa
 aa
 aa
 ab
-aa
-aa
+ac
+aZ
 ac
 az
-al
+uK
 ac
 ac
 ac
@@ -698,8 +929,8 @@ aa
 aa
 aa
 aa
-aa
-ai
+gk
+UJ
 ac
 ac
 ac
@@ -730,9 +961,9 @@ ai
 aa
 aa
 aa
-aa
-ai
-ai
+ab
+TE
+tu
 ac
 ac
 av
@@ -763,8 +994,8 @@ ai
 aa
 aa
 aa
-ai
-ad
+Tv
+TE
 ac
 ac
 al
@@ -796,7 +1027,7 @@ ai
 aa
 ab
 aa
-ai
+ad
 ac
 ac
 ag
@@ -979,7 +1210,7 @@ al
 aC
 ag
 ag
-ac
+iB
 ab
 ab
 ai
@@ -1028,7 +1259,7 @@ aa
 af
 aa
 ac
-al
+CX
 al
 al
 al
@@ -1126,7 +1357,7 @@ ai
 aa
 aa
 aa
-ai
+ad
 ac
 ac
 ag
@@ -1159,8 +1390,8 @@ ai
 aa
 ab
 aa
-ab
-ad
+Tv
+TE
 ac
 ac
 al
@@ -1193,11 +1424,11 @@ aa
 ab
 aa
 ab
-ak
-ai
+TE
+qt
 ac
 ac
-av
+Kb
 av
 al
 al
@@ -1226,8 +1457,8 @@ aa
 ab
 aa
 aa
-ab
-ai
+gk
+OM
 ac
 ac
 ac
@@ -1258,10 +1489,10 @@ ah
 aa
 ak
 aa
-aa
 ab
-aa
-ac
+vU
+Dz
+OZ
 qO
 Eq
 ac
@@ -1272,7 +1503,7 @@ ac
 ac
 ac
 aB
-aB
+ih
 ac
 bm
 ah
@@ -1291,21 +1522,21 @@ ah
 aa
 ab
 ab
-aa
 ab
-aa
 ac
+Rf
+pp
 TH
 cQ
 al
-al
+yx
 aW
 al
 aW
-al
+cD
 aA
-sH
-aB
+aC
+al
 ac
 ah
 aj
@@ -1324,9 +1555,9 @@ ai
 aa
 aa
 ab
-aa
-aa
-aa
+Gr
+ac
+ac
 ac
 aD
 rm
@@ -1369,7 +1600,7 @@ al
 al
 aA
 aC
-al
+oO
 bs
 ac
 ac
@@ -1425,7 +1656,7 @@ aa
 aa
 af
 ab
-ab
+cA
 ai
 ad
 ac

--- a/maps/submaps/surface_submaps/wilderness/Chapel.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Chapel.dmm
@@ -98,6 +98,12 @@
 /obj/item/weapon/flame/candle/candelabra/everburn,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
+"ax" = (
+/obj/structure/closet/crate/trashcart{
+	starts_with = list(/obj/item/weapon/stock_parts/capacitor/omni = 5, /obj/item/weapon/stock_parts/manipulator/omni = 5, /obj/item/weapon/stock_parts/matter_bin/omni = 5, /obj/item/weapon/stock_parts/micro_laser/omni = 5, /obj/item/weapon/stock_parts/scanning_module/omni = 5)
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
 "ay" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/wood/sif,
@@ -107,7 +113,7 @@
 	desc = "A vendor using compressed matter cartridges to store large amounts of clothing.";
 	name = "Morgue Wear";
 	product_ads = "...";
-	products = list(/obj/item/clothing/under/color/black = 50,/obj/item/clothing/under/gentlesuit = 50,/obj/item/clothing/under/color/blackjumpskirt = 50,/obj/item/clothing/under/gentlesuit/skirt = 50,/obj/item/clothing/shoes/black = 100,/obj/item/clothing/shoes/dress = 100)
+	products = list(/obj/item/clothing/under/color/black = 50, /obj/item/clothing/under/gentlesuit = 50, /obj/item/clothing/under/color/blackjumpskirt = 50, /obj/item/clothing/under/gentlesuit/skirt = 50, /obj/item/clothing/shoes/black = 100, /obj/item/clothing/shoes/dress = 100)
 	},
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/Chapel1)
@@ -131,7 +137,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/rtg/advanced{
-	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/omni = 1,/obj/item/weapon/stock_parts/micro_laser/omni = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+	component_parts = list(/obj/item/stack/cable_coil = 5, /obj/item/weapon/stock_parts/capacitor/omni = 1, /obj/item/weapon/stock_parts/micro_laser/omni = 1, /obj/item/stack/material/uranium = 10, /obj/item/stack/material/phoron = 5)
 	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 9
@@ -416,6 +422,30 @@
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/wood/sif,
 /area/submap/Chapel1)
+"bB" = (
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
+"bC" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/Chapel1)
 "cA" = (
 /obj/random/mob/spider{
 	mob_faction = "neutral"
@@ -494,27 +524,13 @@
 	},
 /turf/simulated/wall/log_sif,
 /area/submap/Chapel1)
-"qt" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/cyan{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/turf/simulated/floor/plating/sif/planetuse,
-/area/submap/Chapel1)
 "qO" = (
 /obj/structure/cable/cyan{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/rtg/advanced{
-	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/omni = 1,/obj/item/weapon/stock_parts/micro_laser/omni = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+	component_parts = list(/obj/item/stack/cable_coil = 5, /obj/item/weapon/stock_parts/capacitor/omni = 1, /obj/item/weapon/stock_parts/micro_laser/omni = 1, /obj/item/stack/material/uranium = 10, /obj/item/stack/material/phoron = 5)
 	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 5
@@ -534,7 +550,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/rtg/advanced{
-	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/omni = 1,/obj/item/weapon/stock_parts/micro_laser/omni = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+	component_parts = list(/obj/item/stack/cable_coil = 5, /obj/item/weapon/stock_parts/capacitor/omni = 1, /obj/item/weapon/stock_parts/micro_laser/omni = 1, /obj/item/stack/material/uranium = 10, /obj/item/stack/material/phoron = 5)
 	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 10
@@ -548,13 +564,6 @@
 /obj/structure/closet/grave,
 /turf/simulated/floor/outdoors/rocks,
 /area/template_noop)
-"tu" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/closet/crate/trashcart{
-	starts_with = list(/obj/item/weapon/stock_parts/capacitor/omni = 5,/obj/item/weapon/stock_parts/manipulator/omni = 5,/obj/item/weapon/stock_parts/matter_bin/omni = 5,/obj/item/weapon/stock_parts/micro_laser/omni = 5,/obj/item/weapon/stock_parts/scanning_module/omni = 5)
-	},
-/turf/simulated/floor/plating/sif/planetuse,
-/area/submap/Chapel1)
 "uK" = (
 /obj/structure/closet/body_bag/large,
 /turf/simulated/floor/wood/sif,
@@ -599,7 +608,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/rtg/advanced{
-	component_parts = list(/obj/item/stack/cable_coil = 5,/obj/item/weapon/stock_parts/capacitor/omni = 1,/obj/item/weapon/stock_parts/micro_laser/omni = 1,/obj/item/stack/material/uranium = 10,/obj/item/stack/material/phoron = 5)
+	component_parts = list(/obj/item/stack/cable_coil = 5, /obj/item/weapon/stock_parts/capacitor/omni = 1, /obj/item/weapon/stock_parts/micro_laser/omni = 1, /obj/item/stack/material/uranium = 10, /obj/item/stack/material/phoron = 5)
 	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 6
@@ -619,18 +628,6 @@
 /obj/structure/table/sifwoodentable,
 /obj/item/weapon/storage/firstaid,
 /turf/simulated/floor/wood/sif,
-/area/submap/Chapel1)
-"OM" = (
-/obj/effect/floor_decal/rust,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/Chapel1)
 "OZ" = (
 /obj/structure/cable/cyan{
@@ -687,10 +684,6 @@
 	},
 /obj/structure/cable/cyan,
 /turf/simulated/floor/wood/sif/broken,
-/area/submap/Chapel1)
-"UJ" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/Chapel1)
 
 (1,1,1) = {"
@@ -930,7 +923,7 @@ aa
 aa
 aa
 gk
-UJ
+al
 ac
 ac
 ac
@@ -963,7 +956,7 @@ aa
 aa
 ab
 TE
-tu
+ax
 ac
 ac
 av
@@ -1425,7 +1418,7 @@ ab
 aa
 ab
 TE
-qt
+bB
 ac
 ac
 Kb
@@ -1458,7 +1451,7 @@ ab
 aa
 aa
 gk
-OM
+bC
 ac
 ac
 ac


### PR DESCRIPTION
Added some goodies to the chapel to make it a rest stop for explorers, and a viable base of operations for the gravekeeper drone. Increased it's generator recharge rates and gave it a SMES. If you manage to blow through all that power now...

Fixed the gravekeeper drone's emag item. Apparently, they only get one. Oops. Also gave it the ability to actually clean messes.