### PR TITLE
Update custom_sprites.txt to actually be updated

### DIFF
--- a/config/custom_sprites.txt
+++ b/config/custom_sprites.txt
@@ -1,3 +1,4 @@
 ckey|state
 lunarfleet|Clea-Nor
 jademanique|B.A.U-Kingside
+argonne|RUSS


### PR DESCRIPTION
When the RUSS sprites were ported over, the text file to actually give RUSS's player permission to use them wasn't. This corrects that.