### PR TITLE
Add a general engineering console to the reactor control room

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -17264,10 +17264,10 @@
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "bcv" = (
-/obj/machinery/computer/station_alert{
+/obj/item/device/geiger/wall/south,
+/obj/item/modular_computer/console/preset/engineering{
 	dir = 4
 	},
-/obj/item/device/geiger/wall/south,
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "bcw" = (


### PR DESCRIPTION
This lets you have for example the supermatter monitor up on a console, which for the SM engine seemed kind of useful. (I would add just a SM Monitor console, but... those don't exist on their own! I could add it, but... could also just put this in, so...)