### PR TITLE
Fix for bad topic response in bot channel

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -80,8 +80,8 @@ var/world_topic_spam_protect_ip = "0.0.0.0"
 var/world_topic_spam_protect_time = world.timeofday
 
 /world/Topic(T, addr, master, key)
-	TGS_TOPIC
-	VGS_TOPIC // VOREStation Edit - VGS
+	VGS_TOPIC // VOREStation Edit - VGS //CHOMP Edit swapped lines around
+	TGS_TOPIC //CHOMP Edit swapped lines around
 	log_topic("\"[T]\", from:[addr], master:[master], key:[key]")
 
 	if (T == "ping")


### PR DESCRIPTION
I think maybe this will work? According to coderbus, "Depending on your fork, there was also a bad revision of /tg/ DM code that wrongfully intercepted TGS topics with a rate limiter. You can check this isn't happening by checking the macro TGS_TOPIC is the first thing called in your /world/Topic()"

I am literally just swapping two lines around.