### PR TITLE
Cocoon Crash Counter Code

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
@@ -123,8 +123,8 @@
 	var/obj/effect/spider/cocoon/C = new(AM.loc)
 	var/large_cocoon = FALSE
 	for(var/mob/living/L in C.loc)
-		if(istype(L, /mob/living/simple_mob/animal/giant_spider)) // Cannibalism is bad.
-			continue
+		//if(istype(L, /mob/living/simple_mob/animal/giant_spider)) // Cannibalism is bad. CHOMPEdit BUT IT'S NEEDED TO STOP COCOON BOMBS!
+		//	continue // UNLESS YOU WANT TO FIGURE OUT THE AI TARGETING YOURSELF! TODO TODO TODO.
 		fed++
 		visible_message(span("warning","\The [src] sticks a proboscis into \the [L], and sucks a viscous substance out."))
 		to_chat(src, span("notice", "You've fed upon \the [L], and can now lay [fed] cluster\s of eggs."))

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
@@ -256,9 +256,7 @@
 		for(var/A in targets)
 			if(!isliving(A))
 				targets -= A
-			if(istype(A, /mob/living/simple_mob/animal/giant_spider)) // CHOMPEdit Start. Please do not try to cocoon the things immune to being cocooned, thanks.
-				if(!A?:stat)
-					targets -= A  // CHOMPEdit end. No more Cocoon right-click bombs!
+
 	return ..(targets)
 
 /datum/ai_holder/simple_mob/melee/nurse_spider/can_attack(atom/movable/the_target, var/vision_required = TRUE)

--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
@@ -256,7 +256,9 @@
 		for(var/A in targets)
 			if(!isliving(A))
 				targets -= A
-
+			if(istype(A, /mob/living/simple_mob/animal/giant_spider)) // CHOMPEdit Start. Please do not try to cocoon the things immune to being cocooned, thanks.
+				if(!A?:stat)
+					targets -= A  // CHOMPEdit end. No more Cocoon right-click bombs!
 	return ..(targets)
 
 /datum/ai_holder/simple_mob/melee/nurse_spider/can_attack(atom/movable/the_target, var/vision_required = TRUE)


### PR DESCRIPTION
FIXES #4446
Let's GOOOOOO!

The nurse spiders refuse to not target dead spiders of another faction, even when I put in a check for such. The faction check is overriding everything I try to do to stop these cocoon bombs.

So I'm enabling spider cannibalism.

No more cocoon bombs, just more spiders to deal with.

Spiders eat themselves all the time IRL.

LORE ACCURATE BUGFIX.