### PR TITLE
Un nerfs the autolathe

### DIFF
--- a/modular_chomp/code/datums/autolathe/engineering_ch.dm
+++ b/modular_chomp/code/datums/autolathe/engineering_ch.dm
@@ -1,0 +1,20 @@
+// reverse 'escape plans' the autolathe here, 2017 grudge code be like
+/datum/category_item/autolathe/engineering/capacitor
+	name = "capacitor"
+	path =/obj/item/weapon/stock_parts/capacitor
+
+/datum/category_item/autolathe/engineering/scanning_module
+	name = "scanning module"
+	path =/obj/item/weapon/stock_parts/scanning_module
+
+/datum/category_item/autolathe/engineering/manipulator
+	name = "micro-manipulator"
+	path =/obj/item/weapon/stock_parts/manipulator
+
+/datum/category_item/autolathe/engineering/micro_laser
+	name = "micro laser"
+	path =/obj/item/weapon/stock_parts/micro_laser
+
+/datum/category_item/autolathe/engineering/matter_bin
+	name = "matter bin"
+	path =/obj/item/weapon/stock_parts/matter_bin

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4484,6 +4484,7 @@
 #include "maps\submaps\surface_submaps\wilderness\wilderness.dm"
 #include "maps\submaps\surface_submaps\wilderness\wilderness_areas.dm"
 #include "maps\~map_system\maps.dm"
+#include "modular_chomp\code\datums\autolathe\engineering_ch.dm"
 #include "modular_chomp\code\datums\autolathe\general_ch.dm"
 #include "modular_chomp\code\game\machinery\airconditioner_ch.dm"
 #include "modular_chomp\code\modules\admin\functions\modify_traits.dm"


### PR DESCRIPTION
The autolathe can now print the rest of the t1 parts that was removed back in 2017 because of the scope for upstream.

This should allow for projects to be more easily done and makes the autolathe in engineering more useful.

The parts lathe is staying to prevent map conflicts if such place has one.

The nerf back in 2017 was lazy too, because you were already allowed to print console screens, gears, springs, etc etc with the autolathe.