### PR TITLE
Stealth Staff PMs now display the rank of the sender rather than ADMIN

### DIFF
--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -351,7 +351,7 @@
 			. += "<a href='?priv_msg=\ref[C]'>"
 
 		if(C && C.holder && C.holder.fakekey)
-			. += C.holder.rank
+			. += C.holder.rank // CHOMPEdit: Stealth mode displays staff rank in PM Messages
 		else
 			. += key
 

--- a/code/_helpers/logging.dm
+++ b/code/_helpers/logging.dm
@@ -351,7 +351,7 @@
 			. += "<a href='?priv_msg=\ref[C]'>"
 
 		if(C && C.holder && C.holder.fakekey)
-			. += "Administrator"
+			. += C.holder.rank
 		else
 			. += key
 


### PR DESCRIPTION
As above. I spent way too long on this chasing the wrong path for getting it done oops
