### PR TITLE
Fixes for two communication bugs and feature added for ghosts in belly

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -204,7 +204,12 @@
 				if(M)
 					if(isobserver(M))
 						message = "<span class='emote'><B>[src]</B> ([ghost_follow_link(src, M)]) [input]</span>"
-					M.show_message(message, m_type)
+					//CHOMPEdit Start - If you are in the same tile, right next to, or being held by a person doing an emote, you should be able to see it while blind
+					if(m_type != AUDIBLE_MESSAGE && (src.Adjacent(M) || (istype(src.loc, /obj/item/weapon/holder) && src.loc.loc == M)))
+						M.show_message(message)
+					else
+						M.show_message(message, m_type)
+					//CHOMPEdit End
 					M.create_chat_message(src, "[runemessage]", FALSE, list("emote"), (m_type == AUDIBLE_MESSAGE))
 
 		for(var/obj/O as anything in o_viewers)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -357,7 +357,7 @@ var/list/channel_to_radio_key = new
 
 			if(M && src) //If we still exist, when the spawn processes
 				//VOREStation Add - Ghosts don't hear whispers
-				if(whispering && !is_preference_enabled(/datum/client_preference/whisubtle_vis) && isobserver(M) && !M.client?.holder)
+				if(whispering && !(is_preference_enabled(/datum/client_preference/whisubtle_vis) || (isbelly(M.loc) && src == M.loc:owner)) && isobserver(M) && !M.client?.holder)
 					M.show_message("<span class='game say'><span class='name'>[src.name]</span> [w_not_heard].</span>", 2)
 					return
 				//VOREStation Add End

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -410,7 +410,7 @@ var/list/channel_to_radio_key = new
 /mob/living/proc/say_signlang(var/message, var/verb="gestures", var/verb_understood="gestures", var/datum/language/language, var/type = 1)
 	var/turf/T = get_turf(src)
 	//We're in something, gesture to people inside the same thing
-	if(loc != T)
+	if(loc != T && !istype(loc, /obj/item/weapon/holder)) //CHOMPEdit - Partially fixes sign language while being held.
 		for(var/mob/M in loc)
 			M.hear_signlang(message, verb, verb_understood, language, src, type)
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -106,8 +106,21 @@
 	if(speaking.flags & NONVERBAL)
 		if(sdisabilities & BLIND || blinded)
 			return FALSE
-		if(!other || !(other in view(src)))
+		if(!other) //CHOMPEdit - Fixes seeing non-verbal languages while being held
 			return FALSE
+		//CHOMPEdit Start - Fixes seeing non-verbal languages while being held
+		if(istype(other.loc, /obj/item/weapon/holder))
+			if(istype(src.loc, /obj/item/weapon/holder))
+				if(!(other.loc in view(src.loc.loc)))
+					return FALSE
+			else if(!(other.loc in view(src)))
+				return FALSE
+		else if(istype(src.loc, /obj/item/weapon/holder))
+			if(!other in view(src.loc.loc))
+				return FALSE
+		else if(!other in view(src))
+			return FALSE
+		//CHOMPEdit End
 
 	//Language check.
 	for(var/datum/language/L in languages)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -61,7 +61,7 @@
 		var/list/vis_objs = vis["objs"]
 
 		for(var/mob/M as anything in vis_mobs)
-			if(isobserver(M) && !is_preference_enabled(/datum/client_preference/whisubtle_vis) && !M.client?.holder)
+			if(isobserver(M) && !(is_preference_enabled(/datum/client_preference/whisubtle_vis) && !(isbelly(M.loc) && src == M.loc:owner)) && !M.client?.holder) //CHOMPEdit - Added the belly check so that ghosts in bellies can still see their pred's messages.
 				spawn(0)
 					M.show_message(undisplayed_message, 2)
 			else

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -61,7 +61,7 @@
 		var/list/vis_objs = vis["objs"]
 
 		for(var/mob/M as anything in vis_mobs)
-			if(isobserver(M) && !(is_preference_enabled(/datum/client_preference/whisubtle_vis) && !(isbelly(M.loc) && src == M.loc:owner)) && !M.client?.holder) //CHOMPEdit - Added the belly check so that ghosts in bellies can still see their pred's messages.
+			if(isobserver(M) && !(is_preference_enabled(/datum/client_preference/whisubtle_vis) || (isbelly(M.loc) && src == M.loc:owner)) && !M.client?.holder) //CHOMPEdit - Added the belly check so that ghosts in bellies can still see their pred's messages.
 				spawn(0)
 					M.show_message(undisplayed_message, 2)
 			else


### PR DESCRIPTION
Bug fixed: Sign language and other non-verbal communication couldn't be seen while either the speaker or viewer were being held.
Bug fixed: Blind people can see messages sent with the 'Me' verb now, as long as they are adjacent or being held. (Much like with subtles.)
Feature added: If you are a ghost inside a belly, and the pred sends a subtle while having ghost privacy on, then the ghost inside the belly should be able to see the message. I was unable to test if this works myself, however.