### PR TITLE
Fixes missing sprites for the somatoray and advanced SMG

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -44,6 +44,7 @@
 	name = "floral somatoray"
 	desc = "A tool that discharges controlled radiation which induces mutation in plant cells."
 	description_fluff = "The floral somatoray is a relatively recent invention of the NanoTrasen corporation, turning a process that once involved transferring plants to massive mutating racks, into a remote interface. Do not look directly into the transmission end."
+	icon = 'icons/obj/gun.dmi'
 	icon_state = "floramut100"
 	item_state = "floramut"
 	projectile_type = /obj/item/projectile/energy/floramut

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -17,7 +17,7 @@
 	name = "advanced SMG"
 	desc = "An advanced submachine gun with a reflective laser optic that makes burst fire less inaccurate than other SMGs. Uses 9mm rounds."
 	icon = 'icons/obj/gun.dmi'
-	icon_state = "advanced_smg-empty"
+	icon_state = "advanced_smg-e"
 	w_class = ITEMSIZE_NORMAL
 	load_method = MAGAZINE
 	caliber = "9mm"
@@ -33,7 +33,7 @@
 
 /obj/item/weapon/gun/projectile/automatic/advanced_smg/update_icon()
 	..()
-	icon_state = (ammo_magazine)? "advanced_smg" : "advanced_smg-empty"
+	icon_state = (ammo_magazine)? "advanced_smg" : "advanced_smg-e"
 	return
 
 /obj/item/weapon/gun/projectile/automatic/advanced_smg/loaded
@@ -365,7 +365,7 @@
 		icon_state = "mini-uzi"
 	else
 		icon_state = "mini-uzi-empty"
-		
+
 // CHOMPEdit: Uzi tilting
 /obj/item/weapon/gun/projectile/automatic/mini_uzi/Initialize()
 	. = ..()


### PR DESCRIPTION
Fine. I'll do it myself. Literally 1 line of code change fixes the invisible sprites, because all the gun DMI files are all over the place instead of a parent file anymore.

I tried to fix the WT-550 sprites too but I cant read the code and I AINT touching parent files any time soon.
![dreamseeker_kT0xLh0HsK](https://user-images.githubusercontent.com/10555869/176335284-0564d896-b3eb-473e-8fb6-be001e8580c2.png)

Fixes #4151
Partially fixes #4311