### PR TITLE
Shadekin eject belly contents when dying

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -123,6 +123,7 @@
 
 /datum/species/shadekin/handle_death(var/mob/living/carbon/human/H)
 	spawn(1)
+		H.release_vore_contents(TRUE, TRUE) //CHOMPEdit - Drop all belly contents on death.
 		for(var/obj/item/W in H)
 			H.drop_from_inventory(W)
 		qdel(H)


### PR DESCRIPTION
Prevents people/things inside the bellies from getting qdel'd.