### PR TITLE
Gateway snowfield alt version (empty)

### DIFF
--- a/maps/southern_cross/submaps/gateway/snowfield-alt.dmm
+++ b/maps/southern_cross/submaps/gateway/snowfield-alt.dmm
@@ -787,28 +787,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/public/publicrestroom)
-"aLO" = (
-/obj/effect/landmark/corpse/security{
-	corpseback = /obj/item/weapon/storage/backpack/satchel/military;
-	corpsebelt = /obj/item/weapon/storage/belt/security/tactical;
-	corpseglasses = /obj/item/clothing/glasses/night;
-	corpsegloves = /obj/item/clothing/gloves/tactical;
-	corpsehelmet = /obj/item/clothing/head/helmet/combat;
-	corpseidaccess = "Syndicate";
-	corpseidjob = "N/A";
-	corpsemask = /obj/item/clothing/mask/balaclava;
-	corpsepocket1 = /obj/item/device/binoculars;
-	corpsepocket2 = /obj/item/device/camerabug/spy;
-	corpseradio = /obj/item/device/radio/headset;
-	corpseshoes = /obj/item/clothing/shoes/boots/combat;
-	corpsesuit = /obj/item/clothing/suit/armor/pcarrier/bulletproof/full;
-	corpseuniform = /obj/item/clothing/under/tactical;
-	gender = "male";
-	mobname = "Colt Finnlay";
-	name = "Colt Finnlay"
-	},
-/turf/simulated/floor/outdoors/snow/sif/planetuse,
-/area/awaymission/snowfield/outside)
 "aMa" = (
 /obj/structure/coatrack,
 /turf/simulated/floor/wood,
@@ -11296,10 +11274,6 @@
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/medical/surgery)
-"lEI" = (
-/obj/item/weapon/gun/projectile/automatic/serdy/sr25c,
-/turf/simulated/floor/outdoors/snow/sif/planetuse,
-/area/awaymission/snowfield/outside)
 "lFf" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/button/remote/blast_door{
@@ -30449,9 +30423,9 @@ pun
 imC
 pun
 pun
-aLO
 pun
-lEI
+pun
+pun
 pun
 nin
 imC

--- a/maps/southern_cross/submaps/gateway/snowfield-alt.dmm
+++ b/maps/southern_cross/submaps/gateway/snowfield-alt.dmm
@@ -1,0 +1,89080 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aas" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm10)
+"aaw" = (
+/obj/machinery/door/window/southleft,
+/obj/effect/floor_decal/industrial/loading,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"aaA" = (
+/obj/machinery/door/blast/gate/open,
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/cavern)
+"aaH" = (
+/obj/effect/landmark/gateway_scatter,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"aaO" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"abv" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small/flicker,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"acD" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"acY" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"adq" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/service/publicstaff)
+"adK" = (
+/obj/random/junk,
+/obj/machinery/light_construct/small{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"aeL" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"aeZ" = (
+/obj/machinery/computer/station_alert,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"afc" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/structure/bookcase,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"afo" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"afA" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"afW" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm15)
+"agi" = (
+/obj/structure/fence/post,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"ago" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Cells";
+	req_access = list(1)
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"agT" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"ahu" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/engineering_welding{
+	req_access = null;
+	req_one_access = list (10,11)
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"ahK" = (
+/obj/structure/table/standard,
+/obj/structure/bedsheetbin,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"ahY" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"aip" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"aiv" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway2)
+"aiX" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield bsa maints";
+	name = "BSA Maintenance Window Lockdown";
+	pixel_x = 5;
+	req_one_access = list(1,11,20)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield bsa access";
+	name = "BSA Entry Access";
+	pixel_x = -5;
+	req_one_access = list(20,56)
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"ajG" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"ajH" = (
+/obj/machinery/gibber,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"ajN" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/adv{
+	starts_with = list(/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment)
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	starts_with = list(/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"akM" = (
+/obj/random/tech_supply,
+/obj/structure/table/standard,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"akX" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/toxin,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"alL" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"alU" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"alY" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"amg" = (
+/obj/item/weapon/storage/box/flashbangs,
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"aml" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm14)
+"amp" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/plastic,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"amu" = (
+/obj/structure/catwalk,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"amD" = (
+/obj/structure/bed/chair/oldsofa/right,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"amU" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Lounge"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/service/publicstaff)
+"amZ" = (
+/obj/structure/fence/door{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"aow" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm5)
+"aqv" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"aqB" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/charger)
+"arp" = (
+/obj/machinery/computer/security/engineering,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"arr" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"art" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/toxin,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"aru" = (
+/obj/machinery/door/airlock{
+	name = "Restroom"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"arw" = (
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
+"arB" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"arL" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"asJ" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm13)
+"asS" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"atv" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"atx" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell)
+"auq" = (
+/obj/machinery/computer,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/server)
+"auz" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/monitorroom)
+"avt" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/floodlight,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"axv" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"ayp" = (
+/obj/structure/table/rack,
+/obj/item/clothing/accessory/holster/leg,
+/obj/item/clothing/accessory/holster/leg,
+/obj/item/clothing/accessory/holster/leg,
+/obj/item/clothing/accessory/holster/leg,
+/obj/item/clothing/accessory/holster/leg,
+/obj/item/clothing/accessory/holster/leg,
+/obj/item/clothing/accessory/holster/leg,
+/obj/item/clothing/accessory/holster/leg,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"ayB" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"ayG" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/engineering_welding{
+	req_access = null;
+	req_one_access = list (10,11)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"ayK" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"ayQ" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "17"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"azx" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/table/standard,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"azz" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"aAf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"aAZ" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"aBl" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm7)
+"aBn" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/engineering/restroom)
+"aCh" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm14)
+"aDg" = (
+/obj/structure/bed/padded,
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/security_cell)
+"aDx" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"aDF" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"aDO" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"aEn" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/public/toolstorage1)
+"aFH" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"aFI" = (
+/obj/item/weapon/material/ashtray/glass,
+/obj/item/device/radio/phone,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"aGe" = (
+/obj/machinery/door/window/brigdoor/northleft{
+	health = 1e+006;
+	req_access = null;
+	req_one_access = list(108)
+	},
+/obj/machinery/door/window/brigdoor/southleft{
+	health = 1e+006;
+	req_access = null;
+	req_one_access = list(108)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/structure/fans/tiny,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/server)
+"aGE" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"aHk" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"aHu" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm4)
+"aHD" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"aHQ" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"aHT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"aIt" = (
+/obj/structure/sink{
+	pixel_y = 16
+	},
+/obj/structure/mirror{
+	pixel_y = 35
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"aJI" = (
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/steel_reinforced,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"aKn" = (
+/obj/machinery/door/airlock/glass{
+	name = "Cafeteria"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/cafeteria)
+"aKI" = (
+/obj/machinery/door/airlock/security,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/hallway2)
+"aKJ" = (
+/obj/structure/fence,
+/obj/structure/flora/grass/green,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"aLx" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/l3closet/general,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"aLI" = (
+/obj/structure/table/glass,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"aLO" = (
+/obj/effect/landmark/corpse/security{
+	corpseback = /obj/item/weapon/storage/backpack/satchel/military;
+	corpsebelt = /obj/item/weapon/storage/belt/security/tactical;
+	corpseglasses = /obj/item/clothing/glasses/night;
+	corpsegloves = /obj/item/clothing/gloves/tactical;
+	corpsehelmet = /obj/item/clothing/head/helmet/combat;
+	corpseidaccess = "Syndicate";
+	corpseidjob = "N/A";
+	corpsemask = /obj/item/clothing/mask/balaclava;
+	corpsepocket1 = /obj/item/device/binoculars;
+	corpsepocket2 = /obj/item/device/camerabug/spy;
+	corpseradio = /obj/item/device/radio/headset;
+	corpseshoes = /obj/item/clothing/shoes/boots/combat;
+	corpsesuit = /obj/item/clothing/suit/armor/pcarrier/bulletproof/full;
+	corpseuniform = /obj/item/clothing/under/tactical;
+	gender = "male";
+	mobname = "Colt Finnlay";
+	name = "Colt Finnlay"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"aMa" = (
+/obj/structure/coatrack,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"aMo" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"aMr" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"aMQ" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"aNw" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm1)
+"aNA" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "11"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"aNJ" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/public/toolstorage1)
+"aOC" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/machinery/vending/sovietsoda{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"aON" = (
+/turf/simulated/floor/water/deep,
+/area/awaymission/snowfield/outside)
+"aPl" = (
+/obj/structure/flora/grass/both,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"aPr" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/carpet,
+/area/awaymission/snowfield/security/detective)
+"aPv" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm12)
+"aQV" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms9";
+	name = "Room 9"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm9)
+"aRB" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"aRX" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm5)
+"aSi" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/blue,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"aSS" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/clipboard,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"aTz" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield lab enterance lockdown";
+	name = "Path Blocker Control";
+	pixel_y = 23;
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"aVy" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm16)
+"aVA" = (
+/obj/structure/flora/tree/dead,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"aWq" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/front_desk)
+"aWv" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/fire,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"aWG" = (
+/obj/item/weapon/ore/glass,
+/obj/item/weapon/ore/glass,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/outside)
+"aWJ" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/pen/multi,
+/obj/item/weapon/pen/multi,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"aWM" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/green,
+/obj/structure/cable/heavyduty{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"aXm" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "The Pit";
+	req_one_access = list(1)
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell)
+"aXu" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"aXS" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/adv{
+	starts_with = list(/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment)
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	starts_with = list(/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"aXY" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/hydro)
+"aYT" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"bat" = (
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"bbF" = (
+/obj/machinery/door/blast/regular{
+	id = "snowfield second blast"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"bcu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell)
+"bcy" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm14)
+"beI" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/service/hydro)
+"beV" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/testroom)
+"beW" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/paramedic{
+	req_access = list(33);
+	starts_with = list(/obj/item/weapon/storage/backpack/dufflebag/emt,/obj/item/weapon/storage/box/autoinjectors,/obj/item/weapon/storage/box/syringes,/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,/obj/item/weapon/storage/belt/medical/emt,/obj/item/clothing/mask/gas,/obj/item/clothing/suit/storage/toggle/fr_jacket,/obj/item/clothing/suit/storage/toggle/labcoat/emt,/obj/item/clothing/suit/storage/hooded/wintercoat/medical/para,/obj/item/device/radio/headset/headset_med/alt,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/device/flashlight,/obj/item/weapon/tank/emergency/oxygen/engi,/obj/item/device/radio/off,/obj/item/weapon/tool/crowbar,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/storage/box/freezer,/obj/item/clothing/accessory/storage/white_vest,/obj/item/taperoll/medical)
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"beX" = (
+/obj/structure/catwalk,
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Interrogation Tool";
+	req_access = null;
+	req_one_access = list(2,5)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"bfk" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/command/gateway)
+"bgj" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"bhz" = (
+/obj/structure/table/steel,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/charger)
+"biJ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green,
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"bjz" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/outside)
+"bjA" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/photocopier/faxmachine,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"bjR" = (
+/obj/machinery/computer,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/command/bridge)
+"bjT" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"bjV" = (
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/heavyduty,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"bjY" = (
+/obj/item/weapon/pen/blade/red,
+/obj/machinery/light_construct/small,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"bke" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/folder/red,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"bkM" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "O- Blood Locker";
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"blf" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
+"bnD" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/item/clothing/suit/fire/heavy{
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 60);
+	desc = "Over a suit that protects against extreme fire and heat, this seems to be having a thin layer of coating underneath, providing additional protection against radiation."
+	},
+/obj/item/clothing/suit/fire/heavy{
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 60);
+	desc = "Over a suit that protects against extreme fire and heat, this seems to be having a thin layer of coating underneath, providing additional protection against radiation."
+	},
+/obj/item/device/geiger,
+/obj/item/clothing/head/hardhat/firefighter/atmos,
+/obj/item/clothing/head/hardhat/firefighter/atmos,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"bpn" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/box/donut/empty,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"bpo" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"bpJ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"bpX" = (
+/obj/structure/flora/tree/pine,
+/obj/structure/flora/tree/pine,
+/obj/structure/flora/grass/green,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"bqj" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"bqA" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm4)
+"bqR" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/service/cafeteria)
+"bqV" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"brj" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/command/bridge)
+"brq" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm10)
+"bsc" = (
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"bsl" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 26
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"bsH" = (
+/obj/structure/fence,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"btO" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"buE" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm8)
+"buF" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm13)
+"buJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"bvd" = (
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/cavern)
+"bvf" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"bvj" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm12)
+"bvp" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/vending/sovietvend,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"bxk" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/interrogation)
+"bxC" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"bxE" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/armory_entrance)
+"byc" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"byq" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm16)
+"byr" = (
+/obj/machinery/vending/hydronutrients{
+	dir = 8;
+	pixel_x = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"byw" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"byG" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"byM" = (
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"bAl" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access = null;
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"bAP" = (
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"bAQ" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"bAX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall,
+/area/awaymission/snowfield/checkpointunpowered)
+"bBa" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"bBr" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm2)
+"bBL" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm5)
+"bBU" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering,
+/turf/simulated/floor,
+/area/awaymission/snowfield/checkpointunpowered)
+"bBV" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"bCH" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"bCY" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms8";
+	name = "Room 8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm8)
+"bDb" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/tech_storage)
+"bDr" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/armory)
+"bDs" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield testlab entrance";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/commandhallway)
+"bDz" = (
+/obj/machinery/gateway{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"bEQ" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"bFn" = (
+/obj/structure/outcrop,
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/cavern)
+"bGo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"bGr" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/blue,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"bGu" = (
+/obj/structure/railing/grey,
+/turf/simulated/floor/water/deep,
+/area/awaymission/snowfield/outside)
+"bGI" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield sec front blast";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"bGK" = (
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"bHz" = (
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/glass/bucket/wood,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"bJm" = (
+/obj/structure/flora/grass/both,
+/obj/structure/flora/grass/both,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"bJp" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms16";
+	name = "Room 16"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm16)
+"bJC" = (
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"bKe" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet{
+	closet_appearance = /decl/closet_appearance/bio;
+	name = "Level-3 Biohazard Closet"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"bKx" = (
+/obj/structure/window/reinforced/tinted/frosted,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/security/detective)
+"bKK" = (
+/obj/item/ammo_magazine/ammo_box/b12g/flechette,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/weapon/storage/box/scattershot/large,
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"bLK" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/public/toolstorage1)
+"bLU" = (
+/obj/structure/closet/secure_closet/guncabinet,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/weapon/gun/projectile/serdy_pistols/makarov,
+/obj/item/weapon/gun/projectile/serdy_pistols/makarov,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"bLV" = (
+/obj/machinery/light/small/flicker{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/interrogation)
+"bMi" = (
+/obj/machinery/vending/coffee{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"bMx" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm5)
+"bMS" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"bNA" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/vending/sovietsoda{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"bOj" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/security/armory_entrance)
+"bPf" = (
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/tech_storage)
+"bPg" = (
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/flora/grass/brown,
+/obj/structure/catwalk,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"bPF" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Server Control Room";
+	req_access = list(61);
+	req_one_access = list(61)
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	id = "snowfield sr access"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/server)
+"bQl" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"bRJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"bSM" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"bTs" = (
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield test observation";
+	name = "Test Chamber Observation Access";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/observatory_path)
+"bTS" = (
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/awaymission/snowfield/engineering/locker_room)
+"bTZ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"bUb" = (
+/obj/structure/flora/grass/brown,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"bUq" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm12)
+"bUr" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"bVx" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm15)
+"bVG" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"bWz" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"bXG" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"bXH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"bYx" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 17
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"bYA" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms7";
+	name = "Room 7"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm7)
+"bYP" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"bYR" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/water/deep,
+/area/awaymission/snowfield/outside)
+"bYW" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"bZn" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/firingrange)
+"bZx" = (
+/obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/cloth,
+/obj/fiftyspawner/log,
+/obj/fiftyspawner/log,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"bZP" = (
+/turf/simulated/floor/outdoors/ice,
+/area/awaymission/snowfield/outside)
+"bZV" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"caD" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway2)
+"ccW" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"cdN" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"ceH" = (
+/obj/random/tech_supply,
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 10
+	},
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/public/toolstorage1)
+"ceJ" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/interrogation)
+"cfD" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/security/warden)
+"cfL" = (
+/obj/machinery/oxygen_pump/mobile/anesthetic,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"cgD" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/secure_tech_storage)
+"cgH" = (
+/obj/structure/bed/chair/oldsofa{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"chG" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"cip" = (
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"ciA" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm2)
+"ciN" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"ciQ" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 8
+	},
+/obj/machinery/power/rtg/fake_reactor,
+/turf/simulated/floor/reinforced,
+/area/awaymission/snowfield/engineering/engine)
+"ciR" = (
+/obj/structure/table/reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"cji" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/rdconsole,
+/obj/item/weapon/circuitboard/destructive_analyzer,
+/obj/item/weapon/circuitboard/protolathe,
+/obj/item/weapon/circuitboard/rdserver{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"cju" = (
+/mob/living/simple_mob/vore/rabbit/white,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"cjJ" = (
+/obj/structure/bed/chair/oldsofa/left,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"ckr" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"ckB" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"cle" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"cmo" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/observatory_path)
+"cmU" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"cnh" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/water_cooler/full{
+	dir = 8;
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"cnS" = (
+/obj/structure/closet/radiation,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"cou" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/observatory_path)
+"cpd" = (
+/obj/item/weapon/material/shard/shrapnel{
+	pixel_x = -3;
+	pixel_y = -7
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"cqc" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"cqC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/effect/floor_decal/arrows{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"crN" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"csk" = (
+/obj/machinery/computer/rcon,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"csT" = (
+/obj/machinery/computer,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"ctZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield lab entrance lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"cuv" = (
+/obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/rods,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"cuU" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"cvV" = (
+/obj/structure/morgue,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"cvY" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm11)
+"cxh" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/marble,
+/obj/machinery/reagentgrinder,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"cxk" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"cxN" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/wheelchair,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"cye" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"cyO" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"czk" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"czr" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"czs" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"cBr" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access = null;
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"cBQ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"cCf" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"cCA" = (
+/obj/machinery/door/blast/gate/open,
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/outside)
+"cCM" = (
+/obj/machinery/door/blast/gate/open,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"cDP" = (
+/obj/structure/closet/secure_closet/warden{
+	starts_with = list(/obj/item/clothing/gloves/combat, /obj/item/clothing/accessory/holster, /obj/item/weapon/storage/belt/security, /obj/item/weapon/shield/riot, /obj/item/ammo_magazine/akm = 2, /obj/item/weapon/gun/projectile/automatic/serdy/krinkov, /obj/item/clothing/head/beret/sec/corporate/warden, /obj/item/clothing/head/helmet/warden/hat, /obj/item/clothing/head/helmet/warden, /obj/item/clothing/suit/armor/swat/officer, /obj/item/device/radio/headset/heads/hos/alt, /obj/item/device/radio/headset/heads/hos, /obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec, /obj/item/clothing/shoes/boots/marine, /obj/item/ammo_magazine/s357 = 2, /obj/item/weapon/gun/projectile/revolver/nagant/skinned, /obj/item/clothing/under/soviet, /obj/item/weapon/reagent_containers/spray/pepper, /obj/item/weapon/melee/classic_baton)
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"cEo" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm2)
+"cEx" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/device/multitool,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"cER" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"cGx" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"cGS" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"cHx" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm10)
+"cIk" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"cIz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"cJn" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"cKO" = (
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/cavern)
+"cLD" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"cMa" = (
+/obj/structure/table/steel,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/device/multitool,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"cMA" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"cMG" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm7)
+"cNu" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"cNE" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "7"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"cQm" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/security{
+	starts_with = list(/obj/item/clothing/gloves/black, /obj/item/clothing/accessory/holster, /obj/item/weapon/storage/belt/security, /obj/item/clothing/head/beret/sec/corporate/officer, /obj/item/clothing/head/helmet, /obj/item/device/radio/headset/headset_sec/alt, /obj/item/device/radio/headset/headset_sec, /obj/item/device/radio/off, /obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec, /obj/item/clothing/shoes/boots/marine, /obj/item/clothing/suit/armor/bulletproof, /obj/item/clothing/under/soviet, /obj/item/weapon/reagent_containers/spray/pepper, /obj/item/weapon/melee/classic_baton, /obj/item/ammo_magazine/makarov = 2, /obj/item/weapon/gun/projectile/serdy_pistols/makarov)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_lockerroom)
+"cQE" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell)
+"cQM" = (
+/obj/structure/catwalk,
+/obj/machinery/oxygen_pump/mobile/anesthetic,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"cRf" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"cSr" = (
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"cSU" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"cTa" = (
+/obj/machinery/door/blast/gate,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"cTX" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/machinery/door/window/southright{
+	name = "Shower"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"cVa" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"cVu" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm3)
+"cVw" = (
+/obj/structure/flora/rocks1,
+/turf/simulated/floor/outdoors/ice,
+/area/awaymission/snowfield/outside)
+"cWo" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 4
+	},
+/obj/machinery/power/rtg/fake_reactor,
+/turf/simulated/floor/reinforced,
+/area/awaymission/snowfield/engineering/engine)
+"cWP" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/grey/bordercorner,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"cYR" = (
+/obj/item/device/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/device/flashlight{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"cZe" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/server)
+"dap" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"daH" = (
+/obj/structure/fence,
+/obj/structure/flora/grass/both,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"daJ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm14)
+"daZ" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm/ap,
+/obj/item/ammo_magazine/akm/ap,
+/obj/item/ammo_magazine/akm/ap,
+/obj/item/ammo_magazine/akm/ap,
+/obj/item/ammo_magazine/akm/ap,
+/obj/item/ammo_magazine/akm/ap,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/eastright{
+	name = "Ammo"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"dcd" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/monitorroom)
+"dco" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/monitorroom)
+"dcv" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"dcJ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"dda" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"dds" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"ddF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"ddH" = (
+/obj/structure/prop/blackbox/snowfield_base,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/server)
+"ddJ" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm3)
+"der" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"deC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/secure_tech_storage)
+"dfd" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway2)
+"dfk" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"dgf" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet,
+/area/awaymission/snowfield/security/detective)
+"dgg" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"dgr" = (
+/obj/structure/catwalk,
+/obj/structure/table/steel_reinforced,
+/obj/item/clothing/gloves/knuckledusters,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/clothing/suit/chickensuit,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"dgL" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/turcarpet,
+/area/awaymission/snowfield/medical/staff_room)
+"dgS" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm16)
+"dhs" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm6)
+"dib" = (
+/obj/structure/fence,
+/obj/structure/railing,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"djC" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"dke" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"dkj" = (
+/obj/machinery/vending/blood,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/surgery)
+"dkB" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"dkH" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"dlz" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm6)
+"dmh" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm2)
+"dmp" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"dmy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	opened = 1
+	},
+/obj/item/weapon/gun/projectile/shotgun/pump/shorty{
+	desc = "A clunky, lightly modified special carbine, this gun is often be seen in the old terran's prison, designed to suppress the prison riots.";
+	description_fluff = "Designed to suppress the prison riot, KS-23 has been developed in 1970s in Soviet Russia. Crude, but compact, it is easy to carry around while in patrol, and useful in close combat.";
+	name = "KS-23"
+	},
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"dmB" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"dmZ" = (
+/obj/effect/map_helper/no_tele,
+/turf/simulated/wall/solidrock{
+	block_tele = 0
+	},
+/area/awaymission/snowfield/restricted)
+"dnp" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"dnJ" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"dpf" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/medical_locker)
+"dqC" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/frontgate)
+"drk" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"dsh" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/off{
+	pixel_y = 6
+	},
+/obj/item/device/radio/off{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/item/device/radio/phone,
+/obj/item/device/radio/off,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"dsB" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "entrylockdown";
+	name = "Front SMES lockdown";
+	pixel_x = -23
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"dtp" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm15)
+"dtC" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"dtS" = (
+/obj/machinery/power/smes/buildable{
+	charge = null;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 1000000;
+	output_level = 750000
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"dtZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/structure/coatrack,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"dub" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/hydro)
+"dux" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"dvn" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "28a"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"dvx" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"dvU" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 8
+	},
+/obj/machinery/door/window/brigdoor/eastright{
+	id = Cell 2;
+	name = "Cell 2";
+	req_access = null;
+	req_one_access = list(2,4)
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/security_cell)
+"dwe" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm15)
+"dxg" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm11)
+"dxs" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"dxL" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"dxX" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"dyT" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/observatory_path)
+"dzh" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/suit/fire/heavy{
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 60);
+	desc = "Over a suit that protects against extreme fire and heat, this seems to be having a thin layer of coating underneath, providing additional protection against radiation."
+	},
+/obj/item/clothing/suit/fire/heavy{
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 60);
+	desc = "Over a suit that protects against extreme fire and heat, this seems to be having a thin layer of coating underneath, providing additional protection against radiation."
+	},
+/obj/item/clothing/head/hardhat/firefighter/atmos,
+/obj/item/clothing/head/hardhat/firefighter/atmos,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"dzH" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"dzI" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"dzK" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/item/weapon/soap,
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/closet/secure_closet/medical3{
+	req_access = list(33);
+	starts_with = list(/obj/item/clothing/under/rank/medical,/obj/item/clothing/under/rank/nurse,/obj/item/clothing/under/rank/orderly,/obj/item/clothing/suit/storage/toggle/labcoat,/obj/item/clothing/suit/storage/toggle/labcoat/modern,/obj/item/clothing/suit/storage/toggle/fr_jacket,/obj/item/device/radio/headset/headset_med,/obj/item/device/radio/headset/headset_med/alt,/obj/item/clothing/suit/storage/hooded/wintercoat/medical,/obj/item/clothing/shoes/boots/winter/medical,/obj/item/clothing/under/rank/nursesuit,/obj/item/clothing/head/nursehat,/obj/item/weapon/storage/box/freezer = 3, /obj/item/weapon/storage/belt/medical)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"dzM" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"dzR" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"dzU" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/weapon/gun/projectile/heavysniper{
+	scoped_accuracy = 125
+	},
+/obj/item/ammo_magazine/ammo_box/b145,
+/obj/item/ammo_magazine/ammo_box/b145,
+/obj/item/ammo_magazine/ammo_box/b145,
+/obj/item/ammo_magazine/ammo_box/b145,
+/obj/item/ammo_magazine/ammo_box/b145/highvel,
+/obj/item/ammo_magazine/ammo_box/b145/highvel,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"dAf" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/monitorroom)
+"dAv" = (
+/obj/structure/cable/heavyduty{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"dBB" = (
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"dCq" = (
+/turf/simulated/mineral/cave,
+/area/awaymission/snowfield/restricted)
+"dCP" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm12)
+"dCV" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"dDL" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm8)
+"dDM" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"dEs" = (
+/obj/effect/floor_decal/corner/black/border,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/outside)
+"dEV" = (
+/obj/structure/closet/secure_closet/guncabinet,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/weapon/gun/projectile/serdy_pistols/makarov,
+/obj/item/weapon/gun/projectile/serdy_pistols/makarov,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"dFg" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"dGB" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/security/armory_entrance)
+"dHD" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"dHG" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"dHL" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"dId" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"dIO" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield lab entrance lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/commandhallway)
+"dJc" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	opened = 1
+	},
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74/variantun,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"dJl" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"dJm" = (
+/obj/structure/bonfire,
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/cavern)
+"dJo" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"dJq" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm4)
+"dJx" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/security/armory)
+"dJz" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm6)
+"dJI" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/awaymission/snowfield/security/observatory)
+"dKR" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"dLP" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms15";
+	name = "Room 15"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm15)
+"dLQ" = (
+/obj/structure/table/bench/wooden,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"dMv" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "9"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"dMJ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"dMP" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm9)
+"dNz" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "Armament"
+	},
+/obj/item/weapon/gun/projectile/shotgun/pump/shorty{
+	desc = "A clunky, lightly modified special carbine, this gun is often be seen in the old terran's prison, designed to suppress the prison riots.";
+	description_fluff = "Designed to suppress the prison riot, KS-23 has been developed in 1970s in Soviet Russia. Crude, but compact, it is easy to carry around while in patrol, and useful in close combat.";
+	name = "KS-23"
+	},
+/obj/item/weapon/gun/projectile/shotgun/pump/shorty{
+	desc = "A clunky, lightly modified special carbine, this gun is often be seen in the old terran's prison, designed to suppress the prison riots.";
+	description_fluff = "Designed to suppress the prison riot, KS-23 has been developed in 1970s in Soviet Russia. Crude, but compact, it is easy to carry around while in patrol, and useful in close combat.";
+	name = "KS-23"
+	},
+/obj/item/weapon/gun/projectile/shotgun/pump/shorty{
+	desc = "A clunky, lightly modified special carbine, this gun is often be seen in the old terran's prison, designed to suppress the prison riots.";
+	description_fluff = "Designed to suppress the prison riot, KS-23 has been developed in 1970s in Soviet Russia. Crude, but compact, it is easy to carry around while in patrol, and useful in close combat.";
+	name = "KS-23"
+	},
+/obj/item/weapon/gun/projectile/shotgun/pump/shorty{
+	desc = "A clunky, lightly modified special carbine, this gun is often be seen in the old terran's prison, designed to suppress the prison riots.";
+	description_fluff = "Designed to suppress the prison riot, KS-23 has been developed in 1970s in Soviet Russia. Crude, but compact, it is easy to carry around while in patrol, and useful in close combat.";
+	name = "KS-23"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"dNA" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm14)
+"dNW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering{
+	req_access = null;
+	req_one_access = list(1,10)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/hallway)
+"dOC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"dQj" = (
+/obj/structure/closet/coffin,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"dQr" = (
+/obj/machinery/computer/shutoff_monitor,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"dQQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/space_cleaner{
+	pixel_x = -30
+	},
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"dQR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm15)
+"dQX" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm5)
+"dRK" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"dSA" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm16)
+"dSJ" = (
+/obj/structure/closet/wardrobe/medic_white,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"dTj" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm8)
+"dTO" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"dTU" = (
+/obj/machinery/microscope,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/security/detective)
+"dUn" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm13)
+"dUp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"dUy" = (
+/obj/item/weapon/ore/glass,
+/obj/item/weapon/ore/glass,
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/cavern)
+"dVm" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/smes/buildable{
+	charge = null;
+	cur_coils = 3;
+	input_attempt = 1;
+	input_level = 500000;
+	output_level = 350000
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"dVK" = (
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"dWW" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"dWX" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/security{
+	starts_with = list(/obj/item/clothing/gloves/black, /obj/item/clothing/accessory/holster, /obj/item/weapon/storage/belt/security, /obj/item/clothing/head/beret/sec/corporate/officer, /obj/item/clothing/head/helmet, /obj/item/device/radio/headset/headset_sec/alt, /obj/item/device/radio/headset/headset_sec, /obj/item/device/radio/off, /obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec, /obj/item/clothing/shoes/boots/marine, /obj/item/clothing/suit/armor/bulletproof, /obj/item/clothing/under/soviet, /obj/item/weapon/reagent_containers/spray/pepper, /obj/item/weapon/melee/classic_baton, /obj/item/ammo_magazine/makarov = 2, /obj/item/weapon/gun/projectile/serdy_pistols/makarov)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_lockerroom)
+"dXK" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/clothing/mask/breath,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"dXU" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 17
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green,
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"dXW" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"dYi" = (
+/obj/structure/closet/l3closet/security,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/storage/firstaid/toxin,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"dYu" = (
+/obj/structure/table/bench/wooden,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"dZR" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"dZS" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm7)
+"eab" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm12)
+"ebt" = (
+/obj/machinery/floodlight,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"ecn" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm13)
+"ecC" = (
+/obj/machinery/door/airlock/highsecurity{
+	health = 0;
+	name = "BSA Monitoring Room";
+	req_one_access = list(1,11,20,47,56)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa MR";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"ecQ" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/circuitboard/pointdefense,
+/obj/item/weapon/circuitboard/pointdefense_control{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"edc" = (
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/glass/bucket/wood,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"edJ" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm1)
+"edK" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"eey" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/sub_chamber)
+"eeE" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm3)
+"efr" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm6)
+"efy" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa observation window";
+	opacity = 0
+	},
+/obj/structure/window/reinforced/full{
+	health = 1e+006
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/bsa)
+"egk" = (
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"egT" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"eha" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"ehs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/server)
+"ehQ" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm8)
+"eij" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm11)
+"eim" = (
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/interrogation)
+"eip" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/public/charger)
+"eis" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/server)
+"eiu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"ekx" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"ekO" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"emV" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/public/toolstorage1)
+"emW" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"enk" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"enq" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm12)
+"ens" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/tech_storage)
+"epu" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"epz" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 5
+	},
+/obj/item/weapon/soap,
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/closet/secure_closet/medical3{
+	req_access = list(33);
+	starts_with = list(/obj/item/clothing/under/rank/medical,/obj/item/clothing/under/rank/nurse,/obj/item/clothing/under/rank/orderly,/obj/item/clothing/suit/storage/toggle/labcoat,/obj/item/clothing/suit/storage/toggle/labcoat/modern,/obj/item/clothing/suit/storage/toggle/fr_jacket,/obj/item/device/radio/headset/headset_med,/obj/item/device/radio/headset/headset_med/alt,/obj/item/clothing/suit/storage/hooded/wintercoat/medical,/obj/item/clothing/shoes/boots/winter/medical,/obj/item/clothing/under/rank/nursesuit,/obj/item/clothing/head/nursehat,/obj/item/weapon/storage/box/freezer = 3, /obj/item/weapon/storage/belt/medical)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"epG" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"epH" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.6
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"epO" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/autopsy_scanner,
+/obj/item/weapon/surgical/bioregen,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"epY" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"eqY" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"esc" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm1)
+"esC" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/southright{
+	req_access = list(1)
+	},
+/obj/machinery/door/window/northright{
+	req_access = list(1)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield sec front blast";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/frontgate)
+"esL" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/item/weapon/gun/projectile/automatic/serdy/ppsh,
+/obj/item/weapon/gun/projectile/automatic/serdy/ppsh,
+/obj/item/weapon/gun/projectile/automatic/serdy/ppsh,
+/obj/item/weapon/gun/projectile/automatic/serdy/ppsh,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "Armament"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"etc" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"etd" = (
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "Code Red Armory";
+	req_access = null;
+	req_one_access = list(3)
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"eti" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/panicroom)
+"etU" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"euq" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"eur" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"euC" = (
+/obj/structure/flora/log2,
+/turf/simulated/floor/outdoors/ice,
+/area/awaymission/snowfield/outside)
+"evg" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm1)
+"evA" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm14)
+"evZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"ewC" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"ewG" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	starts_with = list(/obj/item/clothing/accessory/storage/brown_vest,/obj/item/weapon/storage/toolbox/mechanical,/obj/item/device/radio/headset/headset_eng,/obj/item/device/radio/headset/headset_eng/alt,/obj/item/clothing/suit/storage/hazardvest,/obj/item/clothing/mask/gas,/obj/item/weapon/cartridge/engineering,/obj/item/taperoll/engineering,/obj/item/clothing/head/hardhat,/obj/item/clothing/suit/storage/hooded/wintercoat/engineering,/obj/item/clothing/shoes/boots/winter/engineering,/obj/item/weapon/tank/emergency/oxygen/engi,/obj/item/weapon/storage/belt/utility,/obj/item/weapon/reagent_containers/spray/windowsealant)
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"ewW" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/security{
+	locked = 1
+	},
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/seconddesk)
+"exb" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "31"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"exB" = (
+/turf/simulated/mineral/cave,
+/area/awaymission/snowfield/cavern)
+"eyq" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"eyW" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm3)
+"ezy" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/outside)
+"ezz" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"ezV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/security/armory_entrance)
+"eAl" = (
+/obj/machinery/iv_drip,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/surgery)
+"eAM" = (
+/obj/item/weapon/ore/glass,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"eBk" = (
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "O- Blood Locker";
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"eBY" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm10)
+"eCr" = (
+/obj/structure/flora/rocks2,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"eCN" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm8)
+"eDF" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm11)
+"eEy" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm10)
+"eEJ" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_one_access = list(1,11,23,30,56,70)
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"eES" = (
+/obj/structure/flora/grass/both,
+/obj/structure/flora/bush,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"eFe" = (
+/obj/machinery/atmospherics/unary/freezer{
+	icon_state = "freezer_1";
+	set_temperature = 73;
+	use_power = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/server)
+"eFM" = (
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
+	req_access = null
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"eGs" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"eHo" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Armoury Tactical Equipment";
+	req_access = list(3);
+	req_one_access = list(3)
+	},
+/obj/machinery/door/blast/regular{
+	id = "snowfield heavy armory";
+	name = "Assault Weapon Storage"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"eIU" = (
+/obj/structure/sign/signnew/danger,
+/turf/simulated/wall/titanium,
+/area/awaymission/snowfield/outside)
+"eJl" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/commandarmory)
+"eJD" = (
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/multi,
+/obj/item/device/taperecorder{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/structure/table/steel_reinforced,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"eKf" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm9)
+"eLv" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 5
+	},
+/obj/structure/table/steel_reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"eNp" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"eNq" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"eNH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield sec front blast";
+	name = "Emergency Front Desk Lockdown";
+	pixel_y = 23;
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"eNN" = (
+/obj/machinery/vending/sovietsoda,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"eNU" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"eOe" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"ePe" = (
+/obj/structure/table/woodentable,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"ePu" = (
+/obj/machinery/optable,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"eRq" = (
+/obj/structure/kitchenspike,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"eRI" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"eRY" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"eSa" = (
+/obj/machinery/light/small/flicker{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"eSk" = (
+/obj/structure/catwalk,
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Cells";
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"eSJ" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"eSZ" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm5)
+"eTp" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm11)
+"eTC" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm16)
+"eUt" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm1)
+"eUQ" = (
+/obj/machinery/atmospherics/pipe/tank{
+	desc = "A large vessel containing huge amount of water.";
+	dir = 1;
+	icon_state = "o2_map";
+	name = "Water Tank"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"eVa" = (
+/mob/living/simple_mob/vore/sheep,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"eVy" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/secure_data{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/security{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/circuitboard/skills{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"eWn" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/service/janitor)
+"eXv" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
+"eXy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"eXF" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/eastright{
+	name = "Ammo"
+	},
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/flechette,
+/obj/item/ammo_magazine/ammo_box/b12g/flechette,
+/obj/item/ammo_magazine/ammo_box/b12g,
+/obj/item/ammo_magazine/ammo_box/b12g,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"eYO" = (
+/obj/machinery/door/airlock{
+	name = "Restroom"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"eYV" = (
+/obj/structure/curtain/open/shower/security,
+/obj/machinery/door/window/westright{
+	name = "Shower"
+	},
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"eZG" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"fay" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm6)
+"faB" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell)
+"fbr" = (
+/obj/machinery/door/blast/gate/open{
+	dir = 4
+	},
+/obj/structure/flora/grass/brown,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"fbH" = (
+/obj/machinery/computer/med_data,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"fdm" = (
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"fdE" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"feF" = (
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "O- Blood Locker";
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"feZ" = (
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor,
+/area/awaymission/snowfield/checkpoint)
+"ffn" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm8)
+"ffS" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm2)
+"fgW" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"fhb" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"fht" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm2)
+"fik" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/item/weapon/material/ashtray/glass,
+/obj/item/weapon/material/ashtray/glass,
+/obj/item/weapon/material/ashtray/glass,
+/obj/item/weapon/material/ashtray/glass,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"fiF" = (
+/obj/machinery/photocopier,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"fiT" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/panicroom)
+"fjP" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet{
+	closet_appearance = /decl/closet_appearance/bio;
+	name = "Level-3 Biohazard Closet"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"fku" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"fkQ" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"fmV" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"fnD" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/machinery/vending/snack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"fnH" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/weapon/pen/blue{
+	pixel_x = -6
+	},
+/obj/item/weapon/pen/red{
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"fnS" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"fnW" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"foQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/item/weapon/reagent_containers/glass/bucket/wood,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"fpp" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"fqn" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
+"fqI" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	name = "Hydroponics";
+	req_access = null;
+	req_one_access = list(1,28)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/service/hydro)
+"frj" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "14"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"frZ" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "34"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"fsa" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"fsg" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/hallway)
+"fsW" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"fuC" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"fuQ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"fwr" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/lobby)
+"fwu" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"fxn" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "3"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"fyb" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"fyf" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"fAl" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/device/analyzer/plant_analyzer,
+/obj/item/device/analyzer,
+/obj/item/device/analyzer,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"fAI" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield bsa SCA";
+	name = "Tunguska Sub-chamber Lockdown";
+	req_one_access = list(1)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"fBf" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/airless,
+/area/awaymission/snowfield/outside)
+"fBJ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms2";
+	name = "Room 2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm2)
+"fCi" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"fDr" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"fFQ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"fGh" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/public/publicrestroom)
+"fIy" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm2)
+"fJF" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"fJP" = (
+/obj/machinery/gateway{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"fKF" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"fKG" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/surgery)
+"fKO" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/fence/end{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"fKY" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/monitorroom)
+"fLg" = (
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"fLm" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/item/weapon/reagent_containers/food/condiment/mustard,
+/obj/item/weapon/reagent_containers/food/condiment/mustard,
+/obj/item/weapon/reagent_containers/food/condiment/mustard,
+/obj/item/weapon/reagent_containers/food/condiment/mustard,
+/obj/item/weapon/reagent_containers/food/condiment/mustard,
+/obj/item/weapon/reagent_containers/food/condiment/mustard,
+/obj/item/weapon/reagent_containers/food/condiment/mustard,
+/obj/item/weapon/reagent_containers/food/condiment/mustard,
+/obj/item/weapon/reagent_containers/food/condiment/small,
+/obj/item/weapon/reagent_containers/food/condiment/small,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"fMy" = (
+/obj/structure/catwalk,
+/obj/structure/kitchenspike,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"fNe" = (
+/obj/machinery/door/blast/regular{
+	id = "snowfield test room"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/testroom)
+"fND" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 34;
+	pixel_y = -4
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"fNG" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"fNS" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"fNV" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"fOz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/orange/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"fPe" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm12)
+"fPB" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"fQr" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/marble,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/item/weapon/reagent_containers/food/condiment/sugar,
+/obj/item/weapon/reagent_containers/food/condiment/sugar,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"fRn" = (
+/obj/machinery/button/remote/blast_door{
+	id = "Armoury";
+	name = "Emergency Access";
+	pixel_x = 24;
+	req_access = list(3)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/security/armory_entrance)
+"fRZ" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"fSf" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm12)
+"fSp" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/flora/pottedplant/thinbush,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"fSy" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"fSZ" = (
+/obj/item/weapon/ore/coal,
+/obj/item/weapon/ore/coal,
+/obj/item/weapon/ore/coal,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"fTp" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm2)
+"fTI" = (
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/evidence_storage)
+"fTN" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm7)
+"fVU" = (
+/obj/machinery/chemical_analyzer,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"fWi" = (
+/obj/structure/closet/crate/radiation{
+	starts_with = list(/obj/item/clothing/suit/radiation = 8, /obj/item/clothing/head/radiation = 8)
+	},
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"fWQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/awaymission/snowfield/engineering/engine)
+"fXK" = (
+/obj/structure/table/steel,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/tech_storage)
+"fYo" = (
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"fYA" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/monitorroom)
+"fYG" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"fZa" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"fZD" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"gav" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/unary_atmos/heater,
+/obj/item/weapon/circuitboard/unary_atmos/cooler{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"gaS" = (
+/obj/structure/flora/grass/brown,
+/obj/structure/flora/bush,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"gaW" = (
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/awaymission/snowfield/engineering/staff_room)
+"gba" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 5
+	},
+/obj/machinery/appliance/mixer/candy,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"gbz" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"gbE" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	opened = 1
+	},
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74/variantun,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74/variantun,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"gbY" = (
+/obj/machinery/door/blast/gate/open,
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"gca" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/clothing/suit/armor/bulletproof/alt,
+/obj/item/clothing/suit/armor/bulletproof/alt,
+/obj/item/clothing/suit/armor/bulletproof/alt,
+/obj/item/clothing/suit/armor/bulletproof/alt,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"gcu" = (
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/cavern)
+"gcK" = (
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield bsa MCA";
+	name = "BSA Main Chamber Access";
+	req_one_access = list(1)
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"ger" = (
+/obj/machinery/computer,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/command/bridge)
+"geH" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm2)
+"geI" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"geU" = (
+/obj/structure/table/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/catwalk,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"ggo" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm15)
+"ghl" = (
+/obj/machinery/door/airlock/glass{
+	name = "Tool Storage"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/charger)
+"ghv" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/item/ammo_magazine/makarov,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"ghw" = (
+/obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/steel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"ghL" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm3)
+"ghQ" = (
+/obj/structure/flora/grass/both,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"ghU" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm16)
+"giO" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"gjG" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/clothing/head/helmet,
+/obj/item/clothing/head/helmet,
+/obj/item/clothing/head/helmet,
+/obj/item/clothing/head/helmet,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"gjR" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Server Control Room";
+	req_access = list(61);
+	req_one_access = list(61)
+	},
+/obj/machinery/door/blast/regular{
+	id = "snowfield sr access"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/server)
+"gkk" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"gkO" = (
+/obj/machinery/atmospherics/binary/pump,
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"gla" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"glh" = (
+/obj/machinery/door/airlock/command{
+	req_one_access = list(19,47)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/observatory_path)
+"glv" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"glF" = (
+/obj/structure/flora/grass/green,
+/obj/structure/flora/grass/green,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"gmb" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/outside)
+"gmv" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"gnj" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/surgical/retractor,
+/obj/item/weapon/surgical/hemostat,
+/obj/item/weapon/surgical/scalpel,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"gnN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"gom" = (
+/obj/item/weapon/material/shard{
+	icon_state = "medium"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"gox" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bio_hood/general,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"goN" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"goW" = (
+/obj/machinery/dnaforensics,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/security/detective)
+"gpv" = (
+/obj/structure/grille/rustic,
+/obj/structure/window/basic/full,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"gqx" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm7)
+"grk" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"grt" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/charger)
+"gsi" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	starts_with = list(/obj/item/clothing/accessory/storage/brown_vest,/obj/item/weapon/storage/toolbox/mechanical,/obj/item/device/radio/headset/headset_eng,/obj/item/device/radio/headset/headset_eng/alt,/obj/item/clothing/suit/storage/hazardvest,/obj/item/clothing/mask/gas,/obj/item/weapon/cartridge/engineering,/obj/item/taperoll/engineering,/obj/item/clothing/head/hardhat,/obj/item/clothing/suit/storage/hooded/wintercoat/engineering,/obj/item/clothing/shoes/boots/winter/engineering,/obj/item/weapon/tank/emergency/oxygen/engi,/obj/item/weapon/storage/belt/utility,/obj/item/weapon/reagent_containers/spray/windowsealant)
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"gsu" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"gsZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"gue" = (
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/warden)
+"gvk" = (
+/obj/structure/table/steel,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/charger)
+"gvJ" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"gvQ" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm15)
+"gvX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/monitorroom)
+"gwq" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "33"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"gws" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"gwu" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"gwP" = (
+/obj/structure/filingcabinet,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"gxE" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/northhallway)
+"gyZ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"gzE" = (
+/obj/structure/table/woodentable,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"gzF" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm15)
+"gzQ" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"gAd" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"gAn" = (
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"gAs" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"gBk" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"gBI" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm15)
+"gBO" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/ice,
+/area/awaymission/snowfield/outside)
+"gBZ" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm4)
+"gCG" = (
+/obj/item/weapon/material/shard{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/weapon/material/shard{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"gDg" = (
+/obj/structure/flora/grass/brown,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"gDk" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/obj/machinery/appliance/mixer/cereal,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"gEr" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"gGa" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/hallway)
+"gHk" = (
+/obj/structure/catwalk,
+/obj/machinery/light/floortube{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"gHB" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"gHQ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/front_desk)
+"gID" = (
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield heavy armory";
+	name = "Code Red Armory Access";
+	pixel_y = -24;
+	req_access = list(3)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"gJh" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/computer/skills{
+	req_one_access = list(1,19)
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"gJv" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"gKh" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"gKm" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/vending/cigarette{
+	dir = 8;
+	pixel_x = 5;
+	prices = null
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"gKN" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"gLf" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"gLt" = (
+/obj/machinery/door/window/brigdoor/northleft{
+	name = "Code Green Armory";
+	req_access = null
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"gLu" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"gLA" = (
+/obj/effect/floor_decal/industrial/danger,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"gLD" = (
+/obj/structure/table/glass,
+/obj/item/weapon/soap,
+/obj/item/weapon/soap,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"gMg" = (
+/obj/structure/grille/rustic,
+/obj/item/weapon/material/shard{
+	icon_state = "shardmedium"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"gMs" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/photocopier/faxmachine,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"gOc" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/sub_chamber)
+"gOB" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/testroom)
+"gPa" = (
+/obj/machinery/gateway/centeraway{
+	calibrated = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"gPi" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/surgical/scalpel,
+/obj/item/weapon/surgical/retractor,
+/obj/item/weapon/surgical/hemostat,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"gPl" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"gPW" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm10)
+"gPX" = (
+/obj/structure/flora/grass/brown,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"gQt" = (
+/obj/structure/flora/grass/brown,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"gQw" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"gQO" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"gQT" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"gRc" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 6
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"gRd" = (
+/obj/structure/fence/cut/medium{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"gRy" = (
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/security_cell)
+"gSC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/structure/sink{
+	pixel_y = 16
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"gTn" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/armory)
+"gTx" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"gUC" = (
+/obj/structure/catwalk,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/box/syringes,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"gWs" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"gWC" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/red/bordercorner,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"gXo" = (
+/obj/structure/flora/tree/dead,
+/obj/structure/flora/grass/brown,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"gXL" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"gYc" = (
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/outside)
+"gYJ" = (
+/obj/machinery/optable,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"gZp" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
+"gZy" = (
+/obj/structure/table/reinforced,
+/obj/item/device/reagent_scanner,
+/obj/item/device/mass_spectrometer/adv,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/security/detective)
+"haz" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"haJ" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"haO" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"hbh" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"hbK" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm11)
+"hcv" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm9)
+"hcF" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"hcV" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"hdq" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"hds" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/security/armory)
+"hez" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/detective)
+"hfF" = (
+/obj/structure/table/rack,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin/scoped,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin/scoped,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "Armament"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"hfQ" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"hgs" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/public/toolstorage1)
+"hgD" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"hhj" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/warden)
+"hhs" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm15)
+"hhy" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm13)
+"hic" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"hiL" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/heavy_armory)
+"hiX" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"hiZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"hjv" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"hjS" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"hkK" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/public/toolstroage2)
+"hlA" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"hmq" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/hallway)
+"hmr" = (
+/obj/item/modular_computer/console/preset/security{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"hmA" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"hmS" = (
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"hnu" = (
+/obj/structure/table/woodentable,
+/obj/structure/noticeboard{
+	pixel_x = 30
+	},
+/obj/structure/bedsheetbin,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"hnK" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/space_heater,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"hoa" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"hot" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"hoA" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm5)
+"hqb" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"hqU" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"hrj" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/command/bsa)
+"hrB" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"hsO" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"hsQ" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"htH" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "22"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"huG" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"hvz" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"hvD" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm3)
+"hwB" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm4)
+"hxs" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Morgue";
+	req_access = null;
+	req_one_access = list(1,6)
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"hyA" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm/ap,
+/obj/item/ammo_magazine/akm/ap,
+/obj/item/ammo_magazine/akm/ap,
+/obj/item/ammo_magazine/akm/ap,
+/obj/item/ammo_magazine/akm/hp,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"hyD" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/syringes,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"hzb" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/surgical/bonesetter,
+/obj/item/weapon/surgical/bone_clamp{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/surgical/bonegel,
+/obj/item/weapon/surgical/FixOVein,
+/obj/item/weapon/surgical/cautery,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"hAH" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"hAN" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/structure/table/steel,
+/obj/item/weapon/pen,
+/obj/effect/floor_decal/corner/purple/border,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"hBg" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/obj/structure/closet/jcloset,
+/obj/item/weapon/soap/nanotrasen,
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"hBm" = (
+/obj/structure/window/reinforced{
+	health = 1e+006
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced/full{
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa maints";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/bsa)
+"hBv" = (
+/obj/structure/railing,
+/obj/machinery/computer{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"hBO" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm9)
+"hBV" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/hallway)
+"hBZ" = (
+/obj/effect/floor_decal/steeldecal/monofloor,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1,
+/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -32
+	},
+/obj/machinery/door/blast/regular{
+	id = "snowfield bsa access"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"hCo" = (
+/obj/structure/flora/bush,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"hEi" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell)
+"hEz" = (
+/obj/item/weapon/ore/glass,
+/obj/item/weapon/ore/coal,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/outside)
+"hFk" = (
+/obj/machinery/door/blast/regular{
+	id = "snowfield heavy armory";
+	name = "Assault Weapon Storage"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"hGr" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"hGx" = (
+/obj/structure/morgue{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"hHj" = (
+/obj/item/weapon/ore/glass,
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/cavern)
+"hHW" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/public/toolstroage2)
+"hIo" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"hJH" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm8)
+"hKg" = (
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = -5
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"hKj" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/box/glasses/square,
+/obj/item/weapon/storage/box/glasses/square,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"hLq" = (
+/obj/item/weapon/ore/coal,
+/obj/item/weapon/ore/glass,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"hMg" = (
+/obj/structure/table/rack,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"hMq" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/patient_restroom)
+"hMR" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm8)
+"hMS" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"hNw" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"hNS" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"hOE" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/machinery/computer/arcade/battle,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"hOT" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/tech_storage)
+"hPe" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/hydro)
+"hPt" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm6)
+"hQh" = (
+/obj/structure/flora/grass/brown,
+/obj/effect/mine/frag,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"hQr" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing,
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"hRh" = (
+/obj/structure/fence/door/opened,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"hTh" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/awaymission/snowfield/command/server)
+"hTF" = (
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blucarpet,
+/area/awaymission/snowfield/service/publicstaff)
+"hTO" = (
+/turf/simulated/wall/solidrock{
+	block_tele = 0
+	},
+/area/awaymission/snowfield/cavern)
+"hUt" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"hUz" = (
+/obj/machinery/vending/tool{
+	dir = 8;
+	pixel_x = -5;
+	products = list(/obj/item/stack/cable_coil/random = 10, /obj/item/weapon/tool/crowbar = 5, /obj/item/weapon/weldingtool = 3, /obj/item/weapon/tool/wirecutters = 5, /obj/item/weapon/tool/wrench = 5, /obj/item/device/analyzer = 5, /obj/item/weapon/tool/screwdriver = 5, /obj/item/device/flashlight/glowstick = 3, /obj/item/device/flashlight/glowstick/red = 3, /obj/item/device/flashlight/glowstick/blue = 3, /obj/item/device/flashlight/glowstick/orange = 3, /obj/item/device/flashlight/glowstick/yellow = 3)
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/public/toolstorage1)
+"hVe" = (
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"hVG" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/solarshack)
+"hVQ" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm4)
+"hWg" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin/ap,
+/obj/item/ammo_magazine/clip/mosin/ap,
+/obj/item/ammo_magazine/clip/mosin/ap,
+/obj/item/ammo_magazine/clip/mosin/ap,
+/obj/item/ammo_magazine/clip/mosin/ap,
+/obj/item/ammo_magazine/clip/mosin/ap,
+/obj/item/ammo_magazine/clip/mosin/ap,
+/obj/item/ammo_magazine/clip/mosin/ap,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/eastright{
+	name = "Ammo"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"hWF" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield test room";
+	name = "Test room access";
+	req_one_access = list(30,47)
+	},
+/obj/machinery/button/remote/blast_door,
+/obj/machinery/button/remote/blast_door{
+	desc = "It kicks the beat to the horizon.";
+	name = "Remote beat-drop control";
+	pixel_x = 23
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"hWM" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/vault{
+	req_one_access = list(1,20,53)
+	},
+/obj/machinery/door/blast/regular{
+	id = "snowfield vault access"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/testroom)
+"hWV" = (
+/obj/machinery/door/airlock{
+	name = "Unit 4"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"hXq" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/machinery/vending/sovietsoda{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"hZj" = (
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/outside)
+"hZs" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield vault access";
+	name = "Vault Access";
+	req_one_access = list(20,30)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"iaX" = (
+/obj/machinery/light_construct/small{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"ibG" = (
+/obj/structure/table/bench/wooden,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"ibJ" = (
+/obj/structure/window/reinforced{
+	health = 1e+006
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced/full{
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa maints";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/bsa)
+"ibL" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield tool storage lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/public/toolstroage2)
+"icF" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"icW" = (
+/obj/structure/flora/bush,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"idu" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/gloves/combat{
+	armor = list("melee" = 30, "bullet" = 15, "laser" = 5, "energy" = 20, "bomb" = 40, "bio" = 5, "rad" = 20);
+	desc = "Clearly for combat, these tactical gloves are not only somewhat fire and impact resistant, but also has a thin layer of armor. Bulky, but better than having a papercut in combat while naked."
+	},
+/obj/item/clothing/gloves/combat{
+	armor = list("melee" = 30, "bullet" = 15, "laser" = 5, "energy" = 20, "bomb" = 40, "bio" = 5, "rad" = 20);
+	desc = "Clearly for combat, these tactical gloves are not only somewhat fire and impact resistant, but also has a thin layer of armor. Bulky, but better than having a papercut in combat while naked."
+	},
+/obj/item/clothing/gloves/combat{
+	armor = list("melee" = 30, "bullet" = 15, "laser" = 5, "energy" = 20, "bomb" = 40, "bio" = 5, "rad" = 20);
+	desc = "Clearly for combat, these tactical gloves are not only somewhat fire and impact resistant, but also has a thin layer of armor. Bulky, but better than having a papercut in combat while naked."
+	},
+/obj/item/clothing/gloves/combat{
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 10, "energy" = 20, "bomb" = 45, "bio" = 5, "rad" = 20);
+	armorsoak = list("melee" = 5, "bullet" = 0, "laser" = 0, "energy" = 5, "bomb" = 5, "bio" = 0, "rad" = 0);
+	desc = "Clearly for combat, these tactical gloves are not only somewhat fire and impact resistant, but also has a thin layer of armor. Bulky, but better than having a papercut in combat while naked."
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"iej" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm13)
+"ife" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/service/fridge)
+"ifi" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"ifW" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"igl" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	req_one_access = list(2,4)
+	},
+/obj/item/weapon/reagent_containers/syringe/ld50_syringe/choral,
+/obj/item/weapon/reagent_containers/syringe/ld50_syringe/choral,
+/obj/item/weapon/reagent_containers/syringe/ld50_syringe/choral,
+/obj/item/weapon/reagent_containers/syringe/ld50_syringe/choral,
+/obj/item/weapon/reagent_containers/syringe/ld50_syringe/choral,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell)
+"igK" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"igT" = (
+/obj/machinery/door/airlock{
+	name = "Unit 2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"ihi" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/weapon/gun/projectile/automatic/serdy/pkm,
+/obj/item/ammo_magazine/pkm,
+/obj/item/ammo_magazine/pkm,
+/obj/item/ammo_magazine/pkm,
+/obj/item/ammo_magazine/pkm/ap,
+/obj/item/clothing/suit/bomb_suit/security{
+	armor = list("melee" = 90, "bullet" = 100, "laser" = 60, "energy" = 60, "bomb" = 100, "bio" = 0, "rad" = 100);
+	armorsoak = list("melee" = 10, "bullet" = 20, "laser" = 5, "energy" = 5, "bomb" = 20, "bio" = 0, "rad" = 0);
+	desc = "You're up against the wall AND I AM THE FUCKING WALL!";
+	name = "IED-Bullet proof suit"
+	},
+/obj/item/clothing/head/bomb_hood/security{
+	armor = list("melee" = 100, "bullet" = 90, "laser" = 75, "energy" = 75, "bomb" = 100, "bio" = 0, "rad" = 100);
+	armorsoak = list("melee" = 10, "bullet" = 0, "laser" = 5, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0);
+	desc = "Shit just got real!";
+	name = "IED-Bullet proof hood"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"ihx" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/roller,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"iip" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm10)
+"iiz" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"iiU" = (
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 6
+	},
+/obj/item/weapon/storage/box/beakers,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"iiY" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/observatory)
+"iji" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm16)
+"ijF" = (
+/obj/structure/sign/signnew/danger,
+/turf/simulated/wall/titanium,
+/area/awaymission/snowfield/cavern)
+"ikI" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	opened = 1
+	},
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74/variantun,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"ilc" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/obj/machinery/computer/security,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"ilg" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/orange/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"ilY" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"imb" = (
+/obj/structure/outcrop,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/outside)
+"imu" = (
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"imC" = (
+/obj/structure/flora/grass/green,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"inL" = (
+/obj/machinery/door/window/southleft,
+/obj/effect/floor_decal/industrial/loading,
+/obj/effect/floor_decal/steeldecal/steel_decals_central4,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"ioy" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"ipm" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/public/toolstorage1)
+"iqV" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm3)
+"irb" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"irs" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"irP" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"isq" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm9)
+"ist" = (
+/obj/machinery/door/airlock{
+	name = "Unit 3"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"isM" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "24"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"iuB" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm4)
+"ivC" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 17
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"ivP" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"iwo" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm8)
+"iwJ" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm6)
+"iyS" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm7)
+"izt" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"izY" = (
+/obj/machinery/door/blast/regular{
+	id = "snowfield emergency bunk"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/panicroom)
+"iAc" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"iAB" = (
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/glass/bucket/wood,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"iAR" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm4)
+"iAW" = (
+/obj/machinery/icecream_vat,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"iAZ" = (
+/obj/machinery/door/airlock{
+	name = "Unit 2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"iBu" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm3)
+"iBw" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/steeldecal/steel_decals_central7,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"iDe" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"iDi" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/southhallway)
+"iDk" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/public/toolstorage1)
+"iDu" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/morgue)
+"iDx" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"iDC" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"iDF" = (
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/outside)
+"iEm" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/weapon/gun/projectile/automatic/serdy/rpk,
+/obj/item/weapon/gun/projectile/automatic/serdy/rpk,
+/obj/item/ammo_magazine/akm/drum,
+/obj/item/ammo_magazine/akm/drum,
+/obj/item/ammo_magazine/akm/drum,
+/obj/item/ammo_magazine/akm/drum,
+/obj/item/ammo_magazine/akm/drum,
+/obj/item/ammo_magazine/akm/drum,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"iEH" = (
+/obj/structure/catwalk,
+/obj/machinery/vending/food/prison{
+	contraband = list(/obj/item/weapon/reagent_containers/food/snacks/bearstew = 3);
+	icon_state = "hotfood";
+	products = list(/obj/item/weapon/tray = 6, /obj/item/weapon/material/kitchen/utensil/spoon = 20, /obj/item/weapon/reagent_containers/food/snacks/tofu = 10, /obj/item/weapon/reagent_containers/food/snacks/mashedpotato = 10, /obj/item/weapon/reagent_containers/food/snacks/flatbread = 10)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"iFj" = (
+/obj/machinery/door/airlock/engineering{
+	req_access = null;
+	req_one_access = list(1,10)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/hallway)
+"iFm" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm2)
+"iGR" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm10)
+"iHp" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm11)
+"iHr" = (
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/evidence_storage)
+"iHH" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"iHK" = (
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/glass/bucket/wood,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"iHS" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/weapon/syndie/c4explosive/heavy,
+/obj/item/weapon/grenade/explosive,
+/obj/item/weapon/grenade/explosive,
+/obj/item/weapon/grenade/explosive,
+/obj/item/weapon/grenade/explosive,
+/obj/item/weapon/grenade/explosive,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"iHU" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"iIb" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm14)
+"iIf" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"iIA" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/panicroom)
+"iJc" = (
+/obj/structure/closet/coffin,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"iJk" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"iJQ" = (
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	req_access = null;
+	req_one_access = list(1,28)
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/hydro)
+"iJW" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet,
+/area/awaymission/snowfield/engineering/staff_room)
+"iKM" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"iKO" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"iLe" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm6)
+"iLw" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"iLJ" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Armoury Section";
+	req_access = list(3);
+	req_one_access = list(3)
+	},
+/obj/machinery/door/blast/regular{
+	id = "snowfield command armory"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"iMp" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm16)
+"iMs" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"iMC" = (
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
+	req_access = null
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"iMJ" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm11)
+"iNe" = (
+/obj/item/weapon/ore/glass,
+/obj/item/weapon/ore/glass,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"iNn" = (
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow,
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"iNT" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/firstaid/adv{
+	starts_with = list(/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment)
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	starts_with = list(/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment)
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"iNW" = (
+/obj/item/weapon/ore/glass,
+/obj/structure/boulder,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"iOB" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"iPy" = (
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/awaymission/snowfield/command/server)
+"iPD" = (
+/obj/machinery/door/airlock/security{
+	desc = "You may don't want to go in there by force.";
+	name = "Interrogation Room";
+	req_one_access = list(2,5)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"iPW" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"iQR" = (
+/obj/machinery/power/smes/buildable{
+	charge = null;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 1000000;
+	output_level = 750000
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"iRz" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/flora/grass/brown,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"iRT" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm15)
+"iRU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"iSa" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"iUn" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway2)
+"iVZ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
+	},
+/obj/structure/bookcase,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"iWl" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm12)
+"iWo" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/awaymission/snowfield/security/observatory)
+"iXa" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	health = 1e+006
+	},
+/obj/structure/window/reinforced/full{
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa observation window";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/bsa)
+"iXx" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"iXD" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"iXK" = (
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/awaymission/snowfield/command/bridge)
+"iYl" = (
+/obj/machinery/door/airlock/glass{
+	name = "Tool Storage"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/public/toolstorage1)
+"iZz" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"iZY" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/closet/firecloset/full,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"jaS" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/southhallway)
+"jaX" = (
+/mob/living/simple_mob/animal/passive/fox,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"jbe" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm3)
+"jbA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/l3closet/security,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"jcG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"jdW" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "19"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"jdZ" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"jem" = (
+/obj/structure/closet/crate/bin,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/public/charger)
+"jez" = (
+/obj/structure/catwalk,
+/obj/machinery/door/window/brigdoor/eastright{
+	name = "Interrogation Tool";
+	req_access = null;
+	req_one_access = list(2,5)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"jfa" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm3)
+"jfk" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"jfD" = (
+/obj/structure/table/standard,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/folder/red,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"jfF" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"jfU" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "35"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"jgA" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"jgG" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"jgV" = (
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"jhp" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm14)
+"jhu" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"jhx" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"jhM" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 10
+	},
+/obj/machinery/vending/engivend{
+	dir = 8;
+	pixel_x = -5;
+	products = list(/obj/item/device/geiger = 4, /obj/item/device/multitool = 4, /obj/item/weapon/cell/high = 10, /obj/item/weapon/airlock_electronics = 10, /obj/item/weapon/module/power_control = 10, /obj/item/weapon/circuitboard/airalarm = 10, /obj/item/weapon/circuitboard/firealarm = 10, /obj/item/weapon/circuitboard/status_display = 2, /obj/item/weapon/circuitboard/ai_status_display = 2, /obj/item/weapon/circuitboard/newscaster = 2, /obj/item/weapon/circuitboard/intercom = 4, /obj/item/weapon/circuitboard/security/telescreen/entertainment = 4, /obj/item/weapon/stock_parts/motor = 2, /obj/item/weapon/stock_parts/spring = 2, /obj/item/weapon/stock_parts/gear = 2, /obj/item/weapon/circuitboard/atm,/obj/item/weapon/circuitboard/guestpass,/obj/item/weapon/circuitboard/keycard_auth,/obj/item/weapon/circuitboard/geiger,/obj/item/weapon/circuitboard/photocopier,/obj/item/weapon/circuitboard/fax,/obj/item/weapon/circuitboard/request,/obj/item/weapon/circuitboard/microwave,/obj/item/weapon/circuitboard/washing)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"jie" = (
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/security_cell)
+"jil" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm9)
+"jiI" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"jje" = (
+/obj/structure/catwalk,
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"jjw" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"jjP" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"jke" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/closet/secure_closet/guncabinet{
+	opened = 1
+	},
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"jkl" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm10)
+"jkB" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm13)
+"jkM" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/vending/sovietsoda,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"jlx" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"jmh" = (
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"jmu" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Warden's Office";
+	req_access = list(3)
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/warden)
+"jmE" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/borgupload{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/weapon/circuitboard/aiupload{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/secure_tech_storage)
+"jmU" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm1)
+"jnn" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/robotics{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/mecha_control{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/secure_tech_storage)
+"joy" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm14)
+"jpM" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"jqn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"jrf" = (
+/obj/structure/flora/grass/green,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"jro" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Cells";
+	req_access = list(1)
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"jry" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"jsH" = (
+/obj/machinery/computer,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/command/bridge)
+"jsR" = (
+/obj/machinery/door/airlock{
+	name = "Unit 3"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"jtE" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm4)
+"jtJ" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm7)
+"jtR" = (
+/obj/structure/closet/secure_closet/security{
+	starts_with = list(/obj/item/clothing/gloves/black, /obj/item/clothing/accessory/holster, /obj/item/weapon/storage/belt/security, /obj/item/clothing/head/beret/sec/corporate/officer, /obj/item/clothing/head/helmet, /obj/item/device/radio/headset/headset_sec/alt, /obj/item/device/radio/headset/headset_sec, /obj/item/device/radio/off, /obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec, /obj/item/clothing/shoes/boots/marine, /obj/item/clothing/suit/armor/bulletproof, /obj/item/clothing/under/soviet, /obj/item/weapon/reagent_containers/spray/pepper, /obj/item/weapon/melee/classic_baton, /obj/item/ammo_magazine/makarov = 2, /obj/item/weapon/gun/projectile/serdy_pistols/makarov)
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_lockerroom)
+"jtT" = (
+/turf/simulated/wall/solidrock{
+	block_tele = 0
+	},
+/area/awaymission/snowfield/outside)
+"juu" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/machinery/iv_drip,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"jux" = (
+/obj/structure/closet/radiation,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"juJ" = (
+/obj/machinery/door/blast/regular{
+	id = "snowfield third blast"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"jvo" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm16)
+"jvp" = (
+/obj/structure/flora/tree/dead,
+/obj/structure/flora/tree/dead,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"jvw" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"jvz" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"jwn" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"jwN" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/centerhallway)
+"jyn" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/public/toolstorage1)
+"jyr" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "16"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"jyL" = (
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"jzR" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"jBt" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"jBQ" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm3)
+"jBW" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/engineering,
+/turf/simulated/floor,
+/area/awaymission/snowfield/checkpoint)
+"jCI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/cavern)
+"jCJ" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"jDt" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"jDu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"jDx" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/detective{
+	starts_with = list(/obj/item/clothing/gloves/forensic, /obj/item/clothing/accessory/holster, /obj/item/weapon/storage/belt/security, /obj/item/clothing/head/fedora, /obj/item/clothing/head/fedora/brown, /obj/item/clothing/suit/storage/det_trench,/obj/item/clothing/suit/storage/det_trench/grey, /obj/item/clothing/suit/armor/bulletproof, /obj/item/device/radio/headset/headset_sec/alt, /obj/item/device/radio/headset/headset_sec, /obj/item/device/radio/off, /obj/item/weapon/storage/backpack/security, /obj/item/weapon/storage/backpack/satchel/sec, /obj/item/clothing/shoes/boots/marine, /obj/item/clothing/under/soviet, /obj/item/weapon/melee/classic_baton, /obj/item/weapon/reagent_containers/spray/pepper, /obj/item/device/flash, /obj/item/ammo_magazine/s357 = 2, /obj/item/weapon/gun/projectile/revolver/nagant)
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"jDy" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"jDZ" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/monitorroom)
+"jEa" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair/oldsofa,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"jEJ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/vending/sovietsoda,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"jEK" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"jFQ" = (
+/obj/effect/floor_decal/techfloor/orange,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"jGT" = (
+/obj/structure/closet{
+	closet_appearance = /decl/closet_appearance/bio;
+	name = "Level-3 Biohazard Closet";
+	opened = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"jIe" = (
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/ammo_magazine/m762svd,
+/obj/item/ammo_magazine/m762svd,
+/obj/item/ammo_magazine/m762svd,
+/obj/item/ammo_magazine/m762svd,
+/obj/item/ammo_magazine/m762svd,
+/obj/item/ammo_magazine/m762svd,
+/obj/item/ammo_magazine/m762svd/ap,
+/obj/item/ammo_magazine/m762svd/ap,
+/obj/structure/table/rack,
+/obj/item/weapon/gun/projectile/SVD,
+/obj/item/weapon/gun/projectile/SVD,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"jIv" = (
+/obj/structure/cable/yellow,
+/obj/structure/table/standard,
+/obj/item/device/radio/phone,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"jJd" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"jJH" = (
+/obj/effect/map_helper/base_turf{
+	baseturf = /turf/simulated/floor/outdoors/dirt/sif/planetuse
+	},
+/turf/simulated/wall/solidrock{
+	block_tele = 0
+	},
+/area/awaymission/snowfield/restricted)
+"jJK" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/warden)
+"jJO" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/fans/tiny,
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/server)
+"jKy" = (
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"jKD" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm6)
+"jLm" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/structure/table/woodentable,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"jLM" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"jMh" = (
+/obj/structure/reagent_dispensers/fueltank/high,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"jNl" = (
+/obj/machinery/vending/sovietsoda{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"jNF" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm10)
+"jPC" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/machinery/computer/arcade/battle,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"jQq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"jQC" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/tactical,
+/obj/item/clothing/suit/armor/tactical,
+/obj/item/clothing/suit/armor/heavy,
+/obj/item/clothing/suit/armor/heavy,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/item/clothing/head/helmet/combat,
+/obj/item/clothing/head/helmet/combat,
+/obj/item/clothing/head/helmet/combat,
+/obj/item/clothing/head/helmet/combat,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"jQP" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "SMES Access";
+	req_access = list(1,11);
+	req_one_access = null
+	},
+/obj/machinery/door/blast/regular{
+	id = "snowfield command SMES lockdown"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"jRe" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/southhallway)
+"jRr" = (
+/obj/structure/closet{
+	closet_appearance = /decl/closet_appearance/bio;
+	name = "Level-3 Biohazard Closet";
+	opened = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"jRZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"jSi" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/security_restroom)
+"jTf" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2;
+	name = "Cafeteria"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/service/cafeteria)
+"jTB" = (
+/obj/machinery/light_construct/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"jTW" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm9)
+"jUl" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/device/defib_kit/loaded,
+/obj/item/device/defib_kit/loaded,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"jUH" = (
+/obj/structure/railing,
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/outside)
+"jUY" = (
+/obj/machinery/vending/security{
+	description_fluff = "This security vending machine is kindly provided by the-... Sorry, how do you spell this company's name again?";
+	product_ads = "Crack capitalist skulls!;Beat some heads in!;Don't forget - harm is good!;Your weapons are right here.;Handcuffs!;Freeze, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a slice of sandwich.";
+	products = list(/obj/item/weapon/handcuffs = 12, /obj/item/weapon/grenade/flashbang = 4, /obj/item/weapon/reagent_containers/food/snacks/sandwich = 12, /obj/item/weapon/storage/box/evidence = 6,/obj/item/ammo_magazine/makarov = 18,/obj/item/weapon/gun/projectile/serdy_pistols/makarov = 4,/obj/item/weapon/melee/classic_baton = 8)
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_lockerroom)
+"jVm" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"jVo" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/front_desk)
+"jWk" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"jWw" = (
+/obj/machinery/seed_extractor,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"jXb" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/tank/anesthetic,
+/obj/item/weapon/tank/anesthetic,
+/obj/item/weapon/tank/anesthetic,
+/obj/item/weapon/tank/anesthetic,
+/obj/item/weapon/tank/anesthetic,
+/obj/item/weapon/tank/anesthetic,
+/obj/item/weapon/tank/anesthetic,
+/obj/item/weapon/tank/anesthetic,
+/obj/item/clothing/mask/breath/anesthetic,
+/obj/item/clothing/mask/breath/anesthetic,
+/obj/item/clothing/mask/breath/anesthetic,
+/obj/item/clothing/mask/breath/anesthetic,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"jZp" = (
+/obj/effect/fake_sun/cool,
+/turf/simulated/wall/solidrock{
+	block_tele = 0
+	},
+/area/awaymission/snowfield/restricted)
+"jZD" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"jZM" = (
+/obj/structure/bed/chair/oldsofa/right{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"jZQ" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"kbd" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/hallway)
+"kbh" = (
+/obj/structure/window/reinforced{
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced/full{
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa maints";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/bsa)
+"kbn" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"kbP" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"kbV" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/interrogation)
+"kcj" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm7)
+"kcv" = (
+/obj/machinery/door/window/brigdoor/eastright{
+	id = Cell 1;
+	name = "Cell 1";
+	req_access = null;
+	req_one_access = list(2,4)
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/security_cell)
+"kcD" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/command/sub_chamber)
+"kcN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"kdB" = (
+/obj/machinery/door/blast/gate/open,
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/cavern)
+"kdE" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"kei" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/command,
+/obj/machinery/door/blast/regular{
+	id = "snowfield test observation"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/observatory)
+"keG" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Engine Room";
+	req_one_access = list(1,11)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfieldenglockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"keQ" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa SCA";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/monitorroom)
+"keT" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway)
+"kgE" = (
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/glass/bucket/wood,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"khv" = (
+/obj/structure/flora/grass/green,
+/obj/structure/flora/bush,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"kia" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa SCA";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/monitorroom)
+"kig" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"kjm" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 9
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"kjZ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"kke" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm15)
+"kkL" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"klv" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"kmb" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border,
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"kmf" = (
+/obj/structure/boulder,
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/cavern)
+"kmg" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/corner/white/border{
+	dir = 9
+	},
+/obj/machinery/appliance/cooker/fryer,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"kmt" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "27"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"knc" = (
+/obj/item/weapon/ore/glass,
+/obj/item/weapon/ore/glass,
+/obj/item/weapon/ore/glass,
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/outside)
+"knP" = (
+/obj/structure/flora/tree/pine,
+/obj/item/weapon/paper/awaygate/snowfield/note,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"kpg" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"kpG" = (
+/obj/machinery/light,
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"kpM" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"kpY" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/item/weapon/soap,
+/obj/structure/closet/secure_closet/medical3{
+	req_access = list(33);
+	starts_with = list(/obj/item/clothing/under/rank/medical,/obj/item/clothing/under/rank/nurse,/obj/item/clothing/under/rank/orderly,/obj/item/clothing/suit/storage/toggle/labcoat,/obj/item/clothing/suit/storage/toggle/labcoat/modern,/obj/item/clothing/suit/storage/toggle/fr_jacket,/obj/item/device/radio/headset/headset_med,/obj/item/device/radio/headset/headset_med/alt,/obj/item/clothing/suit/storage/hooded/wintercoat/medical,/obj/item/clothing/shoes/boots/winter/medical,/obj/item/clothing/under/rank/nursesuit,/obj/item/clothing/head/nursehat,/obj/item/weapon/storage/box/freezer = 3, /obj/item/weapon/storage/belt/medical)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"krl" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"krB" = (
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target,
+/obj/structure/closet/crate,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"krX" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"kse" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm9)
+"ksm" = (
+/obj/structure/morgue,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"ksW" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"ktp" = (
+/obj/machinery/vending/assist,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"kug" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"kuo" = (
+/obj/structure/sign/signnew/secure,
+/turf/simulated/wall/titanium,
+/area/awaymission/snowfield/cavern)
+"kvO" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"kvQ" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
+"kxl" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"kxF" = (
+/obj/structure/flora/grass/brown,
+/obj/structure/flora/grass/green,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"kxV" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm1)
+"kxY" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"kyg" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"kyr" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"kyw" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/server)
+"kyy" = (
+/obj/machinery/door/airlock/security{
+	name = "Riot Control";
+	req_access = list(2)
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"kyH" = (
+/obj/structure/catwalk,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/service/hydro)
+"kyV" = (
+/obj/structure/morgue{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"kzi" = (
+/obj/structure/window/reinforced{
+	health = 1e+006
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced/full{
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa maints";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/bsa)
+"kzH" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/fence,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"kzQ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/eastright{
+	name = "Coffin Storage"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"kBA" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"kCk" = (
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"kCX" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm9)
+"kEj" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/firstaid/adv{
+	starts_with = list(/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
+"kEt" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/surgery,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"kEv" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/bed/chair/wheelchair,
+/obj/structure/bed/chair/wheelchair,
+/obj/structure/bed/chair/wheelchair,
+/obj/structure/bed/chair/wheelchair,
+/obj/structure/bed/chair/wheelchair,
+/obj/structure/bed/chair/wheelchair,
+/obj/structure/bed/chair/wheelchair,
+/obj/structure/bed/chair/wheelchair,
+/obj/item/weapon/cane,
+/obj/item/weapon/cane,
+/obj/item/weapon/cane,
+/obj/item/weapon/cane,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"kFk" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/clothing/gloves/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/solarshack)
+"kFt" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/eastright{
+	name = "Execution Chamber";
+	req_access = null;
+	req_one_access = list(2,4)
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell)
+"kHE" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	opened = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"kIX" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"kJg" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/warden)
+"kJm" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"kJw" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "SMES Access";
+	req_access = list(1,11);
+	req_one_access = null
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "entrylockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"kJQ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/freezer{
+	name = "Kitchen cold room";
+	req_access = list(28)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/service/fridge)
+"kKi" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/warden)
+"kKm" = (
+/obj/item/weapon/material/shard{
+	icon_state = "medium"
+	},
+/obj/structure/grille/broken,
+/obj/item/weapon/material/shard{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"kKp" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_x = -3
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"kKr" = (
+/obj/structure/closet/secure_closet/brig,
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/security_cell)
+"kKY" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"kMr" = (
+/obj/structure/outcrop,
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/cavern)
+"kMP" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/tech_storage)
+"kNn" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm10)
+"kNs" = (
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/outside)
+"kNJ" = (
+/obj/structure/cable/heavyduty{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/checkpointunpowered)
+"kNP" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"kOt" = (
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"kRT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway)
+"kSB" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/item/weapon/reagent_containers/food/condiment/ketchup,
+/obj/item/weapon/reagent_containers/food/condiment/hotsauce,
+/obj/item/weapon/reagent_containers/food/condiment/soysauce,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"kTd" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm8)
+"kTf" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"kTu" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm12)
+"kTZ" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"kUc" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/carpet/blucarpet,
+/area/awaymission/snowfield/service/publicstaff)
+"kUF" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"kWO" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/power/thermoregulator,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"kXd" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"kXp" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway)
+"kXI" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"kXK" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/security_lockerroom)
+"kXS" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"kYe" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"kYw" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"kYy" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"kYE" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/material/minihoe,
+/obj/item/weapon/material/minihoe,
+/obj/item/weapon/material/minihoe,
+/obj/item/weapon/material/minihoe,
+/obj/item/weapon/material/knife/machete/hatchet,
+/obj/item/weapon/material/knife/machete/hatchet,
+/obj/item/weapon/material/knife/machete/hatchet,
+/obj/item/weapon/material/knife/machete/hatchet,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/effect/floor_decal/corner/green,
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"kYV" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"kZl" = (
+/obj/structure/catwalk,
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"kZp" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_security,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/hallway)
+"kZv" = (
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/multi,
+/obj/item/device/taperecorder{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/structure/table/steel_reinforced,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"kZK" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm10)
+"lap" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate{
+	opened = 1
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"laA" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/monitor_room)
+"laF" = (
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"laJ" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/monitorroom)
+"lbq" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/testroom)
+"lbS" = (
+/obj/structure/railing/grey,
+/turf/simulated/floor/outdoors/ice,
+/area/awaymission/snowfield/outside)
+"lcf" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"lcA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"lcJ" = (
+/obj/structure/catwalk,
+/obj/machinery/light_construct/small,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"lcX" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm14)
+"ldH" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/vending/snack{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"ler" = (
+/obj/structure/table/glass,
+/obj/item/weapon/soap,
+/obj/item/weapon/soap,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"leB" = (
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"leL" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"lfj" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"lfp" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"lfO" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm11)
+"lgo" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm7)
+"lgS" = (
+/turf/simulated/wall/wood,
+/area/awaymission/snowfield/cavern)
+"lgT" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm13)
+"lig" = (
+/obj/machinery/computer/prisoner,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"lii" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"liC" = (
+/obj/machinery/atmospherics/pipe/tank{
+	desc = "A large vessel containing huge amount of water.";
+	dir = 1;
+	icon_state = "o2_map";
+	name = "Water Tank"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"ljd" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/effect/floor_decal/industrial/loading,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"ljs" = (
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"ljz" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/obj/item/weapon/tool/screwdriver,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"lkO" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"llk" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Chemistry Laboratory";
+	req_access = null;
+	req_one_access = list(1,33)
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"llv" = (
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_access = list(1)
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/evidence_storage)
+"llx" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm9)
+"llG" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/testroom)
+"lmq" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"lmC" = (
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"lnc" = (
+/obj/structure/table/steel,
+/obj/item/weapon/module/power_control,
+/obj/item/weapon/module/power_control,
+/obj/item/weapon/module/power_control,
+/obj/item/weapon/module/power_control,
+/obj/item/weapon/airlock_electronics,
+/obj/item/weapon/airlock_electronics,
+/obj/item/weapon/airlock_electronics,
+/obj/item/weapon/airlock_electronics,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"lnh" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/evidence_storage)
+"lnO" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"loh" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway)
+"lom" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = -5
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"loF" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"lpQ" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/marble,
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -6
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"lqv" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"lqC" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/server)
+"lrg" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm9)
+"lro" = (
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"lsi" = (
+/obj/structure/catwalk,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/reagent_containers/glass/beaker/vial{
+	name = "vial (Lexorin)";
+	prefill = list("lexorin" = 30)
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/vial{
+	name = "vial (Zombie Powder)";
+	pixel_x = -5;
+	prefill = list("zombiepowder" = 30)
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/vial{
+	name = "vial (Cryptobiolin)";
+	pixel_x = 5;
+	prefill = list("cryptobiolin" = 30)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"lsw" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"lsV" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"ltg" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"ltp" = (
+/obj/random/tech_supply,
+/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"ltZ" = (
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"lus" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/hallway/dormhallway)
+"luy" = (
+/obj/machinery/light/small/flicker{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/commandarmory)
+"lve" = (
+/obj/structure/bed/chair/oldsofa,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"lvw" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"lwB" = (
+/obj/machinery/door/blast/regular{
+	id = "snowfield third blast"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"lxe" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"lxq" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm11)
+"lxB" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"lxS" = (
+/obj/structure/closet/crate/secure/engineering,
+/obj/item/stack/material/graphite{
+	amount = 50
+	},
+/obj/item/stack/material/graphite{
+	amount = 50
+	},
+/obj/item/stack/material/graphite{
+	amount = 50
+	},
+/obj/item/stack/material/graphite{
+	amount = 50
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"lxV" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/southhallway)
+"lyM" = (
+/obj/machinery/door/window/northright{
+	name = "Kitchen Desk";
+	req_one_access = list(1,28)
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"lyN" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/corner/green/border{
+	dir = 9
+	},
+/obj/structure/bookcase/manuals/medical,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"lzD" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm5)
+"lzM" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/item/weapon/storage/box/donut/empty,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"lBd" = (
+/obj/machinery/door/airlock{
+	name = "Unit 2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"lBK" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/command/testroom)
+"lBV" = (
+/obj/structure/flora/tree/pine,
+/obj/structure/flora/grass/green,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"lBZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Medical Staff Lounge";
+	req_one_access = list(1,5)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"lDj" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	starts_with = list(/obj/item/clothing/accessory/storage/brown_vest,/obj/item/weapon/storage/toolbox/mechanical,/obj/item/device/radio/headset/headset_eng,/obj/item/device/radio/headset/headset_eng/alt,/obj/item/clothing/suit/storage/hazardvest,/obj/item/clothing/mask/gas,/obj/item/weapon/cartridge/engineering,/obj/item/taperoll/engineering,/obj/item/clothing/head/hardhat,/obj/item/clothing/suit/storage/hooded/wintercoat/engineering,/obj/item/clothing/shoes/boots/winter/engineering,/obj/item/weapon/tank/emergency/oxygen/engi,/obj/item/weapon/storage/belt/utility,/obj/item/weapon/reagent_containers/spray/windowsealant)
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"lDr" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"lDs" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"lDA" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"lDX" = (
+/obj/machinery/iv_drip,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/surgery)
+"lEI" = (
+/obj/item/weapon/gun/projectile/automatic/serdy/sr25c,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"lFf" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield testlab entrance";
+	name = "Lab Front Entrance";
+	req_one_access = list(1)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"lFR" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/carpet,
+/area/awaymission/snowfield/security/detective)
+"lGq" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm1)
+"lGB" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"lGI" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell)
+"lGQ" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"lHx" = (
+/obj/machinery/gateway{
+	density = 0;
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"lHG" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"lHN" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway2)
+"lHQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"lIx" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/seconddesk)
+"lID" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm4)
+"lJs" = (
+/obj/structure/table/steel,
+/obj/item/weapon/surgical/scalpel,
+/obj/item/weapon/autopsy_scanner,
+/obj/item/weapon/surgical/cautery,
+/obj/effect/floor_decal/borderfloor,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"lJx" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"lJR" = (
+/obj/structure/flora/grass/green,
+/obj/structure/flora/grass/brown,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"lKj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"lLf" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/closet/secure_closet/medical3{
+	req_access = list(33);
+	starts_with = list(/obj/item/clothing/under/rank/medical,/obj/item/clothing/under/rank/nurse,/obj/item/clothing/under/rank/orderly,/obj/item/clothing/suit/storage/toggle/labcoat,/obj/item/clothing/suit/storage/toggle/labcoat/modern,/obj/item/clothing/suit/storage/toggle/fr_jacket,/obj/item/device/radio/headset/headset_med,/obj/item/device/radio/headset/headset_med/alt,/obj/item/clothing/suit/storage/hooded/wintercoat/medical,/obj/item/clothing/shoes/boots/winter/medical,/obj/item/clothing/under/rank/nursesuit,/obj/item/clothing/head/nursehat,/obj/item/weapon/storage/box/freezer = 3, /obj/item/weapon/storage/belt/medical)
+	},
+/obj/item/weapon/soap,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"lLo" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield bsa MR";
+	name = "Tunguska Monitoring Room Lockdown"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"lLw" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/public/toolstroage2)
+"lMz" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/item/weapon/material/ashtray/glass,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"lNd" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"lNE" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"lPK" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"lQb" = (
+/obj/structure/closet/bombclosetsecurity,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"lQH" = (
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"lRa" = (
+/obj/item/weapon/material/shard{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"lTq" = (
+/obj/machinery/computer/guestpass{
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"lTQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/observatory_path)
+"lUK" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"lWg" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "It pops the climax to the sky.";
+	name = "Remote climax-drop control";
+	pixel_x = -23
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"lWi" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"lWC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/obj/structure/table/steel_reinforced,
+/obj/machinery/chemical_dispenser/bar_soft/full,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"lWJ" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"lWW" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/box/handcuffs,
+/obj/item/weapon/storage/box/handcuffs,
+/obj/item/weapon/storage/box/handcuffs,
+/obj/item/weapon/storage/box/handcuffs,
+/obj/item/weapon/storage/box/flashbangs,
+/obj/item/weapon/storage/box/flashbangs,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"lZH" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"mag" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/public/toolstorage1)
+"maj" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm13)
+"maF" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"maM" = (
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/blue{
+	pixel_x = -6
+	},
+/obj/item/weapon/pen/red{
+	pixel_x = 6
+	},
+/obj/item/weapon/pen,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"maR" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"maX" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/grey/bordercorner,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"mbK" = (
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
+	req_access = null
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"mbT" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"mcC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway)
+"mcZ" = (
+/obj/item/weapon/material/shard{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"mdc" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm7)
+"mde" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/med_data/laptop,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/security/detective)
+"mdQ" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"meq" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"meN" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/tech_storage)
+"mfp" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"mgo" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/crew{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/item/weapon/circuitboard/card{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/weapon/circuitboard/communications{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/secure_tech_storage)
+"mgJ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"mgO" = (
+/obj/structure/window/reinforced{
+	health = 1e+006
+	},
+/obj/structure/window/reinforced/full{
+	health = 1e+006
+	},
+/obj/structure/grille,
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/testroom)
+"mih" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm9)
+"mkt" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"mll" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/weapon/gun/projectile/shotgun/pump/shorty{
+	desc = "A clunky, lightly modified special carbine, this gun is often be seen in the old terran's prison, designed to suppress the prison riots.";
+	description_fluff = "Designed to suppress the prison riot, KS-23 has been developed in 1970s in Soviet Russia. Crude, but compact, it is easy to carry around while in patrol, and useful in close combat.";
+	name = "KS-23"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"mlV" = (
+/obj/structure/closet/crate/freezer/rations,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/machinery/light/small/flicker,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"mlY" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"mmF" = (
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"mmL" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Server Control Room";
+	req_access = list(61);
+	req_one_access = list(61)
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/server)
+"mmX" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/sub_chamber)
+"mmY" = (
+/obj/machinery/light/small,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"mnh" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"mpb" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"mpi" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/autopsy_scanner,
+/obj/item/weapon/surgical/bioregen,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"mpk" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"mpC" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield command SMES lockdown";
+	name = "Command SMES Lockdown";
+	pixel_x = 5;
+	req_one_access = list(3,20)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield command lockdown";
+	name = "Command Room Lockdown";
+	pixel_x = -5;
+	req_one_access = list(3,20)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"mrS" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/engineering/monitor_room)
+"mtq" = (
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"mtE" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"mtO" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"mtW" = (
+/obj/machinery/door/airlock{
+	name = "Restroom"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patients)
+"mun" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"mvU" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"mwl" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm16)
+"mwo" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"mwp" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/marble,
+/obj/item/weapon/material/kitchen/rollingpin,
+/obj/item/weapon/material/knife/butch,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"mwG" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/masks,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"mwM" = (
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"mwO" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"mxJ" = (
+/obj/item/weapon/gun/projectile/shotgun/pump/shorty{
+	desc = "A clunky, lightly modified special carbine, this gun is often be seen in the old terran's prison, designed to suppress the prison riots.";
+	description_fluff = "Designed to suppress the prison riot, KS-23 has been developed in 1970s in Soviet Russia. Crude, but compact, it is easy to carry around while in patrol, and useful in close combat.";
+	name = "KS-23"
+	},
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/structure/closet/secure_closet/guncabinet{
+	req_one_access = list(2,4)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"mxR" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"mxV" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"myq" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security,
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/lobby)
+"myD" = (
+/obj/machinery/door/window/northleft{
+	name = "Kitchen Desk";
+	req_one_access = list(1,28)
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"myF" = (
+/obj/machinery/atmospherics/pipe/tank/nitrous_oxide{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"myX" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"mzy" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"mAs" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"mBp" = (
+/obj/machinery/door/blast/regular{
+	id = "outpost third path blast"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"mCK" = (
+/obj/structure/closet/crate/secure/engineering,
+/obj/item/stack/material/uranium{
+	amount = 50
+	},
+/obj/item/stack/material/uranium{
+	amount = 50
+	},
+/obj/item/stack/material/uranium{
+	amount = 50
+	},
+/obj/item/stack/material/uranium{
+	amount = 50
+	},
+/obj/item/stack/material/uranium{
+	amount = 50
+	},
+/obj/item/stack/material/uranium{
+	amount = 50
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"mDV" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"mEn" = (
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"mEG" = (
+/obj/machinery/chemical_dispenser/full,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"mFq" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm12)
+"mFz" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"mFK" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 6
+	},
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"mFY" = (
+/obj/machinery/power/solar,
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"mGG" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm8)
+"mGP" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm14)
+"mGU" = (
+/obj/item/weapon/bedsheet/orange,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"mGV" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"mHh" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"mHr" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"mHE" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"mIf" = (
+/obj/machinery/vending/sovietsoda{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"mIs" = (
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow,
+/turf/simulated/floor/airless,
+/area/awaymission/snowfield/outside)
+"mIO" = (
+/obj/structure/target_stake,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"mIX" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"mJi" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway2)
+"mJj" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm11)
+"mJs" = (
+/obj/structure/table/bench,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"mJR" = (
+/obj/structure/cable/heavyduty{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"mLz" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm16)
+"mMp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"mMr" = (
+/obj/structure/closet/coffin,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"mMX" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/box/rxglasses,
+/obj/item/weapon/storage/box/rxglasses,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"mNr" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"mNF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"mOc" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"mOn" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/machinery/vending/cigarette{
+	dir = 1;
+	prices = null
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"mPA" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"mPG" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"mPL" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"mQm" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	id = "snowfield bsa gateway path"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"mRr" = (
+/obj/structure/table/rack,
+/obj/item/weapon/pickaxe,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"mRz" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Medical Locker Room";
+	req_one_access = list(1,5)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"mRN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/hallway)
+"mRS" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"mSS" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"mTa" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Armoury Section";
+	req_access = list(3);
+	req_one_access = list(3)
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
+"mTb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/structure/closet/l3closet/janitor,
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"mTf" = (
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/obj/machinery/light_construct,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"mTR" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/floor_decal/borderfloorblack/corner,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/public/toolstorage1)
+"mUx" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"mUF" = (
+/obj/effect/mine/frag,
+/obj/structure/flora/grass/both,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"mUV" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/hallway/commandhallway)
+"mVf" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"mVt" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm13)
+"mVw" = (
+/obj/machinery/computer/security/wooden_tv,
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"mVB" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"mWM" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/blue{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/weapon/pen{
+	pixel_y = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"mWW" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"mWY" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"mXy" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"mYl" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 10
+	},
+/obj/machinery/vending/dinnerware{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"mZG" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"nab" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"naj" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"nau" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"ncx" = (
+/obj/structure/fence/end{
+	dir = 4
+	},
+/obj/structure/fence,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"ncN" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
+	},
+/obj/structure/flora/pottedplant/thinbush,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"ncZ" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm1)
+"ndW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"ned" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"nei" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm13)
+"neq" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/machinery/vending/coffee{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"new" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"nfs" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/monitorroom)
+"nfA" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/kitchenspike,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"nfJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"nfR" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/surgery)
+"ngv" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm1)
+"ngA" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/purple/border,
+/obj/item/weapon/stool/padded,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"nhd" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/monitor_room)
+"nid" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"nin" = (
+/obj/structure/flora/tree/pine,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"niq" = (
+/obj/structure/coatrack,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"niv" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"niM" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"njJ" = (
+/obj/structure/fence/end{
+	dir = 8
+	},
+/obj/structure/fence,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"nkw" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm9)
+"nkF" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"nli" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "1"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"nlv" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm15)
+"nmy" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"nmV" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"nnC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"nos" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/hydro)
+"noR" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"npw" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"nqx" = (
+/obj/structure/boulder,
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/outside)
+"nrK" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/box/chemimp{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/box/trackimp,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"nrQ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"nse" = (
+/obj/structure/outcrop,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"nsj" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm5)
+"nsA" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/storage/firstaid/o2,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"nsC" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "32"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"nsH" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"ntD" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"nue" = (
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"nvM" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"nvO" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"nwE" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm16)
+"nwU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	opened = 1
+	},
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74/variantun,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"nwW" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm1)
+"nxB" = (
+/obj/machinery/gateway{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"nyh" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/handcuffs{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/box/evidence,
+/obj/item/weapon/storage/box/evidence,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_lockerroom)
+"nyy" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/storage_room)
+"nyK" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/sub_chamber)
+"nyV" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/bar_soft/full,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"nzk" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/vending/sovietsoda{
+	dir = 8;
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"nzx" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"nzW" = (
+/obj/structure/fence/corner,
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"nAm" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"nAu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/structure/fireaxecabinet{
+	locked = 0;
+	open = 1;
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"nAG" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/hallway)
+"nAY" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/awaymission/snowfield/security/observatory)
+"nBg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/server)
+"nBi" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor/orange/corner,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"nBs" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/machinery/smartfridge/drying_rack,
+/obj/effect/floor_decal/corner/green,
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"nBW" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/interrogation)
+"nCh" = (
+/obj/structure/cable/yellow,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"nCO" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/surgery)
+"nDh" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"nDs" = (
+/obj/structure/catwalk,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"nDV" = (
+/obj/machinery/door/window/brigdoor/northleft{
+	name = "Code Blue Armory";
+	req_access = null
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"nFz" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/device/multitool,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"nFO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"nGn" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"nHc" = (
+/obj/structure/closet/coffin,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"nHo" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/awaymission/snowfield/command/server)
+"nHt" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"nHA" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/medical_restroom)
+"nHH" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"nHI" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"nIq" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"nIK" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"nKn" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"nLz" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small/flicker{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"nLM" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"nLT" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 2;
+	pixel_y = 3;
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/o2{
+	pixel_x = -2;
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"nMh" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"nMA" = (
+/obj/machinery/door/airlock/glass_security,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/hallway)
+"nNr" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"nOk" = (
+/obj/machinery/door/airlock/highsecurity{
+	req_one_access = list(1,4)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield sec front blast";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"nOq" = (
+/obj/structure/table/steel,
+/obj/item/weapon/paper_bin{
+	pixel_y = -6
+	},
+/obj/item/device/camera{
+	name = "Autopsy Camera";
+	pixel_x = -2;
+	pixel_y = 7
+	},
+/obj/item/weapon/pen/red{
+	pixel_x = -1;
+	pixel_y = -9
+	},
+/obj/item/weapon/pen/blue{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/medical/morgue)
+"nOU" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/black{
+	dir = 1
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/awaymission/snowfield/command/server)
+"nPa" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"nPf" = (
+/obj/structure/catwalk,
+/obj/structure/sink{
+	pixel_y = 16
+	},
+/obj/item/weapon/reagent_containers/glass/bucket/wood{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"nPM" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/structure/closet/crate/bin,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"nQK" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm10)
+"nQZ" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/circuitboard/smes,
+/obj/item/weapon/circuitboard/smes,
+/obj/item/weapon/smes_coil,
+/obj/item/weapon/smes_coil,
+/obj/item/weapon/smes_coil/super_capacity,
+/obj/item/weapon/smes_coil/super_capacity,
+/obj/item/weapon/smes_coil/super_io,
+/obj/item/weapon/smes_coil/super_io,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"nRv" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/interrogation)
+"nSC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"nTe" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm3)
+"nTf" = (
+/obj/item/weapon/pickaxe/hand,
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"nTz" = (
+/obj/machinery/computer/security,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"nVb" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"nVo" = (
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"nVv" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/hydro)
+"nVw" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"nVF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"nWe" = (
+/obj/structure/fence/door,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"nXf" = (
+/obj/structure/cable/yellow,
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/front_desk)
+"nYl" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	health = null;
+	icon_state = "pdoor0";
+	id = "snowfield fourth pathway lock";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"nYG" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"nZe" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"nZx" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"nZN" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"oac" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/monitorroom)
+"oaq" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	req_one_access = list(1,5)
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"obI" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "29"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"obZ" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"och" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm7)
+"ocj" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/item/weapon/card/id/syndicate,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"ocr" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/security_cell)
+"ocF" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/tech_storage)
+"ocP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "SMES Access";
+	req_access = list(1,11);
+	req_one_access = null
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "entrylockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"odb" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"odi" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"oeP" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"ofm" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"ofH" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"ofN" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm4)
+"ofQ" = (
+/obj/machinery/smartfridge/secure/medbay{
+	req_one_access = list(33,66)
+	},
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/chemistry)
+"ogu" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/item/weapon/clipboard,
+/obj/item/weapon/clipboard,
+/obj/item/weapon/pen/multi,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"ogy" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms10";
+	name = "Room 10"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm10)
+"ohs" = (
+/obj/machinery/door/airlock/security,
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/hallway)
+"oii" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/awaymission/snowfield/command/server)
+"oir" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/commandhallway)
+"oiJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/security/armory)
+"ojz" = (
+/obj/machinery/computer/security,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"ojQ" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm3)
+"ojY" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"okk" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"okr" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"okK" = (
+/obj/machinery/vending/tool{
+	dir = 8;
+	pixel_x = -5;
+	products = list(/obj/item/stack/cable_coil/random = 10, /obj/item/weapon/tool/crowbar = 5, /obj/item/weapon/weldingtool = 3, /obj/item/weapon/tool/wirecutters = 5, /obj/item/weapon/tool/wrench = 5, /obj/item/device/analyzer = 5, /obj/item/weapon/tool/screwdriver = 5, /obj/item/device/flashlight/glowstick = 3, /obj/item/device/flashlight/glowstick/red = 3, /obj/item/device/flashlight/glowstick/blue = 3, /obj/item/device/flashlight/glowstick/orange = 3, /obj/item/device/flashlight/glowstick/yellow = 3)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"ola" = (
+/obj/structure/table/standard,
+/obj/item/clothing/accessory/storage/black_vest/fluff,
+/obj/item/clothing/accessory/storage/black_vest/fluff,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_lockerroom)
+"olD" = (
+/obj/machinery/power/solar,
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"olY" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"omd" = (
+/obj/effect/mine/frag,
+/obj/structure/flora/grass/green,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"omf" = (
+/obj/machinery/light/floortube/flicker{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"omt" = (
+/obj/effect/floor_decal/corner/purple/border,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"omG" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"omU" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"onl" = (
+/obj/machinery/computer/secure_data,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"ons" = (
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"onF" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/flora/grass/both,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"onW" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm7)
+"ooF" = (
+/obj/structure/table/bench/steel,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"opn" = (
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"opp" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield test observation";
+	name = "Test Chamber Observation Access";
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"oru" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm4)
+"orY" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm4)
+"osn" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"osv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/window/reinforced,
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"osG" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"osR" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"otE" = (
+/obj/structure/flora/grass/brown,
+/obj/structure/flora/bush,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"otF" = (
+/obj/machinery/gateway{
+	density = 0;
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"oun" = (
+/obj/machinery/door/airlock{
+	name = "Unit 4"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"our" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"ouu" = (
+/obj/machinery/door/airlock{
+	name = "Unit 3"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"ovN" = (
+/obj/structure/cable/yellow,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/warden)
+"owy" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/box/masks,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/surgery)
+"oyB" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/orange,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"ozt" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm9)
+"ozF" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"ozZ" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"oAu" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/hallway)
+"oBU" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"oDj" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm3)
+"oDp" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"oDz" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/hallway)
+"oDD" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/manifold4w/visible/blue,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"oEi" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"oFV" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm12)
+"oGV" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "20"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"oIi" = (
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"oIZ" = (
+/obj/machinery/chemical_dispenser/full,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"oJX" = (
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"oKF" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 26
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"oLd" = (
+/obj/structure/table/steel,
+/obj/item/weapon/storage/bag/circuits/basic,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"oLj" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/clothing/suit/fire/heavy{
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 60);
+	desc = "Over a suit that protects against extreme fire and heat, this seems to be having a thin layer of coating underneath, providing additional protection against radiation."
+	},
+/obj/item/clothing/suit/fire/heavy{
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 60);
+	desc = "Over a suit that protects against extreme fire and heat, this seems to be having a thin layer of coating underneath, providing additional protection against radiation."
+	},
+/obj/item/device/geiger,
+/obj/item/device/geiger,
+/obj/item/clothing/head/hardhat/firefighter/atmos,
+/obj/item/clothing/head/hardhat/firefighter/atmos,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"oLp" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"oLt" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "15"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"oLM" = (
+/turf/simulated/wall/wood,
+/area/awaymission/snowfield/outside)
+"oLW" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"oNd" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"oOF" = (
+/obj/machinery/gateway,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"oPh" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light_construct/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"oPW" = (
+/obj/random/tech_supply,
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/public/toolstorage1)
+"oQl" = (
+/obj/structure/table/steel,
+/obj/item/device/integrated_electronics/debugger{
+	pixel_x = -5
+	},
+/obj/item/device/integrated_electronics/wirer{
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"oQO" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"oSh" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/blucarpet,
+/area/awaymission/snowfield/service/publicstaff)
+"oSk" = (
+/obj/structure/closet/secure_closet/guncabinet{
+	req_one_access = list(2,4)
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 6
+	},
+/obj/item/weapon/gun/projectile/shotgun/pump/shorty{
+	desc = "A clunky, lightly modified special carbine, this gun is often be seen in the old terran's prison, designed to suppress the prison riots.";
+	description_fluff = "Designed to suppress the prison riot, KS-23 has been developed in 1970s in Soviet Russia. Crude, but compact, it is easy to carry around while in patrol, and useful in close combat.";
+	name = "KS-23"
+	},
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"oUL" = (
+/obj/structure/table/glass,
+/obj/item/weapon/hand_labeler,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/item/device/mass_spectrometer/adv,
+/obj/item/device/mass_spectrometer/adv,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"oVb" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm9)
+"oVW" = (
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"oWf" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"oWy" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"oXp" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"oYi" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"oZe" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm2)
+"oZI" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"pah" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/multi,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"pau" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border,
+/obj/machinery/vending/dinnerware{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"paH" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/warden)
+"pbm" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm6)
+"pbB" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/ammo_casing/rocket,
+/obj/item/weapon/gun/launcher/scopedrocket,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"pbJ" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = -5
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"pcm" = (
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/obj/structure/closet/jcloset,
+/obj/item/weapon/soap/nanotrasen,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/janitor)
+"pcH" = (
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"pdB" = (
+/obj/structure/flora/rocks1,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"peo" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/structure/closet/l3closet/janitor,
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"pes" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"pfj" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall,
+/area/awaymission/snowfield/solarshack)
+"pfn" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm14)
+"pfs" = (
+/obj/item/weapon/ore/glass,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/outside)
+"pgd" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/surgery)
+"pgn" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"phA" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"phW" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"plq" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm11)
+"plr" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/turcarpet,
+/area/awaymission/snowfield/medical/staff_room)
+"plx" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Interrogation Viewpoint";
+	req_access = list(1)
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/awaymission/snowfield/security/observatory)
+"pmE" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"pnj" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"pnk" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"poH" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"ppX" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/hallway2)
+"pqu" = (
+/obj/effect/floor_decal/steeldecal/monofloor,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1,
+/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/structure/railing{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/machinery/door/blast/regular{
+	id = "snowfield bsa access"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"pqG" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm11)
+"pqR" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/soap,
+/obj/item/weapon/soap,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"prj" = (
+/obj/item/clothing/suit/fire/heavy{
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 60);
+	desc = "Over a suit that protects against extreme fire and heat, this seems to be having a thin layer of coating underneath, providing additional protection against radiation."
+	},
+/obj/item/clothing/suit/fire/heavy{
+	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 5, "bomb" = 0, "bio" = 0, "rad" = 60);
+	desc = "Over a suit that protects against extreme fire and heat, this seems to be having a thin layer of coating underneath, providing additional protection against radiation."
+	},
+/obj/item/clothing/head/hardhat/firefighter/atmos,
+/obj/item/clothing/head/hardhat/firefighter/atmos,
+/obj/structure/table/rack/shelf/steel,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"prN" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm12)
+"psa" = (
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	health = 1e+006
+	},
+/obj/structure/grille,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/obj/structure/window/reinforced/full{
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"pse" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"psv" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"psX" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"ptm" = (
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"ptK" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/cable_coil/yellow,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/solarshack)
+"pun" = (
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"pus" = (
+/obj/structure/toilet/prison{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/security_cell)
+"puS" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"pvg" = (
+/obj/structure/flora/grass/green,
+/obj/effect/mine/frag,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"pvE" = (
+/obj/structure/table/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"pwo" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/yellow/bordercorner,
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"pwq" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms4";
+	name = "Room 4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm4)
+"pwu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"pxr" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"pxu" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"pxH" = (
+/obj/machinery/computer/secure_data,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/security/detective)
+"pxI" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Interrogation";
+	req_access = list(1)
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/interrogation)
+"pyc" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"pyg" = (
+/obj/structure/cable/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/warden)
+"pyr" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/server)
+"pyu" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/testroom)
+"pzb" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/computer,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/awaymission/snowfield/command/bridge)
+"pzk" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"pzq" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"pzC" = (
+/obj/machinery/door/airlock/security,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway2)
+"pzH" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"pAj" = (
+/obj/structure/table/woodentable,
+/obj/machinery/light_construct/small{
+	dir = 4
+	},
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"pAp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/filingcabinet,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"pAB" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"pBA" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"pBV" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm1)
+"pBX" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/turcarpet,
+/area/awaymission/snowfield/medical/staff_room)
+"pDp" = (
+/obj/random/junk,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"pEd" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway)
+"pEg" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"pEA" = (
+/obj/structure/table/rack,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"pER" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"pGl" = (
+/obj/machinery/door/blast/gate/open{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"pGC" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"pHK" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/public/charger)
+"pHV" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"pHZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/southhallway)
+"pIZ" = (
+/obj/structure/flora/grass/brown,
+/obj/structure/flora/grass/brown,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"pJb" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm4)
+"pJl" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/weapon/gun/projectile/automatic/serdy/akm,
+/obj/item/weapon/gun/projectile/automatic/serdy/krinkov,
+/obj/item/weapon/gun/projectile/automatic/serdy/krinkov,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"pJC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"pJM" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 4;
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	icon_state = "map_vent_out";
+	pressure_checks = 0;
+	pressure_checks_default = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Mainframe Base";
+	nitrogen = 100;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/awaymission/snowfield/command/server)
+"pJW" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "SMES Access";
+	req_access = list(1,11);
+	req_one_access = null
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "entrylockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"pJX" = (
+/obj/structure/table/woodentable,
+/obj/structure/noticeboard{
+	pixel_x = 30
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"pKR" = (
+/obj/item/weapon/ore/glass,
+/obj/item/weapon/ore/glass,
+/obj/item/weapon/ore/coal,
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/outside)
+"pMg" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/arrows{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"pMX" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/engineering/locker_room)
+"pNI" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm1)
+"pNT" = (
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield tool storage lockdown";
+	name = "Path Blocker Control";
+	pixel_y = 23;
+	req_access = list(1)
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"pNW" = (
+/obj/structure/flora/grass/brown,
+/obj/structure/flora/grass/green,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"pOb" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	req_access = list(19,23);
+	req_one_access = newlist()
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/secure_tech_storage)
+"pOV" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"pPu" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield sec front blast";
+	name = "Emergency Front Desk Lockdown";
+	pixel_y = -10;
+	req_access = list(1)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield second blast";
+	name = "Second Access Blast Door-control";
+	req_access = list(1)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield front blast";
+	name = "Front Access Blast Door-control";
+	pixel_y = 10;
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"pPw" = (
+/obj/structure/closet/chefcloset,
+/obj/item/glass_jar,
+/obj/item/weapon/soap/nanotrasen,
+/obj/item/device/destTagger{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/clothing/gloves/sterile/latex,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"pPU" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm13)
+"pQF" = (
+/obj/machinery/door/blast/gate,
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/cavern)
+"pTr" = (
+/obj/machinery/door/window/brigdoor/westright{
+	name = "Code Red Armory";
+	req_access = null;
+	req_one_access = list(3)
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"pTQ" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/monitorroom)
+"pUd" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm8)
+"pUI" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/panicroom)
+"pVg" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm10)
+"pWi" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"pYH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"pZF" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"pZK" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 8
+	},
+/obj/structure/bookcase/manuals/medical,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"qat" = (
+/obj/effect/mine/frag,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"qbB" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/security{
+	name = "Detective's office";
+	req_access = list (4);
+	req_one_access = null
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"qbN" = (
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"qbX" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"qbZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Execution Chamber";
+	req_access = null;
+	req_one_access = list(2,4)
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell)
+"qcy" = (
+/obj/structure/closet/radiation,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"qcI" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced/full{
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa observation window";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/bsa)
+"qcK" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"qcT" = (
+/obj/machinery/door/airlock{
+	name = "Restroom"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"qcU" = (
+/obj/machinery/honey_extractor,
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"qee" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm14)
+"qep" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/command/server)
+"qft" = (
+/obj/structure/table/glass,
+/obj/item/weapon/soap,
+/obj/item/weapon/soap,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"qfC" = (
+/obj/structure/table/steel,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"qfK" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"qfR" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"qfS" = (
+/obj/structure/table/standard,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"qgX" = (
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access = null;
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"qhs" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/flicker{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/testroom)
+"qhx" = (
+/obj/effect/floor_decal/industrial/danger,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"qhV" = (
+/obj/effect/floor_decal/techfloor/orange,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"qij" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "18"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"qir" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/southhallway)
+"qiR" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm14)
+"qjn" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"qjJ" = (
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield emergency bunk";
+	name = "Path Blocker Control";
+	pixel_y = 23;
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/panicroom)
+"qjX" = (
+/obj/structure/cable,
+/obj/structure/cable/heavyduty{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"qkM" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"qlG" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"qlJ" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm6)
+"qlR" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"qme" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 6
+	},
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/public/toolstorage1)
+"qmI" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"qne" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"qni" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"qnK" = (
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"qnP" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"qoa" = (
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/security/detective)
+"qom" = (
+/obj/machinery/door/blast/regular{
+	id = "snowfield bsa gateway path"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"qon" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"qph" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/storage/box/gloves,
+/obj/item/weapon/storage/box/gloves,
+/obj/item/weapon/storage/box/gloves,
+/obj/item/weapon/storage/box/gloves,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/syringes,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"qpk" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/button/crematorium{
+	id = "Chapelburn";
+	pixel_x = 20;
+	pixel_y = -10;
+	req_access = null;
+	req_one_access = list(1,5,6)
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"qpE" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"qqw" = (
+/turf/simulated/mineral,
+/area/awaymission/snowfield/outside)
+"qrh" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"qrz" = (
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/cavern)
+"qrK" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"qsh" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/toxin,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"qsV" = (
+/obj/item/weapon/gun/projectile/shotgun/pump/shorty{
+	desc = "A clunky, lightly modified special carbine, this gun is often be seen in the old terran's prison, designed to suppress the prison riots.";
+	description_fluff = "Designed to suppress the prison riot, KS-23 has been developed in 1970s in Soviet Russia. Crude, but compact, it is easy to carry around while in patrol, and useful in close combat.";
+	name = "KS-23"
+	},
+/obj/item/ammo_magazine/ammo_box/b12g/pellet,
+/obj/structure/closet/secure_closet/guncabinet{
+	req_one_access = list(2,4)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"qtB" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm5)
+"quk" = (
+/obj/item/weapon/ore/coal,
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/cavern)
+"quy" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/tool/wrench,
+/obj/item/weapon/tool/crowbar,
+/obj/item/device/radio/off,
+/obj/item/device/binoculars,
+/obj/machinery/light,
+/obj/item/device/megaphone,
+/obj/item/device/radio/off,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"quU" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"qws" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"qwt" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/item/weapon/reagent_containers/glass/bucket/wood,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"qww" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	pixel_x = -5;
+	req_access = null;
+	req_one_access = list(1,10)
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfieldenglockdown";
+	name = "Engine Room Lockdown";
+	pixel_x = 5;
+	req_one_access = list(1,10)
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"qwU" = (
+/obj/machinery/atmospherics/pipe/tank{
+	desc = "A large vessel containing huge amount of water.";
+	icon_state = "o2_map";
+	name = "Water Tank"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"qxb" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"qxi" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"qxn" = (
+/obj/machinery/door/airlock/hatch{
+	icon_state = "door_locked";
+	id_tag = "emergency path";
+	locked = 1;
+	req_access = null;
+	req_one_access = null
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"qxt" = (
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/item/device/multitool,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"qxH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/structure/closet/l3closet/janitor,
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"qym" = (
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/outside)
+"qyz" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/structure/sink/kitchen{
+	pixel_y = 17
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"qyT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"qAn" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"qBl" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/armory)
+"qCf" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm10)
+"qCv" = (
+/obj/item/weapon/ore/coal,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"qCz" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"qCV" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"qDO" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 9
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"qFo" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm13)
+"qFz" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"qGm" = (
+/obj/structure/catwalk,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/item/clothing/head/cueball,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"qHd" = (
+/obj/machinery/door/airlock/medical{
+	health = 130;
+	locked = 1;
+	name = "Operating Theatre";
+	req_access = list(45)
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/surgery)
+"qHg" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/box{
+	desc = "A box full of soap. Soapy.";
+	name = "Soap box";
+	starts_with = list(/obj/item/weapon/soap = 7)
+	},
+/obj/item/weapon/storage/box/lights/bulbs,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"qHW" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/obj/structure/table/marble,
+/obj/machinery/microwave{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"qID" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/patients)
+"qJA" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"qJL" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"qLa" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.6
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/item/device/defib_kit/loaded,
+/obj/item/device/defib_kit/loaded,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"qLx" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/command/observatory_path)
+"qLV" = (
+/obj/machinery/door/airlock{
+	name = "Unit 2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"qMj" = (
+/obj/item/clothing/shoes/boots/speed,
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"qMk" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"qNN" = (
+/obj/structure/table/standard,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/public/toolstorage1)
+"qNV" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.6
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/flashlight,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"qOv" = (
+/obj/structure/railing,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"qOP" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"qPi" = (
+/obj/machinery/door/airlock/highsecurity{
+	req_one_access = list(1, 53)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"qPu" = (
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"qQs" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"qRo" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/cloning,
+/obj/item/weapon/circuitboard/clonescanner,
+/obj/item/weapon/circuitboard/clonepod,
+/obj/item/weapon/circuitboard/scan_consolenew,
+/obj/item/weapon/circuitboard/med_data{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"qRG" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"qRS" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/northhallway)
+"qSo" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm9)
+"qSJ" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"qTe" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield testlab entrance";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"qTN" = (
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/cavern)
+"qTW" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/security/evidence_storage)
+"qUW" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"qVA" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/item/device/defib_kit/loaded,
+/obj/item/device/defib_kit/loaded,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"qVR" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm14)
+"qVU" = (
+/obj/structure/boulder,
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/cavern)
+"qXw" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"qXC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"qYo" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"qYG" = (
+/obj/structure/outcrop,
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/outside)
+"qZp" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm4)
+"qZA" = (
+/obj/structure/fireplace/barrel,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"qZB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/hallway)
+"rai" = (
+/obj/structure/morgue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"rar" = (
+/obj/machinery/shower{
+	dir = 8;
+	on = 1;
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/structure/curtain/open/shower/security,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"raE" = (
+/obj/structure/railing,
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/remote/blast_door{
+	desc = "It drops the bass to the ground.";
+	name = "Remote bass-drop control"
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"raG" = (
+/obj/structure/fence/cut/large,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"raJ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway2)
+"rbD" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm6)
+"rbG" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/effect/floor_decal/arrows{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"rcQ" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"rcZ" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 26
+	},
+/obj/structure/table/standard,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_lockerroom)
+"rdy" = (
+/obj/effect/floor_decal/techfloor/orange,
+/obj/structure/catwalk,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"rdQ" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "12"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"reQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/orange/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"rft" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/water_cooler/full{
+	dir = 8;
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"rfE" = (
+/obj/structure/closet/wardrobe/chemistry_white,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"rfZ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"rgn" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"rgL" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/commandhallway)
+"rhd" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"rhh" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"rim" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"riQ" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/yellow/border,
+/obj/machinery/recharger,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/public/toolstorage1)
+"rjc" = (
+/obj/structure/sign/signnew/explosives,
+/turf/simulated/wall/titanium,
+/area/awaymission/snowfield/outside)
+"rjo" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"rjE" = (
+/turf/simulated/floor/carpet,
+/area/awaymission/snowfield/engineering/staff_room)
+"rjH" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 17
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"rjM" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"rjV" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm13)
+"rkk" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"rkD" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm9)
+"rkL" = (
+/obj/structure/closet/coffin,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"rkU" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/smes/buildable{
+	charge = null;
+	cur_coils = 4;
+	input_attempt = 1;
+	input_level = 1000000;
+	output_level = 750000
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"rlj" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"rlW" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"rmy" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"rnD" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"roe" = (
+/obj/structure/morgue{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"rof" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/water_cooler/full{
+	dir = 8;
+	pixel_x = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"rou" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm4)
+"roD" = (
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"rpz" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"rqc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/awaymission/snowfield/engineering/staff_room)
+"rqq" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm3)
+"rqZ" = (
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/evidence_storage)
+"rrb" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"rrm" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/tech_storage)
+"rrW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/southhallway)
+"rtq" = (
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/solarshack)
+"ruo" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm11)
+"rvN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"ryu" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"ryV" = (
+/obj/structure/closet/l3closet/security,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"rzL" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/machinery/vending/cigarette{
+	dir = 1;
+	prices = null
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"rCa" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 26
+	},
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_lockerroom)
+"rDV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"rEA" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/seconddesk)
+"rGr" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"rHk" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"rHF" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"rIs" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"rIA" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/machinery/vending/cigarette{
+	dir = 1;
+	prices = null
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"rJe" = (
+/obj/structure/catwalk,
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Cells";
+	req_access = list(1)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"rJI" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/paramedic{
+	req_access = list(33);
+	starts_with = list(/obj/item/weapon/storage/backpack/dufflebag/emt,/obj/item/weapon/storage/box/autoinjectors,/obj/item/weapon/storage/box/syringes,/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,/obj/item/weapon/storage/belt/medical/emt,/obj/item/clothing/mask/gas,/obj/item/clothing/suit/storage/toggle/fr_jacket,/obj/item/clothing/suit/storage/toggle/labcoat/emt,/obj/item/clothing/suit/storage/hooded/wintercoat/medical/para,/obj/item/device/radio/headset/headset_med/alt,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/device/flashlight,/obj/item/weapon/tank/emergency/oxygen/engi,/obj/item/device/radio/off,/obj/item/weapon/tool/crowbar,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/storage/box/freezer,/obj/item/clothing/accessory/storage/white_vest,/obj/item/taperoll/medical)
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"rKt" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/public/toolstorage1)
+"rKJ" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"rLd" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"rLF" = (
+/obj/structure/flora/tree/pine,
+/obj/structure/flora/tree/pine,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"rLP" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"rMl" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"rMo" = (
+/obj/structure/filingcabinet,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"rMR" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm10)
+"rNL" = (
+/obj/machinery/door/airlock{
+	name = "Restroom"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"rNT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/bed/chair/oldsofa{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"rNV" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"rOB" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm7)
+"rOE" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"rPn" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"rQk" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"rSm" = (
+/obj/structure/filingcabinet,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"rSz" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"rSA" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/command/observatory)
+"rSF" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	opened = 1
+	},
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74/variantun,
+/obj/item/ammo_magazine/ak74,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"rSH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"rTx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"rVn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"rVp" = (
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/carpet,
+/area/awaymission/snowfield/security/detective)
+"rVw" = (
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"rVx" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"rWv" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"rWB" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"rWM" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"rXj" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/tech_storage)
+"rYh" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medbay Equipment";
+	req_access = null;
+	req_one_access = list1,5)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/storage_room)
+"rYF" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/server)
+"rYI" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"rZO" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"sai" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/soap,
+/obj/item/weapon/soap,
+/obj/item/weapon/soap,
+/obj/item/weapon/soap,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"saz" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/filingcabinet/chestdrawer{
+	desc = "A large drawer filled with autopsy reports.";
+	name = "Autopsy Reports"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"sbj" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/secure_tech_storage)
+"sbx" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/service/kitchen)
+"sca" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"scm" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"scu" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm3)
+"scB" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"scF" = (
+/obj/machinery/vending/snack{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"sdS" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/centerhallway)
+"sez" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/hallway)
+"seE" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"sfp" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"siu" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"siI" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/blue{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"sjN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"sjV" = (
+/obj/machinery/telecomms/server/presets/unused,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/server)
+"skE" = (
+/obj/structure/table/glass,
+/obj/item/weapon/soap,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"slv" = (
+/obj/machinery/door/airlock{
+	name = "Unit 3"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"slI" = (
+/obj/structure/table/steel_reinforced,
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/glass,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"smE" = (
+/obj/machinery/computer/crew,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"snB" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"snY" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"snZ" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/cavern)
+"sok" = (
+/obj/structure/janitorialcart,
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/janitor)
+"soI" = (
+/obj/machinery/oxygen_pump/mobile/anesthetic,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"soJ" = (
+/obj/item/weapon/material/shard,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"soY" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"spJ" = (
+/obj/effect/floor_decal/techfloor/orange,
+/obj/machinery/door/blast/regular{
+	id = "snowfield bsa gateway path"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"spM" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/structure/table/woodentable,
+/obj/item/device/radio/phone,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"spQ" = (
+/turf/simulated/wall,
+/area/awaymission/snowfield/solarshack)
+"stI" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "21"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"suv" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/observatory_path)
+"suB" = (
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"swJ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 8
+	},
+/obj/machinery/door/window/brigdoor/eastright{
+	id = Cell 3;
+	name = "Cell 3";
+	req_access = null;
+	req_one_access = list(2,4)
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/security_cell)
+"sxb" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"sxi" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"sxD" = (
+/obj/structure/table/standard,
+/obj/item/device/radio/phone,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_lockerroom)
+"syv" = (
+/obj/item/weapon/ore/coal,
+/obj/item/weapon/ore/coal,
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/cavern)
+"syG" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/commandarmory)
+"szB" = (
+/turf/simulated/wall/solidrock{
+	block_tele = 0
+	},
+/area/awaymission/snowfield/restricted)
+"szI" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm5)
+"szJ" = (
+/obj/random/junk,
+/obj/structure/bed,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"szW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"sAx" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/grey/bordercorner,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"sAU" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/engineering/hallway)
+"sBs" = (
+/turf/simulated/wall/titanium,
+/area/awaymission/snowfield/cavern)
+"sBt" = (
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"sBJ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm16)
+"sCi" = (
+/obj/structure/closet/crate/freezer/rations,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"sCX" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/computer/skills{
+	req_one_access = list(1,19)
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"sDe" = (
+/obj/structure/table/standard,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"sDF" = (
+/obj/structure/flora/bush,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"sED" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"sEL" = (
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/engineering/restroom)
+"sFD" = (
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"sGc" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"sGe" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/item/weapon/gun/projectile/automatic/serdy/sks,
+/obj/item/weapon/gun/projectile/automatic/serdy/sks,
+/obj/item/weapon/gun/projectile/automatic/serdy/sks,
+/obj/item/weapon/gun/projectile/automatic/serdy/sks,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "Armament"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"sGl" = (
+/obj/structure/filingcabinet/filingcabinet,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/evidence_storage)
+"sHz" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/machinery/vending/coffee{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"sHH" = (
+/obj/structure/table/rack,
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/commandarmory)
+"sIc" = (
+/obj/effect/floor_decal/techfloor/orange,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"sIm" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet{
+	closet_appearance = /decl/closet_appearance/bio;
+	name = "Level-3 Biohazard Closet"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"sIH" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm8)
+"sKP" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"sMv" = (
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"sMN" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/monitorroom)
+"sNd" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/closet/l3closet/general,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"sNS" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm12)
+"sOc" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/northleft{
+	req_access = list(1)
+	},
+/obj/machinery/door/window/southleft{
+	req_access = list(1)
+	},
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/seconddesk)
+"sOl" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"sOT" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"sPc" = (
+/obj/effect/floor_decal/corner/white/diagonal,
+/obj/structure/table/marble,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"sQa" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"sQk" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm11)
+"sQX" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"sRf" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"sRm" = (
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"sRX" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/fire,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"sSb" = (
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"sSl" = (
+/obj/structure/bed/chair/oldsofa/left{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"sTG" = (
+/obj/structure/table/reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"sUc" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "10"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"sUP" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"sUQ" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm11)
+"sUZ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/security,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway2)
+"sVq" = (
+/turf/simulated/floor/carpet/blucarpet,
+/area/awaymission/snowfield/service/publicstaff)
+"sWl" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm4)
+"sWu" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"sXc" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm1)
+"sXS" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/computer/crew,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"sYf" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"sYg" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"sYA" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/secure_closet/engineering_welding{
+	req_access = null;
+	req_one_access = list (10,11)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"sYZ" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/security/mining,
+/obj/item/weapon/circuitboard/message_monitor{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"tbr" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"tbx" = (
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/evidence_storage)
+"tbG" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"tcL" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"tdM" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"tec" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"tej" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm13)
+"ter" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm2)
+"tfe" = (
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access = null;
+	req_one_access = null
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"tfA" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
+"tfG" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"tgc" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"tgp" = (
+/obj/effect/floor_decal/industrial/danger,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"tgO" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms5";
+	name = "Room 5"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm5)
+"tgU" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"thm" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	opened = 1
+	},
+/obj/item/weapon/gun/projectile/automatic/serdy/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/ammo_magazine/clip/mosin,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74/variantun,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74/variantun,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"thE" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"thY" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm5)
+"tjf" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"tji" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/evidence_storage)
+"tkr" = (
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"tkJ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"tkV" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"tmQ" = (
+/obj/structure/table/standard,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller{
+	pixel_y = 8
+	},
+/obj/item/roller{
+	pixel_y = 8
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"tng" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"tnN" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"tor" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/front_desk)
+"toF" = (
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blucarpet,
+/area/awaymission/snowfield/service/publicstaff)
+"toJ" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/service/hydro)
+"toV" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/server)
+"tpr" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"tpt" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/structure/railing,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"tpu" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm2)
+"tpN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"tqN" = (
+/turf/simulated/floor/carpet/turcarpet,
+/area/awaymission/snowfield/medical/staff_room)
+"trx" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"ttf" = (
+/obj/structure/flora/tree/dead,
+/obj/structure/flora/grass/both,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"ttw" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/item/weapon/material/ashtray/glass,
+/obj/item/weapon/material/ashtray/glass,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"ttQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7,
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/turf/simulated/floor/reinforced,
+/area/awaymission/snowfield/engineering/engine)
+"ttU" = (
+/obj/machinery/iv_drip,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"tuz" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm12)
+"tuC" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "O- Blood Locker";
+	pixel_x = 32
+	},
+/obj/structure/table/steel_reinforced,
+/obj/machinery/recharger,
+/obj/item/weapon/tool/screwdriver,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/surgery)
+"tuW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"twX" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/front_desk)
+"txs" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/monitor_room)
+"txH" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm6)
+"txY" = (
+/obj/machinery/light/small/flicker{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"tzg" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/hallway/northhallway)
+"tzF" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/item/ammo_magazine/akm,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"tzG" = (
+/obj/structure/outcrop/coal,
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/cavern)
+"tAd" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"tAY" = (
+/obj/machinery/door/blast/gate/open,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"tBf" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/chemistry)
+"tBA" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm15)
+"tBQ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/observatory_path)
+"tCv" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"tDm" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Command Room";
+	req_one_access = list(1,11,20,47,56)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield command lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"tEC" = (
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"tET" = (
+/obj/structure/flora/tree/pine,
+/obj/structure/flora/grass/brown,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"tEZ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"tFR" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"tGB" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"tGK" = (
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"tHP" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"tHV" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"tIi" = (
+/obj/item/device/aicard,
+/obj/item/weapon/aiModule/reset,
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"tKo" = (
+/obj/machinery/gateway{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"tKQ" = (
+/obj/structure/flora/tree/pine,
+/obj/structure/flora/grass/both,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"tLI" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/eastright{
+	name = "Ammo"
+	},
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74/ap,
+/obj/item/ammo_magazine/ak74/ap,
+/obj/item/ammo_magazine/ak74/ap,
+/obj/item/ammo_magazine/ak74/ap,
+/obj/item/ammo_magazine/ak74/ap,
+/obj/item/ammo_magazine/ak74/ap,
+/obj/item/ammo_magazine/ak74/ap,
+/obj/item/ammo_magazine/ak74/ap,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"tLV" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"tMK" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm16)
+"tMW" = (
+/obj/item/weapon/ore/glass,
+/obj/item/weapon/ore/glass,
+/obj/item/weapon/ore/glass,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/outside)
+"tOL" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/mask/gas/half,
+/obj/item/clothing/under/tactical{
+	armor = list("melee" = 40, "bullet" = 35, "laser" = 10, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 35);
+	armorsoak = list("melee" = 10, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 5, "bio" = 5, "rad" = 5);
+	desc = "It's covered with  sturdier material than standard jumpsuits, to allow for robust protection. With additional protection, however, it has sacraficed the speed.";
+	name = "tactical armored jumpsuit";
+	slowdown = 0.5
+	},
+/obj/item/clothing/under/tactical{
+	armor = list("melee" = 40, "bullet" = 35, "laser" = 10, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 35);
+	armorsoak = list("melee" = 10, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 5, "bio" = 5, "rad" = 5);
+	desc = "It's covered with  sturdier material than standard jumpsuits, to allow for robust protection. With additional protection, however, it has sacraficed the speed.";
+	name = "tactical armored jumpsuit";
+	slowdown = 0.5
+	},
+/obj/item/clothing/under/tactical{
+	armor = list("melee" = 40, "bullet" = 35, "laser" = 10, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 35);
+	armorsoak = list("melee" = 10, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 5, "bio" = 5, "rad" = 5);
+	desc = "It's covered with  sturdier material than standard jumpsuits, to allow for robust protection. With additional protection, however, it has sacraficed the speed.";
+	name = "tactical armored jumpsuit";
+	slowdown = 0.5
+	},
+/obj/item/clothing/under/tactical{
+	armor = list("melee" = 40, "bullet" = 35, "laser" = 10, "energy" = 10, "bomb" = 10, "bio" = 10, "rad" = 35);
+	armorsoak = list("melee" = 10, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 5, "bio" = 5, "rad" = 5);
+	desc = "It's covered with  sturdier material than standard jumpsuits, to allow for robust protection. With additional protection, however, it has sacraficed the speed.";
+	name = "tactical armored jumpsuit";
+	slowdown = 0.5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"tPx" = (
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"tPy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/structure/janitorialcart,
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"tPE" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"tPK" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"tPY" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"tQf" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/box{
+	desc = "A box full of soap. Soapy.";
+	name = "Soap box";
+	starts_with = list(/obj/item/weapon/soap = 7)
+	},
+/obj/item/weapon/storage/box{
+	desc = "A box full of soap. Soapy.";
+	name = "Soap box";
+	starts_with = list(/obj/item/weapon/soap = 7)
+	},
+/obj/item/weapon/storage/box{
+	desc = "A box full of soap. Soapy.";
+	name = "Soap box";
+	starts_with = list(/obj/item/weapon/soap = 7)
+	},
+/obj/item/weapon/storage/box{
+	desc = "A box full of soap. Soapy.";
+	name = "Soap box";
+	starts_with = list(/obj/item/weapon/soap = 7)
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"tQD" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/structure/reagent_dispensers/fueltank/high,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"tQR" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"tRT" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 10
+	},
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control-switch for Surgery.";
+	id = "Operating Theatre";
+	name = "Surgery";
+	pixel_y = -23;
+	req_one_access = list(1,45)
+	},
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/surgery)
+"tSs" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm16)
+"tTO" = (
+/turf/simulated/wall,
+/area/awaymission/snowfield/checkpoint)
+"tUx" = (
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"tVB" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"tXc" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"tXK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/machinery/vending/tool{
+	dir = 8;
+	pixel_x = -5;
+	products = list(/obj/item/stack/cable_coil/random = 10, /obj/item/weapon/tool/crowbar = 5, /obj/item/weapon/weldingtool = 3, /obj/item/weapon/tool/wirecutters = 5, /obj/item/weapon/tool/wrench = 5, /obj/item/device/analyzer = 5, /obj/item/weapon/tool/screwdriver = 5, /obj/item/device/flashlight/glowstick = 3, /obj/item/device/flashlight/glowstick/red = 3, /obj/item/device/flashlight/glowstick/blue = 3, /obj/item/device/flashlight/glowstick/orange = 3, /obj/item/device/flashlight/glowstick/yellow = 3)
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"tYb" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Storage";
+	req_one_access = list(1,10)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/primary_storage)
+"tYJ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield third blast";
+	name = "Path Blocker Control";
+	pixel_x = -5;
+	pixel_y = 23;
+	req_access = list(1)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "outpost third path blast";
+	name = "Pathway Access Control";
+	pixel_x = 5;
+	pixel_y = 23;
+	req_access = list(1)
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"tYT" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"tZD" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm8)
+"tZS" = (
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"uai" = (
+/obj/structure/catwalk,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"uaU" = (
+/obj/structure/table/standard,
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield sr access";
+	name = "Server Room Access";
+	pixel_x = 23;
+	req_one_access = list(20,30,61)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"ubt" = (
+/mob/living/simple_mob/animal/goat,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"ubF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"ubW" = (
+/obj/item/weapon/grenade/chem_grenade/cleaner,
+/obj/item/weapon/grenade/chem_grenade/cleaner,
+/obj/item/weapon/grenade/chem_grenade/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/structure/table/steel,
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/effect/floor_decal/borderfloor,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/effect/floor_decal/corner/purple/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"uch" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	health = null;
+	icon_state = "pdoor0";
+	id = "snowfield bsa MCA";
+	opacity = 0
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"ucZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 26
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"uda" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/server)
+"udd" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/service/hydro)
+"udJ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small/flicker{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/awaymission/snowfield/security/observatory)
+"uer" = (
+/obj/structure/closet/crate{
+	opened = 1
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"ufs" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield fourth pathway lock";
+	name = "Remote beat-drop control";
+	pixel_x = 23
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"ufA" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/machinery/vending/sovietsoda{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"ugQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/sub_chamber)
+"uhd" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/flour,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"uhg" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/janitor)
+"uhC" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/flora/grass/brown,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"uhM" = (
+/obj/machinery/computer/power_monitor,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"uhR" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/water_cooler/full{
+	dir = 8;
+	pixel_x = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"uiq" = (
+/obj/item/device/radio/phone{
+	pixel_y = -10
+	},
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/patient_restroom)
+"uke" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm6)
+"ukP" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"ulp" = (
+/obj/machinery/atmospherics/valve,
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"ulu" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/machinery/vending/coffee{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"ulH" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"umm" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm7)
+"umu" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"umI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/observatory_path)
+"umM" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm16)
+"unx" = (
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/device/binoculars,
+/obj/item/weapon/material/knife/tacknife/combatknife,
+/obj/item/weapon/material/knife/tacknife/combatknife,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"uoi" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/commandhallway)
+"uoD" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/hallway)
+"uoM" = (
+/turf/simulated/mineral,
+/area/awaymission/snowfield/restricted)
+"uoP" = (
+/obj/machinery/telecomms/hub,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/server)
+"uoV" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/locker_room)
+"uoX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall,
+/area/awaymission/snowfield/checkpointunpowered)
+"upC" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/interrogation)
+"urK" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"urR" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/structure/table/woodentable,
+/obj/item/weapon/material/ashtray/glass,
+/obj/item/weapon/material/ashtray/glass,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"utf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm16)
+"uuq" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm1)
+"uut" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"uuz" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm3)
+"uva" = (
+/obj/structure/toilet,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"uve" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/o2,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"uvm" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/service/cafeteria)
+"uvE" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"uvY" = (
+/obj/machinery/recharger,
+/obj/item/weapon/tool/screwdriver,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"uww" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"uwH" = (
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"uwQ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell)
+"uyr" = (
+/turf/simulated/wall/titanium,
+/area/awaymission/snowfield/outside)
+"uyz" = (
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
+	req_access = null
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"uyU" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Kitchen cold room";
+	req_access = list(28)
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/fridge)
+"uyX" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/weapon/circuitboard/powermonitor{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/weapon/circuitboard/stationalert_engineering{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/circuitboard/security/engineering,
+/obj/item/weapon/circuitboard/atmos_alert{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"uzr" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"uzE" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/server)
+"uBf" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"uBF" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"uCl" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/testroom)
+"uCp" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway)
+"uDw" = (
+/obj/machinery/door/blast/regular{
+	id = "snowfield second blast"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"uDy" = (
+/obj/machinery/computer/crew,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"uDJ" = (
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell)
+"uDQ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"uEn" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms3";
+	name = "Room 3"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm3)
+"uEo" = (
+/obj/structure/kitchenspike,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"uEZ" = (
+/turf/simulated/wall/r_lead,
+/area/awaymission/snowfield/engineering/engine)
+"uFd" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	req_access = null;
+	req_one_access = list(1,10)
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/monitor_room)
+"uFu" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm4)
+"uGb" = (
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"uGe" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm1)
+"uGw" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm15)
+"uGz" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"uHq" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/interrogation)
+"uIh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"uIk" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 9
+	},
+/obj/structure/closet/secure_closet/paramedic{
+	req_access = list(33);
+	starts_with = list(/obj/item/weapon/storage/backpack/dufflebag/emt,/obj/item/weapon/storage/box/autoinjectors,/obj/item/weapon/storage/box/syringes,/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,/obj/item/weapon/storage/belt/medical/emt,/obj/item/clothing/mask/gas,/obj/item/clothing/suit/storage/toggle/fr_jacket,/obj/item/clothing/suit/storage/toggle/labcoat/emt,/obj/item/clothing/suit/storage/hooded/wintercoat/medical/para,/obj/item/device/radio/headset/headset_med/alt,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/device/flashlight,/obj/item/weapon/tank/emergency/oxygen/engi,/obj/item/device/radio/off,/obj/item/weapon/tool/crowbar,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/storage/box/freezer,/obj/item/clothing/accessory/storage/white_vest,/obj/item/taperoll/medical)
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"uIr" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"uIu" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/structure/flora/pottedplant,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"uIw" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/structure/table/marble,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"uIx" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"uIQ" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/interrogation)
+"uJj" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"uJI" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"uKf" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/sub_chamber)
+"uKp" = (
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"uKG" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/awaymission/snowfield/security/observatory)
+"uKQ" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm13)
+"uLb" = (
+/obj/machinery/door/airlock/hatch{
+	icon_state = "door_locked";
+	id_tag = "emergency path";
+	locked = 1;
+	req_access = null;
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"uLk" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/firstaid/adv{
+	starts_with = list(/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment)
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	starts_with = list(/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment,/obj/item/stack/medical/advanced/ointment)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"uLC" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/command/monitorroom)
+"uMp" = (
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"uNc" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/grey/bordercorner,
+/obj/item/device/radio/phone,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"uNR" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"uOb" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/northhallway)
+"uOQ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/security,
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/hallway)
+"uPe" = (
+/obj/structure/filingcabinet,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"uPg" = (
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"uQl" = (
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"uQs" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm1)
+"uRd" = (
+/obj/machinery/vending/security{
+	description_fluff = "This security vending machine is kindly provided by the-... Sorry, how do you spell this company's name again?";
+	product_ads = "Crack capitalist skulls!;Beat some heads in!;Don't forget - harm is good!;Your weapons are right here.;Handcuffs!;Freeze, scumbag!;Don't shoot me bro!;Shoot them, bro.;Why not have a slice of sandwich.";
+	products = list(/obj/item/weapon/handcuffs = 12, /obj/item/weapon/grenade/flashbang = 4, /obj/item/weapon/reagent_containers/food/snacks/sandwich = 12, /obj/item/weapon/storage/box/evidence = 6,/obj/item/ammo_magazine/makarov = 18,/obj/item/weapon/gun/projectile/serdy_pistols/makarov = 4,/obj/item/weapon/melee/classic_baton = 8)
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_lockerroom)
+"uRx" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/fence/door,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"uRE" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"uRO" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Cafeteria"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/service/cafeteria)
+"uUj" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"uUm" = (
+/obj/item/device/radio/phone,
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"uUw" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/hallway)
+"uUD" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"uUV" = (
+/obj/structure/flora/grass/green,
+/obj/structure/flora/grass/both,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"uWW" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/machinery/vending/cigarette{
+	dir = 1;
+	prices = null
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"uXm" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"uXs" = (
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/unary/outlet_injector{
+	dir = 4;
+	frequency = 1443;
+	icon_state = "on";
+	id = "air_in";
+	use_power = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"uYe" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"uYx" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"uYG" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/engineering/primary_storage)
+"uYY" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell)
+"uZn" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"vaD" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"vaJ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"vaM" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"vaV" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"vaZ" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm7)
+"vbE" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"vcq" = (
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74/variantun,
+/obj/structure/closet/secure_closet/guncabinet,
+/obj/item/ammo_magazine/ak74,
+/obj/item/ammo_magazine/ak74,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"vcx" = (
+/turf/simulated/floor,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"vde" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor,
+/area/awaymission/snowfield/checkpointunpowered)
+"vdv" = (
+/obj/structure/table/reinforced,
+/obj/item/device/geiger,
+/obj/item/device/geiger,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"vdz" = (
+/obj/structure/boulder,
+/obj/structure/boulder,
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/cavern)
+"vdE" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm10)
+"vek" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"vep" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"veE" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/dispenser{
+	oxygentanks = 0;
+	phorontanks = 0
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"vfl" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"vfB" = (
+/obj/machinery/door/airlock/glass_security,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"vfM" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/item/weapon/storage/box/donut,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"vfN" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/machinery/appliance/cooker/grill,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"vfO" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"vgl" = (
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"vgM" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"vgV" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"vgX" = (
+/obj/structure/table/rack,
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"vhm" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms13";
+	name = "Room 13"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/dorms/dorm13)
+"vhC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/wall,
+/area/awaymission/snowfield/checkpoint)
+"vir" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"viw" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"viJ" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield bsa observation window";
+	name = "Observation Window Lockdown";
+	pixel_x = -5;
+	req_access = list(20,30)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield bsa gateway path";
+	name = "BSA-Gateway Podlock";
+	pixel_x = 5;
+	req_access = list(20,30)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"viX" = (
+/obj/structure/flora/bush,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"vjy" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/weapon/storage/firstaid/adv,
+/obj/item/weapon/storage/firstaid/adv,
+/obj/item/weapon/storage/firstaid/clotting,
+/obj/item/device/defib_kit/compact/combat/loaded,
+/obj/item/device/defib_kit/compact/combat/loaded,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"vjJ" = (
+/obj/structure/outcrop/coal,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"vjO" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/structure/bookcase/manuals/engineering,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"vke" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/southleft{
+	req_access = list(1)
+	},
+/obj/machinery/door/window/northleft{
+	req_access = list(1)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield sec front blast";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/frontgate)
+"vkB" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"vkG" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/item/ammo_magazine/ppsh,
+/obj/item/ammo_magazine/ppsh,
+/obj/item/ammo_magazine/ppsh,
+/obj/item/ammo_magazine/ppsh,
+/obj/item/ammo_magazine/ppsh,
+/obj/item/ammo_magazine/ppsh,
+/obj/item/ammo_magazine/ppsh,
+/obj/item/ammo_magazine/ppsh,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/eastright{
+	name = "Ammo"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"vmX" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	health = 1e+006
+	},
+/obj/structure/window/reinforced/full{
+	health = 1e+006
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"vny" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"vnP" = (
+/turf/simulated/wall,
+/area/awaymission/snowfield/checkpointunpowered)
+"vnW" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"vot" = (
+/obj/machinery/vending/assist{
+	dir = 4;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"vrX" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm3)
+"vtp" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/brigdoor/southleft{
+	name = "Warden's Desk";
+	req_access = list(3)
+	},
+/obj/machinery/door/window/brigdoor/northleft,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/warden)
+"vuw" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"vuC" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central1,
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"vvh" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms6";
+	name = "Room 6"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm6)
+"vvo" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm2)
+"vvO" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Engine Room";
+	req_one_access = list(1,11)
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfieldenglockdown";
+	opacity = 0
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"vwg" = (
+/obj/structure/catwalk,
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	health = 0;
+	name = "BSA Monitoring Room";
+	req_one_access = list(1,11,20,47,56)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa MR";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"vyf" = (
+/obj/structure/closet/crate/hydroponics{
+	desc = "All you need to start your own honey farm.";
+	name = "beekeeping crate"
+	},
+/obj/item/beehive_assembly,
+/obj/item/bee_smoker,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/bee_pack,
+/obj/item/weapon/tool/crowbar,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"vyo" = (
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/server)
+"vzF" = (
+/obj/structure/table/rack,
+/obj/item/weapon/gun/projectile/automatic/serdy/akm,
+/obj/item/weapon/gun/projectile/automatic/serdy/akm,
+/obj/item/weapon/gun/projectile/automatic/serdy/akm,
+/obj/item/weapon/gun/projectile/automatic/serdy/akm,
+/obj/item/weapon/gun/projectile/automatic/serdy/krinkov,
+/obj/item/weapon/gun/projectile/automatic/serdy/krinkov,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "Armament"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"vzN" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm5)
+"vAc" = (
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"vAF" = (
+/obj/structure/table/steel,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/tech_storage)
+"vBj" = (
+/obj/machinery/door/window/northright{
+	req_access = list(1)
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/evidence_storage)
+"vBW" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"vCb" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm15)
+"vCN" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/box/syringegun,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"vCY" = (
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/hallway)
+"vDh" = (
+/obj/structure/closet/crate/freezer,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"vDF" = (
+/turf/simulated/mineral,
+/area/awaymission/snowfield/cavern)
+"vDR" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm2)
+"vDT" = (
+/obj/structure/catwalk,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/item/clothing/mask/breath/anesthetic,
+/obj/item/weapon/tank/anesthetic,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"vDZ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"vFs" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/testroom)
+"vFE" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"vFQ" = (
+/obj/structure/flora/rocks2,
+/obj/structure/flora/grass/green,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"vGq" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"vGs" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"vGA" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/buildable{
+	charge = null;
+	cur_coils = 3;
+	input_attempt = 1;
+	input_level = 500000;
+	output_level = 350000
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/solarshack)
+"vGX" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"vHd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"vIp" = (
+/obj/machinery/atmospherics/pipe/tank{
+	desc = "A large vessel containing huge amount of water.";
+	icon_state = "o2_map";
+	name = "Water Tank"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"vIw" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"vII" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"vJm" = (
+/obj/machinery/door/airlock{
+	name = "Restroom"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"vJH" = (
+/obj/structure/table/glass,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"vKm" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm5)
+"vKF" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"vKJ" = (
+/obj/machinery/computer/med_data{
+	req_one_access = list(1,5,4,29)
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"vKZ" = (
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"vLR" = (
+/obj/structure/closet/crate/hydroponics{
+	desc = "All you need to start your own honey farm.";
+	name = "beekeeping crate"
+	},
+/obj/item/beehive_assembly,
+/obj/item/bee_smoker,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/bee_pack,
+/obj/item/weapon/tool/crowbar,
+/obj/structure/cable/yellow,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"vNa" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/front_desk)
+"vNd" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/fractal_reactor/fluff/smes,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/panicroom)
+"vNH" = (
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield emergency bunk";
+	name = "Path Blocker Control";
+	pixel_y = 23;
+	req_access = list(53)
+	},
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm13)
+"vOj" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"vOs" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"vOx" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"vOQ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green,
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"vPa" = (
+/obj/item/weapon/ore/glass,
+/obj/item/weapon/ore/coal,
+/obj/item/weapon/ore/coal,
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/outside)
+"vPl" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/lightgrey{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"vQl" = (
+/obj/structure/table/standard,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"vRM" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "5"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"vRR" = (
+/obj/machinery/vending/hydronutrients{
+	dir = 8;
+	pixel_x = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"vSW" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "23"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"vUF" = (
+/obj/structure/sink{
+	pixel_y = 16
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/security_cell)
+"vUR" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/staff_room)
+"vVk" = (
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor,
+/area/awaymission/snowfield/checkpointunpowered)
+"vVl" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/machinery/computer/arcade/battle,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/service/publicstaff)
+"vVq" = (
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/item/weapon/storage/box/beakers,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"vVX" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms1";
+	name = "Room 1"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm1)
+"vWe" = (
+/obj/machinery/atmospherics/pipe/simple/visible/blue{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/engine)
+"vWo" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield command armory";
+	name = "Command Armory Access";
+	req_one_access = list(3,20)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"vWI" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white,
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/machinery/appliance/cooker/oven,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"vXq" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 26
+	},
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"vYw" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	health = null;
+	icon_state = "pdoor0";
+	id = "snowfield bsa MCA";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"vZe" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"vZy" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm14)
+"vZC" = (
+/obj/effect/floor_decal/borderfloor,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"vZL" = (
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"vZQ" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/tank/air,
+/obj/item/clothing/mask/breath,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"wac" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm8)
+"wad" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm14)
+"wav" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/toolbox/emergency,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"waB" = (
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"waU" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"wbr" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/northhallway)
+"wbG" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"wbN" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"wcP" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/hallway)
+"wdf" = (
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"wdl" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"wdB" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway2)
+"wdD" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"weG" = (
+/obj/machinery/power/solar,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"weR" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"wfG" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"wfM" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/catwalk,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"whF" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm8)
+"whG" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/surgical/circular_saw{
+	pixel_y = 8
+	},
+/obj/item/weapon/surgical/surgicaldrill,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"whW" = (
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"wiK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"wiQ" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/yellow/border,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/public/toolstorage1)
+"wjL" = (
+/obj/item/weapon/stamp/ward,
+/obj/item/weapon/stamp/denied{
+	pixel_x = 5
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"wjU" = (
+/obj/structure/catwalk,
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/tape_roll,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"wkh" = (
+/obj/structure/cable/yellow,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm11)
+"wlf" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"wmy" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/front_desk)
+"wnn" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/obj/machinery/iv_drip,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"wnX" = (
+/obj/structure/bed/chair/comfy/brown{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/awaymission/snowfield/engineering/staff_room)
+"wnY" = (
+/obj/structure/flora/tree/dead,
+/obj/structure/flora/grass/green,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"woT" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/public/toolstroage2)
+"woV" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"wpf" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
+"wpl" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/testroom)
+"wpr" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm2)
+"wpC" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm10)
+"wpN" = (
+/obj/structure/table/steel,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/tech_storage)
+"wqu" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"wqI" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	health = null;
+	icon_state = "pdoor0";
+	id = "snowfield fourth pathway lock";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"wrR" = (
+/obj/structure/railing,
+/turf/simulated/floor/outdoors/dirt,
+/area/awaymission/snowfield/outside)
+"wsx" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms11";
+	name = "Room 11"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm11)
+"wtZ" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/item/weapon/soap,
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/closet/secure_closet/medical3{
+	req_access = list(33);
+	starts_with = list(/obj/item/clothing/under/rank/medical,/obj/item/clothing/under/rank/nurse,/obj/item/clothing/under/rank/orderly,/obj/item/clothing/suit/storage/toggle/labcoat,/obj/item/clothing/suit/storage/toggle/labcoat/modern,/obj/item/clothing/suit/storage/toggle/fr_jacket,/obj/item/device/radio/headset/headset_med,/obj/item/device/radio/headset/headset_med/alt,/obj/item/clothing/suit/storage/hooded/wintercoat/medical,/obj/item/clothing/shoes/boots/winter/medical,/obj/item/clothing/under/rank/nursesuit,/obj/item/clothing/head/nursehat,/obj/item/weapon/storage/box/freezer = 3, /obj/item/weapon/storage/belt/medical)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"wuM" = (
+/obj/structure/closet/secure_closet/medical2,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"wvU" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"wwm" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"wwy" = (
+/obj/item/weapon/paper/awaygate/snowfield/diary,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"wwz" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm7)
+"wwS" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm8)
+"wxc" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"wxz" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "empty west bump";
+	pixel_x = -24;
+	start_charge = 0
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/public/toolstroage2)
+"wxW" = (
+/obj/machinery/door/blast/regular{
+	id = "snowfield second blast"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"wzI" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"wAu" = (
+/obj/structure/filingcabinet,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/frontgate)
+"wAV" = (
+/obj/structure/closet/wardrobe/chemistry_white,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"wBv" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"wBP" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"wBU" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock{
+	name = "Custodial Closet";
+	req_access = null
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/janitor)
+"wCq" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway)
+"wDs" = (
+/obj/machinery/biogenerator,
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"wDw" = (
+/obj/structure/fence/door,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"wEG" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/bridge)
+"wEK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"wFJ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering Airlock (Class 5E)";
+	req_one_access = list(1,11)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/locker_room)
+"wFO" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm2)
+"wGu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway)
+"wHr" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"wIq" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm7)
+"wIS" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small/flicker{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"wIT" = (
+/obj/item/weapon/stool,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm5)
+"wJi" = (
+/obj/machinery/smartfridge/produce,
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/service/hydro)
+"wJl" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"wJX" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/southhallway)
+"wKo" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"wKA" = (
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"wKJ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/warden)
+"wLo" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/public/toolstroage2)
+"wLW" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 8;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/bridge)
+"wMf" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"wMn" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"wNc" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering{
+	req_access = null;
+	req_one_access = list(1,10)
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfieldenglockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/monitor_room)
+"wNi" = (
+/obj/structure/toilet,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/patient_restroom)
+"wNk" = (
+/obj/structure/table/rack,
+/obj/machinery/light_construct/small{
+	dir = 8
+	},
+/obj/item/weapon/pickaxe,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"wNv" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"wNO" = (
+/obj/machinery/door/airlock/engineering{
+	req_access = null;
+	req_one_access = list(1,10)
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/staff_room)
+"wOB" = (
+/obj/machinery/door/window/northright{
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled/old_tile/gray,
+/area/awaymission/snowfield/security/evidence_storage)
+"wPg" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
+"wPG" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"wQa" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm5)
+"wQd" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/engineering/secure_tech_storage)
+"wQl" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = 1e+006
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "snowfield bsa observation window";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced/full{
+	health = 1e+006
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/command/bsa)
+"wQH" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"wSr" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"wSz" = (
+/obj/structure/cable/heavyduty,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/checkpoint)
+"wTm" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"wTC" = (
+/obj/machinery/door/blast/gate/open{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"wUf" = (
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"wUo" = (
+/obj/structure/catwalk,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/medical/storage_room)
+"wUO" = (
+/obj/machinery/power/solar_control,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/solarshack)
+"wVE" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border,
+/obj/effect/decal/cleanable/flour,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"wVW" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/front_desk)
+"wWo" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm6)
+"wWw" = (
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield gateway";
+	name = "Gateway Entry Access";
+	req_one_access = list(1,10,20)
+	},
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"wWx" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"wWz" = (
+/obj/machinery/door/airlock/security,
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/seconddesk)
+"wWN" = (
+/obj/structure/fireaxecabinet{
+	pixel_y = 32
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"wXh" = (
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"wXm" = (
+/obj/structure/outcrop/iron,
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/cavern)
+"wXA" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm5)
+"wXF" = (
+/obj/effect/mine/frag,
+/obj/structure/flora/grass/brown,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"wXM" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/commandarmory)
+"wXV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"wYC" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm13)
+"wZf" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm6)
+"wZh" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/monitorroom)
+"wZo" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"wZE" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/item/weapon/material/ashtray/glass,
+/obj/item/weapon/pen/red,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"wZI" = (
+/obj/structure/flora/pottedplant/large,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"wZM" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"wZT" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"xad" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/dorms/dorm9)
+"xai" = (
+/obj/structure/table/rack,
+/obj/item/weapon/grenade/smokebomb,
+/obj/item/weapon/grenade/smokebomb,
+/obj/item/weapon/grenade/smokebomb,
+/obj/item/weapon/grenade/smokebomb,
+/obj/item/weapon/grenade/smokebomb,
+/obj/item/weapon/grenade/smokebomb,
+/obj/item/weapon/grenade/smokebomb,
+/obj/item/weapon/grenade/smokebomb,
+/obj/item/weapon/grenade/smokebomb,
+/obj/item/weapon/grenade/smokebomb,
+/obj/item/weapon/grenade/smokebomb,
+/obj/item/weapon/grenade/smokebomb,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"xaj" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/mask/balaclava,
+/obj/item/clothing/mask/balaclava,
+/obj/item/clothing/suit/armor/pcarrier/light,
+/obj/item/clothing/suit/armor/pcarrier/light,
+/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/army,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/shoes/boots/marine,
+/obj/item/clothing/shoes/boots/marine,
+/obj/item/clothing/shoes/boots/marine,
+/obj/item/clothing/shoes/boots/marine,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/panicroom)
+"xam" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm6)
+"xav" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"xaD" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 6
+	},
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"xaF" = (
+/obj/machinery/seed_storage/garden{
+	dir = 8;
+	pixel_x = 5
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/awaymission/snowfield/service/hydro)
+"xaM" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border,
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"xaT" = (
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "empty east bump";
+	pixel_x = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
+"xbN" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_access = null;
+	req_one_access = list(1,28)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/service/kitchen)
+"xbR" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"xbT" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"xcE" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"xcS" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"xdC" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"xeg" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"xen" = (
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/public/toolstorage1)
+"xeQ" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor,
+/area/awaymission/snowfield/checkpoint)
+"xfF" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/monitorroom)
+"xfQ" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms14";
+	name = "Room 14"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm14)
+"xfZ" = (
+/obj/machinery/door/airlock/medical{
+	name = "Patient Room";
+	req_one_access = list(1,5)
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/patients)
+"xge" = (
+/obj/machinery/gateway{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"xgf" = (
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"xgl" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"xgt" = (
+/obj/structure/boulder,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"xgK" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"xgX" = (
+/obj/item/weapon/storage/belt/security/tactical,
+/obj/item/weapon/storage/belt/security/tactical,
+/obj/item/weapon/storage/belt/security/tactical,
+/obj/item/weapon/storage/belt/security/tactical,
+/obj/item/weapon/storage/belt/security/tactical,
+/obj/item/weapon/storage/belt/security/tactical,
+/obj/item/weapon/storage/belt/security/tactical,
+/obj/item/weapon/storage/belt/security/tactical,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/clothing/mask/balaclava,
+/obj/item/clothing/mask/balaclava,
+/obj/item/clothing/mask/balaclava,
+/obj/item/clothing/mask/balaclava,
+/obj/item/clothing/mask/balaclava,
+/obj/item/clothing/mask/balaclava,
+/obj/item/clothing/mask/balaclava,
+/obj/item/clothing/mask/balaclava,
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"xhl" = (
+/turf/simulated/wall{
+	can_open = 1
+	},
+/area/awaymission/snowfield/emergency_pathway/EP_powered)
+"xhV" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"xir" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm7)
+"xiw" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/medical/hallway)
+"xjh" = (
+/obj/machinery/door/window/westright{
+	name = "Shower"
+	},
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/structure/window/reinforced,
+/obj/structure/curtain/open/shower/security,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/security/security_restroom)
+"xjy" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey,
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/service/cafeteria)
+"xjA" = (
+/obj/structure/table/glass,
+/obj/item/weapon/soap,
+/obj/item/weapon/soap,
+/obj/item/weapon/soap,
+/obj/item/weapon/soap,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"xjH" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/interrogation)
+"xjQ" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet{
+	closet_appearance = /decl/closet_appearance/bio;
+	name = "Level-3 Biohazard Closet";
+	opened = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"xke" = (
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
+"xkl" = (
+/turf/simulated/mineral/floor/cave,
+/area/awaymission/snowfield/cavern)
+"xkM" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
+"xkO" = (
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/item/weapon/reagent_containers/glass/bucket/wood,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"xkV" = (
+/obj/machinery/chemical_dispenser/biochemistry/full,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/chemistry)
+"xlE" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "Armament"
+	},
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74/variantun,
+/obj/item/weapon/gun/projectile/automatic/serdy/ak74/variantun,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"xlS" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair/wheelchair,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
+"xmc" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals7{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "empty north bump";
+	pixel_y = 24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell)
+"xmk" = (
+/obj/structure/fence/cut/large{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"xmq" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control-switch for Surgery.";
+	id = "Operating Theatre";
+	name = "Surgery";
+	pixel_x = 23;
+	req_one_access = list(1,45)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/hallway)
+"xmu" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "6"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"xnd" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"xoa" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/item/weapon/pen{
+	pixel_y = 4
+	},
+/obj/item/weapon/pen/blue,
+/obj/item/weapon/material/ashtray/glass,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/lobby)
+"xod" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/engineering/staff_room)
+"xoN" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/masks,
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/surgery)
+"xpb" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/door/window/northright{
+	req_access = list(1)
+	},
+/obj/machinery/door/window/southright{
+	req_access = list(1)
+	},
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/seconddesk)
+"xph" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light_construct/small{
+	dir = 4
+	},
+/obj/item/weapon/card/id/syndicate,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/checkpointunpowered)
+"xqL" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"xqP" = (
+/obj/structure/table/reinforced,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine)
+"xqW" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Armoury Tactical Equipment";
+	req_access = list(3);
+	req_one_access = list(3)
+	},
+/obj/machinery/door/blast/regular{
+	id = "Armoury";
+	name = "Emergency Access"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"xsa" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
+"xsl" = (
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
+"xsF" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/southhallway)
+"xsM" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "SMES Access";
+	req_access = list(1,11);
+	req_one_access = null
+	},
+/obj/structure/cable/heavyduty{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	id = "snowfield command SMES lockdown"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway_substation)
+"xtd" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/outdoors/rocks,
+/area/awaymission/snowfield/cavern)
+"xtj" = (
+/obj/machinery/door/airlock{
+	name = "Unit 4"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"xtM" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm12)
+"xuc" = (
+/obj/structure/table/wooden_reinforced,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm14)
+"xuh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell)
+"xuw" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm15)
+"xuE" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"xuF" = (
+/obj/item/weapon/ore/coal,
+/obj/structure/boulder,
+/turf/simulated/floor/outdoors/rocks/caves,
+/area/awaymission/snowfield/cavern)
+"xuZ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"xvh" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/engineering/engine)
+"xvl" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/item/weapon/reagent_containers/glass/bucket/wood,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"xwl" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"xxj" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/monitorroom)
+"xxz" = (
+/obj/machinery/vending/coffee{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"xxF" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"xxU" = (
+/obj/structure/table/steel_reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
+"xyE" = (
+/obj/structure/flora/grass/both,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/outside)
+"xzm" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
+"xzW" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
+"xAd" = (
+/obj/structure/cable/heavyduty{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/heavyduty{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"xAe" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm12)
+"xAk" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 10
+	},
+/obj/structure/reagent_dispensers/space_cleaner{
+	pixel_x = -30
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/table/steel,
+/obj/item/device/radio/phone,
+/obj/machinery/power/apc{
+	name = "empty south bump";
+	pixel_y = -24;
+	start_charge = 0
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/service/janitor)
+"xBH" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor,
+/area/awaymission/snowfield/security/security_cell)
+"xBW" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"xDY" = (
+/obj/random/tech_supply,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
+"xEc" = (
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Cells";
+	req_access = list(1)
+	},
+/turf/simulated/floor/tiled/red,
+/area/awaymission/snowfield/security/security_cell_hallway)
+"xEt" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/sub_chamber)
+"xFs" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/radio/phone,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
+"xGh" = (
+/obj/structure/table/steel_reinforced,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/dorm16)
+"xGx" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/command{
+	req_one_access = list(19,47)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/observatory_path)
+"xGV" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpoint)
+"xIj" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/white{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/service/kitchen)
+"xIs" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/firstaid/regular{
+	starts_with = list(/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/weapon/storage/pill_bottle/paracetamol,/obj/item/weapon/storage/pill_bottle/iron)
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
+"xIQ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
+"xJj" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags,
+/obj/item/weapon/storage/box/bodybags,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"xJr" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"xKN" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway)
+"xMy" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/frontgate_substation)
+"xMA" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/southhallway)
+"xMF" = (
+/obj/structure/morgue/crematorium{
+	dir = 1;
+	id = "Chapelburn"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/morgue)
+"xMP" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm8)
+"xNQ" = (
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/checkpointunpowered)
+"xNX" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"xPt" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/outside)
+"xPH" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
+"xPQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/obj/structure/coatrack,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"xPZ" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/firingrange)
+"xQd" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm13)
+"xQk" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/centerhallway)
+"xRh" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/computer/skills{
+	req_one_access = list(1,19)
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"xSb" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm2)
+"xSq" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/engineering/tech_storage)
+"xSU" = (
+/obj/structure/railing,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bridge)
+"xTu" = (
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"xTB" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/observatory_path)
+"xTJ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/yellow/border{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/public/toolstorage1)
+"xTP" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm12)
+"xUj" = (
+/obj/machinery/door/blast/regular{
+	id = "snowfield front blast"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/checkpointhallway)
+"xUz" = (
+/obj/machinery/shower{
+	pixel_y = 18
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm15)
+"xUD" = (
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/surgery)
+"xVB" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"xVV" = (
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/command/commandarmory)
+"xWw" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "30"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"xXB" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm5)
+"xXH" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/monitorroom)
+"xXJ" = (
+/obj/effect/floor_decal/corner/green/diagonal,
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/multi,
+/obj/item/weapon/pen/multi,
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/staff_room)
+"xYC" = (
+/obj/structure/table/rack,
+/obj/item/weapon/material/knife/tacknife/combatknife,
+/obj/item/weapon/material/knife/tacknife/combatknife,
+/obj/item/weapon/material/knife/tacknife/combatknife,
+/obj/item/weapon/material/knife/tacknife/combatknife,
+/obj/item/weapon/material/knife/tacknife/combatknife,
+/obj/item/weapon/material/knife/tacknife/combatknife,
+/obj/item/weapon/material/knife/tacknife/combatknife,
+/obj/item/weapon/material/knife/tacknife/combatknife,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"xYN" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/southhallway)
+"xYW" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/turcarpet,
+/area/awaymission/snowfield/medical/staff_room)
+"xZV" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm11)
+"yam" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/dorms/dorm1)
+"ybj" = (
+/obj/effect/floor_decal/corner/yellow/diagonal,
+/obj/structure/reagent_dispensers/water_cooler/full{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/engineering/staff_room)
+"ybq" = (
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"ybW" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"ycq" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/item/weapon/soap,
+/obj/structure/closet/secure_closet/medical3{
+	req_access = list(33);
+	starts_with = list(/obj/item/clothing/under/rank/medical,/obj/item/clothing/under/rank/nurse,/obj/item/clothing/under/rank/orderly,/obj/item/clothing/suit/storage/toggle/labcoat,/obj/item/clothing/suit/storage/toggle/labcoat/modern,/obj/item/clothing/suit/storage/toggle/fr_jacket,/obj/item/device/radio/headset/headset_med,/obj/item/device/radio/headset/headset_med/alt,/obj/item/clothing/suit/storage/hooded/wintercoat/medical,/obj/item/clothing/shoes/boots/winter/medical,/obj/item/clothing/under/rank/nursesuit,/obj/item/clothing/head/nursehat,/obj/item/weapon/storage/box/freezer = 3, /obj/item/weapon/storage/belt/medical)
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
+"ycX" = (
+/obj/machinery/door/airlock/glass_security,
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"yev" = (
+/obj/effect/floor_decal/steeldecal/monofloor,
+/obj/effect/floor_decal/steeldecal/steel_decals_central1,
+/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	health = null;
+	icon_state = "pdoor0";
+	id = "snowfield gateway";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/gateway)
+"yeM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/awaymission/snowfield/checkpointunpowered)
+"yeW" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/grey/bordercorner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"yfe" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/lobby)
+"yft" = (
+/obj/structure/artilleryplaceholder{
+	icon_state = "13"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"yfY" = (
+/obj/structure/closet/secure_closet/personal,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/dorms/dorm6)
+"ygP" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/bsa)
+"ygS" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/sub_chamber)
+"ygT" = (
+/obj/machinery/door/airlock{
+	name = "Unit 5"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/cafeteria_restroom)
+"ygU" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"yih" = (
+/obj/structure/table/woodentable,
+/obj/item/device/radio/phone,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/awaymission/snowfield/security/observatory)
+"yis" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals5{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/testroom)
+"yiv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
+"yjw" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/engineering/hallway)
+"yjP" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/heavy_armory)
+"ykE" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks,
+/obj/item/ammo_magazine/clip/sks/ap,
+/obj/item/ammo_magazine/clip/sks/ap,
+/obj/item/ammo_magazine/clip/sks/ap,
+/obj/item/ammo_magazine/clip/sks/ap,
+/obj/item/ammo_magazine/clip/sks/ap,
+/obj/item/ammo_magazine/clip/sks/ap,
+/obj/item/ammo_magazine/clip/sks/ap,
+/obj/item/ammo_magazine/clip/sks/ap,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/door/window/brigdoor/eastright{
+	name = "Ammo"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory)
+"ykS" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
+"ylp" = (
+/obj/machinery/door/airlock{
+	name = "Unit 2"
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/medical/medical_restroom)
+"ylN" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
+"ylU" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorms12";
+	name = "Room 12"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/dorms/dorm12)
+
+(1,1,1) = {"
+dmZ
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+"}
+(2,1,1) = {"
+jJH
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+szB
+"}
+(3,1,1) = {"
+jZp
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(4,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(5,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(6,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(7,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(8,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(9,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(10,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(11,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+uoM
+uoM
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(12,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+vZL
+vZL
+rWB
+vZL
+vZL
+vZL
+vZL
+vZL
+nLz
+vZL
+vZL
+vZL
+vZL
+vZL
+rWB
+vZL
+vZL
+vZL
+vZL
+vZL
+rWB
+vZL
+uLb
+vZL
+vZL
+vZL
+rWB
+vZL
+vZL
+vZL
+vZL
+vZL
+rWB
+vZL
+vZL
+vZL
+vZL
+vZL
+vZL
+vZL
+rWB
+vZL
+vZL
+vZL
+vZL
+nGn
+uoM
+uoM
+bVG
+bVG
+uww
+bVG
+uww
+bVG
+uww
+bVG
+ukP
+lom
+lom
+bVG
+bVG
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(13,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+vZL
+nGn
+uoM
+uoM
+bVG
+bVG
+jsR
+bVG
+iAZ
+bVG
+nIq
+bVG
+bAP
+bAP
+bAP
+bVG
+bVG
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(14,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+qat
+bUb
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+rKt
+hUz
+bLK
+aNJ
+aNJ
+oPW
+ceH
+nGn
+jlx
+nGn
+nGn
+nGn
+nGn
+nGn
+lfp
+bAP
+bAP
+bAP
+bAP
+oQO
+bAP
+bAP
+vny
+bVG
+bVG
+uvm
+uvm
+uvm
+uvm
+uvm
+uvm
+uvm
+uvm
+uvm
+uvm
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(15,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bUb
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+imC
+pun
+wXF
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+gbz
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xvh
+xvh
+xvh
+xvh
+xvh
+xvh
+xvh
+xvh
+xvh
+xvh
+xvh
+xvh
+xvh
+xvh
+rKt
+jyn
+xen
+xen
+xen
+xen
+wiQ
+xhl
+vZL
+vZL
+vZL
+uLb
+vZL
+xhl
+ivC
+bAP
+bAP
+bAP
+bAP
+oQO
+bAP
+krl
+bVG
+bVG
+bVG
+uvm
+uvm
+uvm
+uvm
+uvm
+uvm
+uvm
+uvm
+uvm
+adq
+adq
+adq
+adq
+adq
+sXc
+sXc
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(16,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+uyr
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+imC
+xyE
+pun
+xyE
+xyE
+qat
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xvh
+xvh
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+rKt
+xTJ
+qNN
+mag
+xen
+xen
+riQ
+nGn
+vZL
+nGn
+nGn
+nGn
+nGn
+nGn
+iMC
+bVG
+ygT
+bVG
+xtj
+bVG
+bAP
+bAP
+xjA
+bVG
+hdq
+wbG
+gLu
+wbG
+wbG
+wbG
+wbG
+gLu
+eNU
+uvm
+adq
+adq
+adq
+adq
+adq
+sXc
+sXc
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(17,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+pun
+imC
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+wXF
+pun
+pun
+pun
+pun
+xyE
+qYo
+imC
+xyE
+qat
+pun
+bUb
+pun
+qat
+pun
+qat
+pun
+imC
+pun
+pun
+bUb
+bUb
+imC
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xvh
+xvh
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+qwU
+siI
+liC
+uEZ
+rKt
+jyn
+xen
+xen
+xen
+xen
+aEn
+nGn
+uLb
+nGn
+vDF
+vDF
+vDF
+bVG
+xkO
+bVG
+fnW
+bVG
+fnW
+bVG
+bAP
+pAB
+kUF
+vJm
+vGq
+nHI
+tPx
+tPx
+tPx
+tPx
+tPx
+tPx
+gQT
+uvm
+jPC
+qbX
+viw
+viw
+fnD
+sXc
+sXc
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(18,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+imC
+pun
+pun
+xyE
+fKO
+bsH
+bsH
+bsH
+bsH
+bsH
+aKJ
+bsH
+bsH
+bsH
+aKJ
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+uyr
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xvh
+xvh
+uEZ
+uEZ
+cWo
+uEZ
+cWo
+uEZ
+cWo
+uEZ
+vIp
+bGr
+eUQ
+uEZ
+rKt
+emV
+hgs
+ipm
+iDk
+mTR
+qme
+nGn
+vZL
+nGn
+fGh
+fGh
+fGh
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+bVG
+fwu
+gvJ
+ePe
+gzE
+ePe
+ePe
+gzE
+ePe
+gQT
+uvm
+hOE
+kUc
+sVq
+sVq
+neq
+sXc
+sXc
+sXc
+sXc
+sXc
+sXc
+sXc
+vDR
+vDR
+vDR
+vDR
+vDR
+vDR
+jBQ
+jBQ
+jBQ
+jBQ
+jBQ
+jBQ
+sWl
+sWl
+sWl
+sWl
+sWl
+sWl
+sWl
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(19,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+imC
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+uyr
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xvh
+xvh
+uEZ
+uEZ
+ttQ
+uEZ
+ttQ
+uEZ
+ttQ
+uEZ
+dJl
+vWe
+mCK
+uEZ
+rKt
+rKt
+rKt
+rKt
+iYl
+rKt
+rKt
+nGn
+xhl
+nGn
+fGh
+fGh
+fGh
+fGh
+nos
+beI
+nos
+nos
+nos
+nos
+nos
+beI
+nos
+toJ
+fwu
+gvJ
+bJC
+bJC
+bJC
+bJC
+bJC
+bJC
+gQT
+uvm
+hOE
+kUc
+sVq
+sVq
+ufA
+sXc
+sXc
+sXc
+sXc
+sXc
+sXc
+sXc
+vDR
+vDR
+vDR
+vDR
+vDR
+vDR
+jBQ
+jBQ
+jBQ
+jBQ
+jBQ
+jBQ
+sWl
+sWl
+sWl
+sWl
+sWl
+sWl
+sWl
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(20,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+bUb
+bUb
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+imC
+pun
+pun
+mFY
+pgn
+iNn
+pun
+pun
+weG
+dnp
+sRm
+pun
+pun
+qbN
+vKF
+sRm
+pun
+pun
+qYo
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xvh
+xvh
+uEZ
+uEZ
+jQq
+dUp
+jQq
+dUp
+jQq
+dUp
+dJl
+vWe
+lxS
+uEZ
+tzg
+tzg
+tzg
+hMS
+evZ
+fnS
+fuQ
+fGh
+pbJ
+pbJ
+pbJ
+fGh
+edc
+fGh
+nos
+udd
+udd
+udd
+udd
+udd
+udd
+udd
+nos
+toJ
+xjy
+gvJ
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+lDs
+uvm
+vVl
+kUc
+sVq
+sVq
+mOn
+sXc
+jmU
+yam
+sXc
+kxV
+ncZ
+sXc
+vvo
+wFO
+vDR
+ciA
+tpu
+vDR
+ddJ
+ojQ
+jBQ
+jfa
+hvD
+jBQ
+orY
+jtE
+sWl
+oru
+gBZ
+sWl
+sWl
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(21,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+qYo
+pun
+pun
+imC
+pun
+olD
+mwo
+iNn
+pun
+pun
+weG
+cGS
+sRm
+pun
+pun
+qbN
+cGS
+iNn
+pun
+pun
+qYo
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+uEZ
+uEZ
+jzR
+jqn
+dzR
+jqn
+dzR
+jqn
+jDu
+vWe
+lqv
+uEZ
+tzg
+tzg
+tzg
+hMS
+fYG
+sUP
+sUP
+rNL
+tec
+fYo
+fYo
+eFM
+tfG
+fGh
+nos
+udd
+nos
+nos
+nos
+nos
+nos
+udd
+nos
+toJ
+jEJ
+gvJ
+tPx
+tPx
+tPx
+tPx
+tPx
+tPx
+gQT
+uvm
+hOE
+kUc
+sVq
+sVq
+fik
+sXc
+pNI
+uGe
+esc
+pBV
+pBV
+sXc
+fht
+iFm
+bBr
+ter
+ter
+vDR
+oDj
+eyW
+iqV
+nTe
+nTe
+jBQ
+lID
+uFu
+dJq
+iuB
+iuB
+sWl
+sWl
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(22,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+bUb
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+cGS
+iNn
+pun
+pun
+qbN
+cGS
+sRm
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+wIS
+vZL
+uLb
+vZL
+vZL
+vZL
+rWB
+vZL
+vZL
+vZL
+vZL
+dxs
+vZL
+vZL
+vZL
+vZL
+vZL
+vZL
+rWB
+vZL
+vZL
+vZL
+vZL
+vZL
+nGn
+uEZ
+uEZ
+qpE
+aSi
+oDD
+aSi
+oDD
+aSi
+pBA
+kjm
+vdv
+uEZ
+tzg
+tzg
+tzg
+hMS
+qne
+uOb
+ned
+fGh
+gLD
+fYo
+fYo
+fGh
+fGh
+fGh
+hPe
+udd
+udd
+udd
+udd
+udd
+udd
+udd
+dub
+toJ
+jEJ
+gvJ
+ePe
+gzE
+ePe
+ePe
+gzE
+ePe
+gQT
+uvm
+pOV
+sVq
+sVq
+sVq
+sYg
+sXc
+sXc
+sXc
+sXc
+pBV
+aNw
+sXc
+vDR
+vDR
+vDR
+ter
+fIy
+vDR
+jBQ
+jBQ
+jBQ
+nTe
+eeE
+jBQ
+sWl
+sWl
+sWl
+iuB
+rou
+sWl
+sWl
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(23,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+imC
+pun
+xyE
+pun
+wXF
+pun
+pun
+pun
+pun
+pun
+qat
+pun
+imC
+imC
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+mwo
+iNn
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+weG
+cGS
+sRm
+pun
+pun
+qYo
+pun
+xyE
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+vZL
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+vZL
+nGn
+uEZ
+uEZ
+jQq
+ubF
+jQq
+ubF
+jQq
+ubF
+mMp
+lmC
+xqP
+uEZ
+tzg
+tzg
+tzg
+hMS
+qne
+uOb
+ned
+fGh
+aLI
+fYo
+fYo
+tGK
+gEr
+fGh
+nos
+udd
+nos
+nos
+nos
+nos
+nos
+udd
+nos
+toJ
+bvp
+gvJ
+bJC
+bJC
+bJC
+bJC
+bJC
+bJC
+gQT
+uvm
+pOV
+hTF
+hTF
+hTF
+sYg
+sXc
+evg
+evg
+eUt
+pBV
+uQs
+sXc
+xSb
+xSb
+ffS
+ter
+fTp
+vDR
+vrX
+vrX
+cVu
+nTe
+scu
+jBQ
+qZp
+qZp
+hVQ
+iuB
+ofN
+sWl
+sWl
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(24,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+xyE
+pun
+bUb
+pun
+pun
+pun
+nin
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+mwo
+sRm
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+weG
+cGS
+sRm
+pun
+bUb
+qYo
+pun
+xyE
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+jlx
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+jlx
+nGn
+uEZ
+uEZ
+fWQ
+uEZ
+fWQ
+uEZ
+fWQ
+uEZ
+dnJ
+lmC
+kKp
+uEZ
+tzg
+tzg
+tzg
+iLw
+qne
+uOb
+ylN
+fGh
+uBf
+fYo
+fYo
+fGh
+fGh
+fGh
+nos
+udd
+udd
+udd
+udd
+udd
+udd
+udd
+nos
+toJ
+bvp
+gvJ
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+gQT
+uvm
+pOV
+oSh
+oSh
+oSh
+sYg
+sXc
+eUt
+eUt
+eUt
+pBV
+lGq
+sXc
+ffS
+ffS
+ffS
+ter
+cEo
+vDR
+cVu
+cVu
+cVu
+nTe
+iBu
+jBQ
+hVQ
+hVQ
+hVQ
+iuB
+iAR
+sWl
+sWl
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(25,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+nin
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+xgl
+sRm
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+weG
+xgl
+sRm
+pun
+pun
+qYo
+pun
+pun
+pun
+imC
+pun
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+uEZ
+uEZ
+ciQ
+uEZ
+ciQ
+uEZ
+ciQ
+uEZ
+iQR
+cqc
+geU
+uEZ
+tzg
+tzg
+tzg
+hMS
+qne
+uOb
+ned
+fGh
+fYo
+fYo
+fYo
+lBd
+gEr
+fGh
+aXY
+kyH
+nVv
+aXY
+aXY
+aXY
+nVv
+kyH
+aXY
+toJ
+lGQ
+gvJ
+tPx
+tPx
+tPx
+tPx
+tPx
+tPx
+lDs
+uvm
+rWM
+toF
+toF
+toF
+tCv
+sXc
+ngv
+edJ
+eUt
+pBV
+lGq
+sXc
+wpr
+geH
+ffS
+ter
+cEo
+vDR
+ghL
+jbe
+cVu
+nTe
+iBu
+jBQ
+aHu
+bqA
+hVQ
+iuB
+iAR
+sWl
+sWl
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(26,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xyE
+bUb
+pun
+imC
+imC
+pun
+pun
+bUb
+pun
+aVA
+pun
+pun
+lBV
+pun
+pun
+nin
+imC
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+xgl
+sRm
+pun
+pun
+weG
+xgl
+sRm
+pun
+pun
+weG
+mwo
+sRm
+pun
+pun
+qYo
+pun
+pun
+pun
+imC
+pun
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+uLb
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+uLb
+nGn
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+keG
+uEZ
+uEZ
+tzg
+tzg
+tzg
+hMS
+qne
+uOb
+ned
+fGh
+qOP
+fYo
+fYo
+fGh
+fGh
+fGh
+dXU
+vOQ
+biJ
+nBs
+nBs
+kYE
+biJ
+vOQ
+cEx
+toJ
+jJd
+gvJ
+ePe
+gzE
+ePe
+ePe
+gzE
+ePe
+gQT
+aKn
+pOV
+sVq
+sVq
+sVq
+sYg
+sXc
+eUt
+eUt
+eUt
+pBV
+lGq
+sXc
+ffS
+ffS
+ffS
+ter
+cEo
+vDR
+cVu
+cVu
+cVu
+nTe
+iBu
+jBQ
+hVQ
+hVQ
+hVQ
+iuB
+iAR
+sWl
+sWl
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(27,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+omd
+nin
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+cGS
+iNn
+pun
+pun
+weG
+cGS
+sRm
+pun
+pun
+weG
+cGS
+iNn
+imC
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+iDu
+iDu
+iDu
+iDu
+iDu
+nGn
+vZL
+nGn
+iDu
+iDu
+pMX
+pMX
+pMX
+pMX
+pMX
+pMX
+pMX
+pMX
+vZL
+nGn
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+rjM
+niM
+rWv
+bBa
+jux
+uEZ
+tzg
+tzg
+tzg
+hMS
+qne
+uOb
+ned
+fGh
+ykS
+fYo
+fYo
+ouu
+gEr
+fGh
+qcU
+nVb
+nVb
+nVb
+nVb
+nVb
+nVb
+nVb
+nFz
+toJ
+fLm
+gvJ
+bJC
+bJC
+bJC
+bJC
+bJC
+bJC
+gQT
+uvm
+btO
+nCh
+rft
+nsH
+mWW
+sXc
+evg
+evg
+eUt
+nwW
+uuq
+sXc
+xSb
+xSb
+ffS
+oZe
+dmh
+vDR
+vrX
+vrX
+cVu
+rqq
+uuz
+jBQ
+qZp
+qZp
+hVQ
+pJb
+hwB
+sWl
+sWl
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(28,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+bUb
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+aLO
+pun
+lEI
+pun
+nin
+imC
+pun
+imC
+pun
+pun
+pun
+aVA
+pun
+imC
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+mwo
+iNn
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+qbN
+cGS
+iNn
+pun
+pun
+qYo
+pun
+pun
+xyE
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+iDu
+iDu
+iDu
+iDu
+iDu
+nGn
+xhl
+nGn
+iDu
+iDu
+pMX
+pMX
+pMX
+pMX
+pMX
+pMX
+pMX
+pMX
+bTS
+pMX
+pMX
+pMX
+xvh
+xvh
+uEZ
+uEZ
+fsW
+mkt
+sai
+uXm
+qcy
+uEZ
+tzg
+tzg
+tzg
+hMS
+qne
+uOb
+ned
+fGh
+cTX
+fYo
+fYo
+fGh
+fGh
+fGh
+wDs
+nVb
+nVb
+nVb
+nVb
+nVb
+nVb
+nVb
+vyf
+toJ
+kSB
+gvJ
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+gQT
+uvm
+amU
+adq
+adq
+adq
+adq
+sXc
+sXc
+sXc
+sXc
+vVX
+sXc
+sXc
+vDR
+vDR
+vDR
+fBJ
+vDR
+vDR
+jBQ
+jBQ
+jBQ
+uEn
+jBQ
+jBQ
+sWl
+sWl
+sWl
+pwq
+sWl
+sWl
+sWl
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(29,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+bUb
+aVA
+pun
+imC
+imC
+pun
+pun
+imC
+nin
+imC
+pun
+imC
+wXF
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+xgl
+iNn
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+qbN
+cGS
+iNn
+pun
+pun
+qYo
+pun
+pun
+xyE
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+iDu
+iDu
+ksm
+cvV
+cvV
+jLM
+trx
+nHc
+rkL
+mMr
+pMX
+pMX
+jfF
+cuU
+cuU
+uoV
+oLj
+bnD
+pzH
+tXK
+jhM
+pMX
+vDF
+xvh
+uEZ
+uEZ
+fsW
+mkt
+aHQ
+uXm
+qcy
+uEZ
+tzg
+tzg
+tzg
+iLw
+qne
+uOb
+ylN
+fGh
+cTX
+fYo
+fYo
+oun
+gEr
+fGh
+jWw
+pzk
+pzk
+vRR
+byr
+xaF
+xaF
+aGE
+vLR
+toJ
+xhV
+gvJ
+tPx
+tPx
+tPx
+tPx
+tPx
+tPx
+gQT
+uvm
+xYN
+rLP
+lus
+urK
+qUW
+jfk
+qUW
+qUW
+qUW
+kug
+qUW
+jfk
+qUW
+qUW
+qUW
+kug
+qUW
+jfk
+qUW
+qUW
+qUW
+kug
+qUW
+jfk
+qUW
+qUW
+qUW
+kug
+rfZ
+lus
+lus
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(30,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+imC
+nin
+pun
+imC
+pun
+bUb
+pun
+imC
+mUF
+imC
+pun
+aVA
+imC
+pvg
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+imC
+pun
+olD
+xgl
+sRm
+pun
+pun
+qbN
+mwo
+sRm
+pun
+pun
+qbN
+xgl
+iNn
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+nGn
+txY
+nGn
+vDF
+vDF
+vDF
+iDu
+iDu
+vfl
+rQk
+rQk
+rQk
+vZC
+kzQ
+iJc
+dQj
+pMX
+pMX
+bXH
+wlf
+wlf
+wlf
+wlf
+wlf
+wlf
+qCz
+mHr
+pMX
+vDF
+xvh
+uEZ
+uEZ
+fsW
+dxL
+hoa
+hcV
+cnS
+uEZ
+tzg
+tzg
+tzg
+hMS
+qne
+uOb
+ned
+fGh
+fGh
+fGh
+fGh
+fGh
+fGh
+fGh
+toJ
+iJQ
+wJi
+toJ
+toJ
+toJ
+toJ
+fqI
+toJ
+toJ
+hsQ
+gvJ
+ePe
+gzE
+ePe
+ePe
+gzE
+ePe
+lDs
+uvm
+xYN
+rnD
+lus
+nDh
+gBk
+gBk
+gBk
+gBk
+gBk
+iZz
+gBk
+gBk
+gBk
+gBk
+gBk
+iZz
+gBk
+gBk
+gBk
+gBk
+gBk
+iZz
+gBk
+gBk
+gBk
+gBk
+gBk
+pmE
+wbN
+lus
+lus
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(31,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+lBV
+imC
+omd
+xyE
+pun
+pun
+pun
+pun
+imC
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+xgl
+sRm
+pun
+pun
+qbN
+cGS
+iNn
+pun
+pun
+qbN
+xgl
+sRm
+pun
+pun
+qYo
+pun
+bUb
+pun
+xyE
+pun
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+iDu
+iDu
+kxl
+rQk
+rQk
+rQk
+qon
+jLM
+jLM
+gYJ
+pMX
+pMX
+dLQ
+dYu
+dYu
+dYu
+wlf
+wlf
+wlf
+irb
+nLT
+pMX
+vDF
+xvh
+uEZ
+uEZ
+uEZ
+uEZ
+uEZ
+vvO
+uEZ
+uEZ
+mIX
+mIX
+mIX
+hMS
+qne
+uOb
+ned
+ife
+pPw
+imu
+nIK
+ife
+kmg
+loF
+cye
+cye
+uhd
+asS
+loF
+mYl
+sbx
+lPK
+tdM
+uvm
+xhV
+gvJ
+bJC
+bJC
+bSM
+bJC
+bJC
+bJC
+gQT
+uvm
+xYN
+rnD
+lus
+kug
+cWP
+tkJ
+xsa
+xsa
+xsa
+kug
+xsa
+tkJ
+xsa
+xsa
+xsa
+kug
+xsa
+tkJ
+xsa
+xsa
+xsa
+kug
+xsa
+tkJ
+xsa
+xsa
+xsa
+kug
+sca
+lus
+lus
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(32,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+bUb
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+cGS
+iNn
+pun
+pun
+qbN
+cGS
+iNn
+pun
+pun
+qbN
+mwo
+iNn
+pun
+pun
+qYo
+pun
+imC
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+iDu
+iDu
+roe
+rai
+rai
+bsc
+rQk
+rQk
+rQk
+lJs
+pMX
+pMX
+bXH
+wlf
+wlf
+wlf
+wlf
+wlf
+wlf
+irb
+dsh
+pMX
+vDF
+xvh
+xvh
+xvh
+xvh
+mIX
+xIs
+krX
+mxV
+mxV
+mxV
+mxV
+mIX
+hMS
+qne
+uOb
+ned
+ife
+suB
+imu
+nIK
+ife
+vfN
+kJm
+kJm
+kJm
+kJm
+kJm
+kJm
+pau
+sbx
+lPK
+dHD
+uvm
+rSz
+gvJ
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+gQT
+uvm
+xYN
+rnD
+lus
+kug
+wbN
+hoA
+hoA
+hoA
+hoA
+tgO
+hoA
+hoA
+wWo
+wWo
+wWo
+vvh
+wWo
+wWo
+vaZ
+vaZ
+vaZ
+bYA
+vaZ
+vaZ
+sIH
+sIH
+sIH
+bCY
+sIH
+sIH
+sIH
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(33,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+nin
+pun
+imC
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+cGS
+iNn
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+qbN
+mwo
+sRm
+pun
+pun
+qYo
+pun
+imC
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+iDu
+iDu
+vfl
+rQk
+rQk
+rQk
+rQk
+rQk
+rQk
+nOq
+pMX
+pMX
+ewG
+gsi
+gsi
+lDj
+wlf
+pwo
+mnh
+gmv
+mPL
+pMX
+vDF
+vDF
+vDF
+vDF
+vDF
+mIX
+rVn
+krX
+ajG
+ajG
+ajG
+ajG
+mIX
+hMS
+qne
+uOb
+ned
+ife
+vDh
+imu
+kXd
+ife
+vWI
+kJm
+kJm
+sPc
+nyV
+kJm
+kJm
+kmb
+sbx
+xQk
+npw
+uvm
+vek
+gvJ
+tPx
+vkB
+tPx
+tPx
+vkB
+vkB
+lDs
+uvm
+xsF
+sxi
+lus
+dvx
+wbN
+hoA
+aow
+aow
+vKm
+bMx
+qtB
+hoA
+dhs
+dhs
+dJz
+rbD
+dlz
+wWo
+onW
+onW
+kcj
+mdc
+iyS
+vaZ
+mGG
+mGG
+kTd
+tZD
+hJH
+sIH
+sIH
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(34,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+bUb
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+cGS
+sRm
+pun
+pun
+qbN
+cGS
+iNn
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+iDu
+iDu
+kyV
+hGx
+hGx
+saz
+afo
+bUr
+qpk
+xMF
+pMX
+pMX
+ayG
+sYA
+sYA
+ahu
+wlf
+gwu
+pMX
+wFJ
+pMX
+pMX
+aBn
+aBn
+aBn
+aBn
+aBn
+mIX
+wXV
+krX
+ajG
+ajG
+ajG
+wxc
+mIX
+iLw
+qne
+uOb
+ylN
+ife
+ajH
+imu
+kXd
+ife
+uIw
+kJm
+kJm
+mwp
+lpQ
+kJm
+kJm
+kmb
+sbx
+lPK
+dHD
+uvm
+uJI
+gvJ
+ePe
+gzE
+ePe
+ePe
+gzE
+ePe
+gQT
+uvm
+xYN
+rnD
+lus
+kug
+wbN
+hoA
+vKm
+vKm
+vKm
+vzN
+xXB
+hoA
+dJz
+dJz
+dJz
+iLe
+yfY
+wWo
+kcj
+kcj
+kcj
+fTN
+jtJ
+vaZ
+kTd
+kTd
+kTd
+dTj
+pUd
+sIH
+sIH
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(35,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+nin
+pun
+pun
+imC
+wXF
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+cSr
+mtE
+pun
+pun
+pun
+cSr
+mtE
+cSr
+pun
+pun
+cSr
+mtE
+cSr
+pun
+pun
+qYo
+imC
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+iDu
+iDu
+iDu
+iDu
+iDu
+iDu
+hxs
+iDu
+iDu
+iDu
+pMX
+pMX
+vFE
+wlf
+wlf
+wlf
+wlf
+oLW
+pMX
+yjw
+uUw
+aBn
+jCJ
+aBn
+jCJ
+aBn
+jCJ
+mIX
+ajG
+krX
+ojz
+qfS
+vQl
+ajG
+mIX
+hMS
+qne
+uOb
+ned
+ife
+eRq
+imu
+kXd
+ife
+uIw
+kJm
+kJm
+fQr
+cxh
+kJm
+kJm
+xIj
+xbN
+rYI
+gJv
+uRO
+byG
+scB
+bJC
+bJC
+bSM
+bSM
+bJC
+bSM
+gQT
+uvm
+xYN
+rnD
+lus
+kug
+wbN
+hoA
+bBL
+nsj
+vKm
+vzN
+xXB
+hoA
+xam
+uke
+dJz
+iLe
+yfY
+wWo
+dZS
+xir
+kcj
+fTN
+jtJ
+vaZ
+buE
+ehQ
+kTd
+dTj
+pUd
+sIH
+sIH
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(36,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+mUF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+xPt
+noR
+fdE
+xuZ
+xuZ
+noR
+noR
+fdE
+xuZ
+noR
+noR
+noR
+snY
+xuZ
+xuZ
+noR
+uRx
+xuZ
+oXp
+bUb
+pun
+pun
+pun
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+amp
+tQf
+wnn
+ybq
+ybW
+uLk
+aXS
+ajN
+pMX
+pMX
+jRZ
+dap
+dap
+hNS
+wlf
+gwu
+pMX
+yjw
+uUw
+aBn
+slv
+aBn
+qLV
+aBn
+rKJ
+mIX
+hrB
+vOj
+smE
+fDr
+ajG
+ajG
+mIX
+hMS
+qne
+uOb
+ned
+ife
+uEo
+imu
+imu
+uyU
+gyZ
+kJm
+kJm
+crN
+kJm
+kJm
+kJm
+wVE
+sbx
+xQk
+npw
+uvm
+sMv
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+gQT
+uvm
+xYN
+rnD
+lus
+kug
+wbN
+hoA
+vKm
+vKm
+vKm
+vzN
+xXB
+hoA
+dJz
+dJz
+dJz
+iLe
+yfY
+wWo
+kcj
+kcj
+kcj
+fTN
+jtJ
+vaZ
+kTd
+kTd
+kTd
+dTj
+pUd
+sIH
+sIH
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(37,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+mtE
+pun
+pun
+pun
+cSr
+mtE
+pun
+pun
+pun
+pun
+mtE
+pun
+pun
+pun
+qYo
+pun
+mtE
+bUb
+xyE
+imC
+pun
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+wUo
+oWf
+oWf
+jDy
+pZF
+oWf
+oWf
+osG
+pMX
+pMX
+bXH
+wlf
+wlf
+wlf
+wlf
+gwu
+pMX
+sez
+uUw
+aBn
+sEL
+sEL
+sEL
+sEL
+sEL
+aBn
+mrS
+wNc
+mrS
+mrS
+mrS
+mIX
+mIX
+hMS
+qne
+uOb
+ned
+ife
+eRq
+imu
+iAW
+ife
+qyz
+kJm
+kJm
+kJm
+kJm
+kJm
+kJm
+mHE
+myD
+lPK
+dHD
+uvm
+fwu
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+nNr
+gQT
+uvm
+xYN
+rnD
+lus
+kug
+wbN
+hoA
+aow
+aow
+vKm
+vzN
+wIT
+hoA
+dhs
+dhs
+dJz
+iLe
+iwJ
+wWo
+onW
+onW
+kcj
+fTN
+aBl
+vaZ
+mGG
+mGG
+kTd
+dTj
+hMR
+sIH
+sIH
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(38,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+nin
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+weG
+iKO
+sRm
+pun
+pun
+weG
+iKO
+sRm
+pun
+pun
+weG
+iKO
+sRm
+pun
+pun
+qYo
+pun
+mtE
+pun
+xyE
+pun
+pun
+vDF
+vDF
+vDF
+nGn
+wIS
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+kEt
+uvE
+bvf
+ybq
+ybW
+aWv
+sRX
+rMl
+pMX
+pMX
+bKe
+fjP
+fjP
+sIm
+jMh
+vPl
+pMX
+yjw
+uUw
+aBn
+sEL
+nKn
+sEL
+sEL
+sEL
+aBn
+xIQ
+txs
+uhM
+ciR
+mrS
+nvM
+nvM
+hMS
+qne
+uOb
+ned
+ife
+nfA
+wPg
+iAW
+ife
+gba
+gDk
+dxX
+qHW
+qHW
+hNw
+lDr
+eNp
+lyM
+lPK
+dHD
+uvm
+eLv
+quU
+quU
+quU
+cnh
+rof
+cCf
+cCf
+aDF
+uvm
+xsF
+sxi
+lus
+dvx
+wbN
+hoA
+hoA
+hoA
+hoA
+vzN
+aRX
+hoA
+wWo
+wWo
+wWo
+iLe
+pbm
+wWo
+vaZ
+vaZ
+vaZ
+fTN
+rOB
+vaZ
+sIH
+sIH
+sIH
+dTj
+whF
+sIH
+sIH
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(39,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bUb
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qYo
+pun
+sED
+pun
+pun
+xyE
+pun
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+wUo
+oWf
+oWf
+jDy
+pZF
+oWf
+oWf
+osG
+xod
+xod
+xod
+xod
+xod
+xod
+xod
+xod
+xod
+yjw
+uUw
+aBn
+hWV
+aBn
+bYx
+sEL
+sEL
+aBn
+xIQ
+txs
+csk
+rcQ
+mrS
+nvM
+nvM
+hMS
+qne
+uOb
+umu
+ife
+ife
+kJQ
+ife
+ife
+sbx
+sbx
+sbx
+sbx
+sbx
+sbx
+sbx
+sbx
+sbx
+dzH
+dHD
+uvm
+uvm
+uvm
+uvm
+uvm
+uvm
+uvm
+bqR
+jTf
+uvm
+uvm
+pHZ
+rnD
+lus
+kug
+wbN
+hoA
+eSZ
+wXA
+szI
+vzN
+vzN
+hoA
+qlJ
+fay
+efr
+iLe
+iLe
+wWo
+umm
+och
+wIq
+fTN
+fTN
+vaZ
+wwS
+iwo
+xMP
+dTj
+dTj
+sIH
+sIH
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(40,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+wXF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qbN
+tPK
+sRm
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qYo
+pun
+sED
+pun
+icW
+pun
+pun
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+dXK
+vZQ
+jXb
+ybq
+ybW
+acY
+aqv
+mHh
+xod
+vjO
+qrK
+qrK
+urR
+spM
+fnH
+gWs
+xod
+yjw
+uUw
+aBn
+pEg
+aBn
+iHK
+sEL
+sEL
+aBn
+lcA
+txs
+dQr
+nab
+mrS
+dfk
+nvM
+hMS
+qne
+uOb
+yeW
+nYl
+mwO
+mun
+tnN
+dcv
+dcv
+dcv
+tnN
+dcv
+dcv
+dcv
+dcv
+tnN
+dcv
+lPK
+lHG
+dcv
+tnN
+dcv
+dcv
+dcv
+dcv
+tnN
+dcv
+dcv
+hbh
+alY
+xYN
+rnD
+lus
+djC
+wbN
+hoA
+thY
+wQa
+hoA
+lzD
+dQX
+hoA
+txH
+jKD
+wWo
+hPt
+wZf
+wWo
+wwz
+lgo
+vaZ
+gqx
+cMG
+vaZ
+eCN
+wac
+sIH
+ffn
+dDL
+sIH
+sIH
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(41,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+imC
+pun
+bUb
+pun
+pun
+imC
+pun
+pun
+qat
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+weG
+tPK
+sRm
+pun
+pun
+qbN
+iKO
+iNn
+pun
+pun
+qYo
+pun
+mtE
+pun
+cju
+bUb
+pun
+pun
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+wUo
+oWf
+oWf
+jDy
+pZF
+oWf
+oWf
+osG
+xod
+afc
+qrK
+qrK
+qrK
+qrK
+qrK
+ybj
+xod
+sez
+uUw
+aBn
+aBn
+aBn
+aBn
+aBn
+sEL
+aBn
+kYw
+txs
+wZo
+nab
+mrS
+nvM
+nvM
+hMS
+qne
+uOb
+qRS
+nYl
+sdS
+lPK
+jwN
+jwN
+jwN
+jwN
+jwN
+jwN
+jwN
+jwN
+jwN
+jwN
+jwN
+lPK
+jwN
+jwN
+jwN
+jwN
+jwN
+jwN
+jwN
+jwN
+jwN
+jwN
+lxV
+lxV
+xYN
+qmI
+qUW
+kug
+wbN
+xad
+xad
+xad
+xad
+xad
+xad
+xad
+vdE
+vdE
+vdE
+vdE
+vdE
+vdE
+eij
+eij
+eij
+eij
+eij
+eij
+fSf
+fSf
+fSf
+fSf
+fSf
+fSf
+fSf
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(42,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qbN
+iKO
+iNn
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+weR
+kEv
+vaV
+ybq
+ybW
+akX
+art
+qsh
+xod
+afc
+qrK
+qrK
+qrK
+qrK
+qrK
+wZM
+xod
+yjw
+uUw
+aBn
+cip
+ilY
+sEL
+sEL
+sEL
+aBn
+kYw
+nhd
+czs
+iXx
+mrS
+nvM
+nvM
+hMS
+phA
+sUP
+bTZ
+wqI
+rkk
+kcN
+bCH
+bCH
+bCH
+bCH
+bCH
+bCH
+bCH
+bCH
+bCH
+bCH
+bCH
+kcN
+bCH
+bCH
+bCH
+bCH
+bCH
+bCH
+bCH
+bCH
+bCH
+bCH
+rrW
+jRe
+wJX
+rrW
+gBk
+dJo
+wbN
+xad
+oVb
+kse
+xad
+kCX
+hcv
+xad
+eBY
+eEy
+vdE
+pVg
+brq
+vdE
+lxq
+iHp
+eij
+dxg
+lfO
+eij
+mFq
+kTu
+fSf
+prN
+xtM
+fSf
+fSf
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(43,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+pun
+pun
+pun
+bUb
+pun
+bUb
+pun
+xyE
+mUF
+imC
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qbN
+szW
+iNn
+pun
+pun
+qbN
+iKO
+iNn
+pun
+pun
+qYo
+pun
+sED
+pun
+pun
+xyE
+bUb
+pun
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+wUo
+oWf
+oWf
+jDy
+pZF
+oWf
+oWf
+osG
+xod
+uIu
+qrK
+qrK
+qrK
+qrK
+qrK
+tFR
+wNO
+kbd
+uUw
+aBn
+aIt
+sEL
+sEL
+sEL
+sEL
+aBn
+lcA
+txs
+qww
+nab
+mrS
+mxR
+nvM
+hMS
+uNR
+uOb
+maX
+nYl
+ufs
+bqV
+xNX
+bqV
+bqV
+bqV
+xNX
+bqV
+bqV
+bqV
+bqV
+xNX
+bqV
+bqV
+bqV
+bqV
+xNX
+bqV
+bqV
+bqV
+bqV
+xNX
+bqV
+bqV
+jjP
+xYN
+lxV
+rnD
+lus
+kug
+wbN
+xad
+hBO
+mih
+lrg
+nkw
+nkw
+xad
+jNF
+jkl
+kNn
+rMR
+rMR
+vdE
+sUQ
+ruo
+sQk
+xZV
+xZV
+eij
+oFV
+sNS
+dCP
+xAe
+xAe
+fSf
+fSf
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(44,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+bUb
+pun
+pun
+pun
+pun
+xyE
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+qbN
+tPK
+sRm
+pun
+pun
+qbN
+tPK
+sRm
+pun
+pun
+qbN
+iKO
+sRm
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+xyE
+pun
+pun
+vDF
+vDF
+nGn
+wIS
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+qph
+mwG
+wav
+pzq
+kbP
+nsA
+uve
+mVB
+xod
+rjE
+rjE
+rjE
+rjE
+rjE
+qrK
+kpM
+xod
+yjw
+uUw
+aBn
+aIt
+sEL
+sEL
+sEL
+sEL
+aBn
+ozF
+txs
+arp
+rcQ
+mrS
+jkM
+nvM
+hMS
+uNR
+uOb
+oBU
+kXK
+kXK
+kXK
+kXK
+kXK
+kXK
+kXK
+kXK
+kXK
+kXK
+kXK
+kXK
+kKi
+kKi
+kKi
+kKi
+kKi
+kKi
+bxE
+bxE
+bxE
+bxE
+bxE
+bxE
+bxE
+arL
+xYN
+lxV
+sxi
+lus
+dvx
+wbN
+xad
+xad
+xad
+xad
+nkw
+isq
+xad
+vdE
+vdE
+vdE
+rMR
+iGR
+vdE
+eij
+eij
+eij
+xZV
+mJj
+eij
+fSf
+fSf
+fSf
+xAe
+enq
+fSf
+fSf
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(45,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+imC
+pun
+pun
+pun
+nin
+wXF
+pun
+pun
+pun
+pun
+imC
+pun
+qat
+nin
+bUb
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+qbN
+szW
+sRm
+pun
+pun
+qbN
+szW
+iNn
+pun
+pun
+weG
+iKO
+sRm
+pun
+pun
+qYo
+pun
+sED
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+bAQ
+vaD
+dTO
+qws
+tgU
+aLx
+sNd
+sNd
+xod
+wnX
+wnX
+wnX
+wnX
+rjE
+qrK
+qrK
+xod
+sez
+uUw
+aBn
+aIt
+nKn
+sEL
+qJL
+ndW
+aBn
+ozF
+laA
+aeZ
+ciR
+mrS
+eNN
+nvM
+hMS
+uNR
+uOb
+ned
+kXK
+sxD
+xgf
+hnK
+cQm
+dWX
+dWX
+dWX
+dWX
+jtR
+xgf
+wZI
+kKi
+jJK
+gue
+kJg
+gue
+gue
+bxE
+bxE
+bxE
+bxE
+bxE
+bxE
+bxE
+mSS
+xYN
+lxV
+rnD
+lus
+kug
+wbN
+xad
+qSo
+qSo
+jil
+nkw
+dMP
+xad
+aas
+aas
+wpC
+rMR
+qCf
+vdE
+plq
+plq
+iMJ
+xZV
+eTp
+eij
+bUq
+bUq
+fPe
+xAe
+iWl
+fSf
+fSf
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(46,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+imC
+xyE
+imC
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+qbN
+szW
+iNn
+pun
+pun
+qbN
+iKO
+iNn
+pun
+pun
+weG
+tPK
+sRm
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+rgn
+ybq
+ybq
+ybq
+ybW
+ybq
+ybq
+kyr
+xod
+iJW
+iJW
+iJW
+iJW
+rjE
+qrK
+sHz
+xod
+yjw
+uUw
+aBn
+aBn
+aBn
+aBn
+aBn
+qcT
+aBn
+mrS
+uFd
+mrS
+mrS
+mrS
+tzg
+tzg
+fgW
+qne
+uOb
+ned
+kXK
+nyh
+xgf
+xgK
+iXD
+iXD
+iXD
+iXD
+iXD
+iXD
+okk
+tng
+jmu
+hhj
+paH
+paH
+paH
+cfD
+mTa
+dGB
+eXv
+kvQ
+bxE
+bxE
+bxE
+mSS
+xYN
+lxV
+rnD
+lus
+kug
+wbN
+xad
+jil
+jil
+jil
+nkw
+ozt
+xad
+wpC
+wpC
+wpC
+rMR
+cHx
+vdE
+iMJ
+iMJ
+iMJ
+xZV
+pqG
+eij
+fPe
+fPe
+fPe
+xAe
+bvj
+fSf
+fSf
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(47,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bUb
+xyE
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+bUb
+pun
+pun
+bUb
+pun
+imC
+omd
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+mUF
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qbN
+iKO
+iNn
+pun
+imC
+qbN
+tPK
+sRm
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+ybq
+ybq
+ybq
+ybq
+ybW
+ybq
+ybq
+ybq
+xod
+gaW
+gaW
+gaW
+gaW
+rjE
+qrK
+hXq
+xod
+gGa
+nAG
+nAG
+nAG
+nAG
+nAG
+nAG
+oDz
+nAG
+wcP
+oDz
+nAG
+nAG
+mRN
+fsg
+dNW
+etc
+vfO
+uOb
+ned
+kXK
+rCa
+xgf
+xgf
+xgf
+xgf
+xgf
+xgf
+xgf
+xgf
+mDV
+kpG
+kKi
+lig
+wKJ
+wKJ
+lGB
+uRE
+bxE
+arw
+wpf
+blf
+bxE
+bxE
+bxE
+mSS
+xYN
+lxV
+rnD
+lus
+kug
+wbN
+xad
+rkD
+eKf
+jil
+nkw
+ozt
+xad
+gPW
+nQK
+wpC
+rMR
+cHx
+vdE
+eDF
+cvY
+iMJ
+xZV
+pqG
+eij
+xTP
+aPv
+fPe
+xAe
+bvj
+fSf
+fSf
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(48,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+bUb
+pun
+pun
+xyE
+pun
+pun
+pun
+xyE
+imC
+pun
+lBV
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qbN
+iKO
+iNn
+pun
+pun
+qbN
+szW
+sRm
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+iZY
+yiv
+osv
+wdf
+nmV
+irP
+yiv
+iZY
+xod
+rjE
+rjE
+rjE
+rjE
+rqc
+qrK
+uWW
+xod
+yjw
+uUw
+qZB
+uUw
+uUw
+uUw
+qZB
+uUw
+uUw
+yjw
+uUw
+uUw
+qZB
+uUw
+hmq
+iFj
+rlj
+qne
+uOb
+ned
+kXK
+rcZ
+xgf
+xgf
+ibG
+xkM
+xkM
+xkM
+xkM
+ibG
+mDV
+qnK
+vtp
+ozZ
+cRf
+cRf
+cRf
+pWi
+bxE
+arw
+wpf
+kEj
+bxE
+bxE
+bxE
+mSS
+xYN
+lxV
+rnD
+lus
+kug
+wbN
+xad
+jil
+jil
+jil
+nkw
+ozt
+xad
+wpC
+wpC
+wpC
+rMR
+cHx
+vdE
+iMJ
+iMJ
+iMJ
+xZV
+pqG
+eij
+fPe
+fPe
+fPe
+xAe
+bvj
+fSf
+fSf
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(49,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+imC
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+imC
+imC
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qbN
+szW
+iNn
+pun
+pun
+qYo
+pun
+sED
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+nGn
+qxn
+nGn
+vDF
+vDF
+vDF
+nyy
+nyy
+nyy
+nyy
+nyy
+nyy
+rYh
+nyy
+nyy
+nyy
+uYG
+uYG
+uYG
+uYG
+uYG
+uYG
+uYG
+uYG
+uYG
+tYb
+uYG
+xSq
+xSq
+xSq
+xSq
+xSq
+xSq
+xSq
+yjw
+uUw
+eip
+eip
+eip
+eip
+eip
+gKh
+qne
+uOb
+ylN
+kXK
+ola
+xgf
+xgf
+iiY
+iiY
+iiY
+iiY
+iiY
+iiY
+ekO
+pMg
+pyg
+cRf
+cRf
+cRf
+cRf
+quy
+bxE
+tfA
+fqn
+arw
+bxE
+bxE
+bxE
+arL
+xYN
+lxV
+sxi
+lus
+dvx
+wbN
+xad
+qSo
+qSo
+jil
+jTW
+llx
+xad
+aas
+aas
+wpC
+kZK
+iip
+vdE
+plq
+plq
+iMJ
+hbK
+wkh
+eij
+bUq
+bUq
+fPe
+eab
+tuz
+fSf
+fSf
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(50,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+imC
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+qbN
+iKO
+sRm
+pun
+pun
+weG
+iKO
+sRm
+pun
+pun
+qbN
+szW
+iNn
+pun
+pun
+spQ
+spQ
+hVG
+spQ
+spQ
+spQ
+pun
+pun
+vDF
+pun
+bUb
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hBV
+drk
+siu
+dDM
+mVf
+myX
+uYG
+nZN
+rGr
+tQD
+avt
+rGr
+ebt
+cuv
+rGr
+hqb
+uYG
+tIi
+oLd
+cYR
+lnc
+cMa
+oQl
+xSq
+yjw
+uUw
+eip
+gvk
+gvk
+jem
+eip
+hMS
+qne
+uOb
+ned
+kXK
+jUY
+xgf
+xgf
+iiY
+yih
+iWo
+udJ
+uKG
+plx
+puS
+cqC
+ovN
+fpp
+wjL
+bYP
+cRf
+whW
+bxE
+gZp
+wpf
+xPH
+bxE
+bxE
+bxE
+mSS
+xYN
+lxV
+rnD
+lus
+kug
+wbN
+xad
+xad
+xad
+xad
+aQV
+xad
+xad
+vdE
+vdE
+vdE
+ogy
+vdE
+vdE
+eij
+eij
+eij
+wsx
+eij
+eij
+fSf
+fSf
+fSf
+ylU
+fSf
+fSf
+fSf
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(51,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+pun
+pun
+pun
+bUb
+pun
+pun
+lBV
+xyE
+pun
+imC
+imC
+pun
+pun
+xyE
+pun
+pun
+imC
+qat
+nin
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+qbN
+tPK
+iNn
+pun
+pun
+weG
+tPK
+sRm
+pun
+pun
+weG
+tPK
+sRm
+pun
+pun
+spQ
+wUO
+bqj
+rNV
+pse
+spQ
+pun
+pun
+vDF
+pun
+bUb
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hBV
+vir
+iJk
+uGz
+kjZ
+cIk
+uYG
+nZN
+emW
+tQD
+avt
+emW
+avt
+slI
+emW
+hqb
+uYG
+meN
+rXj
+bDb
+bDb
+bDb
+kMP
+eEJ
+uoD
+qZB
+eip
+grt
+aqB
+pHK
+ghl
+rvN
+tPY
+uOb
+ned
+kXK
+uRd
+xgf
+xgf
+iiY
+dJI
+nAY
+nAY
+dJI
+iiY
+mDV
+xgf
+kKi
+cDP
+hcF
+iRU
+cRf
+hmr
+bxE
+fRn
+bOj
+ezV
+bxE
+bxE
+bxE
+mSS
+xYN
+lxV
+rnD
+lus
+kug
+rhd
+jfk
+qUW
+qUW
+qUW
+kug
+qUW
+jfk
+qUW
+qUW
+qUW
+kug
+qUW
+jfk
+qUW
+qUW
+qUW
+kug
+qUW
+jfk
+qUW
+qUW
+qUW
+kug
+rfZ
+lus
+lus
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(52,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+pun
+pvg
+pun
+pun
+pun
+omd
+lBV
+imC
+pun
+imC
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+bUb
+qbN
+dOC
+iNn
+pun
+pun
+weG
+ckr
+iNn
+pun
+pun
+weG
+dOC
+sRm
+pun
+pun
+spQ
+rtq
+rtq
+rtq
+vGA
+spQ
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vUR
+vUR
+vUR
+vUR
+vUR
+vUR
+vUR
+vUR
+vUR
+siu
+cIk
+uYG
+emW
+uKp
+emW
+emW
+uKp
+emW
+emW
+uKp
+kBA
+uYG
+ktp
+rrm
+hOT
+hOT
+hOT
+bPf
+xSq
+sAU
+sAU
+eip
+bhz
+bhz
+bhz
+eip
+hMS
+qne
+uOb
+ned
+qTW
+qTW
+qTW
+iHr
+qTW
+nBW
+kbV
+nRv
+nBW
+nBW
+kZp
+nMA
+qBl
+qBl
+qBl
+qBl
+qBl
+qBl
+qBl
+qBl
+xqW
+qBl
+qBl
+qBl
+qBl
+mSS
+xYN
+lxV
+rnD
+lus
+kbn
+bjT
+gBk
+gBk
+gBk
+gBk
+iZz
+gBk
+gBk
+gBk
+gBk
+gBk
+iZz
+gBk
+gBk
+gBk
+gBk
+gBk
+iZz
+gBk
+gBk
+gBk
+gBk
+gBk
+pmE
+wbN
+lus
+lus
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(53,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+imC
+pun
+imC
+pun
+imC
+nin
+imC
+pun
+aVA
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+spQ
+epY
+wfG
+wfG
+uIh
+spQ
+spQ
+spQ
+ltg
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vUR
+vUR
+lyN
+vDZ
+fuC
+fuC
+kXS
+jLm
+vUR
+siu
+cIk
+uYG
+rim
+uKp
+kWO
+nQZ
+emW
+fWi
+ghw
+emW
+oEi
+uYG
+bat
+rrm
+ecQ
+gav
+eVy
+fAl
+eWn
+eWn
+eWn
+eWn
+eWn
+eWn
+eWn
+eWn
+hMS
+qne
+uOb
+ned
+qTW
+rqZ
+wOB
+fTI
+qTW
+eim
+eim
+eim
+bxk
+nBW
+uCp
+xKN
+qBl
+qBl
+qBl
+ykE
+vkG
+hWg
+hmS
+oiJ
+dJx
+hds
+qBl
+qBl
+qBl
+mSS
+xYN
+lxV
+rnD
+lus
+pyc
+hUt
+tkJ
+xsa
+xsa
+xsa
+kug
+xsa
+tkJ
+xsa
+xsa
+xsa
+kug
+xsa
+tkJ
+xsa
+xsa
+xsa
+kug
+xsa
+tkJ
+xsa
+xsa
+xsa
+kug
+sca
+lus
+lus
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(54,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+spQ
+ptK
+rtq
+rtq
+vep
+qjX
+hfQ
+pfj
+obZ
+kTf
+pun
+pun
+vDF
+vDF
+vDF
+vUR
+vUR
+pZK
+wTm
+iDx
+iDx
+wTm
+ulu
+vUR
+mzy
+cJn
+uYG
+rim
+emW
+kWO
+haJ
+emW
+lap
+bZx
+emW
+xzW
+uYG
+tkr
+rrm
+hOT
+hOT
+hOT
+ens
+eWn
+qwt
+xvl
+foQ
+xvl
+dQQ
+xAk
+eWn
+iLw
+qne
+uOb
+ylN
+qTW
+rqZ
+wOB
+lnh
+qTW
+eim
+uIQ
+eim
+uHq
+nBW
+mcC
+pEd
+qBl
+qBl
+qBl
+bDr
+bDr
+bDr
+gLt
+mmF
+xVB
+nrK
+qBl
+qBl
+qBl
+arL
+xYN
+lxV
+sxi
+eti
+eti
+izY
+asJ
+asJ
+asJ
+asJ
+vhm
+asJ
+asJ
+aCh
+aCh
+aCh
+xfQ
+aCh
+afW
+afW
+afW
+afW
+dLP
+afW
+afW
+umM
+umM
+umM
+bJp
+umM
+umM
+umM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(55,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+qat
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+qbN
+dnp
+sRm
+pun
+pun
+weG
+dnp
+sRm
+pun
+pun
+qbN
+dnp
+sRm
+pun
+pun
+spQ
+kFk
+rtq
+rtq
+dVm
+mtq
+nAm
+spQ
+byM
+gQt
+pun
+vDF
+vDF
+vDF
+vDF
+vUR
+vUR
+iVZ
+wTm
+xXJ
+iDx
+wTm
+aOC
+vUR
+siu
+cIk
+uYG
+emW
+uKp
+emW
+emW
+uKp
+emW
+emW
+uKp
+xzW
+uYG
+bat
+rrm
+cji
+uyX
+sYZ
+qRo
+eWn
+gSC
+uhg
+uhg
+uhg
+uhg
+omt
+wBU
+rvN
+odi
+uOb
+ned
+qTW
+sGl
+wOB
+fTI
+iHr
+eim
+upC
+upC
+xjH
+pxI
+wGu
+keT
+qBl
+qBl
+qBl
+gTn
+bDr
+bDr
+hmS
+ayp
+tQR
+nVw
+qBl
+qBl
+qBl
+mSS
+xYN
+lxV
+rnD
+eti
+qjJ
+byw
+asJ
+vNH
+wYC
+wYC
+nei
+buF
+asJ
+xuc
+xuc
+xuc
+qiR
+iIb
+afW
+bVx
+bVx
+bVx
+iRT
+hhs
+afW
+mwl
+mwl
+mwl
+byq
+iji
+umM
+umM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(56,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+glF
+imC
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+qbN
+xgl
+sRm
+pun
+pun
+weG
+mwo
+sRm
+pun
+pun
+qbN
+mwo
+iNn
+pun
+pun
+spQ
+wUO
+wdD
+der
+iDC
+mtq
+mtq
+spQ
+mwM
+kTf
+icW
+vDF
+vDF
+vDF
+vDF
+vUR
+vUR
+ncN
+wTm
+nmy
+nmy
+wTm
+rIA
+vUR
+siu
+cIk
+uYG
+kkL
+uKp
+kkL
+kkL
+emW
+aDx
+aDx
+emW
+veE
+uYG
+qxt
+rrm
+hOT
+wQd
+wQd
+wQd
+eWn
+gSC
+uhg
+uhg
+uhg
+uhg
+ubW
+eWn
+hMS
+qne
+uOb
+ned
+qTW
+tbx
+wOB
+lnh
+qTW
+eim
+ceJ
+ceJ
+eim
+nBW
+mcC
+pEd
+qBl
+qBl
+qBl
+sGe
+esL
+hfF
+hmS
+xYC
+tQR
+dYi
+qBl
+qBl
+qBl
+mSS
+xYN
+lxV
+rnD
+eti
+fiT
+byw
+asJ
+lgT
+lgT
+jkB
+maj
+dUn
+asJ
+aml
+pfn
+aml
+wad
+dNA
+afW
+gvQ
+kke
+gvQ
+xuw
+vCb
+afW
+nwE
+aVy
+nwE
+eTC
+dSA
+umM
+umM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(57,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+xgl
+sRm
+pun
+pun
+weG
+cGS
+sRm
+pun
+pun
+qbN
+cGS
+iNn
+pun
+pun
+spQ
+spQ
+hVG
+spQ
+spQ
+spQ
+spQ
+spQ
+lro
+kTf
+pun
+pun
+vDF
+vDF
+vDF
+vUR
+vUR
+bpJ
+wTm
+wTm
+wTm
+wTm
+ttw
+vUR
+siu
+cIk
+uYG
+kkL
+emW
+kkL
+kkL
+emW
+aDx
+aDx
+uKp
+veE
+uYG
+qfC
+rrm
+ens
+wQd
+sbj
+jnn
+eWn
+tPy
+sok
+sok
+sok
+uhg
+hAN
+eWn
+hMS
+qne
+uOb
+ned
+qTW
+tbx
+vBj
+tji
+qTW
+bLV
+eim
+eim
+eim
+nBW
+mcC
+pEd
+qBl
+qBl
+qBl
+qBl
+qBl
+qBl
+qBl
+xai
+tQR
+dYi
+qBl
+qBl
+qBl
+mSS
+xYN
+lxV
+rnD
+eti
+vNd
+vnW
+asJ
+iej
+lgT
+lgT
+maj
+maj
+asJ
+mGP
+pfn
+pfn
+wad
+wad
+afW
+dQR
+kke
+kke
+xuw
+xuw
+afW
+utf
+aVy
+aVy
+eTC
+eTC
+umM
+umM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(58,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+mUF
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+omd
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+mwo
+iNn
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+qbN
+cGS
+iNn
+pun
+pun
+qYo
+pun
+sED
+pun
+icW
+pun
+pun
+pun
+sSb
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vUR
+vUR
+tqN
+pBX
+pBX
+tqN
+wTm
+xaM
+vUR
+siu
+cIk
+uYG
+fhb
+uKp
+fhb
+fhb
+emW
+aDx
+aDx
+emW
+veE
+uYG
+pvE
+ocF
+bDb
+pOb
+deC
+mgo
+eWn
+hBg
+pcm
+pcm
+pcm
+uhg
+leL
+eWn
+hMS
+qne
+uOb
+ned
+qTW
+qTW
+qTW
+llv
+qTW
+nBW
+nBW
+nBW
+nBW
+nBW
+mcC
+pEd
+qBl
+qBl
+qBl
+tLI
+eXF
+daZ
+hmS
+lWW
+tQR
+gkk
+qBl
+qBl
+qBl
+mSS
+xYN
+lxV
+rnD
+eti
+pUI
+kvO
+asJ
+lgT
+lgT
+lgT
+maj
+maj
+asJ
+pfn
+pfn
+pfn
+wad
+wad
+afW
+kke
+kke
+kke
+xuw
+xuw
+afW
+aVy
+aVy
+aVy
+eTC
+eTC
+umM
+umM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(59,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+imC
+pun
+xyE
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+mwo
+sRm
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+weG
+cGS
+sRm
+pun
+pun
+qYo
+pun
+mtE
+bUb
+pun
+pun
+pun
+pun
+ljs
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vUR
+vUR
+plr
+xYW
+xYW
+tqN
+wTm
+qlG
+vUR
+siu
+cIk
+uYG
+fhb
+tkV
+fhb
+fhb
+tkV
+aDx
+aDx
+uPg
+haJ
+uYG
+vAF
+wpN
+fXK
+wQd
+cgD
+jmE
+eWn
+mlY
+uhg
+uhg
+uhg
+uhg
+leL
+eWn
+iLw
+qne
+uOb
+ylN
+hez
+pxH
+qoa
+jgA
+jDx
+mVw
+kZv
+ddF
+qPu
+hez
+mcC
+keT
+qBl
+qBl
+qBl
+bDr
+bDr
+bDr
+nDV
+mmF
+tQR
+vgX
+qBl
+qBl
+qBl
+arL
+xYN
+lxV
+sxi
+eti
+iIA
+sWu
+asJ
+pPU
+wYC
+pPU
+maj
+xQd
+asJ
+joy
+xuc
+joy
+wad
+evA
+afW
+tBA
+bVx
+tBA
+xuw
+gzF
+afW
+tMK
+mwl
+tMK
+eTC
+iMp
+umM
+umM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(60,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+cGS
+iNn
+pun
+pun
+weG
+xgl
+iNn
+pun
+pun
+weG
+cGS
+sRm
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+pun
+dBB
+qOv
+mwM
+kTf
+pun
+pun
+vDF
+vDF
+vDF
+vUR
+vUR
+tqN
+dgL
+dgL
+tqN
+lmq
+mFK
+vUR
+mzy
+cJn
+uYG
+uYG
+uYG
+uYG
+uYG
+uYG
+uYG
+uYG
+uYG
+uYG
+uYG
+xSq
+xSq
+xSq
+wQd
+wQd
+wQd
+eWn
+uYx
+uhg
+uhg
+uhg
+uhg
+ngA
+eWn
+hMS
+qne
+uOb
+ned
+hez
+gZy
+bKx
+jgA
+qPu
+rVp
+lFR
+aPr
+qPu
+hez
+mcC
+pEd
+qBl
+qBl
+qBl
+gTn
+bDr
+bDr
+hmS
+lQb
+tQR
+hMg
+qBl
+qBl
+qBl
+mSS
+xYN
+lxV
+rnD
+eti
+iIA
+sWu
+asJ
+asJ
+asJ
+asJ
+maj
+maj
+asJ
+aCh
+aCh
+aCh
+wad
+wad
+afW
+afW
+afW
+afW
+xuw
+xuw
+afW
+umM
+umM
+umM
+eTC
+eTC
+umM
+umM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(61,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+qat
+imC
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+mwo
+iNn
+pun
+pun
+qbN
+xgl
+sRm
+pun
+pun
+weG
+xgl
+sRm
+pun
+pun
+qYo
+pun
+mtE
+pun
+bUb
+pun
+pun
+qOv
+byM
+kTf
+pun
+pun
+pun
+vDF
+vDF
+vUR
+vUR
+vUR
+vUR
+vUR
+vUR
+lBZ
+vUR
+vUR
+siu
+cIk
+hBV
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+dpf
+dpf
+dpf
+dpf
+dpf
+dpf
+eWn
+qxH
+peo
+mTb
+peo
+geI
+xaD
+eWn
+hMS
+qne
+uOb
+ned
+hez
+mde
+bKx
+fSy
+dke
+dgf
+dgf
+dgf
+dke
+qbB
+wGu
+pEd
+qBl
+qBl
+qBl
+xlE
+dNz
+vzF
+hmS
+lQb
+tQR
+mmF
+qBl
+qBl
+qBl
+mSS
+xYN
+lxV
+rnD
+eti
+fiT
+sWu
+asJ
+rjV
+hhy
+tej
+maj
+maj
+asJ
+lcX
+daJ
+vZy
+wad
+wad
+afW
+xUz
+uGw
+nlv
+xuw
+xuw
+afW
+tSs
+sBJ
+jvo
+eTC
+eTC
+umM
+umM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(62,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+imC
+pun
+pun
+pun
+imC
+pun
+imC
+pun
+pun
+imC
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+cGS
+iNn
+pun
+pun
+weG
+xgl
+sRm
+pun
+pun
+qbN
+xgl
+sRm
+pun
+pun
+qYo
+pun
+sED
+pun
+pun
+pun
+dBB
+wrR
+byM
+kTf
+pun
+pun
+pun
+vDF
+vDF
+vUR
+vUR
+vUR
+vUR
+vUR
+hBV
+siu
+dDM
+dDM
+siu
+cIk
+hBV
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+dpf
+uIk
+beW
+rJI
+cmU
+jke
+eWn
+eWn
+eWn
+eWn
+eWn
+eWn
+eWn
+eWn
+hMS
+qne
+uOb
+ned
+hez
+dTU
+bKx
+jgA
+qPu
+rVp
+lFR
+aPr
+qPu
+hez
+mcC
+pEd
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+pTr
+etd
+hiL
+hiL
+hiL
+mSS
+xYN
+lxV
+rnD
+eti
+iIA
+sWu
+asJ
+ecn
+uKQ
+asJ
+mVt
+qFo
+asJ
+qVR
+bcy
+aCh
+qee
+jhp
+afW
+ggo
+gBI
+afW
+dwe
+dtp
+afW
+ghU
+mLz
+umM
+dgS
+xGh
+umM
+umM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(63,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+cGS
+iNn
+pun
+pun
+weG
+mwo
+sRm
+pun
+pun
+qbN
+xgl
+sRm
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+pun
+pun
+wrR
+byM
+kTf
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hBV
+hBV
+jry
+uGz
+uGz
+dcJ
+cIk
+hBV
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+dpf
+wWN
+roD
+roD
+roD
+wwm
+dpf
+fZD
+cBQ
+qVA
+ihx
+cBQ
+scF
+vNa
+hMS
+qne
+uOb
+ned
+hez
+goW
+bKx
+xaT
+jDx
+mVw
+eJD
+rTx
+qPu
+hez
+wCq
+loh
+hiL
+hiL
+hiL
+jIe
+iEm
+dzU
+pbB
+hiL
+xgX
+aaO
+hiL
+hiL
+hiL
+mSS
+xYN
+lxV
+rnD
+eti
+iIA
+wMf
+asJ
+asJ
+asJ
+asJ
+asJ
+asJ
+asJ
+aCh
+aCh
+aCh
+aCh
+aCh
+afW
+afW
+afW
+afW
+afW
+afW
+afW
+umM
+umM
+umM
+umM
+umM
+umM
+umM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(64,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+imC
+pun
+imC
+pun
+imC
+nin
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+cGS
+sRm
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+qbN
+mwo
+sRm
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+pun
+pun
+qOv
+byM
+kTf
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+hBV
+hBV
+hBV
+hBV
+hBV
+siu
+cIk
+hBV
+vDF
+tBf
+tBf
+tBf
+tBf
+tBf
+tBf
+tBf
+tBf
+tBf
+dpf
+wWN
+roD
+roD
+roD
+xJj
+dpf
+fbH
+eyq
+jgV
+jgV
+jgV
+bMi
+vNa
+iLw
+qne
+uOb
+ylN
+jSi
+jSi
+jSi
+jSi
+jSi
+jSi
+jSi
+jSi
+jSi
+jSi
+oAu
+vCY
+hiL
+hiL
+hiL
+hFk
+hFk
+hFk
+hFk
+hiL
+idu
+sKP
+hiL
+hiL
+hiL
+arL
+xYN
+lxV
+sxi
+eti
+eti
+qPi
+asJ
+asJ
+asJ
+asJ
+asJ
+asJ
+asJ
+aCh
+aCh
+aCh
+aCh
+aCh
+afW
+afW
+afW
+afW
+afW
+afW
+afW
+umM
+umM
+umM
+umM
+umM
+umM
+umM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(65,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+lBV
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+qat
+pun
+pun
+pun
+qYo
+pun
+pun
+imC
+pun
+mFY
+mwo
+sRm
+pun
+pun
+qbN
+cGS
+iNn
+pun
+pun
+weG
+cGS
+sRm
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+pun
+pun
+qOv
+mwM
+kTf
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+hBV
+hBV
+hBV
+hBV
+hBV
+siu
+cIk
+hBV
+vDF
+tBf
+mEG
+bpo
+fdm
+tVB
+lUK
+glv
+wAV
+rfE
+dpf
+qLa
+epH
+qNV
+roD
+hyD
+dpf
+uDy
+jWk
+jgV
+jgV
+jgV
+mIf
+vNa
+hMS
+qne
+uOb
+ned
+jSi
+rPn
+jSi
+rPn
+jSi
+rPn
+jSi
+hKg
+hKg
+jSi
+uCp
+xKN
+hiL
+hiL
+hiL
+cIz
+lxB
+lxB
+sjN
+eHo
+yjP
+gID
+hiL
+hiL
+hiL
+mSS
+xYN
+lxV
+rnD
+eti
+eti
+qSJ
+tUx
+jgG
+jgG
+eti
+eti
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(66,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+omd
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+qat
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+xgl
+sRm
+pun
+pun
+qbN
+mwo
+sRm
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+pun
+pun
+wrR
+byM
+kTf
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hBV
+hBV
+mzy
+cJn
+hBV
+vDF
+tBf
+alU
+gzQ
+kOt
+kOt
+kOt
+kOt
+kOt
+kdE
+dpf
+dzK
+kpY
+lLf
+roD
+vCN
+dpf
+uvY
+maM
+aFI
+wXh
+jgV
+rzL
+vNa
+hMS
+qne
+uOb
+ned
+jSi
+ist
+jSi
+igT
+jSi
+nYG
+jSi
+leB
+leB
+jSi
+mcC
+pEd
+hiL
+hiL
+hiL
+hFk
+hFk
+hFk
+hFk
+hiL
+aaO
+aaO
+hiL
+hiL
+hiL
+mSS
+xYN
+lxV
+rnD
+eti
+eti
+giO
+vBW
+vBW
+vBW
+eti
+eti
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(67,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+pun
+pun
+pun
+aVA
+imC
+pun
+pun
+nin
+icW
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+xgl
+iNn
+pun
+pun
+qbN
+xgl
+sRm
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+pun
+pun
+qOv
+mwM
+kTf
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hBV
+hBV
+siu
+cIk
+hBV
+vDF
+tBf
+xkV
+sTG
+fVU
+kOt
+kOt
+kOt
+ljz
+oUL
+dpf
+pes
+roD
+roD
+roD
+mMX
+dpf
+xlS
+jgV
+jgV
+jgV
+jgV
+nPM
+vNa
+hMS
+qne
+uOb
+ned
+jSi
+leB
+leB
+leB
+leB
+leB
+leB
+leB
+mOc
+jSi
+mcC
+keT
+hiL
+hiL
+hiL
+jQC
+tOL
+ihi
+iHS
+hiL
+xbT
+vjy
+hiL
+hiL
+hiL
+mSS
+xYN
+lxV
+rnD
+eti
+eti
+qHg
+xaj
+vBW
+ooF
+eti
+eti
+szB
+uoM
+uoM
+uoM
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(68,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+vDF
+vDF
+vDF
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+xyE
+pun
+pun
+pun
+icW
+imC
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+cGS
+iNn
+pun
+imC
+qbN
+fBf
+sRm
+pun
+pun
+weG
+cGS
+iNn
+pun
+pun
+qYo
+pun
+sED
+pun
+pun
+pun
+dBB
+qOv
+mwM
+kTf
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hBV
+hBV
+siu
+cIk
+hBV
+vDF
+tBf
+alU
+gzQ
+kOt
+kOt
+kOt
+kOt
+kOt
+kdE
+dpf
+wJl
+roD
+roD
+roD
+wwm
+dpf
+cxN
+jgV
+jgV
+jgV
+jgV
+bkM
+vNa
+iLw
+qne
+uOb
+ylN
+jSi
+leB
+leB
+leB
+leB
+leB
+leB
+ojY
+klv
+jSi
+kXp
+pEd
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+mSS
+xYN
+lxV
+rnD
+eti
+eti
+oaq
+unx
+vBW
+ooF
+eti
+eti
+szB
+uoM
+uoM
+szB
+szB
+szB
+rSA
+rSA
+rSA
+rSA
+rSA
+lBK
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(69,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+vDF
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+lBV
+imC
+imC
+pun
+imC
+imC
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+cGS
+iNn
+pun
+pun
+qbN
+cGS
+mIs
+pun
+pun
+weG
+mwo
+sRm
+pun
+pun
+qYo
+pun
+sED
+pun
+pun
+pun
+dBB
+qOv
+lro
+kTf
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hBV
+hBV
+siu
+cIk
+hBV
+vDF
+tBf
+oIZ
+dzM
+sFD
+iHH
+uUD
+mtO
+vVq
+iiU
+dpf
+epz
+ycq
+wtZ
+ioy
+dSJ
+dpf
+sQa
+jgV
+jgV
+jgV
+aWq
+nXf
+vNa
+gQO
+qne
+uOb
+ned
+jSi
+rar
+xjh
+eYV
+sBt
+vJH
+qft
+fFQ
+vGX
+jSi
+wCq
+kRT
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+hiL
+arL
+xYN
+lxV
+sxi
+eti
+eti
+giO
+vBW
+vBW
+mlV
+eti
+eti
+szB
+szB
+uoM
+szB
+szB
+szB
+rSA
+rSA
+rSA
+rSA
+rSA
+lBK
+lBK
+lBK
+lBK
+lBK
+lBK
+lBK
+lBK
+lBK
+lBK
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(70,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+imC
+imC
+imC
+imC
+pun
+qat
+lBV
+pun
+imC
+pun
+pun
+pun
+pun
+imC
+pun
+qYo
+pun
+pun
+pun
+pun
+cSr
+mtE
+cSr
+pun
+pun
+pun
+mtE
+pun
+pun
+pun
+cSr
+sED
+pun
+pun
+pun
+qYo
+pun
+mtE
+pun
+pun
+pun
+pun
+qOv
+lro
+kTf
+pun
+xyE
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hBV
+hBV
+siu
+cIk
+hBV
+hBV
+tBf
+tBf
+tBf
+tBf
+tBf
+llk
+ofQ
+tBf
+tBf
+dpf
+dpf
+dpf
+dpf
+mRz
+dpf
+dpf
+mpb
+jgV
+jgV
+jgV
+tor
+juu
+tfe
+fku
+qne
+uOb
+ned
+jSi
+jSi
+jSi
+jSi
+jSi
+jSi
+jSi
+eYO
+jSi
+jSi
+uOQ
+ohs
+bZn
+bZn
+bZn
+bZn
+bZn
+bZn
+bZn
+bZn
+bZn
+bZn
+bZn
+bZn
+bZn
+mSS
+xYN
+lxV
+rnD
+eti
+eti
+icF
+vBW
+vBW
+sCi
+eti
+eti
+szB
+szB
+uoM
+szB
+szB
+szB
+rSA
+rSA
+seE
+lWg
+lDA
+lBK
+lBK
+lBK
+lBK
+lBK
+lBK
+lBK
+lBK
+lBK
+lBK
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(71,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+lBV
+imC
+imC
+pun
+pvg
+bpX
+imC
+pun
+qat
+pun
+pun
+imC
+icW
+imC
+pun
+pun
+qat
+pun
+pun
+qYo
+pun
+pun
+pun
+xPt
+noR
+fdE
+noR
+noR
+xuZ
+xuZ
+fdE
+xuZ
+xuZ
+noR
+noR
+fdE
+xuZ
+noR
+noR
+wDw
+noR
+vbE
+pun
+pun
+pun
+pun
+qOv
+lro
+kTf
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hBV
+hBV
+iJk
+uGz
+iHU
+uGz
+rLd
+uGz
+uGz
+iHU
+uGz
+xiw
+uGz
+uGz
+iHU
+uGz
+thE
+uGz
+hsO
+hjS
+uGz
+cBr
+wmy
+wmy
+wmy
+wVW
+jVo
+twX
+bAl
+phW
+lvw
+uOb
+ned
+fwr
+lWC
+tpr
+pYH
+tpr
+tpr
+tpr
+izt
+pYH
+tpr
+izt
+osn
+bZn
+krB
+niv
+qkM
+dzI
+rSH
+rSH
+rSH
+eXy
+lNE
+bZn
+bZn
+bZn
+mSS
+xYN
+lxV
+rnD
+eti
+eti
+gHB
+gAn
+vBW
+uer
+eti
+eti
+szB
+szB
+szB
+szB
+szB
+szB
+rSA
+rSA
+wiK
+uYe
+hBv
+mgO
+bXG
+lKj
+sYf
+sYf
+sYf
+lKj
+sYf
+lBK
+lBK
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(72,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+imC
+pun
+imC
+imC
+aVA
+imC
+imC
+imC
+pun
+pun
+imC
+pun
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+cSr
+mtE
+cSr
+pun
+pun
+cSr
+mtE
+pun
+pun
+pun
+cSr
+mtE
+cSr
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+qOv
+mwM
+kTf
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+pgd
+pgd
+pgd
+pgd
+fCi
+nZx
+dux
+nZx
+ptm
+xmq
+nZx
+dux
+nZx
+nZx
+nZx
+nZx
+dux
+nZx
+nZx
+nZx
+dux
+siu
+sxb
+qgX
+goN
+jhu
+vGs
+vGs
+gHQ
+iiz
+vNa
+xcS
+qne
+uOb
+ned
+fwr
+hKj
+vII
+vII
+vII
+vII
+vII
+qCV
+qMk
+qMk
+rOE
+naj
+bZn
+amg
+niv
+inL
+wPG
+xPZ
+xPZ
+xPZ
+xPZ
+mIO
+bZn
+bZn
+bZn
+mSS
+xYN
+lxV
+rnD
+eti
+eti
+lsw
+wfM
+vBW
+vBW
+eti
+eti
+mUV
+mUV
+qLx
+qLx
+qLx
+qLx
+qLx
+rSA
+bGo
+xsl
+hBv
+mgO
+kNP
+bGK
+bGK
+bGK
+bGK
+bGK
+bGK
+lBK
+lBK
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(73,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+imC
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+iKO
+sRm
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+weG
+tPK
+sRm
+pun
+pun
+qYo
+pun
+pun
+pun
+bUb
+pun
+pun
+jUH
+byM
+kTf
+pun
+pun
+xyE
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+qHd
+pgd
+hMq
+hMq
+hMq
+hMq
+hMq
+hMq
+qID
+qID
+qID
+qID
+qID
+xfZ
+qID
+qID
+nHA
+nHA
+nHA
+nHA
+aru
+nHA
+nHA
+iLw
+qne
+uOb
+ylN
+fwr
+ucZ
+vII
+vII
+cLD
+cLD
+eSJ
+eSJ
+eSJ
+vII
+pnj
+azx
+bZn
+tzF
+niv
+mdQ
+xPZ
+xPZ
+xPZ
+xPZ
+xPZ
+jDt
+bZn
+bZn
+bZn
+mSS
+xYN
+lxV
+rnD
+eti
+eti
+eti
+eti
+eti
+eti
+eti
+eti
+mUV
+mUV
+qLx
+qLx
+qLx
+qLx
+qLx
+rSA
+opp
+jEK
+hBv
+mgO
+kNP
+bGK
+bGK
+bGK
+bGK
+bGK
+bGK
+lBK
+lBK
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(74,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+cju
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+qat
+nin
+imC
+imC
+pun
+imC
+pun
+icW
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+szW
+sRm
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+weG
+szW
+sRm
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+jUH
+byM
+kTf
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+pgd
+pgd
+whG
+mpi
+gnj
+soI
+cfL
+wuM
+nCO
+tRT
+hMq
+iAB
+mbK
+tEC
+cxk
+cxk
+qID
+kYy
+kYy
+kYy
+kYy
+nMh
+jIv
+qID
+nVo
+nHt
+etU
+etU
+xxF
+ler
+nHA
+hMS
+qne
+uOb
+ned
+fwr
+ucZ
+vII
+vII
+psv
+vfM
+lzM
+ogu
+grk
+vII
+pnj
+maF
+bZn
+ghv
+niv
+aaw
+xPZ
+xPZ
+xPZ
+xPZ
+xPZ
+mIO
+bZn
+bZn
+bZn
+arL
+xYN
+lxV
+sxi
+eti
+eti
+eti
+eti
+eti
+eti
+eti
+eti
+mUV
+mUV
+qLx
+qLx
+bTs
+dyT
+umI
+kei
+vuC
+uYe
+raE
+mgO
+kNP
+bGK
+bGK
+qMj
+bGK
+bGK
+bGK
+lBK
+lBK
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(75,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+imC
+pun
+imC
+imC
+lBV
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+imC
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+szW
+iNn
+pun
+pun
+weG
+iKO
+sRm
+pun
+pun
+weG
+iKO
+sRm
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+dBB
+wrR
+byM
+kTf
+pun
+pun
+pun
+icW
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+pgd
+pgd
+hzb
+jKy
+jKy
+jKy
+jKy
+bMS
+nfR
+xoN
+hMq
+hMq
+hMq
+hVe
+hVe
+hVe
+qID
+qyT
+fLg
+fLg
+fLg
+our
+tmQ
+qID
+rjH
+nVo
+nVo
+nVo
+nVo
+nVo
+nHA
+hMS
+qne
+uOb
+ned
+fwr
+ucZ
+vII
+vII
+psv
+wZE
+fJF
+xoa
+jfD
+vII
+pnj
+maF
+bZn
+wSr
+rVx
+aJI
+gWC
+afA
+afA
+afA
+okr
+ahY
+bZn
+bZn
+bZn
+mSS
+xYN
+lxV
+cNu
+mUV
+lJx
+oLp
+oLp
+oLp
+oLp
+oLp
+oLp
+ulH
+ikI
+qLx
+qLx
+cmo
+suv
+qLx
+rSA
+haz
+xsl
+hBv
+mgO
+kNP
+bGK
+bGK
+bGK
+bGK
+bGK
+bGK
+lBK
+lBK
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(76,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+aaH
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+imC
+pun
+pun
+lBV
+imC
+aVA
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+glF
+pun
+pun
+pun
+qYo
+pun
+bUb
+pun
+pun
+olD
+tPK
+iNn
+pun
+pun
+qbN
+szW
+sRm
+pun
+pun
+qbN
+iKO
+sRm
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+qOv
+byM
+kTf
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+pgd
+pgd
+iNT
+kCk
+ePu
+jKy
+jKy
+bMS
+fKG
+dkj
+hMq
+uva
+hVe
+hVe
+hVe
+lQH
+qID
+kYy
+kYy
+kYy
+kYy
+our
+ttU
+qID
+nHA
+uyz
+nHA
+ylp
+nHA
+kXI
+nHA
+iLw
+qne
+uOb
+ned
+fwr
+aip
+vII
+vII
+mpk
+vgM
+vgM
+mpk
+mpk
+vII
+pnj
+azx
+ppX
+ppX
+sUZ
+ppX
+ppX
+ppX
+ppX
+ppX
+ppX
+ppX
+ppX
+ppX
+ppX
+mSS
+xYN
+lxV
+iDi
+bDs
+oir
+rgL
+rgL
+rgL
+rgL
+rgL
+rgL
+uUm
+vOx
+qLx
+qLx
+lTQ
+tBQ
+qLx
+rSA
+bGo
+xsl
+hBv
+mgO
+kNP
+bGK
+bGK
+bGK
+bGK
+bGK
+bGK
+lBK
+lBK
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(77,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+imC
+pun
+imC
+pvg
+pun
+pun
+pun
+qat
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+iKO
+iNn
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qbN
+iKO
+iNn
+pun
+pun
+qYo
+pun
+xyE
+pun
+pun
+pun
+pun
+qOv
+mwM
+kTf
+pun
+pun
+pun
+pun
+pun
+bUb
+vDF
+vDF
+vDF
+vDF
+pgd
+pgd
+iNT
+kCk
+xUD
+jKy
+jKy
+bMS
+fKG
+lDX
+hMq
+hMq
+uiq
+hVe
+hVe
+skE
+qID
+fLg
+fLg
+fLg
+fLg
+our
+ttU
+qID
+kgE
+xTu
+nHA
+eha
+nHA
+eha
+nHA
+hMS
+aMQ
+rvN
+fRZ
+myq
+aHT
+qMk
+qMk
+qMk
+qMk
+qMk
+pJC
+qMk
+qMk
+ekx
+cER
+aKI
+iUn
+raJ
+mJi
+mJi
+mJi
+mJi
+mJi
+mJi
+mJi
+mJi
+aiv
+pzC
+mvU
+qir
+rrW
+jaS
+qTe
+vIw
+uZn
+uZn
+uZn
+uZn
+jhx
+rgL
+aHk
+nid
+qLx
+qLx
+cmo
+tBQ
+qLx
+rSA
+wiK
+uYe
+hBv
+mgO
+mNr
+maR
+fNS
+yis
+eGs
+maR
+ygU
+lBK
+lBK
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(78,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+xyE
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+iKO
+sRm
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qbN
+szW
+sRm
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+qOv
+lro
+kTf
+pun
+pun
+pun
+gXo
+pun
+pun
+pun
+vDF
+vDF
+vDF
+pgd
+pgd
+hzb
+jKy
+jKy
+jKy
+jKy
+bMS
+fKG
+eAl
+hMq
+uva
+hVe
+hVe
+hVe
+opn
+qID
+kYy
+kYy
+kYy
+kYy
+our
+feF
+qID
+nHA
+nHA
+nHA
+nHA
+nHA
+nHA
+nHA
+bxC
+wbr
+gxE
+xJr
+fwr
+xPQ
+dtZ
+uhR
+nzk
+gKm
+xcE
+nnC
+eiu
+lHQ
+nnC
+yfe
+ppX
+dfd
+wdB
+lHN
+wdB
+wdB
+wdB
+wdB
+lHN
+wdB
+wdB
+caD
+ppX
+mvU
+xMA
+mWY
+dId
+mUV
+dXW
+bZV
+bZV
+bZV
+qrh
+gsZ
+rgL
+mZG
+nid
+qLx
+qLx
+cmo
+tBQ
+qLx
+rSA
+uIr
+hWF
+waU
+lBK
+lBK
+lBK
+lBK
+fNe
+lBK
+lBK
+lBK
+lBK
+lBK
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(79,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+nin
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+wXF
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+tPK
+sRm
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qbN
+szW
+sRm
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+qOv
+lro
+kTf
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+vDF
+vDF
+vDF
+pgd
+pgd
+whG
+epO
+gPi
+jUl
+pqR
+sQX
+tuC
+owy
+hMq
+hMq
+uiq
+hVe
+hVe
+cdN
+qID
+qyT
+fLg
+fLg
+fLg
+our
+eBk
+qID
+nHA
+nHA
+nHA
+nHA
+nHA
+nHA
+nHA
+lwB
+juJ
+mBp
+lwB
+lIx
+lIx
+lIx
+lIx
+lIx
+lIx
+lIx
+ewW
+aMr
+xEc
+jro
+aMr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+tAd
+tAd
+tAd
+dMJ
+gsZ
+rgL
+mZG
+nid
+qLx
+qLx
+lTQ
+tBQ
+qLx
+rSA
+rSA
+rSA
+rSA
+lBK
+lBK
+lBK
+pyu
+gOB
+beV
+lBK
+lBK
+lBK
+lBK
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(80,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+bUb
+pun
+imC
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+knP
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+bUb
+pun
+pun
+pun
+mFY
+szW
+sRm
+pun
+pun
+qbN
+iKO
+iNn
+pun
+pun
+weG
+tPK
+sRm
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+qOv
+mwM
+kTf
+xyE
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+hMq
+wNi
+hVe
+hVe
+hVe
+ccW
+mtW
+wvU
+qXC
+qXC
+qXC
+tpN
+fLg
+qID
+hTO
+hTO
+hTO
+hTO
+hTO
+kig
+kig
+eOe
+qAn
+sOT
+vZe
+lIx
+bsl
+dsB
+vKJ
+qfR
+fmV
+fSp
+woV
+aMr
+wEK
+iMs
+aMr
+uDJ
+uDJ
+ocr
+uDJ
+uDJ
+uDJ
+uDJ
+uDJ
+uDJ
+faB
+uDJ
+ocr
+wjU
+dgr
+lsi
+gUC
+vDT
+ocr
+ocr
+egT
+egT
+egT
+dMJ
+gsZ
+rgL
+aHk
+nid
+qLx
+qLx
+cou
+xTB
+qLx
+rSA
+rSA
+rSA
+rSA
+lBK
+lBK
+lBK
+vFs
+uCl
+uCl
+lBK
+lBK
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(81,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+omd
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+iRz
+pun
+pun
+pun
+pun
+mFY
+szW
+sRm
+pun
+pun
+weG
+iKO
+sRm
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+dBB
+wrR
+mwM
+kTf
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+pgd
+hMq
+hMq
+hMq
+hMq
+hMq
+hMq
+qID
+ahK
+xav
+sOl
+fLg
+sOl
+oIi
+qID
+hTO
+hTO
+kig
+kig
+kig
+kig
+kig
+gAd
+lkO
+pcH
+ljd
+sOc
+xzm
+gQw
+onl
+rEA
+gQw
+gQw
+lcf
+aMr
+uJj
+byc
+aMr
+uDJ
+uDJ
+ocr
+uDJ
+xBH
+uDJ
+uDJ
+uDJ
+uDJ
+uDJ
+uDJ
+ocr
+beX
+qGm
+amu
+amu
+jez
+ocr
+ocr
+lFf
+aHk
+aHk
+dMJ
+gsZ
+rgL
+iDe
+vOx
+qLx
+qLx
+glh
+xGx
+qLx
+rSA
+rSA
+rSA
+rSA
+lBK
+lBK
+lBK
+wpl
+lbq
+llG
+lBK
+lBK
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(82,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+xyE
+pun
+bUb
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+szW
+sRm
+pun
+pun
+weG
+iKO
+sRm
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+qOv
+lro
+kTf
+pun
+pun
+pun
+pun
+cju
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hMq
+hMq
+hMq
+hMq
+hMq
+hMq
+qID
+qID
+qID
+qID
+qID
+qID
+qID
+qID
+hTO
+hTO
+kig
+kig
+euq
+xMy
+pJW
+uDQ
+xuE
+pcH
+ljd
+xpb
+xzm
+gQw
+gJh
+gQw
+gQw
+gQw
+lcf
+xEc
+uJj
+nzx
+aMr
+ocr
+aXm
+ocr
+uYY
+xBH
+uDJ
+uDJ
+uDJ
+uDJ
+cQE
+uDJ
+ocr
+mFz
+mFz
+mFz
+mFz
+mFz
+ocr
+ocr
+vcq
+oNd
+mZG
+kpg
+gsZ
+uoi
+sAx
+rSF
+brj
+brj
+kYe
+qjn
+prj
+dzh
+dzh
+ryV
+jbA
+ryV
+lBK
+lBK
+lBK
+hWM
+lBK
+lBK
+lBK
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(83,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+icW
+pun
+aVA
+pun
+pun
+pun
+pun
+ttf
+pun
+bUb
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+olD
+szW
+iNn
+pun
+imC
+weG
+iKO
+sRm
+pun
+pun
+weG
+iKO
+iNn
+imC
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+dBB
+qOv
+lro
+kTf
+pun
+pun
+pun
+pun
+xyE
+xyE
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+kig
+kig
+kig
+kig
+kig
+kig
+kig
+kig
+kig
+tbr
+rjo
+kig
+czr
+lkO
+rbG
+nvO
+lIx
+tYJ
+gQw
+aRB
+gQw
+gQw
+gQw
+ldH
+aMr
+jwn
+hqU
+aMr
+iEH
+mFz
+ocr
+uDJ
+xBH
+uDJ
+uDJ
+uDJ
+uDJ
+uDJ
+uDJ
+ocr
+nPf
+mFz
+mFz
+mFz
+mFz
+ocr
+ocr
+mUV
+mUV
+mUV
+mUV
+ctZ
+dIO
+mUV
+brj
+brj
+brj
+qni
+dkB
+wKA
+wKA
+wKA
+wKA
+tPE
+qni
+lBK
+lBK
+lBK
+qhs
+lBK
+lBK
+lBK
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(84,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+vDF
+pun
+imC
+pun
+pun
+omd
+pun
+pun
+pvg
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+iKO
+iNn
+pun
+pun
+weG
+tPK
+sRm
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qYo
+pun
+pun
+pun
+xyE
+pun
+kNs
+qOv
+lro
+kTf
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+icW
+aVA
+xyE
+xyE
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+kig
+kig
+waB
+kig
+rkU
+iIf
+iIf
+hAH
+kig
+euq
+pxr
+kig
+gAd
+lkO
+rbG
+nvO
+lIx
+vXq
+gQw
+gQw
+gQw
+gQw
+gQw
+xxz
+aMr
+uJj
+byc
+aMr
+kZl
+mFz
+ocr
+qbZ
+kFt
+igl
+lGI
+lGI
+lGI
+lGI
+lGI
+ocr
+cQM
+mFz
+jje
+mFz
+fMy
+ocr
+ocr
+mUV
+mUV
+mUV
+ciN
+gsZ
+rgL
+jvw
+brj
+brj
+brj
+qlR
+qlR
+qlR
+qlR
+qlR
+qlR
+rHF
+mAs
+lBK
+lBK
+lBK
+hWM
+lBK
+lBK
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(85,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+aaH
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+bUb
+pun
+pun
+pun
+uUV
+pun
+xyE
+pun
+aaH
+pun
+bUb
+pun
+bUb
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+iKO
+iNn
+pun
+pun
+weG
+iKO
+iNn
+pun
+pun
+qbN
+tPK
+iNn
+pun
+pun
+qYo
+pun
+pun
+pun
+nin
+pun
+kNs
+qOv
+lro
+kTf
+pun
+pun
+pun
+icW
+pun
+pun
+pun
+xyE
+bUb
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+kig
+kig
+eZG
+kig
+tbG
+uzr
+uzr
+hvz
+kJw
+lfj
+vuw
+kig
+gAd
+lkO
+nHH
+nvO
+wWz
+fsa
+gQw
+gQw
+gQw
+gQw
+gQw
+bNA
+aMr
+uJj
+byc
+aMr
+bHz
+mFz
+mFz
+mFz
+mFz
+mFz
+mFz
+mFz
+mFz
+mFz
+mFz
+ocr
+mFz
+mFz
+mFz
+mFz
+mFz
+ocr
+ocr
+hTO
+mUV
+mUV
+aTz
+gsZ
+rgL
+nid
+brj
+brj
+qni
+qni
+scm
+qni
+scm
+qni
+scm
+azz
+pnk
+gPl
+hiX
+gPl
+epG
+brj
+brj
+szB
+szB
+szB
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(86,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+pun
+imC
+pun
+imC
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+iKO
+iNn
+pun
+pun
+qbN
+szW
+sRm
+pun
+pun
+qbN
+szW
+sRm
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+bUb
+pun
+qOv
+mwM
+kTf
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+bJm
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+kig
+kig
+dAv
+ocP
+vHd
+uzr
+dmp
+uzr
+kig
+hic
+euq
+kig
+pHV
+tEZ
+xqL
+gLf
+lIx
+eNH
+gQw
+gQw
+gQw
+lMz
+gQw
+lcf
+aMr
+uJj
+byc
+aMr
+mFz
+mFz
+mFz
+mFz
+mFz
+mFz
+mFz
+mFz
+mFz
+mFz
+xke
+iPD
+fNV
+mFz
+nDs
+mFz
+mFz
+ocr
+ocr
+hTO
+mUV
+mUV
+dMJ
+gsZ
+rgL
+nid
+brj
+brj
+qni
+qni
+bjR
+sGc
+bjR
+sGc
+bjR
+qXw
+jyL
+jVm
+mGV
+mGV
+mGV
+brj
+brj
+nGn
+nGn
+nGn
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(87,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+icW
+xyE
+pun
+cju
+pun
+pun
+pun
+xyE
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+mFY
+qxb
+sRm
+pun
+pun
+qbN
+dOC
+sRm
+pun
+pun
+qbN
+qxb
+sRm
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+xyE
+pun
+qOv
+mwM
+kTf
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+kig
+kig
+psa
+kig
+kig
+kig
+kig
+kig
+kig
+kig
+kig
+kig
+uDw
+wxW
+bbF
+uDw
+lIx
+gXL
+gQw
+rEA
+eur
+bjA
+qRG
+iKM
+aMr
+uJj
+byc
+aMr
+iBw
+uXs
+dFg
+mFz
+mFz
+dFg
+mFz
+mFz
+dFg
+mFz
+mFz
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+hTO
+mUV
+mUV
+dMJ
+gsZ
+rgL
+nid
+brj
+brj
+omf
+qni
+jsH
+uBF
+jsH
+uBF
+jsH
+hjv
+xSU
+ofH
+mGV
+mGV
+mGV
+iXK
+iaX
+uLb
+vZL
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(88,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+lBV
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+bUb
+pun
+pun
+pun
+qOv
+byM
+kTf
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+kig
+kig
+tZS
+dqC
+nwU
+lNd
+jNl
+gwP
+wAu
+oYi
+lWi
+bGI
+wMn
+tgc
+sOT
+vZe
+lIx
+uPe
+gQw
+rEA
+aSS
+bke
+qRG
+lcf
+aMr
+uJj
+byc
+aMr
+eSk
+rJe
+ocr
+kcv
+jie
+ocr
+dvU
+jie
+ocr
+swJ
+jie
+ocr
+wLo
+wLo
+wLo
+wLo
+wLo
+wLo
+wLo
+wLo
+wLo
+wLo
+dMJ
+gsZ
+rgL
+enk
+brj
+brj
+qni
+qni
+ger
+sGc
+ger
+sGc
+ger
+qXw
+aAZ
+hZs
+mGV
+mGV
+wBP
+brj
+brj
+nGn
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(89,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+rjc
+eIU
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+fKO
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+nzW
+pun
+pun
+pun
+pun
+pun
+pun
+jUH
+byM
+kTf
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+icW
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+kig
+kig
+tZS
+dqC
+dJc
+kyg
+kyg
+kyg
+kyg
+kyg
+vgV
+dqC
+aYT
+nHH
+nHH
+nvO
+lIx
+uPe
+gQw
+rEA
+aWJ
+bke
+qRG
+lcf
+aMr
+lsV
+nzx
+aMr
+mFz
+pwu
+ocr
+gRy
+aDg
+ocr
+gRy
+aDg
+ocr
+gRy
+aDg
+ocr
+wLo
+lii
+rZO
+ewC
+rIs
+vot
+okK
+cle
+wxz
+wLo
+dMJ
+gsZ
+rgL
+nid
+brj
+brj
+qni
+qni
+scm
+qni
+scm
+qni
+scm
+ivP
+scm
+mGV
+mGV
+mGV
+mGV
+brj
+brj
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(90,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+pun
+pun
+pun
+pun
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+dBB
+jUH
+byM
+kTf
+pun
+pun
+pun
+aVA
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+kig
+kig
+tZS
+dqC
+gMs
+kyg
+kyg
+kyg
+kyg
+kyg
+lTq
+dqC
+acD
+nHH
+nHH
+pxu
+lIx
+fiF
+gQw
+rEA
+aXu
+bpn
+qRG
+lcf
+aMr
+uJj
+byc
+aMr
+xmc
+hEi
+ocr
+vUF
+gRy
+ocr
+vUF
+gRy
+ocr
+vUF
+gRy
+ocr
+wLo
+lii
+lLw
+woT
+woT
+woT
+woT
+woT
+hkK
+ibL
+uZn
+mgJ
+rgL
+nid
+brj
+brj
+qni
+qni
+scm
+qni
+scm
+qni
+scm
+rHF
+scm
+mGV
+mGV
+mGV
+ofH
+brj
+brj
+hTO
+nGn
+lcJ
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(91,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+xyE
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+cju
+pun
+pun
+pun
+pun
+pun
+imC
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+jUH
+byM
+wqu
+ltg
+ltg
+ltg
+ltg
+ltg
+onF
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+vDF
+vDF
+vDF
+kig
+kig
+tZS
+dqC
+pah
+kyg
+kyg
+kyg
+kyg
+kyg
+qcK
+vke
+mPA
+nHH
+nHH
+nvO
+lIx
+sXS
+qRG
+gQw
+gQw
+gQw
+gQw
+lcf
+aMr
+uJj
+qfK
+ago
+uwQ
+xuh
+ocr
+gRy
+gRy
+ocr
+gRy
+gRy
+ocr
+gRy
+gRy
+ocr
+wLo
+cle
+hHW
+cle
+cle
+cle
+cle
+cle
+oVW
+wLo
+pNT
+gsZ
+rgL
+nid
+brj
+brj
+qni
+qni
+bjR
+sGc
+bjR
+sGc
+bjR
+qXw
+jyL
+mpC
+mGV
+mGV
+wEG
+brj
+brj
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(92,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+aaH
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+pun
+pun
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+qOv
+xAd
+iOB
+gsu
+vAc
+gsu
+iOB
+iOB
+iOB
+gsu
+vAc
+iOB
+iOB
+gsu
+vAc
+vAc
+gsu
+gsu
+vAc
+vAc
+vAc
+gsu
+iOB
+iOB
+iOB
+iOB
+iOB
+iOB
+iOB
+gsu
+jdZ
+jdZ
+vmX
+hGr
+fkQ
+dqC
+nTz
+tHP
+tHP
+kyg
+kyg
+kyg
+sRf
+esC
+mPA
+nHH
+nHH
+nvO
+lIx
+ilc
+jvz
+jvz
+iAc
+jvz
+gbE
+thm
+aMr
+vaJ
+omG
+xEc
+atx
+bcu
+ocr
+kKr
+pus
+ocr
+kKr
+pus
+ocr
+kKr
+pus
+ocr
+wLo
+aAf
+hHW
+cle
+cle
+cle
+cle
+cle
+mTf
+wLo
+dMJ
+gsZ
+rgL
+nid
+brj
+brj
+gHk
+qni
+jsH
+uBF
+jsH
+uBF
+jsH
+aMo
+xSU
+vWo
+olY
+mGV
+ofH
+brj
+brj
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(93,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+lBV
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+pun
+kNs
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+iRz
+pun
+pun
+bUb
+pun
+pun
+dBB
+dBB
+sSb
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+gPX
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eRY
+eNq
+vDF
+kig
+kig
+kig
+dqC
+hot
+pPu
+dRK
+kKY
+tLV
+nAu
+dmy
+dqC
+eqY
+xqL
+xqL
+gLf
+lIx
+lIx
+lIx
+lIx
+lIx
+lIx
+lIx
+lIx
+aMr
+kyy
+aMr
+aMr
+aMr
+jcG
+aMr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+wLo
+lii
+hHW
+cle
+cle
+cle
+cle
+cle
+lii
+wLo
+kIX
+gsZ
+rgL
+enk
+brj
+brj
+qni
+qni
+ger
+sGc
+ger
+sGc
+pzb
+qXw
+aAZ
+jVm
+mGV
+mGV
+ofH
+brj
+brj
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(94,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+pun
+pun
+pun
+pun
+pun
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+xyE
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+bUb
+pun
+pun
+pun
+pun
+pun
+dBB
+lro
+kNs
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+kig
+kig
+kig
+dqC
+dqC
+dqC
+dqC
+dqC
+nOk
+dqC
+dqC
+dqC
+xUj
+xUj
+xUj
+xUj
+lIx
+lIx
+lIx
+lIx
+lIx
+lIx
+lIx
+lIx
+aMr
+bRJ
+ulp
+dmB
+gkO
+tuW
+aMr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+ocr
+wLo
+uaU
+hHW
+cle
+ltp
+akM
+xDY
+akM
+akM
+wLo
+dMJ
+gsZ
+rgL
+nid
+brj
+brj
+cSU
+gTx
+nrQ
+wUf
+wLW
+wKA
+wLW
+qnP
+tYT
+mGV
+wBv
+rmy
+aFH
+brj
+brj
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(95,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aaH
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+kNs
+kNs
+kNs
+pun
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+qYo
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+imC
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+lro
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nVF
+dBB
+dBB
+dBB
+kTZ
+gYc
+ezy
+ezy
+dEs
+jZD
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+aMr
+myF
+uGb
+buJ
+ulp
+aeL
+aMr
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+qep
+qep
+qep
+bPF
+gjR
+qep
+bWz
+bWz
+bWz
+bWz
+bWz
+dMJ
+gsZ
+rgL
+nid
+brj
+brj
+brj
+tDm
+brj
+brj
+brj
+brj
+brj
+brj
+brj
+brj
+brj
+iLJ
+brj
+brj
+brj
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(96,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+mEn
+nse
+mEn
+mEn
+hTO
+qTN
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+lxe
+uyr
+qFz
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+lxe
+uyr
+qFz
+pun
+pun
+pun
+pun
+dBB
+dBB
+mwM
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+agT
+haO
+haO
+haO
+haO
+oZI
+dBB
+dBB
+vDF
+vDF
+vDF
+vDF
+hTO
+aMr
+aMr
+aMr
+aMr
+aMr
+aMr
+aMr
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+qep
+qep
+qep
+pyr
+uzE
+qep
+bWz
+bWz
+bWz
+bWz
+bWz
+fPB
+gsZ
+rgL
+lnO
+oLp
+ofm
+gKN
+fZa
+rlW
+osR
+mUV
+xVV
+wXM
+wXM
+luy
+wXM
+wXM
+eJl
+syG
+xVV
+xVV
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(97,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+sBs
+vDF
+vDF
+vDF
+vDF
+kuo
+bjz
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xtd
+kuo
+vDF
+nse
+mEn
+vDF
+vDF
+vDF
+bvd
+mEn
+bvd
+bvd
+kMr
+bvd
+kMr
+bvd
+bvd
+sBs
+bvd
+vDF
+vDF
+mEn
+mEn
+vDF
+vDF
+vDF
+vDF
+sBs
+mEn
+mEn
+qTN
+mEn
+sBs
+jCI
+kNs
+kNs
+dBB
+dBB
+dBB
+dBB
+dBB
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+kNs
+kNs
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+gbY
+pun
+pun
+dBB
+pun
+pun
+kNs
+kNs
+kNs
+pun
+pun
+pun
+dBB
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+tAY
+pun
+pun
+pun
+dBB
+kNs
+kNs
+iSa
+nue
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+kNs
+dBB
+dBB
+dBB
+dBB
+dBB
+kNs
+kNs
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+qep
+qep
+qep
+qep
+qep
+qep
+qep
+qep
+qep
+qep
+qep
+pyr
+uzE
+qep
+bWz
+dWW
+lZH
+gAs
+jQP
+vIw
+huG
+rgL
+rgL
+rgL
+rgL
+rgL
+dVK
+lLo
+wNv
+mUV
+xVV
+gox
+wXM
+bKK
+wXM
+mll
+wXM
+gjG
+xVV
+xVV
+hTO
+nGn
+lcJ
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(98,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+cTa
+mEn
+xgt
+nse
+laF
+cTa
+mEn
+qym
+dBB
+dBB
+dBB
+pun
+pun
+pun
+dBB
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+pun
+dBB
+laF
+aaA
+mEn
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+cCM
+bvd
+bvd
+bvd
+bvd
+kdB
+qTN
+kNs
+kNs
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+kNs
+pun
+pun
+pun
+dBB
+gbY
+dBB
+dBB
+dBB
+pun
+pun
+dBB
+kNs
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+tAY
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+iSa
+nue
+psX
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+dBB
+dBB
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+kNs
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+dBB
+pun
+pun
+pun
+dBB
+pun
+pun
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+qep
+sjV
+iPy
+nHo
+uoP
+uoP
+iPy
+jJO
+auq
+eis
+qep
+toV
+cZe
+qep
+bWz
+dtS
+nau
+aWM
+xsM
+jBt
+rrb
+rrb
+rrb
+rrb
+rrb
+rrb
+bjV
+uIx
+mRS
+mUV
+xVV
+sHH
+wXM
+hyA
+wXM
+pJl
+wXM
+gca
+xVV
+xVV
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(99,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+xgt
+mEn
+laF
+mEn
+mEn
+pQF
+bvd
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+aaA
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+aaA
+bvd
+bvd
+bvd
+bvd
+aaA
+bvd
+kNs
+dBB
+dBB
+kNs
+kNs
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+kNs
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+gbY
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+dBB
+dBB
+pun
+pun
+tAY
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+nue
+psX
+kNs
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+kNs
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+pun
+dBB
+pun
+dBB
+dBB
+pun
+pun
+bUb
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+qep
+sjV
+iPy
+iPy
+uoP
+uoP
+iPy
+jJO
+auq
+lqC
+qep
+pyr
+cZe
+qep
+bWz
+sDe
+ons
+jZQ
+bWz
+oeP
+bZV
+bgj
+bZV
+bZV
+ifW
+uoi
+nfJ
+uNc
+oSk
+mUV
+xVV
+pEA
+wXM
+nPa
+wXM
+ifi
+wXM
+qxi
+xVV
+xVV
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(100,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nse
+mEn
+mEn
+mEn
+cTa
+gcu
+dBB
+dBB
+kNs
+pun
+dBB
+pun
+dBB
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+cCM
+mEn
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+aaA
+bvd
+bvd
+bvd
+bvd
+aaA
+bvd
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+kNs
+pun
+pun
+pun
+gbY
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+tAY
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+mwM
+pun
+kNs
+kNs
+kNs
+kNs
+pun
+dBB
+dBB
+dBB
+pun
+dBB
+kNs
+kNs
+kNs
+kNs
+kNs
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+dBB
+kNs
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+kNs
+kNs
+pun
+pun
+dBB
+dBB
+dBB
+pun
+bUb
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+qep
+sjV
+iPy
+iPy
+iPy
+iPy
+pJM
+qep
+ddH
+rYF
+mmL
+kyw
+cZe
+qep
+bWz
+bWz
+bWz
+bWz
+bWz
+mUV
+mUV
+mUV
+mUV
+mUV
+mUV
+ecC
+vwg
+mUV
+mUV
+mUV
+uLC
+kcD
+kcD
+kcD
+kcD
+kcD
+kcD
+kcD
+kcD
+kcD
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(101,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+mEn
+cTa
+qym
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+kNs
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+aaA
+gcu
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+aaA
+bvd
+bvd
+bvd
+bvd
+aaA
+qTN
+dBB
+dBB
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+kNs
+pun
+pun
+dBB
+gbY
+dBB
+dBB
+dBB
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+kNs
+cCA
+dBB
+dBB
+pun
+pun
+dBB
+dBB
+iSa
+nue
+psX
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+kNs
+kNs
+kNs
+dBB
+dBB
+dBB
+kNs
+dBB
+dBB
+dBB
+pun
+pun
+dBB
+dBB
+kNs
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+kNs
+pun
+pun
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+qep
+sjV
+iPy
+iPy
+sjV
+sjV
+nOU
+aGe
+ehs
+nBg
+qep
+uzE
+vyo
+qep
+hTO
+hTO
+hTO
+uLC
+uLC
+uLC
+uLC
+uLC
+qJA
+qQs
+xfF
+gvX
+nfs
+laJ
+xFs
+mxJ
+uLC
+qsV
+poH
+lWJ
+jRr
+kcD
+kcD
+kcD
+kcD
+kcD
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(102,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+mEn
+cTa
+dBB
+dBB
+dBB
+dBB
+pun
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+dBB
+kNs
+kNs
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+aaA
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+aaA
+bvd
+bvd
+bvd
+bvd
+aaA
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+kNs
+kNs
+pun
+pun
+dBB
+dBB
+dBB
+pun
+pun
+dBB
+gbY
+dBB
+dBB
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+tAY
+pun
+dBB
+kNs
+dBB
+kNs
+dBB
+iSa
+nue
+psX
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+kNs
+dBB
+dBB
+pun
+pun
+pun
+dBB
+dBB
+kNs
+kNs
+dBB
+dBB
+dBB
+kNs
+kNs
+kNs
+kNs
+kNs
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+qep
+sjV
+iPy
+hTh
+sjV
+sjV
+oii
+qep
+eFe
+uda
+qep
+uzE
+vyo
+qep
+hTO
+hTO
+hTO
+uLC
+uLC
+uLC
+uLC
+uLC
+csT
+qJA
+fYA
+pTQ
+oac
+dAf
+epu
+xBW
+uLC
+nFO
+poH
+poH
+wWx
+kcD
+kcD
+kcD
+kcD
+kcD
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(103,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+nse
+mEn
+laF
+mEn
+mEn
+laF
+cTa
+mEn
+kNs
+kNs
+dBB
+pun
+pun
+pun
+pun
+dBB
+kNs
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+dBB
+vKZ
+dBB
+bvd
+aaA
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+aaA
+bvd
+bvd
+bvd
+bvd
+aaA
+kNs
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+pun
+pun
+dBB
+gbY
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+pun
+pun
+kNs
+kNs
+kNs
+dBB
+dBB
+dBB
+dBB
+tAY
+pun
+dBB
+kNs
+dBB
+dBB
+dBB
+iSa
+nue
+psX
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+kNs
+pun
+kNs
+kNs
+kNs
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+pun
+dBB
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+qep
+qep
+qep
+qep
+qep
+qep
+qep
+qep
+qep
+qep
+nGn
+xhl
+nGn
+snZ
+hTO
+hTO
+hTO
+uLC
+uLC
+uLC
+uLC
+uLC
+csT
+xBW
+fYA
+pTQ
+oac
+dAf
+fAI
+qJA
+uLC
+wKo
+vOs
+gcK
+poH
+kcD
+kcD
+kcD
+kcD
+kcD
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(104,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+xgt
+xgt
+cTa
+mEn
+xgt
+mEn
+nse
+cTa
+qym
+qym
+dBB
+dBB
+pun
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+qTN
+cCM
+mEn
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+mEn
+mEn
+mEn
+mEn
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+bvd
+aaA
+bvd
+bvd
+bvd
+qTN
+kdB
+dBB
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+tAY
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+gbY
+dBB
+kNs
+kNs
+dBB
+dBB
+pun
+pun
+mwM
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+eES
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+xyE
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+nGn
+vZL
+nGn
+hTO
+hTO
+hTO
+hTO
+uLC
+uLC
+uLC
+uLC
+uLC
+viJ
+qJA
+fYA
+pTQ
+oac
+xxj
+fKY
+xXH
+uLC
+eey
+nyK
+gOc
+nyK
+kcD
+kcD
+kcD
+kcD
+kcD
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(105,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+sBs
+vDF
+vDF
+vDF
+vDF
+ijF
+rhh
+qym
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xtd
+ijF
+nse
+mEn
+nse
+bvd
+bvd
+bvd
+bvd
+mEn
+vDF
+vDF
+vDF
+mEn
+mEn
+vDF
+vDF
+sBs
+bvd
+bvd
+bvd
+vDF
+bvd
+kMr
+bvd
+vDF
+vDF
+sBs
+nse
+bvd
+bvd
+qTN
+sBs
+gmb
+kNs
+kNs
+kNs
+pun
+pun
+kNs
+kNs
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+kNs
+pun
+pun
+dBB
+dBB
+pun
+kNs
+kNs
+gbY
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+dBB
+kNs
+kNs
+kNs
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+gbY
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+bPg
+kNs
+kNs
+dBB
+kNs
+pun
+pun
+pun
+pun
+icW
+pun
+pun
+pun
+dBB
+pun
+dBB
+dBB
+dBB
+kNs
+kNs
+pun
+pun
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+nGn
+xdC
+nGn
+hTO
+hTO
+hTO
+hTO
+uLC
+uLC
+uLC
+uLC
+uLC
+dgg
+qJA
+fYA
+pTQ
+jDZ
+dco
+auz
+wZh
+kia
+xEt
+wHr
+cVa
+mmX
+kcD
+kcD
+kcD
+kcD
+kcD
+hTO
+nGn
+abv
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(106,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+cKO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+mEn
+mEn
+nse
+xgt
+hTO
+kNs
+kNs
+kNs
+pun
+pun
+pun
+pun
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+lxe
+uyr
+qFz
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+lxe
+uyr
+qFz
+pun
+pun
+pun
+pun
+pun
+pun
+byM
+pun
+pun
+pun
+imC
+bUb
+bUb
+pun
+pun
+cju
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+bUb
+pun
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+nGn
+vZL
+nGn
+hTO
+hTO
+hTO
+hTO
+uLC
+uLC
+uLC
+uLC
+uLC
+csT
+xBW
+fYA
+pTQ
+pTQ
+pTQ
+pTQ
+pTQ
+keQ
+fKF
+tjf
+odb
+mmX
+kcD
+kcD
+kcD
+kcD
+kcD
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(107,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+kNs
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+cGx
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+ubt
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+egk
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+icW
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+cGx
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+cGx
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+nGn
+vZL
+nGn
+hTO
+hTO
+hTO
+hTO
+uLC
+uLC
+uLC
+uLC
+uLC
+csT
+qJA
+sMN
+dcd
+dcd
+dcd
+dcd
+dcd
+uLC
+ugQ
+tjf
+odb
+uKf
+kcD
+kcD
+kcD
+kcD
+kcD
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(108,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+pun
+pun
+kNs
+kNs
+pun
+kNs
+pun
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+vnP
+vnP
+ycX
+vnP
+vVk
+vVk
+vnP
+vnP
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+fKO
+bsH
+bsH
+bsH
+bsH
+bsH
+amZ
+dib
+mwM
+kzH
+amZ
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+ncx
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+daH
+bsH
+bsH
+bsH
+bsH
+daH
+uyr
+pGl
+pGl
+pGl
+pGl
+pGl
+fbr
+wTC
+uyr
+bsH
+bsH
+bsH
+uyr
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+nGn
+uLb
+nGn
+hTO
+hTO
+hTO
+hTO
+uLC
+uLC
+uLC
+uLC
+uLC
+jGT
+eRI
+mXy
+mXy
+mXy
+gws
+xjQ
+jGT
+uLC
+nyK
+hmA
+nLM
+ygS
+kcD
+kcD
+kcD
+kcD
+kcD
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(109,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+aaH
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+qYo
+pun
+vnP
+niq
+vgl
+vgl
+mPG
+xRh
+fNG
+vnP
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+qOv
+lro
+kTf
+pun
+pun
+imC
+icW
+pun
+pun
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+cju
+pun
+pun
+pun
+imC
+pun
+pun
+xyE
+bUb
+uUj
+dBB
+dBB
+pun
+dBB
+dBB
+dBB
+pun
+qYo
+bUb
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+hTO
+hTO
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+hrj
+hrj
+qcI
+wQl
+efy
+iXa
+hrj
+hrj
+hrj
+kcD
+vYw
+uch
+kcD
+kcD
+kcD
+kcD
+kcD
+kcD
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(110,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+pun
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+vnP
+niq
+vgl
+vgl
+mPG
+wZT
+hIo
+vnP
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+bUb
+pun
+pun
+pun
+pun
+qOv
+lro
+kTf
+pun
+pun
+pun
+imC
+pun
+bUb
+aVA
+pun
+eES
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+qYo
+bUb
+pun
+pun
+hQh
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+hTO
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+qDO
+jjw
+wQH
+wQH
+wQH
+wQH
+jjw
+pGC
+hBZ
+fyb
+cyO
+dZR
+uQl
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(111,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+vnP
+amD
+vgl
+vgl
+mPG
+sfp
+vgl
+vnP
+uUV
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+qOv
+mwM
+kTf
+bUb
+xyE
+pun
+icW
+pun
+pun
+imC
+khv
+pun
+bUb
+bUb
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kxF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+icW
+pun
+pun
+bUb
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+xdC
+nGn
+vDF
+vDF
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+alL
+ygP
+ygP
+ygP
+ygP
+gLA
+sIc
+pqu
+ayK
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+jlx
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(112,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+xyE
+pun
+pun
+bUb
+pun
+aVA
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+vnP
+jEa
+vgl
+vgl
+vgl
+vgl
+uMp
+vnP
+vnP
+vnP
+pun
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+jiI
+gDg
+ltg
+ltg
+ltg
+pun
+pun
+qOv
+byM
+kTf
+pun
+pun
+aPl
+ltg
+jrf
+ltg
+sDF
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+jiI
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+ltg
+bUb
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+qYo
+pun
+pvg
+bUb
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+uut
+oDp
+nli
+yft
+oDp
+qhx
+jFQ
+hrj
+aiX
+soY
+soY
+vaM
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(113,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+vnP
+lve
+vgl
+vgl
+vgl
+vgl
+ckB
+uoX
+kNJ
+bBU
+hQr
+gsu
+vAc
+vAc
+gsu
+gsu
+gsu
+iOB
+iOB
+iOB
+iOB
+iOB
+gsu
+edK
+vAc
+tpt
+mJR
+edK
+vAc
+tpt
+iOB
+iOB
+gsu
+gsu
+vAc
+vAc
+gsu
+gsu
+iOB
+iOB
+gsu
+vAc
+vAc
+vAc
+gsu
+iOB
+gsu
+gsu
+vAc
+vAc
+edK
+jBW
+wSz
+vhC
+nSC
+czk
+oJX
+tTO
+rSm
+oJX
+mNF
+oJX
+kYV
+nkF
+tTO
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+qYo
+pun
+pun
+icW
+imC
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+irs
+uut
+oDp
+rpz
+frj
+oDp
+qhx
+qhV
+kzi
+dKR
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(114,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+hTO
+hTO
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+imC
+vnP
+cjJ
+vgl
+vgl
+vgl
+rMo
+pAp
+vnP
+vde
+vnP
+pun
+gPX
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+uhC
+eNq
+eNq
+eNq
+eNq
+pun
+pun
+pun
+eNq
+pun
+pun
+pun
+eNq
+otE
+eNq
+ghQ
+pNW
+eNq
+ghQ
+eNq
+hCo
+eNq
+eNq
+ryu
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+eNq
+pun
+tTO
+xeQ
+tTO
+ntD
+xGV
+hgD
+tTO
+rSm
+oJX
+oJX
+tGB
+dHL
+sCX
+feZ
+pun
+pun
+pun
+kNs
+dBB
+dBB
+dBB
+dBB
+pun
+iRz
+pun
+pun
+bUb
+xyE
+pvg
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+uut
+oDp
+rpz
+frj
+oDp
+qhx
+qhV
+hBm
+xbR
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(115,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+icW
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+imC
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+vnP
+vnP
+ycX
+vnP
+vnP
+vnP
+bAX
+vnP
+vnP
+vnP
+bUb
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+nWe
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+bUb
+pun
+pun
+xyE
+pun
+khv
+pun
+pun
+pun
+pun
+pun
+nWe
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+tTO
+tTO
+tTO
+oKF
+tGB
+hgD
+tTO
+oJX
+oJX
+oJX
+oJX
+oJX
+oJX
+feZ
+bUb
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+qYo
+pun
+pun
+pun
+imC
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+uut
+oDp
+fxn
+oLt
+oDp
+qhx
+rdy
+hrj
+xxU
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(116,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+ubt
+pun
+icW
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+vnP
+dEV
+vgl
+vgl
+mUx
+mUx
+pER
+vnP
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+xyE
+qYo
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+tTO
+rDV
+oJX
+oJX
+tTO
+oJX
+oJX
+oJX
+oJX
+oJX
+oJX
+tTO
+viX
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+bUb
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+uut
+oDp
+new
+jyr
+kmt
+qhx
+qhV
+kzi
+xbR
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(117,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+icW
+pun
+pun
+xyE
+cju
+pun
+pun
+pun
+xyE
+pun
+bUb
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+xyE
+pun
+imC
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+bUb
+gaS
+pun
+pun
+cju
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+qYo
+pun
+vnP
+vgl
+vgl
+vgl
+sfp
+bQl
+xeg
+vnP
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+imC
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+tTO
+oJX
+oJX
+oJX
+vfB
+oJX
+oJX
+oJX
+oJX
+oJX
+oJX
+vfB
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+pun
+kNs
+qYo
+pun
+pun
+imC
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+uut
+oDp
+vRM
+ayQ
+dvn
+qhx
+qhV
+ibJ
+hiZ
+soY
+soY
+vaM
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(118,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+vnP
+vgl
+vgl
+yeM
+fND
+rHk
+vgl
+vnP
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+xyE
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+xyE
+pun
+pun
+pun
+tTO
+oJX
+oJX
+bLU
+tTO
+jZM
+cgH
+rNT
+sSl
+aMa
+aMa
+tTO
+pun
+pun
+pun
+dBB
+dBB
+dBB
+kNs
+pun
+pun
+nWe
+pun
+pun
+icW
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+xdC
+nGn
+vDF
+vDF
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+irs
+uut
+oDp
+xmu
+qij
+obI
+qhx
+qhV
+ibJ
+mfp
+soY
+ltZ
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+mmY
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(119,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+aVA
+pun
+bUb
+pun
+pun
+pun
+rLF
+pun
+pun
+aVA
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+exB
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+icW
+pun
+xyE
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+vnP
+vnP
+vnP
+vnP
+vnP
+vnP
+vnP
+vnP
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+icW
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+tTO
+pun
+pun
+pun
+dBB
+dBB
+dBB
+kNs
+pun
+pun
+qYo
+pun
+imC
+bUb
+xyE
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+uut
+oDp
+cNE
+jdW
+xWw
+qhx
+qhV
+ibJ
+mfp
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(120,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+imC
+icW
+imC
+ttf
+pun
+pun
+imC
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+exB
+vDF
+vDF
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+xyE
+pun
+bUb
+pun
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+xyE
+pun
+pun
+bUb
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+imC
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+bUb
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+pun
+pun
+kNs
+pun
+bUb
+qYo
+pun
+pun
+hQh
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+uut
+oDp
+oWy
+oGV
+exb
+qhx
+qhV
+hBm
+xbR
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(121,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+icW
+pun
+pun
+pun
+imC
+pun
+pun
+imC
+nin
+bUb
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+nin
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+xyE
+gaS
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+bUb
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+icW
+pun
+pun
+qYo
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+cGx
+dBB
+dBB
+pun
+pun
+dBB
+dBB
+bUb
+qYo
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xhl
+vZL
+nGn
+vDF
+vDF
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+uut
+oDp
+dMv
+stI
+nsC
+qhx
+rdy
+hrj
+xxU
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(122,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+aaH
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+xyE
+pun
+pun
+pun
+nin
+icW
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+xyE
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+ksW
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+njJ
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+njJ
+bsH
+bsH
+bsH
+bsH
+daH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+bsH
+uyr
+pGl
+pGl
+pGl
+wTC
+pGl
+pGl
+wTC
+uyr
+bsH
+aKJ
+bsH
+uyr
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+uut
+oDp
+sUc
+htH
+gwq
+qhx
+qhV
+kzi
+wdl
+soY
+soY
+vaM
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(123,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+bUb
+ubt
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+icW
+pun
+pun
+pun
+pun
+bUb
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+uUj
+kNs
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+uUj
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+hTO
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+irs
+uut
+oDp
+aNA
+vSW
+frZ
+qhx
+qhV
+ibJ
+mfp
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(124,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+xyE
+pun
+pun
+bUb
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+hTO
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+uut
+oDp
+rdQ
+isM
+jfU
+qhx
+qhV
+ibJ
+hiZ
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(125,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+xyE
+pun
+pun
+jaX
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+xdC
+nGn
+vDF
+hTO
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+dHG
+dds
+ezz
+ezz
+ezz
+ezz
+bYW
+qhV
+ibJ
+hiZ
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+mmY
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(126,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+aVA
+pun
+bUb
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+imC
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+cju
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+dBB
+dBB
+dBB
+dBB
+pun
+icW
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+hTO
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+bBV
+hlA
+ilg
+arB
+arB
+nBi
+dCV
+gRc
+kbh
+aDO
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(127,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+jvp
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+cju
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+imC
+bUb
+pun
+pun
+xyE
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+imC
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+hTO
+hTO
+hTO
+hTO
+hrj
+hrj
+hrj
+hrj
+hrj
+hrj
+hrj
+mQm
+qom
+qom
+spJ
+hrj
+hrj
+hrj
+wWw
+soY
+soY
+vaM
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(128,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+imC
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+pun
+dBB
+dBB
+dBB
+pun
+dBB
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+hTO
+hTO
+hTO
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+dtC
+fOz
+atv
+atv
+reQ
+mbT
+axv
+yev
+gnN
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(129,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+icW
+pun
+imC
+pun
+icW
+pun
+pun
+pun
+jaX
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+pun
+dBB
+dBB
+dBB
+pun
+dBB
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+hTO
+hTO
+hTO
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+jpM
+tHV
+tHV
+tHV
+tHV
+tgp
+gla
+yev
+gnN
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(130,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+tET
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+bUb
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+hTO
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+jpM
+tHV
+fJP
+nxB
+otF
+tgp
+iPW
+bfk
+cMA
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(131,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+cju
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+xyE
+pun
+nin
+pun
+imC
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+icW
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+pun
+dBB
+dBB
+kNs
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+hTO
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+chG
+tHV
+xge
+gPa
+oOF
+tgp
+uai
+bfk
+aHD
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(132,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qqw
+qqw
+qqw
+qqw
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+hHj
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+xyE
+pun
+xyE
+pun
+xyE
+pun
+pun
+icW
+pun
+eES
+xyE
+pun
+pun
+imC
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+glF
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+kNs
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+xdC
+nGn
+vDF
+vDF
+hTO
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+jpM
+tHV
+tKo
+bDz
+lHx
+tgp
+ayB
+bfk
+snB
+soY
+soY
+vaM
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+mmY
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(133,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qqw
+qqw
+qqw
+qqw
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+bFn
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+cju
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+xyE
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+kNs
+dBB
+dBB
+kNs
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+hTO
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+jpM
+tHV
+tHV
+tHV
+tHV
+tgp
+gla
+yev
+gnN
+soY
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(134,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qqw
+qqw
+qqw
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+bFn
+xkl
+xkl
+hHj
+hHj
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+nin
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+xyE
+xyE
+pun
+pun
+pun
+pun
+eVa
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+pun
+dBB
+dBB
+dBB
+dBB
+kNs
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+hTO
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+xwl
+arr
+arr
+arr
+arr
+tXc
+bEQ
+yev
+gnN
+omU
+soY
+igK
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(135,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qqw
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+tKQ
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+nse
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+dBB
+dBB
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(136,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+icW
+pun
+pun
+pun
+pun
+pun
+qqw
+qqw
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+xyE
+xyE
+pun
+xyE
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+pun
+dBB
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(137,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+dda
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+pun
+dBB
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(138,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+nin
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+vDF
+vDF
+vDF
+qVU
+mEn
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+xyE
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+cju
+pun
+xyE
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+pun
+dBB
+bUb
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(139,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+vDF
+vDF
+bvd
+mEn
+xkl
+cKO
+mEn
+xkl
+xkl
+xkl
+xkl
+bFn
+nse
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pIZ
+pun
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+dBB
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+xdC
+nGn
+vDF
+vDF
+vDF
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+mmY
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(140,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xyE
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bvd
+cKO
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xkl
+hHj
+nse
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+icW
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+pun
+dBB
+dBB
+dBB
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(141,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bvd
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+eAM
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+pun
+pun
+dBB
+kNs
+dBB
+dBB
+dBB
+kNs
+kNs
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(142,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+xyE
+pun
+pun
+pun
+pun
+cKO
+mEn
+xkl
+xkl
+dJm
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+dBB
+kNs
+kNs
+dBB
+dBB
+kNs
+kNs
+kNs
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(143,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+bvd
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+nse
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+kNs
+pun
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(144,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+vDF
+vDF
+xkl
+xkl
+cKO
+xkl
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+hTO
+hTO
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+bfk
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(145,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+nse
+vjJ
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+kNs
+kNs
+qYG
+nqx
+qym
+pun
+qym
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+gbz
+nGn
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(146,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nse
+xkl
+xkl
+hHj
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+kNs
+kNs
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+mEn
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+kNs
+nqx
+qqw
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+nGn
+mmY
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(147,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+ksW
+bsH
+pun
+qym
+raG
+bsH
+bsH
+pun
+pun
+agi
+raG
+bUb
+fyf
+pun
+pun
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+imb
+hZj
+kNs
+hZj
+qym
+kNs
+kNs
+kmf
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(148,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+imC
+pun
+pun
+xmk
+pun
+pun
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+qym
+kNs
+kNs
+kNs
+kNs
+kNs
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+hTO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hTO
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(149,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+mEn
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nse
+vDF
+vDF
+vDF
+vDF
+vDF
+kmf
+qTN
+xkl
+xkl
+xkl
+qTN
+qTN
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(150,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+qVU
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+imC
+vnP
+vnP
+vnP
+vnP
+vnP
+gCG
+vnP
+vnP
+pun
+pun
+aVA
+qYo
+qym
+imC
+pun
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+mEn
+mEn
+vDF
+vDF
+vDF
+vDF
+kmf
+qVU
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(151,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+qVU
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+bUb
+vnP
+oyB
+wzI
+szJ
+rVw
+jmh
+cpd
+vnP
+pun
+pun
+pun
+xmk
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nse
+bFn
+quk
+xkl
+xkl
+xkl
+xkl
+mEn
+mEn
+mEn
+xkl
+qVU
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+mEn
+mEn
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+bFn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+uLb
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+vZL
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(152,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+vnP
+jTB
+jmh
+rVw
+gom
+jmh
+bjY
+vnP
+pun
+pun
+pun
+qYo
+pun
+pun
+imC
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+mEn
+mEn
+vjJ
+hLq
+fSZ
+qCv
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+bFn
+xgt
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+mEn
+mEn
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+bFn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vcx
+vcx
+vcx
+uLb
+vZL
+meq
+vZL
+vZL
+vZL
+vZL
+meq
+vZL
+vZL
+vZL
+vZL
+vZL
+vZL
+meq
+vZL
+vZL
+vZL
+vZL
+vZL
+vZL
+meq
+vZL
+vZL
+vZL
+vZL
+vZL
+vZL
+mmY
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(153,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+bUb
+pun
+vnP
+mGU
+rVw
+jmh
+jmh
+jmh
+mWM
+vnP
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nse
+xgt
+mEn
+qCv
+mEn
+eAM
+mEn
+mEn
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+quk
+xgt
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xgt
+xgt
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+eSa
+vcx
+vcx
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+nGn
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(154,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+vnP
+szJ
+wzI
+oyB
+rVw
+jmh
+hnu
+vnP
+pun
+pun
+qZA
+pun
+pun
+qym
+pun
+pun
+pfs
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vjJ
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+vcx
+vcx
+nTf
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(155,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+vnP
+vnP
+vnP
+vnP
+vnP
+xNQ
+vnP
+vnP
+pun
+pun
+pun
+pun
+pun
+qym
+hEz
+pun
+aWG
+lgS
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nGn
+qxn
+nGn
+nGn
+nGn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(156,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+cKO
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+vnP
+oPh
+tcL
+ocj
+kxY
+jmh
+wNk
+vnP
+pDp
+pun
+pun
+qym
+pun
+pun
+pun
+kNs
+qym
+nqx
+mEn
+mEn
+eAM
+mEn
+eAM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+lgS
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uwH
+uwH
+nZe
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(157,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+pdB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+lRa
+gpv
+rVw
+rVw
+jmh
+jmh
+jmh
+mRr
+vnP
+adK
+pun
+pDp
+qYo
+pun
+pun
+aWG
+qym
+hEz
+vPa
+mEn
+xuF
+xgt
+mEn
+xkl
+tzG
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+mEn
+xgt
+qCv
+xgt
+mEn
+mEn
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+lgS
+mEn
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+lgS
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(158,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+soJ
+pun
+kKm
+mJs
+dkH
+dkH
+xnd
+wwy
+jmh
+xNQ
+pun
+pun
+pun
+hRh
+pun
+pun
+pun
+pun
+tMW
+nqx
+vdz
+eAM
+mEn
+xgt
+mEn
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xgt
+eAM
+xgt
+iNW
+mEn
+qCv
+xkl
+xkl
+xkl
+bFn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(159,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pdB
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+gMg
+mcZ
+rVw
+rVw
+rVw
+jmh
+xnd
+vnP
+pun
+pun
+pun
+pun
+pun
+pfs
+pun
+qym
+pfs
+jtT
+kNs
+mEn
+eAM
+xkl
+xkl
+xkl
+lgS
+bFn
+xkl
+xkl
+xkl
+lgS
+xkl
+xkl
+hHj
+mEn
+xgt
+iNe
+xkl
+hHj
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+lgS
+xkl
+xkl
+xkl
+quk
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+mEn
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+eAM
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+eAM
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(160,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+qqw
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+vnP
+xph
+tcL
+tcL
+kHE
+pJX
+pAj
+vnP
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+kNs
+nqx
+nqx
+knc
+xgt
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xgt
+lgS
+qVU
+quk
+xkl
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+lgS
+xkl
+xkl
+xkl
+xkl
+lgS
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+iNe
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(161,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+imC
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+qqw
+qqw
+qqw
+qqw
+qqw
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+vnP
+vnP
+vnP
+gpv
+gpv
+vnP
+vnP
+vnP
+pDp
+pun
+qym
+qym
+pun
+qym
+pfs
+kNs
+pKR
+nqx
+aWG
+mEn
+quk
+xkl
+xkl
+xkl
+qVU
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+quk
+vDF
+vDF
+vDF
+qVU
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+qVU
+vDF
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+hHj
+lgS
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+hHj
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(162,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qqw
+qqw
+qqw
+qqw
+qqw
+qqw
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+gRd
+pun
+pun
+qym
+nqx
+nqx
+kNs
+pfs
+xgt
+xkl
+mEn
+xkl
+xkl
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+qVU
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+qVU
+vDF
+vDF
+vDF
+mEn
+xkl
+mEn
+mEn
+xkl
+syv
+quk
+bFn
+vDF
+vDF
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nse
+xkl
+xkl
+mEn
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(163,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+qqw
+qqw
+qqw
+qqw
+qqw
+qqw
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+qym
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+qYo
+pun
+pfs
+qym
+oLM
+nqx
+nqx
+mEn
+xkl
+hHj
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+qVU
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+qCv
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+bFn
+dUy
+bFn
+vDF
+vDF
+mEn
+qCv
+mEn
+xkl
+xkl
+xkl
+lgS
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+xkl
+vDF
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+mEn
+xkl
+mEn
+xkl
+vDF
+vDF
+vDF
+vDF
+nse
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+mEn
+nse
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(164,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+cju
+pun
+imC
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+qym
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bFn
+xkl
+xkl
+xkl
+lgS
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+quk
+tzG
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+lgS
+xkl
+xkl
+xkl
+xkl
+quk
+xkl
+xkl
+xkl
+bFn
+lgS
+xkl
+qVU
+qVU
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+xkl
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+xgt
+xkl
+vDF
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+mEn
+mEn
+hHj
+xkl
+xkl
+vDF
+vDF
+xgt
+eAM
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(165,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+imC
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+qym
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+bFn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+quk
+xkl
+xkl
+xkl
+xkl
+lgS
+hHj
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xgt
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+mEn
+xgt
+xgt
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(166,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pdB
+pun
+imC
+pun
+pun
+pun
+imC
+pdB
+pun
+bUb
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+lgS
+mEn
+qym
+pun
+pun
+qym
+qym
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bFn
+mEn
+xkl
+xkl
+xkl
+hHj
+bFn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+mEn
+xkl
+xkl
+qVU
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+eAM
+xgt
+xgt
+eAM
+mEn
+mEn
+xkl
+mEn
+mEn
+xkl
+xkl
+xkl
+mEn
+mEn
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xkl
+mEn
+mEn
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(167,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+imC
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+icW
+pdB
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+mEn
+mEn
+mEn
+eAM
+mEn
+mEn
+qym
+qym
+qym
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+mEn
+qCv
+nse
+xkl
+qCv
+syv
+xkl
+mEn
+bFn
+dUy
+wXm
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+mEn
+mEn
+xkl
+xkl
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+mEn
+mEn
+mEn
+mEn
+xgt
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(168,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+bUb
+icW
+pun
+pun
+pun
+nin
+bUb
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+laF
+mEn
+mEn
+mEn
+lgS
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nse
+mEn
+mEn
+mEn
+xkl
+mEn
+mEn
+nse
+quk
+qVU
+xkl
+quk
+xkl
+hHj
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+mEn
+mEn
+mEn
+mEn
+xgt
+mEn
+eAM
+mEn
+xkl
+xkl
+qVU
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(169,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+tzG
+xkl
+xkl
+qVU
+qVU
+xgt
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+xkl
+qVU
+iNe
+fSZ
+qCv
+xkl
+xkl
+mEn
+xkl
+xkl
+qVU
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+mEn
+eAM
+xgt
+mEn
+mEn
+mEn
+qVU
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+mEn
+mEn
+mEn
+mEn
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(170,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+nin
+pdB
+pun
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+qrz
+xkl
+qVU
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+mEn
+xgt
+xgt
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nse
+eAM
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(171,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+imC
+pun
+imC
+pun
+pun
+vFQ
+icW
+imC
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+hHj
+hHj
+hHj
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vjJ
+vjJ
+nse
+qCv
+mEn
+xkl
+eAM
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(172,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+imC
+aVA
+pun
+pun
+imC
+xyE
+pun
+imC
+pun
+pun
+pun
+cju
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+qVU
+qVU
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+nse
+xkl
+xkl
+xkl
+xkl
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(173,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+imC
+pun
+pun
+pun
+pun
+pun
+pun
+pdB
+bUb
+pun
+pun
+pdB
+imC
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+qVU
+lgS
+vDF
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(174,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+wnY
+xyE
+pun
+pun
+lJR
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+hHj
+hHj
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bFn
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(175,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xkl
+qrz
+hHj
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(176,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+ubt
+pun
+pun
+pun
+pun
+pun
+lBV
+imC
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+xgt
+mEn
+vjJ
+xkl
+xkl
+hHj
+qVU
+xgt
+xgt
+lgS
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(177,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+aVA
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+bvd
+bvd
+nse
+lgS
+hHj
+vDF
+nse
+vDF
+lgS
+mEn
+xkl
+xkl
+xkl
+qVU
+hHj
+eAM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(178,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+pun
+nin
+pdB
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+dBB
+bvd
+mEn
+mEn
+mEn
+mEn
+hHj
+vDF
+nse
+mEn
+xkl
+xkl
+xkl
+xkl
+qrz
+hHj
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(179,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+imC
+pun
+imC
+pun
+icW
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bvd
+mEn
+mEn
+xkl
+xkl
+mEn
+hHj
+xkl
+xkl
+xkl
+xkl
+xkl
+eAM
+xgt
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(180,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+lBV
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+dBB
+vDF
+bvd
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+nse
+mEn
+hHj
+lgS
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(181,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+cju
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+qym
+mEn
+mEn
+mEn
+mEn
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+tzG
+xgt
+nse
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(182,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+mEn
+mEn
+mEn
+nse
+hHj
+xkl
+xkl
+xkl
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(183,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+dBB
+dBB
+dBB
+bvd
+kMr
+mEn
+mEn
+lgS
+xgt
+xgt
+vjJ
+qVU
+lgS
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+dCq
+szB
+"}
+(184,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+exB
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+dCq
+szB
+"}
+(185,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(186,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(187,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(188,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(189,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(190,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(191,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+nin
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(192,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bUb
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(193,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pdB
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(194,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(195,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+cju
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+nin
+pun
+xyE
+pun
+icW
+pun
+pun
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(196,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+xyE
+pun
+pun
+pun
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(197,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bZP
+bZP
+pun
+pun
+pun
+pun
+pun
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(198,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+cVw
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(199,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+euC
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(200,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+pun
+eCr
+pun
+bZP
+lbS
+iDF
+iDF
+iDF
+gBO
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(201,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+pun
+pun
+pun
+bZP
+bZP
+bZP
+bZP
+lbS
+iDF
+iDF
+iDF
+gBO
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(202,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+pun
+pun
+pun
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+lbS
+iDF
+iDF
+iDF
+gBO
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(203,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+lbS
+iDF
+iDF
+iDF
+gBO
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(204,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+cVw
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+lbS
+iDF
+iDF
+iDF
+gBO
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(205,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+euC
+bGu
+iDF
+iDF
+iDF
+gBO
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(206,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bGu
+iDF
+iDF
+iDF
+bYR
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(207,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+aON
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(208,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+aON
+aON
+aON
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(209,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+bZP
+aON
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(210,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+aON
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(211,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(212,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+aON
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+euC
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(213,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+aON
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(214,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+aON
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(215,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(216,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(217,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+euC
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(218,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(219,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(220,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(221,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(222,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(223,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(224,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(225,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(226,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(227,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(228,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(229,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+bZP
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(230,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+bZP
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(231,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(232,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(233,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(234,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(235,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(236,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(237,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(238,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(239,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(240,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(241,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(242,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(243,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(244,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(245,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(246,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+vDF
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(247,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(248,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(249,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(250,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(251,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(252,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(253,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(254,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(255,1,1) = {"
+szB
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+uoM
+szB
+"}
+(256,1,1) = {"
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+szB
+"}

--- a/maps/southern_cross/submaps/gateway/snowfield-alt.dmm
+++ b/maps/southern_cross/submaps/gateway/snowfield-alt.dmm
@@ -20,10 +20,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/security/heavy_armory)
 "abv" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small/flicker,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/awaymission/snowfield/emergency_pathway/EP_powered)
+/area/awaymission/snowfield/command/commandarmory)
 "acD" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -1783,12 +1784,6 @@
 /obj/item/weapon/gun/projectile/serdy_pistols/makarov,
 /turf/simulated/floor/wood,
 /area/awaymission/snowfield/checkpoint)
-"bLV" = (
-/obj/machinery/light/small/flicker{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/awaymission/snowfield/security/interrogation)
 "bMi" = (
 /obj/machinery/vending/coffee{
 	dir = 1
@@ -4763,7 +4758,7 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/awaymission/snowfield/outside)
 "eSa" = (
-/obj/machinery/light/small/flicker{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor,
@@ -10720,11 +10715,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5,
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/engineering/monitor_room)
-"lcJ" = (
-/obj/structure/catwalk,
-/obj/machinery/light_construct/small,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/awaymission/snowfield/emergency_pathway/EP_powered)
 "lcX" = (
 /obj/machinery/shower{
 	pixel_y = 18
@@ -11102,12 +11092,6 @@
 "lus" = (
 /turf/simulated/wall/r_wall,
 /area/awaymission/snowfield/hallway/dormhallway)
-"luy" = (
-/obj/machinery/light/small/flicker{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/awaymission/snowfield/command/commandarmory)
 "lve" = (
 /obj/structure/bed/chair/oldsofa,
 /turf/simulated/floor/wood,
@@ -11810,17 +11794,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/command/commandarmory)
-"mlV" = (
-/obj/structure/closet/crate/freezer/rations,
-/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
-/obj/machinery/light/small/flicker,
-/turf/simulated/floor/tiled/steel_grid,
-/area/awaymission/snowfield/dorms/panicroom)
 "mlY" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -11944,6 +11917,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/security/security_cell)
+"mqp" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/interrogation)
 "mrS" = (
 /turf/simulated/wall/r_wall,
 /area/awaymission/snowfield/engineering/monitor_room)
@@ -13335,13 +13314,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/engineering/restroom)
-"nLz" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small/flicker{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/awaymission/snowfield/emergency_pathway/EP_powered)
 "nLM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15629,9 +15601,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/light/small/flicker{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/command/testroom)
@@ -18421,13 +18390,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/public/publicrestroom)
-"txY" = (
-/obj/machinery/light/small/flicker{
-	dir = 1
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/awaymission/snowfield/emergency_pathway/EP_powered)
 "tzg" = (
 /turf/simulated/wall/r_wall,
 /area/awaymission/snowfield/hallway/northhallway)
@@ -19009,7 +18971,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/light/small/flicker{
+/obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -21572,13 +21534,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/dorms/dorm7)
-"wIS" = (
-/obj/structure/catwalk,
-/obj/machinery/light/small/flicker{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/awaymission/snowfield/emergency_pathway/EP_powered)
 "wIT" = (
 /obj/item/weapon/stool,
 /obj/machinery/light,
@@ -26422,7 +26377,7 @@ vZL
 vZL
 vZL
 vZL
-nLz
+rWB
 vZL
 vZL
 vZL
@@ -26453,8 +26408,8 @@ vZL
 vZL
 vZL
 vZL
-vZL
 rWB
+vZL
 vZL
 vZL
 vZL
@@ -28993,7 +28948,7 @@ vDF
 vDF
 vDF
 nGn
-wIS
+gbz
 vZL
 uLb
 vZL
@@ -31057,7 +31012,7 @@ vDF
 vDF
 vDF
 nGn
-txY
+gbz
 nGn
 vDF
 vDF
@@ -33121,7 +33076,7 @@ vDF
 vDF
 vDF
 nGn
-wIS
+gbz
 nGn
 vDF
 vDF
@@ -34669,7 +34624,7 @@ pun
 vDF
 vDF
 nGn
-wIS
+vZL
 nGn
 vDF
 vDF
@@ -34927,7 +34882,7 @@ pun
 vDF
 vDF
 nGn
-vZL
+gbz
 nGn
 vDF
 vDF
@@ -38072,7 +38027,7 @@ tbx
 vBj
 tji
 qTW
-bLV
+mqp
 eim
 eim
 sDm
@@ -41197,7 +41152,7 @@ eti
 giO
 vBW
 vBW
-mlV
+sCi
 eti
 eti
 szB
@@ -46638,7 +46593,7 @@ brj
 brj
 hTO
 nGn
-lcJ
+jlx
 nGn
 uoM
 uoM
@@ -48176,8 +48131,8 @@ osR
 mUV
 xVV
 wXM
+abv
 wXM
-luy
 wXM
 mCn
 eJl
@@ -48444,7 +48399,7 @@ xVV
 xVV
 hTO
 nGn
-lcJ
+jlx
 nGn
 uoM
 uoM
@@ -50250,7 +50205,7 @@ kcD
 kcD
 hTO
 nGn
-vZL
+jlx
 nGn
 uoM
 uoM
@@ -50508,7 +50463,7 @@ kcD
 kcD
 hTO
 nGn
-abv
+vZL
 nGn
 uoM
 uoM

--- a/maps/southern_cross/submaps/gateway/snowfield-alt.dmm
+++ b/maps/southern_cross/submaps/gateway/snowfield-alt.dmm
@@ -1195,6 +1195,18 @@
 /obj/item/weapon/folder/red,
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/security/seconddesk)
+"bkt" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
 "bkM" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/green/border,
@@ -2313,14 +2325,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
 /obj/machinery/door/blast/regular{
 	density = 0;
 	icon_state = "pdoor0";
 	id = "snowfield lab entrance lockdown";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/hallway/commandhallway)
 "cuv" = (
 /obj/structure/table/steel_reinforced,
@@ -2417,6 +2428,9 @@
 	dir = 1
 	},
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -3424,6 +3438,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/effect/floor_decal/industrial/warning,
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/frontgate_substation)
@@ -4885,6 +4900,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/frontgate_substation)
 "fay" = (
@@ -5145,6 +5162,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/awaymission/snowfield/security/armory_entrance)
+"fqH" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/commandhallway)
 "fqI" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -5524,15 +5553,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/awaymission/snowfield/security/armory_entrance)
 "fRZ" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/grey/border,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/awaymission/snowfield/hallway/northhallway)
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/hallway/frontgate_substation)
 "fSf" = (
 /turf/simulated/wall/r_wall,
 /area/awaymission/snowfield/dorms/dorm12)
@@ -6344,15 +6369,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/security/seconddesk)
 "gJv" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/grey/border,
 /turf/simulated/floor/tiled/techfloor,
-/area/awaymission/snowfield/hallway/centerhallway)
+/area/awaymission/snowfield/hallway/frontgate_substation)
 "gKh" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -6861,6 +6882,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/frontgate_substation)
@@ -6918,6 +6942,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/medical/hallway)
 "hkK" = (
@@ -6931,6 +6956,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/industrial/warning,
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/public/toolstroage2)
@@ -7057,13 +7083,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/engineering/engine_checkpoint)
 "hsO" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/awaymission/snowfield/medical/hallway)
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/checkpointhallway)
 "hsQ" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -7099,6 +7129,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/floor_decal/industrial/warning,
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/frontgate_substation)
@@ -7172,7 +7203,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/catwalk,
+/obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/frontgate_substation)
@@ -7499,18 +7530,16 @@
 	},
 /area/awaymission/snowfield/cavern)
 "hUt" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/grey/border{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
 /area/awaymission/snowfield/hallway/dormhallway)
 "hUz" = (
 /obj/machinery/vending/tool{
@@ -7587,7 +7616,9 @@
 	name = "Test room access";
 	req_one_access = list(30,47)
 	},
-/obj/machinery/button/remote/blast_door,
+/obj/machinery/button/remote/blast_door{
+	id = "snowfield test room"
+	},
 /obj/machinery/button/remote/blast_door{
 	desc = "It kicks the beat to the horizon.";
 	name = "Remote beat-drop control";
@@ -7680,7 +7711,7 @@
 	id = "snowfield tool storage lockdown";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/public/toolstroage2)
 "icF" = (
 /obj/structure/table/rack/shelf/steel,
@@ -9151,7 +9182,6 @@
 /turf/simulated/floor,
 /area/awaymission/snowfield/engineering/engine)
 "jBt" = (
-/obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -9160,6 +9190,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/commandhallway)
 "jBQ" = (
@@ -10737,7 +10768,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/awaymission/snowfield/service/janitor)
 "lfj" = (
-/obj/structure/catwalk,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
@@ -10748,6 +10778,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/frontgate_substation)
 "lfp" = (
@@ -11280,6 +11314,18 @@
 	id = "snowfield testlab entrance";
 	name = "Lab Front Entrance";
 	req_one_access = list(1)
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/commandhallway)
+"lFJ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/hallway/commandhallway)
@@ -11933,19 +11979,17 @@
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/medical/patients)
 "mun" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/grey/border{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/awaymission/snowfield/hallway/centerhallway)
+/obj/structure/catwalk,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/dorms/panicroom)
 "mvU" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/hallway/southhallway)
@@ -14338,6 +14382,9 @@
 /area/awaymission/snowfield/dorms/dorm9)
 "oVW" = (
 /obj/structure/closet/crate/bin,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/public/toolstroage2)
 "oWf" = (
@@ -14539,12 +14586,6 @@
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/northhallway)
 "phW" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/grey/border{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -14553,7 +14594,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/catwalk,
+/turf/simulated/floor,
 /area/awaymission/snowfield/hallway/northhallway)
 "plq" = (
 /obj/structure/bed,
@@ -14861,6 +14903,7 @@
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 5
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/hallway/dormhallway)
 "pyg" = (
@@ -15212,6 +15255,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -15630,6 +15676,9 @@
 	name = "Path Blocker Control";
 	pixel_y = 23;
 	req_access = list(1)
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/dorms/panicroom)
@@ -16125,6 +16174,12 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/engineering/restroom)
+"qKg" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/hallway/commandhallway)
 "qLa" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16528,10 +16583,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/frontgate_substation)
 "rjE" = (
@@ -17911,6 +17969,9 @@
 	},
 /obj/machinery/power/terminal{
 	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor,
@@ -19388,6 +19449,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/checkpointhallway)
@@ -20527,6 +20591,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/frontgate_substation)
@@ -21143,13 +21210,20 @@
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/engineering/locker_room)
 "wmy" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/awaymission/snowfield/medical/front_desk)
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/dormhallway)
 "wnn" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -21348,6 +21422,7 @@
 	pixel_x = -24;
 	start_charge = 0
 	},
+/obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/public/toolstroage2)
@@ -21600,16 +21675,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/grey/border{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/catwalk,
+/turf/simulated/floor,
 /area/awaymission/snowfield/hallway/checkpointhallway)
 "wNc" = (
 /obj/structure/cable/yellow{
@@ -22895,6 +22965,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/industrial/warning,
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/frontgate_substation)
@@ -32335,7 +32406,7 @@ kJm
 xIj
 xbN
 rYI
-gJv
+bCH
 uRO
 byG
 scB
@@ -33612,7 +33683,7 @@ uOb
 yeW
 nYl
 mwO
-mun
+lPK
 tnN
 dcv
 dcv
@@ -36996,7 +37067,7 @@ rnD
 lus
 pyc
 hUt
-tkJ
+wmy
 xsa
 xsa
 xsa
@@ -37511,7 +37582,7 @@ lxV
 rnD
 eti
 qjJ
-byw
+mun
 asJ
 vNH
 wYC
@@ -41593,13 +41664,13 @@ iHU
 uGz
 thE
 uGz
-hsO
+uGz
 hjS
 uGz
 cBr
-wmy
-wmy
-wmy
+wVW
+wVW
+wVW
 wVW
 jVo
 twX
@@ -43155,7 +43226,7 @@ nHA
 hMS
 aMQ
 rvN
-fRZ
+rvN
 myq
 aHT
 qMk
@@ -44184,7 +44255,7 @@ kig
 kig
 kig
 kig
-gAd
+hsO
 lkO
 pcH
 ljd
@@ -44481,7 +44552,7 @@ vcq
 oNd
 mZG
 kpg
-gsZ
+bkt
 uoi
 sAx
 rSF
@@ -44955,7 +45026,7 @@ iIf
 iIf
 hAH
 kig
-euq
+gJv
 pxr
 kig
 gAd
@@ -44997,8 +45068,8 @@ mUV
 mUV
 mUV
 ciN
-gsZ
-rgL
+fqH
+qKg
 jvw
 brj
 brj
@@ -45469,7 +45540,7 @@ ocP
 vHd
 uzr
 dmp
-uzr
+fRZ
 kig
 hic
 euq
@@ -46286,7 +46357,7 @@ okK
 ioP
 wxz
 wLo
-dMJ
+lFJ
 gsZ
 rgL
 nid
@@ -46544,7 +46615,7 @@ woT
 woT
 hkK
 ibL
-uZn
+vIw
 mgJ
 rgL
 nid

--- a/maps/southern_cross/submaps/gateway/snowfield-alt.dmm
+++ b/maps/southern_cross/submaps/gateway/snowfield-alt.dmm
@@ -581,6 +581,9 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 6
 	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/service/cafeteria)
 "aDO" = (
@@ -603,6 +606,12 @@
 /obj/machinery/cell_charger,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/public/toolstorage1)
+"aEG" = (
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/security_lockerroom)
 "aFH" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -883,6 +892,14 @@
 /obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/dorms/dorm12)
+"aPP" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/command/gateway)
 "aQV" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -920,6 +937,13 @@
 /obj/item/weapon/clipboard,
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/security/seconddesk)
+"aTf" = (
+/obj/machinery/icecream_vat,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/service/fridge)
 "aTz" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -1333,6 +1357,9 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
+	},
+/obj/machinery/light_switch{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/awaymission/snowfield/service/publicstaff)
@@ -1857,6 +1884,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
 /turf/simulated/floor,
 /area/awaymission/snowfield/security/security_cell_hallway)
 "bSM" = (
@@ -1904,6 +1934,9 @@
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/medical/morgue)
@@ -2015,6 +2048,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 5
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/medical/patient_restroom)
@@ -2227,6 +2263,9 @@
 /obj/structure/closet/radiation,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/engineering/engine)
@@ -2473,6 +2512,18 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/steel_grid,
 /area/awaymission/snowfield/dorms/dorm2)
+"cEt" = (
+/obj/structure/catwalk,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/plating,
+/area/awaymission/snowfield/engineering/primary_storage)
 "cEx" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/device/multitool,
@@ -2642,12 +2693,32 @@
 	pixel_x = 24;
 	start_charge = 0
 	},
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/command/bridge)
 "cTa" = (
 /obj/machinery/door/blast/gate,
 /turf/simulated/floor/outdoors/rocks/caves,
 /area/awaymission/snowfield/cavern)
+"cTz" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/security/hallway)
 "cTX" = (
 /obj/machinery/shower{
 	pixel_y = 18
@@ -3389,6 +3460,13 @@
 "dCq" = (
 /turf/simulated/mineral/cave,
 /area/awaymission/snowfield/restricted)
+"dCA" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm13)
 "dCP" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -3425,6 +3503,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/outside)
+"dEI" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/southhallway)
 "dEV" = (
 /obj/structure/closet/secure_closet/guncabinet,
 /obj/item/weapon/gun/projectile/automatic/serdy/mosin,
@@ -3459,6 +3549,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/awaymission/snowfield/security/armory_entrance)
+"dHj" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm10)
 "dHD" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/grey/border,
@@ -3653,6 +3749,12 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/steel_grid,
 /area/awaymission/snowfield/dorms/dorm14)
+"dNO" = (
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/sub_chamber)
 "dNW" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -3737,6 +3839,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/security/frontgate)
+"dSo" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/awaymission/snowfield/security/seconddesk)
 "dSA" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/steel_grid,
@@ -3953,7 +4063,6 @@
 	layer = 2.9
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/weapon/circuitboard/pointdefense,
 /obj/item/weapon/circuitboard/pointdefense_control{
 	pixel_x = 3;
 	pixel_y = -3
@@ -4374,9 +4483,11 @@
 /turf/simulated/mineral/cave,
 /area/awaymission/snowfield/cavern)
 "eyq" = (
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/neutral,
-/area/awaymission/snowfield/medical/front_desk)
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/carpet/turcarpet,
+/area/awaymission/snowfield/medical/staff_room)
 "eyW" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4548,6 +4659,14 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/service/cafeteria)
+"eMd" = (
+/obj/structure/table/steel,
+/obj/machinery/cell_charger,
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/charger)
 "eNp" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 6
@@ -5095,6 +5214,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/catwalk,
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
 /turf/simulated/floor,
 /area/awaymission/snowfield/engineering/hallway)
 "fsW" = (
@@ -5233,6 +5355,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/engineering/engine_checkpoint)
+"fEp" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/security/security_cell_hallway)
 "fFQ" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -5776,6 +5910,12 @@
 /obj/item/clothing/head/helmet,
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/command/commandarmory)
+"gjO" = (
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm5)
 "gjR" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Server Control Room";
@@ -6215,6 +6355,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/security/heavy_armory)
+"gIL" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm16)
 "gJh" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/computer/skills{
@@ -7062,6 +7209,9 @@
 /obj/item/weapon/pen,
 /obj/effect/floor_decal/corner/purple/border,
 /obj/item/weapon/paper_bin,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/awaymission/snowfield/service/janitor)
 "hBg" = (
@@ -7726,6 +7876,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/medical/front_desk)
 "iiU" = (
@@ -7827,6 +7980,12 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/medical/medical_locker)
+"ioP" = (
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/public/toolstroage2)
 "ipm" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/yellow{
@@ -7993,6 +8152,12 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/public/cafeteria_restroom)
+"iBq" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm2)
 "iBu" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/steel_grid,
@@ -8797,14 +8962,6 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/borgupload{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/obj/item/weapon/circuitboard/aiupload{
-	pixel_x = 2;
-	pixel_y = -2
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/engineering/secure_tech_storage)
@@ -8819,15 +8976,8 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/robotics{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/obj/item/weapon/circuitboard/mecha_control{
-	pixel_x = 1;
-	pixel_y = -1
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/circuitboard/security/mining,
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/engineering/secure_tech_storage)
 "joy" = (
@@ -9178,6 +9328,9 @@
 	pixel_x = -24;
 	start_charge = 0
 	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/medical/patients)
 "jJd" = (
@@ -9233,6 +9386,9 @@
 	name = "empty north bump";
 	pixel_y = 24;
 	start_charge = 0
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/awaymission/snowfield/security/warden)
@@ -10064,6 +10220,13 @@
 /obj/item/weapon/towel/random,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/dorms/dorm9)
+"kDZ" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm14)
 "kEj" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/storage/firstaid/adv{
@@ -10071,6 +10234,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/awaymission/snowfield/security/armory_entrance)
+"kEl" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/front_desk)
 "kEt" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/structure/window/reinforced{
@@ -10338,6 +10513,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/public/cafeteria_restroom)
 "kWO" = (
@@ -10575,6 +10753,9 @@
 	name = "empty west bump";
 	pixel_x = -24;
 	start_charge = 0
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/medical/medical_restroom)
@@ -11073,6 +11254,12 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/medical/staff_room)
+"lCu" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm12)
 "lDj" = (
 /obj/structure/closet/secure_closet/engineering_personal{
 	starts_with = list(/obj/item/clothing/accessory/storage/brown_vest,/obj/item/weapon/storage/toolbox/mechanical,/obj/item/device/radio/headset/headset_eng,/obj/item/device/radio/headset/headset_eng/alt,/obj/item/clothing/suit/storage/hazardvest,/obj/item/clothing/mask/gas,/obj/item/weapon/cartridge/engineering,/obj/item/taperoll/engineering,/obj/item/clothing/head/hardhat,/obj/item/clothing/suit/storage/hooded/wintercoat/engineering,/obj/item/clothing/shoes/boots/winter/engineering,/obj/item/weapon/tank/emergency/oxygen/engi,/obj/item/weapon/storage/belt/utility,/obj/item/weapon/reagent_containers/spray/windowsealant)
@@ -11393,6 +11580,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/security/frontgate)
 "lWC" = (
@@ -11567,14 +11757,6 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/item/weapon/circuitboard/card{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/weapon/circuitboard/communications{
-	pixel_x = 5;
-	pixel_y = -5
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/engineering/secure_tech_storage)
@@ -11608,6 +11790,12 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/dorms/dorm9)
+"mjU" = (
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/medical/storage_room)
 "mkt" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -11694,6 +11882,15 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/engineering/locker_room)
+"mor" = (
+/obj/effect/floor_decal/steeldecal/steel_decals5,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
 "mpb" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/spray/cleaner,
@@ -11740,6 +11937,13 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/awaymission/snowfield/command/bridge)
+"mpJ" = (
+/obj/structure/catwalk,
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/security/security_cell)
 "mrS" = (
 /turf/simulated/wall/r_wall,
 /area/awaymission/snowfield/engineering/monitor_room)
@@ -11939,6 +12143,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/hallway/checkpointhallway)
+"mCn" = (
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/awaymission/snowfield/command/commandarmory)
 "mCK" = (
 /obj/structure/closet/crate/secure/engineering,
 /obj/item/stack/material/uranium{
@@ -12236,6 +12446,9 @@
 /obj/item/weapon/tank/emergency/oxygen/double,
 /obj/item/weapon/tank/emergency/oxygen/double,
 /obj/machinery/light,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/engineering/locker_room)
 "mQm" = (
@@ -12341,6 +12554,9 @@
 "mTR" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/borderfloorblack/corner,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/public/toolstorage1)
 "mUx" = (
@@ -12494,6 +12710,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/engineering/restroom)
 "ned" = (
@@ -12625,6 +12844,18 @@
 /obj/structure/coatrack,
 /turf/simulated/floor/wood,
 /area/awaymission/snowfield/checkpointunpowered)
+"niu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled,
+/area/awaymission/snowfield/command/observatory)
 "niv" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/steel,
@@ -13710,6 +13941,12 @@
 /obj/structure/bed,
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/dorms/dorm7)
+"ool" = (
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm7)
 "ooF" = (
 /obj/structure/table/bench/steel,
 /turf/simulated/floor/tiled/steel_grid,
@@ -13785,6 +14022,9 @@
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 10
 	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/hallway/commandhallway)
 "otE" = (
@@ -13822,6 +14062,12 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/public/publicrestroom)
+"ovi" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm11)
 "ovN" = (
 /obj/structure/cable/yellow,
 /obj/structure/window/reinforced{
@@ -14090,6 +14336,9 @@
 	},
 /obj/item/device/integrated_electronics/wirer{
 	pixel_x = 5
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/engineering/tech_storage)
@@ -14832,6 +15081,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/snowfield/checkpointunpowered)
+"pFu" = (
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm8)
 "pGl" = (
 /obj/machinery/door/blast/gate/open{
 	dir = 4
@@ -15136,6 +15391,12 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/security/warden)
+"pXE" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm9)
 "pYH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -15292,6 +15553,9 @@
 /obj/structure/table/glass,
 /obj/item/weapon/soap,
 /obj/item/weapon/soap,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/security/security_restroom)
 "qfC" = (
@@ -16009,15 +16273,17 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/awaymission/snowfield/command/monitorroom)
+"qQS" = (
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/engineering/monitor_room)
 "qRo" = (
 /obj/structure/table/rack{
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/cloning,
-/obj/item/weapon/circuitboard/clonescanner,
-/obj/item/weapon/circuitboard/clonepod,
-/obj/item/weapon/circuitboard/scan_consolenew,
 /obj/item/weapon/circuitboard/med_data{
 	pixel_x = 3;
 	pixel_y = -3
@@ -16045,6 +16311,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/awaymission/snowfield/dorms/panicroom)
@@ -16317,6 +16586,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/frontgate_substation)
 "rjE" = (
@@ -17203,6 +17475,9 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 6
 	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/medical/hallway)
 "sxi" = (
@@ -17317,6 +17592,12 @@
 /obj/structure/table/standard,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/commandhallway_substation)
+"sDm" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/interrogation)
 "sDF" = (
 /obj/structure/flora/bush,
 /obj/structure/railing{
@@ -17577,6 +17858,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/command/bsa)
+"sUu" = (
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm6)
 "sUP" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
@@ -17655,11 +17942,6 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/item/weapon/circuitboard/security/mining,
-/obj/item/weapon/circuitboard/message_monitor{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/engineering/tech_storage)
@@ -17694,6 +17976,12 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/plating,
 /area/awaymission/snowfield/checkpointunpowered)
+"tdo" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/engineering/engine_checkpoint)
 "tdM" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -17855,6 +18143,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/old_tile/gray,
 /area/awaymission/snowfield/security/evidence_storage)
 "tkr" = (
@@ -17990,6 +18281,14 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/medical/morgue)
+"tsW" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/green/border,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/awaymission/snowfield/medical/medical_locker)
 "ttf" = (
 /obj/structure/flora/tree/dead,
 /obj/structure/flora/grass/both,
@@ -18108,6 +18407,20 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/awaymission/snowfield/dorms/dorm6)
+"txW" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = -5
+	},
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/awaymission/snowfield/public/publicrestroom)
 "txY" = (
 /obj/machinery/light/small/flicker{
 	dir = 1
@@ -18149,6 +18462,12 @@
 "tBf" = (
 /turf/simulated/wall/r_wall,
 /area/awaymission/snowfield/medical/chemistry)
+"tBi" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm3)
 "tBA" = (
 /obj/structure/bed,
 /turf/simulated/floor/tiled/steel,
@@ -18214,6 +18533,12 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/awaymission/snowfield/hallway/checkpointhallway)
+"tFy" = (
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/command/monitorroom)
 "tFR" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -18245,8 +18570,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/command/gateway)
 "tIi" = (
-/obj/item/device/aicard,
-/obj/item/weapon/aiModule/reset,
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/engineering/tech_storage)
@@ -18470,6 +18793,9 @@
 	req_one_access = list(1,45)
 	},
 /obj/item/device/radio/phone,
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/medical/surgery)
 "tSs" = (
@@ -18865,6 +19191,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/hallway/commandhallway)
+"uop" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/grey/border,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/awaymission/snowfield/hallway/northhallway)
 "uoD" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -19302,6 +19636,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/awaymission/snowfield/security/observatory)
 "uKQ" = (
@@ -19413,6 +19750,12 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel_grid,
 /area/awaymission/snowfield/dorms/dorm1)
+"uQU" = (
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/simulated/floor/lino,
+/area/awaymission/snowfield/security/detective)
 "uRd" = (
 /obj/machinery/vending/security{
 	description_fluff = "This security vending machine is kindly provided by the-... Sorry, how do you spell this company's name again?";
@@ -19455,6 +19798,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/awaymission/snowfield/service/cafeteria)
+"uSV" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm4)
 "uUj" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -19723,6 +20072,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/security/frontgate)
 "vgX" = (
@@ -19853,6 +20205,12 @@
 	},
 /turf/simulated/floor/tiled/red,
 /area/awaymission/snowfield/security/frontgate)
+"vkz" = (
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm1)
 "vkB" = (
 /obj/effect/floor_decal/corner/lightgrey/diagonal,
 /obj/structure/bed/chair/wood{
@@ -20312,9 +20670,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/awaymission/snowfield/security/seconddesk)
 "vKZ" = (
-/obj/effect/decal/cleanable/ash,
-/turf/simulated/floor/outdoors/dirt,
-/area/awaymission/snowfield/outside)
+/obj/structure/outcrop,
+/turf/simulated/floor/outdoors/snow/sif/planetuse,
+/area/awaymission/snowfield/cavern)
 "vLR" = (
 /obj/structure/closet/crate/hydroponics{
 	desc = "All you need to start your own honey farm.";
@@ -20344,6 +20702,9 @@
 	name = "empty east bump";
 	pixel_x = 24;
 	start_charge = 0
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/awaymission/snowfield/service/hydro)
@@ -20457,6 +20818,18 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/awaymission/snowfield/service/hydro)
+"vSU" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor,
+/area/awaymission/snowfield/hallway/dormhallway)
 "vSW" = (
 /obj/structure/artilleryplaceholder{
 	icon_state = "23"
@@ -20497,6 +20870,9 @@
 	dir = 4
 	},
 /obj/item/weapon/storage/box/beakers,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/medical/chemistry)
 "vVX" = (
@@ -21506,6 +21882,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/steel,
 /area/awaymission/snowfield/service/kitchen)
 "wVW" = (
@@ -21626,6 +22005,9 @@
 "wZM" = (
 /obj/effect/floor_decal/corner/yellow/diagonal,
 /obj/structure/closet/crate/bin,
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/neutral,
 /area/awaymission/snowfield/engineering/staff_room)
 "wZT" = (
@@ -21752,6 +22134,13 @@
 	},
 /turf/simulated/floor/lino,
 /area/awaymission/snowfield/security/detective)
+"xaU" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/awaymission/snowfield/dorms/dorm15)
 "xbN" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -22641,6 +23030,9 @@
 	dir = 5
 	},
 /obj/structure/coatrack,
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/awaymission/snowfield/security/lobby)
 "xPZ" = (
@@ -22669,6 +23061,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/awaymission/snowfield/checkpointunpowered)
+"xRo" = (
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/awaymission/snowfield/security/armory_entrance)
 "xSb" = (
 /obj/structure/bed,
 /turf/simulated/floor/tiled/steel,
@@ -22697,6 +23095,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/awaymission/snowfield/command/observatory_path)
@@ -28121,7 +28522,7 @@ evZ
 fnS
 fuQ
 fGh
-pbJ
+txW
 pbJ
 pbJ
 fGh
@@ -29961,25 +30362,25 @@ mWW
 sXc
 evg
 evg
-eUt
+vkz
 nwW
 uuq
 sXc
 xSb
 xSb
-ffS
+iBq
 oZe
 dmh
 vDR
 vrX
 vrX
-cVu
+tBi
 rqq
 uuz
 jBQ
 qZp
 qZp
-hVQ
+uSV
 pJb
 hwB
 sWl
@@ -31509,25 +31910,25 @@ wbN
 hoA
 aow
 aow
-vKm
+gjO
 bMx
 qtB
 hoA
 dhs
 dhs
-dJz
+sUu
 rbD
 dlz
 wWo
 onW
 onW
-kcj
+ool
 mdc
 iyS
 vaZ
 mGG
 mGG
-kTd
+pFu
 tZD
 hJH
 sIH
@@ -32241,7 +32642,7 @@ hrB
 vOj
 smE
 fDr
-ajG
+tdo
 ajG
 mIX
 hMS
@@ -32509,7 +32910,7 @@ ned
 ife
 eRq
 imu
-iAW
+aTf
 ife
 qyz
 kJm
@@ -32533,7 +32934,7 @@ nNr
 nNr
 gQT
 uvm
-xYN
+dEI
 rnD
 lus
 kug
@@ -33052,7 +33453,7 @@ uvm
 pHZ
 rnD
 lus
-kug
+vSU
 wbN
 hoA
 eSZ
@@ -33530,7 +33931,7 @@ aBn
 kYw
 txs
 wZo
-nab
+qQS
 mrS
 nvM
 nvM
@@ -34559,7 +34960,7 @@ sEL
 qJL
 ndW
 aBn
-ozF
+mor
 laA
 aeZ
 ciR
@@ -34572,7 +34973,7 @@ uOb
 ned
 kXK
 sxD
-xgf
+aEG
 hnK
 cQm
 dWX
@@ -35056,7 +35457,7 @@ ybq
 ybW
 ybq
 ybq
-ybq
+mjU
 xod
 gaW
 gaW
@@ -35363,7 +35764,7 @@ cRf
 cRf
 pWi
 bxE
-arw
+xRo
 wpf
 kEj
 bxE
@@ -35637,25 +36038,25 @@ wbN
 xad
 qSo
 qSo
-jil
+pXE
 jTW
 llx
 xad
 aas
 aas
-wpC
+dHj
 kZK
 iip
 vdE
 plq
 plq
-iMJ
+ovi
 hbK
 wkh
 eij
 bUq
 bUq
-fPe
+lCu
 eab
 tuz
 fSf
@@ -35840,7 +36241,7 @@ rGr
 ebt
 cuv
 rGr
-hqb
+cEt
 uYG
 tIi
 oLd
@@ -35853,7 +36254,7 @@ yjw
 uUw
 eip
 gvk
-gvk
+eMd
 jem
 eip
 hMS
@@ -37185,25 +37586,25 @@ byw
 asJ
 vNH
 wYC
-wYC
+dCA
 nei
 buF
 asJ
 xuc
 xuc
-xuc
+kDZ
 qiR
 iIb
 afW
 bVx
 bVx
-bVx
+xaU
 iRT
 hhs
 afW
 mwl
 mwl
-mwl
+gIL
 byq
 iji
 umM
@@ -37674,7 +38075,7 @@ qTW
 bLV
 eim
 eim
-eim
+sDm
 nBW
 mcC
 pEd
@@ -38405,7 +38806,7 @@ vUR
 tqN
 dgL
 dgL
-tqN
+eyq
 lmq
 mFK
 vUR
@@ -38448,7 +38849,7 @@ qPu
 rVp
 lFR
 aPr
-qPu
+uQU
 hez
 mcC
 pEd
@@ -39204,7 +39605,7 @@ roD
 wwm
 dpf
 fZD
-cBQ
+kEl
 qVA
 ihx
 cBQ
@@ -39462,7 +39863,7 @@ roD
 xJj
 dpf
 fbH
-eyq
+jgV
 jgV
 jgV
 jgV
@@ -39721,7 +40122,7 @@ hyD
 dpf
 uDy
 jWk
-jgV
+jWk
 jgV
 jgV
 mIf
@@ -40491,7 +40892,7 @@ wJl
 roD
 roD
 roD
-wwm
+tsW
 dpf
 cxN
 jgV
@@ -40772,7 +41173,7 @@ qft
 fFQ
 vGX
 jSi
-wCq
+cTz
 kRT
 hiL
 hiL
@@ -42567,7 +42968,7 @@ nHA
 iLw
 qne
 uOb
-ned
+uop
 fwr
 aip
 vII
@@ -42871,7 +43272,7 @@ cmo
 tBQ
 qLx
 rSA
-wiK
+niu
 uYe
 hBv
 mgO
@@ -43865,7 +44266,7 @@ onl
 rEA
 gQw
 gQw
-lcf
+dSo
 aMr
 uJj
 byc
@@ -44641,7 +45042,7 @@ gQw
 gQw
 xxz
 aMr
-uJj
+fEp
 byc
 aMr
 kZl
@@ -45456,7 +45857,7 @@ jsH
 hjv
 xSU
 ofH
-mGV
+olY
 mGV
 mGV
 iXK
@@ -45934,7 +46335,7 @@ aMr
 lsV
 nzx
 aMr
-mFz
+mpJ
 pwu
 ocr
 gRy
@@ -45953,7 +46354,7 @@ ewC
 rIs
 vot
 okK
-cle
+ioP
 wxz
 wLo
 dMJ
@@ -46086,7 +46487,7 @@ pun
 pun
 pun
 pun
-kNs
+pun
 pun
 pun
 pun
@@ -46600,7 +47001,7 @@ hTO
 hTO
 pun
 pun
-kNs
+pun
 pun
 pun
 pun
@@ -46856,9 +47257,9 @@ vDF
 vDF
 hTO
 pun
-kNs
-kNs
-kNs
+pun
+pun
+pun
 pun
 pun
 pun
@@ -47118,7 +47519,7 @@ pun
 pun
 pun
 pun
-kNs
+pun
 pun
 pun
 pun
@@ -47371,10 +47772,10 @@ hTO
 hTO
 hTO
 kNs
-kNs
-kNs
+dBB
+dBB
 pun
-kNs
+pun
 pun
 pun
 pun
@@ -47778,7 +48179,7 @@ wXM
 wXM
 luy
 wXM
-wXM
+mCn
 eJl
 syG
 xVV
@@ -47887,8 +48288,8 @@ qTN
 mEn
 sBs
 jCI
-kNs
-kNs
+dBB
+dBB
 dBB
 dBB
 dBB
@@ -48111,7 +48512,7 @@ dBB
 pun
 pun
 dBB
-laF
+mEn
 aaA
 mEn
 bvd
@@ -48145,8 +48546,8 @@ bvd
 bvd
 kdB
 qTN
-kNs
-kNs
+dBB
+dBB
 dBB
 dBB
 dBB
@@ -48403,7 +48804,7 @@ bvd
 bvd
 aaA
 bvd
-kNs
+dBB
 dBB
 dBB
 kNs
@@ -48887,7 +49288,7 @@ dBB
 dBB
 dBB
 aaA
-gcu
+bvd
 bvd
 bvd
 bvd
@@ -49065,7 +49466,7 @@ xFs
 mxJ
 uLC
 qsV
-poH
+dNO
 lWJ
 jRr
 kcD
@@ -49176,9 +49577,9 @@ bvd
 bvd
 bvd
 aaA
-kNs
-kNs
-kNs
+dBB
+dBB
+dBB
 kNs
 kNs
 kNs
@@ -49399,7 +49800,7 @@ pun
 pun
 pun
 dBB
-vKZ
+dBB
 dBB
 bvd
 aaA
@@ -49434,9 +49835,9 @@ bvd
 bvd
 bvd
 aaA
-kNs
-kNs
-kNs
+dBB
+dBB
+dBB
 pun
 pun
 pun
@@ -49578,7 +49979,7 @@ pTQ
 oac
 dAf
 fAI
-qJA
+tFy
 uLC
 wKo
 vOs
@@ -49672,8 +50073,8 @@ bvd
 bvd
 bvd
 mEn
-mEn
-mEn
+bvd
+bvd
 mEn
 bvd
 bvd
@@ -49693,8 +50094,8 @@ bvd
 qTN
 kdB
 dBB
-kNs
-kNs
+dBB
+dBB
 pun
 pun
 pun
@@ -49930,7 +50331,7 @@ mEn
 vDF
 vDF
 vDF
-mEn
+bvd
 mEn
 vDF
 vDF
@@ -49951,8 +50352,8 @@ bvd
 qTN
 sBs
 gmb
-kNs
-kNs
+dBB
+dBB
 kNs
 pun
 pun
@@ -50175,7 +50576,7 @@ pun
 pun
 pun
 kNs
-cKO
+vKZ
 hTO
 hTO
 hTO
@@ -50466,9 +50867,9 @@ hTO
 hTO
 hTO
 hTO
-kNs
-kNs
-kNs
+pun
+pun
+pun
 pun
 pun
 pun
@@ -50726,7 +51127,7 @@ hTO
 hTO
 pun
 pun
-kNs
+pun
 kNs
 pun
 kNs
@@ -51241,7 +51642,7 @@ vDF
 vDF
 hTO
 pun
-kNs
+pun
 pun
 pun
 pun
@@ -51647,7 +52048,7 @@ pqu
 ayK
 soY
 soY
-igK
+aPP
 bfk
 bfk
 bfk
@@ -66056,13 +66457,13 @@ xkl
 xkl
 xkl
 xkl
-mEn
 xkl
-mEn
-mEn
-mEn
-mEn
-xgt
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
 xkl
 xkl
 xkl
@@ -66314,15 +66715,15 @@ xkl
 mEn
 mEn
 mEn
-mEn
-mEn
-xgt
-mEn
-eAM
-mEn
 xkl
 xkl
-qVU
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
+xkl
 xkl
 xkl
 xkl
@@ -66574,12 +66975,12 @@ xkl
 xkl
 xkl
 xkl
-mEn
-mEn
+xkl
+xkl
 eAM
 xgt
-mEn
-mEn
+xkl
+xkl
 mEn
 qVU
 xkl

--- a/maps/southern_cross/submaps/gateway/snowfield-alt_ch.dm
+++ b/maps/southern_cross/submaps/gateway/snowfield-alt_ch.dm
@@ -52,7 +52,6 @@
 /area/awaymission/snowfield/hallway/checkpointhallway
 	name = "Gate Hallway"
 	icon_state = "entry_1"
-	requires_power = 0
 
 /area/awaymission/snowfield/hallway/northhallway
 	name = "Northern Hallway"
@@ -87,14 +86,10 @@
 /area/awaymission/snowfield/security/frontgate
 	name = "Front Gate Checkpoint"
 	icon_state = "checkpoint1"
-	requires_power = 0
-	power_equip = 1 // Powering entry
 
 /area/awaymission/snowfield/security/seconddesk
 	name = "Second Gate Checkpoint"
 	icon_state = "checkpoint2"
-	requires_power = 0
-	power_equip = 1 // Powering entry
 
 /area/awaymission/snowfield/security/lobby
 	name = "Security Lobby"

--- a/maps/southern_cross/submaps/gateway/snowfield-alt_ch.dm
+++ b/maps/southern_cross/submaps/gateway/snowfield-alt_ch.dm
@@ -1,0 +1,680 @@
+// -- Areas -- //
+
+/area/awaymission/snowfield
+	icon_state = "blank"
+	base_turf = /turf/simulated/floor/outdoors/dirt
+
+/area/awaymission/snowfield/cavern
+	icon_state = "blue"
+	ambience = list('sound/ambience/ambimine.ogg', 'sound/ambience/song_game.ogg', 'sound/music/LRRMenu.ogg', 'sound/music/LRRTrack3.ogg', \
+	'sound/ambience/cave/AmbCaveDebriA.ogg', 'sound/ambience/cave/AmbCaveDebriB.ogg', 'sound/ambience/cave/AmbCaveDebriC.ogg', \
+	'sound/ambience/cave/AmbCaveDebriD.ogg')
+	always_unpowered = 1
+
+/area/awaymission/snowfield/outside
+	icon_state = "green"
+	always_unpowered = 0
+	dynamic_lighting = 1
+	outdoors = 1
+	requires_power = 0
+
+/area/awaymission/snowfield/checkpoint
+	name = "Checkpoint"
+	icon_state = "checkpoint1"
+	requires_power = 0
+
+/area/awaymission/snowfield/solarshack
+	name = "Solarshack"
+	icon_state = "panelsA"
+
+/area/awaymission/snowfield/checkpointunpowered // Limiting powered area
+	name = "Checkpoint"
+	icon_state = "darkred"
+
+/area/awaymission/snowfield/emergency_pathway/EP_powered
+	name = "Emergency Pathway"
+	icon_state = "green"
+	requires_power = 0
+
+/area/awaymission/snowfield/emergency_pathway/EP_unpowered
+	name = "Emergency Pathway"
+	icon_state = "darkred"
+	always_unpowered = 1
+	power_equip = 0
+	power_environ = 0
+	power_light = 0
+
+/area/awaymission/snowfield/restricted
+	icon_state = "red"
+
+// Base Area
+
+/area/awaymission/snowfield/hallway/checkpointhallway
+	name = "Gate Hallway"
+	icon_state = "entry_1"
+	requires_power = 0
+
+/area/awaymission/snowfield/hallway/northhallway
+	name = "Northern Hallway"
+	icon_state = "north"
+
+/area/awaymission/snowfield/hallway/centerhallway
+	name = "Center Hallway"
+	icon_state = "center"
+
+/area/awaymission/snowfield/hallway/southhallway
+	name = "Southern Hallway"
+	icon_state = "south"
+
+/area/awaymission/snowfield/hallway/dormhallway
+	name = "Dorm Hallway"
+	icon_state = "hallC"
+
+/area/awaymission/snowfield/hallway/commandhallway
+	name = "Command Hallway"
+	icon_state = "hallC1"
+
+/area/awaymission/snowfield/hallway/frontgate_substation
+	name = "Front Gate Substation"
+	icon_state = "substation"
+
+/area/awaymission/snowfield/hallway/commandhallway_substation
+	name = "Command Substation"
+	icon_state = "substation"
+
+// Security
+
+/area/awaymission/snowfield/security/frontgate
+	name = "Front Gate Checkpoint"
+	icon_state = "checkpoint1"
+	requires_power = 0
+	power_equip = 1 // Powering entry
+
+/area/awaymission/snowfield/security/seconddesk
+	name = "Second Gate Checkpoint"
+	icon_state = "checkpoint2"
+	requires_power = 0
+	power_equip = 1 // Powering entry
+
+/area/awaymission/snowfield/security/lobby
+	name = "Security Lobby"
+	icon_state = "security"
+
+/area/awaymission/snowfield/security/security_restroom
+	name = "Security Restroom"
+	icon_state = "security_bathroom"
+
+/area/awaymission/snowfield/security/hallway
+	name = "Security Hallway"
+	icon_state = "red"
+
+/area/awaymission/snowfield/security/detective
+	name = "Detective's Office"
+	icon_state = "detective"
+
+/area/awaymission/snowfield/security/evidence_storage
+	name = "Evidence Storage"
+	icon_state = "evidence_storage"
+
+/area/awaymission/snowfield/security/security_lockerroom
+	name = "Security Locker Room"
+	icon_state = "security_lockerroom"
+
+/area/awaymission/snowfield/security/interrogation
+	name = "Security Interrogation Room"
+	icon_state = "interrogation"
+
+/area/awaymission/snowfield/security/observatory
+	name = "Security Observation Room"
+	icon_state = "observatory"
+
+/area/awaymission/snowfield/security/warden
+	name = "Warden's Office"
+	icon_state = "Warden"
+
+/area/awaymission/snowfield/security/armory_entrance
+	name = "Armory Entrance"
+	icon_state = "armory_entrance"
+
+/area/awaymission/snowfield/security/armory
+	name = "Armory"
+	icon_state = "armory"
+	requires_power = 0
+
+/area/awaymission/snowfield/security/heavy_armory
+	name = "Heavy Armory"
+	icon_state = "riot_control"
+	requires_power = 0
+
+/area/awaymission/snowfield/security/hallway2
+	name = "Security South Hallway"
+	icon_state = "red"
+
+/area/awaymission/snowfield/security/firingrange
+	name = "Firing Range"
+	icon_state = "firingrange"
+
+/area/awaymission/snowfield/security/security_cell_hallway
+	name = "Cell Hallway"
+	icon_state = "security_cell_hallway"
+
+/area/awaymission/snowfield/security/security_cell
+	name = "Security Cell"
+	icon_state = "brig"
+
+// Medical
+
+/area/awaymission/snowfield/medical/front_desk
+	name = "Medical Front Desk"
+	icon_state = "medbay"
+
+/area/awaymission/snowfield/medical/hallway
+	name = "Medical Hallway"
+	icon_state = "medbay4"
+
+/area/awaymission/snowfield/medical/patients
+	name = "Medical Patients Room"
+	icon_state = "patients"
+
+/area/awaymission/snowfield/medical/medical_restroom
+	name = "Medical Restroom"
+	icon_state = "restrooms"
+
+/area/awaymission/snowfield/medical/patient_restroom
+	name = "Medical Patient Restroom"
+	icon_state = "restrooms"
+
+/area/awaymission/snowfield/medical/medical_locker
+	name = "Medical Locker Room"
+	icon_state = "medbay3"
+
+/area/awaymission/snowfield/medical/chemistry
+	name = "Chemistry"
+	icon_state = "chem"
+
+/area/awaymission/snowfield/medical/surgery
+	name = "Surgery"
+	icon_state = "surgery"
+
+/area/awaymission/snowfield/medical/medbay_breakroom
+	name = "Medical Breakroom"
+	icon_state = "medbay_breakroom"
+
+/area/awaymission/snowfield/medical/staff_room
+	name = "Medical Staffroom"
+	icon_state = "medbay2"
+
+/area/awaymission/snowfield/medical/storage_room
+	name = "Medical Storage Room"
+	icon_state = "medbay_primary_storage"
+
+/area/awaymission/snowfield/medical/morgue
+	name = "Morgue"
+	icon_state = "morgue"
+
+//Engineering
+
+/area/awaymission/snowfield/engineering/hallway
+	name = "Engineering Hallway"
+	icon_state = "yellow"
+
+/area/awaymission/snowfield/engineering/tech_storage
+	name = "Engineering Tech Storage"
+	icon_state = "storage"
+
+/area/awaymission/snowfield/engineering/secure_tech_storage
+	name = "Engineering Secure Tech Storage"
+	icon_state = "auxstorage"
+
+/area/awaymission/snowfield/engineering/primary_storage
+	name = "Engineering Primary Storage"
+	icon_state = "primarystorage"
+
+/area/awaymission/snowfield/engineering/staff_room
+	name = "Engineering Staffroom"
+	icon_state = "engineering_break"
+
+/area/awaymission/snowfield/engineering/locker_room
+	name = "Engineering Locker Room"
+	icon_state = "engineering_locker"
+
+/area/awaymission/snowfield/engineering/restroom
+	name = "Engineering Restroom"
+	icon_state = "restrooms"
+
+/area/awaymission/snowfield/engineering/monitor_room
+	name = "Engine Monitor Room"
+	icon_state = "engine_monitoring"
+
+/area/awaymission/snowfield/engineering/engine_checkpoint
+	name = "Engine Checkpoint"
+	icon_state = "security"
+
+/area/awaymission/snowfield/engineering/engine
+	name = "Engine Room"
+	icon_state = "engine"
+
+//Public/Service area
+
+/area/awaymission/snowfield/service/janitor
+	name = "Custodial Closet"
+	icon_state = "janitor"
+
+/area/awaymission/snowfield/service/fridge
+	name = "Fridge"
+	icon_state = "fridge"
+
+/area/awaymission/snowfield/service/kitchen
+	name = "Kitchen"
+	icon_state = "kitchen"
+
+/area/awaymission/snowfield/service/hydro
+	name = "Hydroponics"
+	icon_state = "hydro"
+
+/area/awaymission/snowfield/service/cafeteria
+	name = "Canteen"
+	icon_state = "cafeteria"
+
+/area/awaymission/snowfield/service/publicstaff
+	name = "Public Staffroom"
+	icon_state = "recreation_area"
+
+/area/awaymission/snowfield/public/charger
+	name = "Tool Storage"
+	icon_state = "yellow"
+
+/area/awaymission/snowfield/public/toolstorage1
+	name = "Tool Storage 2"
+	icon_state = "emergencystorage"
+
+/area/awaymission/snowfield/public/toolstroage2
+	name = "Command Toolstorage"
+	icon_state = "emergencystorage"
+
+/area/awaymission/snowfield/public/publicrestroom
+	name = "Public Restroom"
+	icon_state = "restrooms"
+
+/area/awaymission/snowfield/public/cafeteria_restroom
+	name = "Canteen Restroom"
+	icon_state = "restrooms"
+
+//dorms
+
+/area/awaymission/snowfield/dorms/dorm1
+	name = "Room 1"
+
+/area/awaymission/snowfield/dorms/dorm2
+	name = "Room 2"
+
+/area/awaymission/snowfield/dorms/dorm3
+	name = "Room 3"
+
+/area/awaymission/snowfield/dorms/dorm4
+	name = "Room 4"
+
+/area/awaymission/snowfield/dorms/dorm5
+	name = "Room 5"
+
+/area/awaymission/snowfield/dorms/dorm6
+	name = "Room 6"
+
+/area/awaymission/snowfield/dorms/dorm7
+	name = "Room 7"
+
+/area/awaymission/snowfield/dorms/dorm8
+	name = "Room 8"
+
+/area/awaymission/snowfield/dorms/dorm9
+	name = "Room 9"
+
+/area/awaymission/snowfield/dorms/dorm10
+	name = "Room 10"
+
+/area/awaymission/snowfield/dorms/dorm11
+	name = "Room 11"
+
+/area/awaymission/snowfield/dorms/dorm12
+	name = "Room 12"
+
+/area/awaymission/snowfield/dorms/dorm13
+	name = "Room 13"
+
+/area/awaymission/snowfield/dorms/dorm14
+	name = "Room 14"
+
+/area/awaymission/snowfield/dorms/dorm15
+	name = "Room 15"
+
+/area/awaymission/snowfield/dorms/dorm16
+	name = "Room 16"
+
+/area/awaymission/snowfield/dorms/panicroom
+	name = "Panic Room"
+	icon_state = "purple"
+	requires_power = 0
+
+//commandroom
+
+/area/awaymission/snowfield/command/server
+	name = "Server/Blackbox Room"
+	icon_state = "dark128"
+	requires_power = 0
+
+/area/awaymission/snowfield/command/bridge
+	name = "Main Control/Monitoring Room"
+	icon_state = "bridge"
+
+/area/awaymission/snowfield/command/observatory_path
+	name = "Observation Hallway"
+	icon_state = "entry_4"
+
+/area/awaymission/snowfield/command/observatory
+	name = "Observation Room"
+	icon_state = "research"
+	requires_power = 0
+
+/area/awaymission/snowfield/command/testroom
+	name = "Testing Chamber"
+	icon_state = "thunder"
+	requires_power = 0
+
+/area/awaymission/snowfield/command/commandarmory
+	name = "Emergency Armory"
+	icon_state = "armory"
+
+/area/awaymission/snowfield/command/monitorroom
+	name = "BSA Monitoring Room"
+	icon_state = "entry_1"
+
+/area/awaymission/snowfield/command/sub_chamber
+	name = "BSA Sub-Chamber"
+	icon_state = "entry_2"
+
+/area/awaymission/snowfield/command/gateway
+	name = "BSA-Gateway Chamber"
+	icon_state = "teleporter"
+
+/area/awaymission/snowfield/command/bsa
+	name = "BSA Chamber"
+	icon_state = "security_sub"
+	requires_power = 0
+
+//Limited function
+
+/area/awaymission/snowfield/base // Limiting powered areas
+	icon_state = "away"
+	requires_power = 0
+	power_equip = 1
+	power_environ = 1
+	power_light = 1
+
+/area/awaymission/snowfield/powerless // Limiting powered areas
+	icon_state = "darkred"
+	always_unpowered = 1
+	power_equip = 0
+	power_environ = 0
+	power_light = 0
+
+// -- Items -- //
+
+// For fake solar power.
+/obj/machinery/power/fractal_reactor/fluff/smes
+	name = "power storage unit"
+	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit. The controls are locked."
+	icon_state = "smes"
+
+//For fake engine
+/obj/machinery/power/rtg/fake_reactor
+	name = "Nuclear Reactor"
+	desc = "PTTO-3, an industrial all-in-one nuclear power plant by Neo-Chernobyl GmbH. The controls are locked."
+	power_gen = 150000
+	icon_state = "potatoon"
+
+/obj/effect/landmark/away
+	name = "awaystart"
+
+//Gateway mission exclusive special loot
+
+/obj/item/weapon/gun/projectile/automatic/serdy/sr25c
+	name = "SR-25 Carbine"
+	icon_state="m4"
+	desc = "Heavily modified, this gun uses 7.62mm rather than 5.54mm and still has its automated fire mode. Equipped with suppressor, telescopic sight and the red dot sight on its side, it has a capability of handling the CQC and both in long range combat, without making much noises. Multi-dozens of accessories provides the improvement on the recoil, too. An old terran flag stamp and a spec-ops mark on the receiver approves its authentic state. Unmodified, cheep slack-off can be found just about everywhere, but this versions are very hard to come by. Chambered in 7.62x51mm."
+	description_info = "This is a ballistic weapon.  To fire the weapon, ensure your intent is *not* set to 'help', have your gun mode set to 'fire', then click where you want to fire.  To reload, click the weapon in your hand to unload (if needed), then add the appropriate ammo. To use the scope, use the appropriate verb in the object tab. The description will tell you what caliber you need."
+	caliber = "7.62mm"
+	magazine_type = /obj/item/ammo_magazine/m762
+	allowed_magazines = list(/obj/item/ammo_magazine/m762, /obj/item/ammo_magazine/m762/ext)
+	projectile_type = /obj/item/projectile/bullet/rifle/a762
+	firemodes = list(
+		list(mode_name="semiauto",       burst=1, fire_delay=0,    move_delay=null, burst_accuracy=null, dispersion=null),
+		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4,    burst_accuracy=list(0,-5,-5), dispersion=list(0.0, 0.2, 0.4))
+	)
+	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY | LOCK_SLAPPABLE
+	load_method = MAGAZINE
+	muzzle_velocity = 880
+	w_class = ITEMSIZE_HUGE
+	action_button_name = "Use Scope"
+	accuracy = 10
+	scoped_accuracy = 20
+	one_handed_penalty = 65
+	silenced = 1
+	recoil = 0.5
+
+/obj/item/weapon/gun/projectile/automatic/serdy/sr25c/ui_action_click()
+	scope()
+
+/obj/item/weapon/gun/projectile/automatic/serdy/sr25c/verb/scope()
+	set category = "Object"
+	set name = "Use Scope"
+	set popup_menu = 1
+
+	toggle_scope(2.0)
+
+/obj/item/weapon/gun/launcher/scopedrocket
+	name = "scoped rocket launcher"
+	desc = "Upon looking into the scope, you see the word on its center: MAGGOT."
+	icon_state = "rocket"
+	item_state = "rocket"
+	w_class = ITEMSIZE_HUGE //CHOMP Edit.
+	action_button_name = "Use Scope"
+	scoped_accuracy = 20
+	one_handed_penalty = 150 //Good luck shooting one handed.
+	throw_speed = 2
+	throw_range = 10
+	force = 5.0
+	slot_flags = 0
+	origin_tech = list(TECH_COMBAT = 8, TECH_MATERIAL = 5)
+	fire_sound = 'sound/weapons/rpg.ogg'
+
+	release_force = 15
+	throw_distance = 30
+	var/max_rockets = 1
+	var/list/rockets = new/list()
+
+/obj/item/weapon/gun/launcher/scopedrocket/examine(mob/user)
+	. = ..()
+	if(get_dist(user, src) <= 2)
+		. += "<font color='blue'>[rockets.len] / [max_rockets] rockets.</font>"
+
+/obj/item/weapon/gun/launcher/scopedrocket/attackby(obj/item/I as obj, mob/user as mob)
+	if(istype(I, /obj/item/ammo_casing/rocket))
+		if(rockets.len < max_rockets)
+			user.drop_item()
+			I.loc = src
+			rockets += I
+			to_chat(user, "<font color='blue'>You put the rocket in [src].</font>")
+			to_chat(user, "<font color='blue'>[rockets.len] / [max_rockets] rockets.</font>")
+		else
+			to_chat(usr, "<font color='red'>[src] cannot hold more rockets.</font>")
+
+/obj/item/weapon/gun/launcher/scopedrocket/consume_next_projectile()
+	if(rockets.len)
+		var/obj/item/ammo_casing/rocket/I = rockets[1]
+		rockets -= I
+		return new I.projectile_type(src)
+	return null
+
+/obj/item/weapon/gun/launcher/scopedrocket/handle_post_fire(mob/user, atom/target)
+	message_admins("[key_name_admin(user)] fired a rocket from a rocket launcher ([src.name]) at [target].")
+	log_game("[key_name_admin(user)] used a rocket launcher ([src.name]) at [target].")
+	..()
+
+/obj/item/weapon/gun/launcher/scopedrocket/ui_action_click()
+	scope()
+
+/obj/item/weapon/gun/launcher/scopedrocket/verb/scope()
+	set category = "Object"
+	set name = "Use Scope"
+	set popup_menu = 1
+
+	toggle_scope(2.0)
+
+//Lore Notes
+
+/obj/item/weapon/paper/awaygate/snowfield/evacuation_order
+	name = "Order Directives"
+	info = "<center><B><font size=\"6\">HIGH PRIORITY ORDERS</font></B><BR><BR><BR>ORDERS \
+	TO <B>ALL CLASS 1, 2, 3 PERSONNEL</B><BR>Date of Order : <B>April 10, 1979</B>.</center> <BR><BR><BR>\
+	Directives : <B>Evacuation preparation from Facility. <BR>All related personnel, EXCLUDING 3M personnel \
+	must head to Chelyabinsk until 2100, April 10 and await for further directives.<BR>Base MUST \
+	maintain necessary items only. </B><BR><BR>Further directives and details shall be guided by <B>Class 4 \
+	or above personnel.</B>"
+
+/obj/item/weapon/paper/awaygate/snowfield/evacuation_order2
+	name = "Mid Command Order Directives"
+	info = "<center><B><font size=\"6\">HIGH PRIORITY ORDERS</font></B><BR><BR><BR>ORDERS \
+	TO <B>ALL CLASS 4 PERSONNEL</B><BR>Date of Order : <B>April 10, 1979</B>.</center> <BR><BR><BR>\
+	Directives : <B>Evacuation preparation from Facility. <BR>All class 1,2,3 personnel must head to \
+	Chelyabinsk and empty the facility, EXCLUDING Medical team. (3M)<BR>Base MUST maintain necessary items only \
+	to operate 'Tunguska' and supplies for the crews who remains. 'Tunguska' Activation time at 0300, April 11, \
+	1979.</B><BR><BR>Further directives and details shall be guided by <B>Class 6 or above personnel.</B>"
+
+/obj/item/weapon/paper/awaygate/snowfield/evacuation_order3
+	name = "High Command Order Directives"
+	info = "<center><B><font size=\"6\">HIGH PRIORITY ORDERS</font></B><BR><BR><BR>ORDERS \
+	TO <B>ALL CLASS 5, 6 PERSONNEL</B><BR>Date of Order : <B>April 10, 1979</B>.</center> <BR><BR><BR>\
+	Directives : <B>Evacuation preparation from Facility. <BR>All Class 1, 2, 3 personnel must head to \
+	Chelyabinsk and empty the facility, excluding Class 3M, guided by Class 4 personnel. <BR>All Class 5, 6 must \
+	check the stability of 'Tunguska' before the operation. Activation time at 0300, April 11, 1979.</B>"
+
+/obj/item/weapon/paper/awaygate/snowfield/activation_order
+	name = "High Command Order Directives"
+	info = "<center><B><font size=\"6\">HIGH PRIORITY ORDERS</font></B><BR><BR><BR>ORDERS \
+	TO <B>ALL CLASS 5, 6 PERSONNEL</B><BR>Date of Order : <B>April 11, 1979</B>.</center> <BR><BR><BR>\
+	Directives : <B>Activation of 'Tunguska.' <BR>All class 5, 6 personnel must have a full search by \
+	Class 4 before entering the operation room. <BR>Any personnel who is not on the operations area shall \
+	be terminated on the spot. Notify to nearest Class 4 and 6 personnel if necessary.</B><BR><BR>Further directives \
+	and details shall be guided by <B>Class 6 Personnel.</B>"
+
+/obj/item/weapon/paper/awaygate/snowfield/interrogation
+	name = "Interrogation note"
+	info = "(Recording Start)<BR>(00:00) This is Yemelyan Fedoro, the Warden of Sector 108.<BR>(00:09) Time of the \
+	record... <BR>(00:14) Twenty one-Fourty.<BR>(00:17) Three months of interrogation is finally coming up with \
+	a progress.<BR>(00:20) The lizard finally speaks, telling us the key points of the blueprint.<BR>(00:25) \
+	There are missing important componant followed by the blueprint,<BR>(00:32) however, we may manage to get enough \
+	from the asteroid back from 1908.<BR>(00:39) Exactly what the research team needs, whatever they say. Something \
+	they won't be able to get in their lifetime, what they say.<BR>(00:52) Vlad is just using the lizard as their \
+	Punching bag, now. <BR>(00:59) Gosh, their screams are worser than my grandma. Who would know an overgrown lizard \
+	would sound like that..<BR>(01:07) Best to finish up, now. We can get more informations from'em. Yemelyan Fedoro, out."
+
+/obj/item/weapon/paper/awaygate/snowfield/note // Little easter egg for appreciation.
+	desc = "A gift card with a heart on the cover. Hey, there's a scribble on its back..."
+	name = "letter"
+	icon_state = "greetingcard_heart"
+	info = "<center><B><font size=\"6\">Congradulations!</font></B></center><BR><BR>You have just found a paper that \
+	was sitting at out of nowhere.<BR>Let there be a celebration to you, finding this tiny paper. But leaving this empty \
+	will be awkward, so, some few honorable mentions shall be here.<BR><BR><B>Maker of the Map:</B> H.K <BR><BR><B>Huge \
+	Emotional Support (And my life changer):</B> BlackMajor, Salty S<BR><BR><B>Supporters in the most troubled times</B>: \
+	BlackMajor, Ender, Jack, Lone/Einarr, Mango, Nickner, Salty S, Serdy, Skitz, Verkister<BR><BR><B>Helpers on the map work:</B> \
+	BlackMajor, Blitzkrieg, Dan 'Clanker' Neposh, Kassc, Mango, Rykka Stormheart, Salty S, Serdy, Verkister<BR><BR>\
+	<B>Map recovery helper (Curse you github, almost deleting the project):</B> BlackMajor, Helmian, Jennard.L, Kashtan <BR>\
+	<B>Also, not to forget - Huge thank you to</B>:You, who is reading this note. <BR><BR><BR>Let this be my 25c to remember."
+
+/obj/item/weapon/paper/awaygate/snowfield/diary
+	desc = "A part of a ripped paper, likely from the book."
+	name = "diary, 18 of January, 1971"
+	info = "Dear diary.<BR><BR> This will be the last diary I write in this little outpost.<BR><BR> Militsiya \
+	has came today, to this middle-out-of-nowhere outpost,<BR> telling us to leave at once.<BR> Thankfully, \
+	cave is almost dry of coal, and Dmitry wasn't drunk for once just by the time militsiya came. \
+	Thank goodness. <BR> What the militsiya says it is from the government's orders. We had to leave \
+	sometime soon and find another coal vein, anyways. <BR><BR> Anatoly, two days ago, said he saw the army \
+	truck passing by few times around the mountains, so I think this is one of it. <BR><BR> Best to \
+	take our stuffs tomorrow. And some vodka bottles I have hidden.<BR><BR><BR><BR><B>BLAST, \
+	IT'S EMPTY! DIMITRY, THAT SCUMBAG - HOW DID HE EVEN KNEW THE BOTTLE'S THERE?!</B>"
+
+/obj/item/weapon/card/id/gateway/snowfield // Basic access
+	name = "Class 1 ID"
+	desc = "An ID card with a basic access for the base. There's a mark of a \
+	red star in the corner with hammer and sickle inside."
+	initial_sprite_stack = list("base-stamp", "top-generic", "stamp-s", "clip")
+
+/obj/item/weapon/card/id/gateway/snowfield/class2 // Service
+	name = "Class 2 ID"
+	desc = "An ID card with a service work access for the base.There's a mark of \
+	a red star in the corner with hammer and sickle inside."
+	initial_sprite_stack = list("base-stamp","top-green", "stamp-s", "clip")
+	access = list(26, 28)
+
+/obj/item/weapon/card/id/gateway/snowfield/class3M // Medical
+	name = "Class 3M ID"
+	desc = "An ID card with an advanced medical support access for the base. \
+	There's a mark of a red star in the corner with hammer and sickle inside."
+	initial_sprite_stack = list("base-stamp","top-medblu", "stamp-s", "pips-medblu", "clip")
+	access = list(5, 33, 45)
+
+/obj/item/weapon/card/id/gateway/snowfield/class3E // Engineering Part time worker
+	name = "Class 3E ID"
+	desc = "An ID card with a basic engineering support access for the base. \
+	There's a mark of a red star in the corner with hammer and sickle inside."
+	initial_sprite_stack = list("base-stamp", "top-orange", "stamp-s", "clip")
+	access = list (10)
+
+/obj/item/weapon/card/id/gateway/snowfield/class4 // Security
+	name = "Class 4 ID"
+	desc = "An ID card with a security access for the base. There's a mark of a \
+	red star in the corner with hammer and sickle inside."
+	initial_sprite_stack = list("base-stamp", "top-red", "stamp-s", "clip")
+	access = list (1, 2)
+
+/obj/item/weapon/card/id/gateway/snowfield/class4D // Detective
+	name = "Class 4D ID"
+	desc = "An ID card with a forensic security access for the base. There's a mark \
+	of a red star in the corner with hammer and sickle inside."
+	initial_sprite_stack = list("base-stamp", "top-red", "pips-brown", "stamp-s", "clip")
+	access = list (1, 2, 4)
+
+/obj/item/weapon/card/id/gateway/snowfield/class5R // Researcher
+	name = "Class 5R ID"
+	desc = "An ID card with a research access for the base. There's a mark of a red \
+	star in the corner with hammer and sickle inside."
+	initial_sprite_stack = list("base-stamp", "top-purple", "stamp-s", "clip")
+	access = list (47, 61)
+
+/obj/item/weapon/card/id/gateway/snowfield/class5E // Engineering
+	name = "Class 5E ID"
+	desc = "An ID card with an advanced engineering access for the base. There's a mark \
+	of a red star in the corner with hammer and sickle inside."
+	initial_sprite_stack = list("base-stamp-dark", "top-orange", "stripe-white", "stamp-s", "clip")
+	access = list (10, 11)
+
+/obj/item/weapon/card/id/gateway/snowfield/class6S // Head of Security-Warden
+	name = "Class 6S ID"
+	desc = "An ID card with a full access towards the security of the base. There's a \
+	mark of a red star in the corner with hammer and sickle inside."
+	initial_sprite_stack = list("base-stamp-dark", "top-red", "stripe-gold", "stamp-s", "clip")
+	access = list (1, 2, 3, 4)
+
+/obj/item/weapon/card/id/gateway/snowfield/class6R // Research Director
+	name = "Class 6R ID"
+	desc = "An ID card with a full access towards the secrets of the base. There's a mark of a red \
+	star in the corner with hammer and sickle inside."
+	initial_sprite_stack = list("base-stamp-dark", "top-purple", "stripe-gold", "stamp-s", "clip")
+	access = list (30, 47, 61)
+
+/obj/item/weapon/card/id/gateway/snowfield/class7 // Facility Director
+	name = "Class 7"
+	desc = "An ID card with a full access through out the base. There's a mark of a red \
+	star in the corner with hammer and sickle inside."
+	initial_sprite_stack = list("base-stamp-dark", "top-blue", "pips-gold", "stripe-gold", "stamp-s", "clip")
+	access = list (1, 2, 3, 4, 5, 10, 11, 20, 26, 28, 30, 33, 45, 47, 53, 56, 61)


### PR DESCRIPTION
Made upon request and suggestion of the peoples on the past.

Completely empty version of the Snowfield base, for anyone who may use it.

All the doors, buttons and lock down blast doors are functional and linked.

Access are already on pre-set by the Snowfield-ID cards.

Do not merge, for someone wants to make a use of the map.
This is a raw version of the map; not intended for live game without adjustment of the others, or within moderation of someone's.
(It is actually fully functional to play on as station crews, however.)

![1](https://user-images.githubusercontent.com/6038359/174627537-1b1d8d17-261d-49de-8bed-86d2ee408be6.png)

