### PR TITLE
Medbay Overhaul

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -799,6 +799,16 @@
 /obj/item/stack/rods,
 /turf/space,
 /area/space)
+"acc" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "ack" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -1670,6 +1680,13 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"aen" = (
+/obj/structure/bed/chair/sofa/right/teal,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
 "aeo" = (
 /obj/structure/closet{
 	name = "Prisoner's Locker"
@@ -2295,6 +2312,28 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/fp_emergency)
+"agb" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "agc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -2833,6 +2872,17 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
+"ahx" = (
+/obj/machinery/chemical_dispenser,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "ahz" = (
 /obj/random/junk,
 /turf/simulated/floor,
@@ -3316,6 +3366,12 @@
 /obj/item/stack/tile/floor/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"aiY" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/light/spot,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "aiZ" = (
 /obj/machinery/door/window/westleft{
 	name = "Shower"
@@ -3381,22 +3437,6 @@
 	},
 /turf/simulated/wall,
 /area/quartermaster/warehouse)
-"ajf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "ajl" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/target_stake,
@@ -5312,16 +5352,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/central)
-"apP" = (
-/obj/machinery/atmospherics/unary/freezer{
-	icon_state = "freezer"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/medical/cryo)
 "apR" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -5464,7 +5494,7 @@
 /area/engineering/atmos)
 "aql" = (
 /turf/simulated/wall,
-/area/medical/medbay_primary_storage)
+/area/medical/morgue)
 "aqm" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5891,6 +5921,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/eva)
+"aru" = (
+/obj/structure/table/reinforced,
+/obj/item/device/gps/medical,
+/obj/item/device/gps/medical,
+/obj/item/device/gps/medical,
+/obj/item/device/gps/medical,
+/obj/item/device/gps/medical,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "arv" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -7157,28 +7206,9 @@
 /turf/simulated/floor,
 /area/engineering/engineer_eva)
 "avH" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id = "medbayrecquar";
-	name = "Medbay Emergency Quarantine Shutters";
-	opacity = 0
-	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 10
-	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white,
-/area/medical/foyer)
-"avI" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/pink/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/chemistry)
 "avJ" = (
 /obj/structure/closet,
 /obj/item/clothing/glasses/welding,
@@ -8690,22 +8720,6 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/security/prison)
-"aAu" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
 "aAv" = (
 /obj/structure/table/steel,
 /obj/item/weapon/newspaper,
@@ -9370,15 +9384,6 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor,
 /area/engineering/engine_room)
-"aDv" = (
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp/green,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
 "aDw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/effect/floor_decal/industrial/warning,
@@ -9677,6 +9682,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
+"aEa" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/noticeboard/medical{
+	dir = 1
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "MedbayLockdown"
+	},
+/turf/simulated/floor/plating,
+/area/medical/reception)
 "aEb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -10048,16 +10065,6 @@
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"aFA" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
 "aFB" = (
 /turf/simulated/wall,
 /area/security/security_equiptment_storage)
@@ -10127,11 +10134,14 @@
 /area/security/security_hallway)
 "aFT" = (
 /obj/machinery/door/airlock/multi_tile/glass{
-	id_tag = null;
-	name = "EMT Bay";
+	name = "External Response Bay";
 	req_access = list(5)
 	},
 /obj/machinery/door/firedoor/multi_tile/glass,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "MedbayLockdown"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/medical/medbay_emt_bay)
 "aFW" = (
@@ -10142,12 +10152,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "MedbayLockdown"
+	},
 /turf/simulated/floor/plating,
-/area/medical/reception)
+/area/medical/psych)
 "aGd" = (
-/obj/structure/sign/nosmoking_1,
+/obj/structure/sign/warning/nosmoking_2,
 /turf/simulated/wall/r_wall,
-/area/medical/reception)
+/area/medical/foyer)
 "aGg" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/lab)
@@ -10535,25 +10549,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence_storage)
-"aHB" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/bordercorner2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_emt_bay)
-"aHD" = (
-/obj/structure/sign/nosmoking_1,
-/turf/simulated/wall/r_wall,
-/area/medical/medbay_emt_bay)
 "aHF" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -10654,6 +10649,12 @@
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
+"aHU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "aHZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -10928,19 +10929,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/sc/hop)
-"aIY" = (
-/obj/machinery/vending/cola{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "aIZ" = (
 /turf/simulated/floor/airless,
 /area/rnd/test_area)
@@ -11429,6 +11417,12 @@
 /obj/structure/stairs/spawner/south,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/stairwell)
+"aKt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "aKz" = (
 /obj/machinery/papershredder,
 /obj/item/device/radio/intercom{
@@ -11489,109 +11483,34 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/sc/hop)
-"aKG" = (
-/obj/machinery/suit_cycler/medical,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/medbay_emt_bay)
-"aKH" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_emt_bay)
-"aKJ" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_emt_bay)
-"aKK" = (
-/obj/structure/table/steel,
-/obj/item/device/multitool,
-/obj/item/weapon/deck/cards,
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - EMT Bay";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"aKM" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/food/drinks/britcup,
-/obj/random/medical,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = -5
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"aKN" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/item/device/denecrotizer/medical,
-/obj/item/device/sleevemate,
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "aKO" = (
-/obj/item/modular_computer/console/preset/medical{
+/obj/structure/bed/chair/sofa/left/teal{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"aKP" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	health = 1e+006
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "medbayrecquar";
-	name = "Medbay Entrance Quarantine Shutters Control";
-	pixel_x = -4;
-	pixel_y = -4;
-	req_access = list(5)
-	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"aKQ" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/computer/transhuman/designer{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
+"aKP" = (
+/obj/structure/fireaxecabinet,
+/turf/simulated/wall/r_wall,
+/area/medical/medbay_emt_bay)
+"aKQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Mental Health Office";
+	req_access = list(64)
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 4;
+	id = "MedbayLockdown"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/psych)
 "aKR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -12038,80 +11957,36 @@
 /turf/simulated/floor/plating,
 /area/maintenance/central)
 "aMg" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/computer/transhuman/resleeving{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
+/obj/machinery/light/spot{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/area/medical/resleeving)
 "aMi" = (
 /obj/structure/sign/deck/second,
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/seconddeck/stairwell)
-"aMm" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/random/medical,
-/obj/random/medical,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
-"aMn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
 "aMo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/chemical_dispenser/biochemistry,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
 	},
+/obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"aMp" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
+/area/medical/chemistry)
 "aMr" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/borderfloor{
@@ -12389,6 +12264,11 @@
 /obj/random/toolbox,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"aNy" = (
+/obj/machinery/atmospherics/unary/cryo_cell,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "aNz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -12406,90 +12286,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/apcenter)
-"aNB" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/pink/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_emt_bay)
-"aNC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/pink/bordercorner2{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_emt_bay)
-"aND" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "exam_window_tint"
-	},
-/turf/simulated/floor/plating,
-/area/medical/exam_room)
-"aNE" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/medical{
-	name = "Examination Room";
-	req_access = list(5)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/exam_room)
-"aNG" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"aNH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "aNI" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
 "aNL" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -13034,24 +12835,15 @@
 /turf/simulated/wall/r_wall,
 /area/medical/medbay_emt_bay)
 "aPm" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/machinery/door/airlock/multi_tile/glass{
-	id_tag = null;
-	name = "EMT Bay";
-	req_access = list(5)
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/multi_tile/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/medbay_emt_bay)
-"aPn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/medbay_emt_bay)
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "aPo" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -13301,6 +13093,12 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_room)
+"aPR" = (
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
 "aPS" = (
 /obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller{
 	id_tag = "engine_room_airlock";
@@ -13370,9 +13168,9 @@
 /area/engineering/workshop)
 "aQb" = (
 /obj/machinery/door/window/northleft{
-	req_one_access = list(35,28);
+	name = "Animal Pen";
 	req_access = newlist();
-	name = "Animal Pen"
+	req_one_access = list(35,28)
 	},
 /turf/simulated/floor/grass,
 /area/hydroponics)
@@ -13667,30 +13465,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/prison)
-"aRg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"aRh" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"aRi" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "aRo" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -14285,25 +14059,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/main)
-"aTe" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "aTf" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
@@ -14671,6 +14426,13 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
+"aUb" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "aUc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15307,25 +15069,6 @@
 "aWi" = (
 /turf/simulated/wall,
 /area/maintenance/robotics)
-"aWj" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -21
-	},
-/obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "aWl" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -15641,6 +15384,29 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
+"aWS" = (
+/obj/structure/table/reinforced,
+/obj/item/device/defib_kit,
+/obj/item/device/radio/emergency,
+/obj/item/device/radio/emergency,
+/obj/machinery/light/spot,
+/obj/item/device/defib_kit,
+/obj/item/device/defib_kit,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/weapon/hand_labeler,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -30
+	},
+/obj/item/weapon/reagent_containers/blood,
+/obj/item/weapon/reagent_containers/blood,
+/obj/item/weapon/reagent_containers/blood,
+/obj/item/weapon/reagent_containers/blood,
+/obj/item/weapon/reagent_containers/blood,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "aWZ" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -15681,26 +15447,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/port)
-"aXf" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id = "medbayrecquar";
-	name = "Medbay Emergency Quarantine Shutters";
-	opacity = 0
-	},
-/obj/machinery/light,
-/obj/effect/landmark{
-	name = "lightsout"
-	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
 "aXj" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
@@ -15780,6 +15526,22 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/seconddeck/fpcenter)
+"aXt" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Observation Room";
+	req_access = list(5)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/medbay2)
 "aXu" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -16044,6 +15806,10 @@
 	req_access = list(5);
 	req_one_access = null
 	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "MedbayLockdown"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
 "aYs" = (
@@ -16256,9 +16022,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/port)
-"aZf" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
 "aZg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17132,16 +16895,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fpcenter)
 "bbE" = (
-/obj/machinery/photocopier,
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 1
 	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -21
-	},
+/obj/effect/landmark/start/chemist,
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/area/medical/chemistry)
 "bbF" = (
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/ascenter)
@@ -17471,6 +17230,24 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/engineering/engine_monitoring)
+"bcz" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "bcB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -17504,18 +17281,6 @@
 "bcM" = (
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/port)
-"bcR" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/item/device/radio/intercom/department/medbay{
-	pixel_y = -21
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "bcS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -18238,28 +18003,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/warden)
 "bfD" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bfE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning{
+/obj/effect/landmark/start/chemist,
+/obj/structure/bed/chair/bay/comfy/teal{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/cryo)
+/area/medical/chemistry)
 "bfF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18401,16 +18150,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/engineer_hallway)
-"bfW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "bfY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19096,9 +18835,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"biv" = (
-/turf/simulated/wall/r_wall,
-/area/medical/exam_room)
 "biw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/ai_status_display{
@@ -19125,29 +18861,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
-"biB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"biC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/skills{
-	pixel_y = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/blue/bordercorner,
-/obj/item/device/gps/medical/cmo,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
 "biD" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -19723,176 +19436,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/sc/hop)
-"bka" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/pink/bordercorner2{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_emt_bay)
-"bkc" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"bkd" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/folder/white,
-/obj/item/weapon/pen,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
-"bke" = (
-/obj/structure/table/glass,
-/obj/item/weapon/cane,
-/obj/item/weapon/cane{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/box/rxglasses,
-/obj/random/medical,
-/obj/random/firstaid,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = 21
-	},
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
-"bkf" = (
-/obj/machinery/vending/snack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"bkh" = (
-/obj/structure/bed/chair,
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = 21
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"bki" = (
-/obj/structure/bed/chair,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"bkj" = (
-/obj/structure/noticeboard{
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"bkk" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "bkl" = (
 /obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4;
-	health = 1e+006
+/obj/item/weapon/surgical/bioregen,
+/obj/item/weapon/surgical/surgicaldrill,
+/obj/item/weapon/autopsy_scanner,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/machinery/computer/med_data/laptop,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/area/medical/surgery2)
 "bkm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -20045,18 +19601,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/as_emergency)
-"bkJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/iv_drip,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "bkK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -20156,16 +19700,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/seconddeck/construction1)
-"bkZ" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "bla" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20259,6 +19793,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/security_processing)
+"blj" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "blk" = (
 /obj/machinery/photocopier,
 /obj/effect/floor_decal/borderfloor{
@@ -20355,101 +19899,27 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/ascenter)
-"blN" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "blR" = (
 /obj/structure/table/reinforced,
-/obj/item/device/radio{
-	anchored = 1;
-	canhear_range = 1;
-	frequency = 1487;
-	icon = 'icons/obj/items.dmi';
-	icon_state = "red_phone";
-	name = "Reception Emergency Phone";
-	pixel_x = -5
-	},
-/obj/machinery/door/window/eastleft{
-	name = "Medical Reception";
-	req_access = list(5)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/reagentgrinder,
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
+/obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/area/medical/chemistry)
 "blS" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/patient_restroom)
 "blT" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
-/area/medical/foyer)
-"blU" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
+/area/medical/patient_a)
 "blV" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
@@ -20652,6 +20122,21 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_room)
+"bmq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/medical/patient_restroom)
 "bmt" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/sign/warning/nosmoking_2{
@@ -20857,27 +20342,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"bnl" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
 "bno" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
 	},
-/obj/item/weapon/stool/padded,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/area/medical/foyer)
 "bnq" = (
 /obj/structure/sign/warning/high_voltage{
 	pixel_y = 32
@@ -20891,63 +20367,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"bnr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/med_data/laptop{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bns" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/blue/border,
-/obj/item/modular_computer/console/preset/medical{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bnu" = (
-/obj/machinery/photocopier,
-/obj/item/device/radio/intercom/department/medbay{
-	pixel_y = -21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bnw" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -21
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Cryogenics";
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/computer/transhuman/resleeving{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
 "bnx" = (
 /obj/machinery/door/blast/regular{
 	id = "toxinsdriver";
@@ -21464,163 +20883,11 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/seconddeck/apcenter)
-"bpa" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/obj/structure/fireaxecabinet{
-	pixel_x = -32
-	},
-/obj/item/weapon/stool/padded,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/landmark/start{
-	name = "Paramedic"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"bpb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_emt_bay)
-"bpc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_emt_bay)
-"bpf" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 36;
-	pixel_y = -6
-	},
-/obj/machinery/button/windowtint{
-	id = "exam_window_tint";
-	pixel_x = 36;
-	pixel_y = 6
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
-"bph" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"bpi" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "bpj" = (
 /obj/machinery/light/small,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"bpk" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"bpl" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"bpm" = (
-/obj/structure/table/reinforced,
-/obj/item/device/radio{
-	anchored = 1;
-	canhear_range = 1;
-	frequency = 1487;
-	icon = 'icons/obj/items.dmi';
-	icon_state = "red_phone";
-	name = "Reception Emergency Phone"
-	},
-/obj/machinery/door/window/eastright{
-	name = "Medical Reception";
-	req_access = list(5)
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"bpn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
 "bpo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -22040,91 +21307,6 @@
 "bra" = (
 /turf/simulated/wall,
 /area/medical/medbay_emt_bay)
-"brb" = (
-/obj/item/roller,
-/obj/item/roller{
-	pixel_y = 8
-	},
-/obj/item/roller{
-	pixel_y = 16
-	},
-/obj/structure/table/glass,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
-"brc" = (
-/obj/structure/table/glass,
-/obj/machinery/recharger,
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Medical Break Area";
-	dir = 4
-	},
-/obj/item/weapon/tool/screwdriver,
-/obj/item/organ/internal/lungs/erikLungs,
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"brd" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"bre" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4;
-	health = 1e+006
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/item/device/defib_kit/loaded,
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"brf" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
-"brg" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
 "brh" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -22531,16 +21713,6 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
-"bso" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/vending/medical,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "bsp" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22594,20 +21766,25 @@
 /obj/machinery/clonepod/full,
 /turf/simulated/floor/tiled/white,
 /area/medical/genetics)
-"bsC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"bsB" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Operating Room 1";
+	req_access = list(45)
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Patient Room B"
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/medical/patient_b)
+/area/medical/medbay2)
 "bsD" = (
 /obj/random/trash_pile,
 /turf/simulated/floor,
@@ -22743,43 +21920,23 @@
 /turf/simulated/floor/tiled,
 /area/security/security_hallway)
 "bth" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/machinery/door/airlock/glass_medical{
+	name = "Mental Health Office";
+	req_access = list(64)
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/psych)
 "bti" = (
 /turf/simulated/wall,
-/area/medical/reception)
-"btj" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/item/weapon/book/manual/stasis,
-/obj/item/weapon/book/manual/medical_diagnostics_manual{
-	pixel_y = 7
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"btk" = (
-/obj/structure/filingcabinet/chestdrawer{
-	name = "Medical Forms"
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "btl" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -22792,25 +21949,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/bar)
-"btq" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "btr" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
@@ -22861,66 +21999,25 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"btH" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"btJ" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/gloves{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/box/masks,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for Surgery.";
-	id = "Surgery";
-	name = "Surgery";
-	pixel_y = 36
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "btL" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Locker Room";
+	req_access = list(66)
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/medbay4)
 "btO" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -22942,21 +22039,6 @@
 /obj/structure/railing,
 /turf/simulated/floor,
 /area/maintenance/disposal)
-"btU" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "btV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -23040,11 +22122,6 @@
 	},
 /turf/simulated/open,
 /area/quartermaster/lockerroom)
-"bup" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/patient_b)
 "buq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23160,51 +22237,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/security_hallway)
-"buJ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 8;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"buK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"buL" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/glass_medical{
-	name = "Medical Reception";
-	req_access = list(5)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/reception)
 "buM" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
+/obj/structure/filingcabinet/medical,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "buN" = (
 /turf/simulated/wall/r_wall,
-/area/medical/reception)
+/area/medical/psych)
 "buO" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23729,6 +22777,22 @@
 "bvW" = (
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/apcenter)
+"bvY" = (
+/obj/machinery/door/firedoor/multi_tile/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/multi_tile/glass{
+	id_tag = "meddoor";
+	name = "Medbay Entry";
+	req_access = list(5)
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "bvZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -23762,6 +22826,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/ascenter)
+"bwh" = (
+/obj/machinery/recharger/wallcharger,
+/turf/simulated/wall/r_wall,
+/area/medical/medbay_emt_bay)
 "bwj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 6
@@ -23791,86 +22859,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"bwo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bwp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bwq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bws" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bwu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bwz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass_medical,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/medbay)
 "bwB" = (
 /turf/simulated/wall/r_wall,
 /area/medical/foyer)
@@ -24407,60 +23395,6 @@
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"byj" = (
-/obj/structure/sign/warning/high_voltage{
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"byk" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bym" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "byn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24480,99 +23414,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/ascenter)
-"byp" = (
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Medical Hallway Port 1";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"byq" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/sign/goldenplaque{
-	desc = "Done No Harm.";
-	name = "Best Doctor 2552";
-	pixel_y = -32
-	},
-/obj/machinery/door/airlock/glass_medical,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/medbay)
-"byr" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	pixel_y = -21
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"bys" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"byt" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"byu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"byv" = (
-/obj/machinery/computer/guestpass{
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "byx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -25376,22 +24217,6 @@
 "bzW" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/seconddeck/ascenter)
-"bAc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "bAi" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/sign/redcross{
@@ -25409,33 +24234,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/starboard)
-"bAj" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/sleeper)
-"bAk" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
 "bAl" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -25950,51 +24748,6 @@
 "bBH" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/substation/medical)
-"bBL" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/fancy/vials{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/fancy/vials,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bBN" = (
-/obj/machinery/atmospherics/unary/freezer{
-	icon_state = "freezer"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/medical/sleeper)
-"bBQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bBR" = (
-/obj/machinery/atmospherics/unary/cryo_cell,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/medical/sleeper)
 "bCd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26193,12 +24946,6 @@
 /obj/item/weapon/storage/bag/trash,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
-"bCM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "bCP" = (
 /obj/machinery/light{
 	dir = 8
@@ -26242,17 +24989,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/cargo)
-"bDd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "bDf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -26416,101 +25152,27 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/airless,
 /area/maintenance/cargo)
-"bDG" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/item/weapon/tool/crowbar,
-/obj/item/weapon/tool/crowbar,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/device/radio{
-	frequency = 1487;
-	icon_state = "med_walkietalkie";
-	name = "Medbay Emergency Radio Link"
-	},
-/obj/item/device/radio{
-	frequency = 1487;
-	icon_state = "med_walkietalkie";
-	name = "Medbay Emergency Radio Link"
-	},
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
-"bDH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
 "bDJ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bDK" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/command{
-	id_tag = null;
-	name = "CMO's Quarters";
+/obj/machinery/door/airlock/glass_command{
+	name = "Medical Director Office";
 	req_access = list(40)
 	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/heads/sc/cmo)
-"bDL" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bDO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "bDQ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"bDT" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bDU" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bDV" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "bDZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -26868,6 +25530,12 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/ascenter)
+"bFb" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "bFh" = (
 /turf/simulated/wall,
 /area/storage/emergency_storage/seconddeck/as_emergency)
@@ -26907,67 +25575,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
-"bFm" = (
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine{
-	department = "CMO's Office"
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = -26
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bFn" = (
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bFo" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/clipboard,
-/obj/item/weapon/folder/white_cmo,
-/obj/item/weapon/stamp/cmo,
-/obj/item/weapon/pen/multi,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bFq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/obj/machinery/iv_drip,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bFv" = (
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/sleeper)
-"bFy" = (
-/obj/machinery/body_scanconsole,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bFD" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
 "bFF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27365,6 +25972,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/office)
+"bGF" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "bGG" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -27496,197 +26115,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/seconddeck/artgallery)
+"bGY" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "bGZ" = (
 /turf/simulated/wall,
 /area/maintenance/substation/medical)
-"bHd" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -36;
-	pixel_y = -6
-	},
-/obj/machinery/button/windowtint{
-	id = "cmooffice";
-	pixel_x = -36;
-	pixel_y = 6
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/obj/structure/dogbed{
-	name = "\improper Runtime's bed"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bHe" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bHf" = (
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for shutters.";
-	id = "medbayquar";
-	name = "Medbay Emergency Lockdown Control";
-	pixel_x = -32;
-	pixel_y = 36;
-	req_access = list(5)
-	},
-/obj/machinery/button/remote/blast_door{
-	desc = "A remote control-switch for shutters.";
-	id = "virologyquar";
-	name = "Virology Emergency Lockdown Control";
-	pixel_x = -28;
-	pixel_y = 28;
-	req_access = list(5)
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control switch for the CMO's office.";
-	id = "cmodoor";
-	name = "CMO Office Door Control";
-	pixel_x = -38;
-	pixel_y = 28
-	},
-/obj/effect/landmark/start{
-	name = "Chief Medical Officer"
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bHg" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/belt/medical,
-/obj/item/clothing/accessory/stethoscope,
-/obj/item/clothing/glasses/sunglasses/medhud,
-/obj/item/device/radio{
-	frequency = 1487;
-	name = "Medbay Emergency Radio Link"
-	},
-/obj/item/device/megaphone,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bHh" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "cmooffice"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/sc/cmo)
-"bHo" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bHp" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bHq" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/curtain/open/privacy,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/cryo)
-"bHr" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
-"bHs" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/table/bench/padded,
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
-"bHt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
-"bHu" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/button/windowtint{
-	id = "cryo_tint";
-	pixel_x = 36;
-	pixel_y = 6
-	},
-/obj/machinery/light_switch{
-	name = "light switch ";
-	pixel_x = 36;
-	pixel_y = -6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
 "bHv" = (
 /obj/machinery/light{
 	dir = 1
@@ -27729,49 +26166,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
-"bHC" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/structure/closet/secure_closet/medical_wall{
-	name = "O- Blood Locker";
-	pixel_y = -32
-	},
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bHD" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bHE" = (
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Patient Ward Starboard";
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bHF" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "bHG" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -27823,6 +26217,10 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/seconddeck/artgallery)
+"bHU" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_b)
 "bHV" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -27973,124 +26371,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/medical)
-"bIJ" = (
-/obj/structure/closet/secure_closet/CMO,
-/obj/machinery/ai_status_display{
-	pixel_x = -32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 10
-	},
-/obj/item/device/defib_kit/compact/combat/loaded,
-/obj/item/weapon/cmo_disk_holder,
-/obj/item/device/denecrotizer/medical,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bIL" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "cmooffice"
-	},
-/turf/simulated/floor/plating,
-/area/crew_quarters/heads/sc/cmo)
-"bIM" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/medical/sleeper)
 "bIO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bIP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/sleeper{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bIQ" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
+/obj/structure/flora/pottedplant/minitree,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
-	},
-/obj/structure/closet/secure_closet/medical_wall/pills{
-	pixel_x = 32
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bIS" = (
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Diagnostics";
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
 	dir = 9
 	},
-/obj/effect/floor_decal/corner/pink/bordercorner2,
-/obj/effect/floor_decal/corner/pink/bordercorner2{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bIT" = (
-/obj/structure/closet/secure_closet/medical_wall{
-	name = "O- Blood Locker";
-	pixel_y = -32
-	},
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/item/weapon/reagent_containers/blood/OMinus,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/area/medical/medbay4)
 "bIX" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/portables_connector{
@@ -28320,6 +26610,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
+"bJC" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "bJF" = (
 /turf/simulated/wall,
 /area/maintenance/emergencyeva)
@@ -28433,9 +26738,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"bKn" = (
-/turf/simulated/wall/r_wall,
-/area/crew_quarters/heads/sc/cmo)
 "bKp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28445,39 +26747,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
-"bKs" = (
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - CMO"
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"bKt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bKu" = (
-/turf/simulated/wall,
-/area/medical/sleeper)
-"bKF" = (
-/turf/simulated/wall,
-/area/medical/cryo)
 "bKI" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -28715,6 +26984,9 @@
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"bLz" = (
+/turf/simulated/wall,
+/area/medical/resleeving)
 "bLC" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -28843,67 +27115,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"bMb" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/obj/structure/curtain/open/privacy,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bMc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bMf" = (
-/obj/structure/closet/wardrobe/medic_white,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bMh" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
-/obj/structure/curtain/open/privacy,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
-	},
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "bMj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29026,6 +27237,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
+"bMM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "bMS" = (
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
@@ -29033,19 +27250,6 @@
 "bMU" = (
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"bMW" = (
-/obj/machinery/vending/cola,
-/obj/effect/floor_decal/borderfloor{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
 "bNb" = (
 /obj/structure/loot_pile/maint/junk,
 /turf/simulated/floor/plating,
@@ -29231,147 +27435,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"bNL" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bNM" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bNO" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bNQ" = (
-/obj/structure/table/glass,
-/obj/item/device/radio{
-	anchored = 1;
-	canhear_range = 7;
-	frequency = 1487;
-	icon = 'icons/obj/items.dmi';
-	icon_state = "red_phone";
-	name = "Surgery Emergency Phone"
-	},
-/obj/random/medical,
-/obj/random/medical,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bNR" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bNS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bNT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "bNU" = (
-/obj/machinery/light{
+/obj/structure/table/woodentable,
+/obj/machinery/computer/med_data/laptop{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
-	},
-/obj/machinery/washing_machine,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bNV" = (
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/plating,
-/area/medical/ward)
-"bNW" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bNX" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bNY" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "bNZ" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -29381,28 +27451,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"bOa" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "bOb" = (
-/turf/simulated/wall,
-/area/medical/morgue)
+/obj/machinery/oxygen_pump/anesthetic,
+/turf/simulated/wall/r_wall,
+/area/medical/surgery2)
 "bOc" = (
 /obj/item/weapon/stool/padded,
 /obj/structure/disposalpipe/segment,
@@ -29705,6 +27757,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/lobby)
+"bOP" = (
+/obj/structure/curtain/open/shower/medical,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "bOQ" = (
 /turf/unsimulated/mask,
 /area/quartermaster/office)
@@ -29797,87 +27859,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance Access";
-	req_access = list(5)
-	},
 /turf/simulated/floor/plating,
-/area/medical/ward)
-"bPz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/area/maintenance/medbay)
+"bPD" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bPA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bPC" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bPG" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = 21
-	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/area/medical/medical_lockerroom)
 "bPI" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
-"bPK" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "bPM" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
@@ -30102,31 +28103,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"bQN" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -36
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 9
-	},
-/obj/machinery/iv_drip,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "bQO" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -30140,45 +28116,13 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/medbay)
-"bQY" = (
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bQZ" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bRa" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/vending/wallmed1{
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
+"bQT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bRb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/area/medical/foyer)
 "bRf" = (
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/atmos)
@@ -30515,19 +28459,12 @@
 /area/maintenance/medbay)
 "bSm" = (
 /turf/simulated/wall/r_wall,
-/area/medical/ward)
+/area/medical/resleeving)
 "bSo" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "st1_tint"
-	},
-/turf/simulated/floor/plating,
-/area/medical/surgery)
-"bSp" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre 1";
-	req_access = list(45)
+/obj/machinery/door/airlock/glass_medical{
+	name = "External Response Bay";
+	req_access = list(66)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -30537,32 +28474,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_grid,
-/area/medical/surgery)
+/area/medical/medbay_emt_bay)
 "bSq" = (
-/turf/simulated/wall,
-/area/medical/surgery)
-"bSt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bSu" = (
-/turf/simulated/wall,
-/area/medical/ward)
+/area/medical/resleeving)
 "bSx" = (
 /turf/simulated/wall,
-/area/medical/surgery2)
+/area/medical/patient_a)
 "bSB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -30988,151 +28913,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/security)
-"bTG" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 9
-	},
-/obj/structure/closet/secure_closet/medical2,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"bTH" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"bTI" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"bTJ" = (
-/obj/structure/sink{
-	pixel_y = 16
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "surgeryobs";
-	name = "Privacy Shutters";
-	pixel_x = 26
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"bTM" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/holosign/surgery,
-/obj/machinery/door/airlock/medical{
-	id_tag = "surgery_observation";
-	name = "Observation Room";
-	req_access = null;
-	req_one_access = null
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/surgeryobs)
-"bTO" = (
-/turf/simulated/wall,
-/area/medical/surgeryobs)
 "bTQ" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"bTR" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 24
-	},
-/obj/machinery/button/windowtint{
-	id = "st2_tint";
-	pixel_x = -11;
-	pixel_y = 22
-	},
-/obj/structure/cable/green{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/button/holosign{
-	pixel_x = -11;
-	pixel_y = 30
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"bTS" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
 "bTT" = (
 /obj/structure/cable/green{
 	d2 = 8;
@@ -31363,120 +29151,29 @@
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
 "bUS" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"bUT" = (
-/obj/effect/floor_decal/industrial/loading,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"bUU" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"bUX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 6
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/medical/patient_restroom)
+"bUX" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/surgeryobs)
-"bUY" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"bVa" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bVb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/medical/cryo)
-"bVc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"bVd" = (
-/obj/effect/floor_decal/industrial/loading,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/area/medical/medbay4)
 "bVe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -31784,80 +29481,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/sc/hos)
-"bWl" = (
-/obj/machinery/oxygen_pump/anesthetic,
-/turf/simulated/wall,
-/area/medical/surgery)
-"bWm" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"bWn" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"bWp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/medical/surgeryobs)
-"bWq" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/surgeryobs)
-"bWr" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "surgeryobs2";
-	name = "Operating Theatre Privacy Shutters";
-	opacity = 0
-	},
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/surgeryobs)
-"bWt" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
 "bWu" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
@@ -32118,12 +29741,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"bXv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/medical/surgeryobs)
 "bXA" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/wingrille_spawn/reinforced,
@@ -32174,37 +29791,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
-"bXF" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 24
-	},
-/obj/machinery/button/windowtint{
-	id = "st1_tint";
-	pixel_x = -11;
-	pixel_y = 22
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/button/holosign{
-	pixel_x = -11;
-	pixel_y = 30
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/pink/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "bXH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/meter,
@@ -32452,43 +30038,16 @@
 "bYD" = (
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
-"bYF" = (
-/obj/machinery/ai_status_display{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/pink/border,
-/obj/structure/table/standard,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/item/weapon/autopsy_scanner,
-/obj/item/weapon/surgical/FixOVein,
-/obj/item/weapon/surgical/surgicaldrill,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "bYH" = (
-/turf/simulated/wall/r_wall,
-/area/medical/surgeryobs)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "bYI" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/box/cups,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -21
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/medical/surgeryobs)
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "bYL" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -33032,17 +30591,6 @@
 /obj/structure/loot_pile/maint/boxfort,
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
-"caZ" = (
-/obj/item/device/radio/intercom/department/medbay{
-	pixel_y = -24
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/surgical/hemostat,
-/obj/item/weapon/surgical/cautery,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/pink/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "cba" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -33482,14 +31030,18 @@
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
 "ccj" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"cck" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
+/area/medical/medbay4)
 "ccl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -33572,18 +31124,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/lawoffice)
 "cct" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"ccu" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/machinery/washing_machine,
+/obj/machinery/light/spot{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/medical/surgery)
+/area/awaymission/snowfield/medical/patient_restroom)
 "ccv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -33684,34 +31230,21 @@
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
 "ccK" = (
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	pixel_y = 24
+/obj/machinery/door/airlock/multi_tile/glass{
+	id_tag = "meddoor";
+	name = "Medbay Entry";
+	req_access = list(5)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/door/firedoor/multi_tile/glass,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/medbay4)
 "ccM" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
@@ -33804,20 +31337,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/barrestroom)
-"cda" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/patient_a)
-"cde" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "cdk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -33877,19 +31396,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/security/lobby)
-"cdr" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "cds" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/airlock/glass_security{
@@ -34768,32 +32274,11 @@
 /turf/simulated/wall,
 /area/security/lobby)
 "cfO" = (
-/obj/machinery/optable,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
+/turf/simulated/wall,
+/area/awaymission/snowfield/medical/patient_restroom)
 "cfP" = (
-/obj/machinery/computer/operating{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"cfQ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 4;
-	icon_state = "shutter0";
-	id = "surgeryobs";
-	name = "Operating Theatre Privacy Shutters";
-	opacity = 0
-	},
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/surgeryobs)
+/area/awaymission/snowfield/medical/patient_restroom)
 "cfR" = (
 /turf/simulated/wall,
 /area/crew_quarters/heads/sc/hos)
@@ -34985,12 +32470,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
-"cgg" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "cgk" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/lime/bordercorner,
@@ -35335,11 +32814,11 @@
 	dir = 4
 	},
 /obj/structure/curtain/black{
+	dir = 2;
 	icon_state = "open";
 	layer = 2;
 	name = "privacy curtain";
-	opacity = 0;
-	dir = 2
+	opacity = 0
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/seconddeck/artgallery)
@@ -36265,6 +33744,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
+"cjY" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "ckd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36743,23 +34226,23 @@
 	dir = 4
 	},
 /obj/item/clothing/suit/storage/apron/white{
-	pixel_y = 7;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 7
 	},
 /obj/item/clothing/suit/storage/apron/white{
-	pixel_y = 7;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = 7
 	},
 /obj/item/clothing/suit/storage/apron/white{
 	pixel_y = 6
 	},
 /obj/item/clothing/glasses/regular/hipster{
-	pixel_y = -2;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = -2
 	},
 /obj/item/clothing/mask/smokable/pipe/cobpipe{
-	pixel_y = 3;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 3
 	},
 /obj/item/clothing/head/beret{
 	pixel_x = 5;
@@ -37087,11 +34570,11 @@
 	name = "Gallery"
 	},
 /obj/structure/curtain/black{
+	dir = 2;
 	icon_state = "open";
 	layer = 2;
 	name = "privacy curtain";
-	opacity = 0;
-	dir = 2
+	opacity = 0
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/seconddeck/artgallery)
@@ -37174,8 +34657,8 @@
 /obj/item/weapon/reagent_containers/food/drinks/smallmilk,
 /obj/item/weapon/reagent_containers/food/drinks/smallmilk,
 /obj/structure/closet/secure_closet/freezer/fridge{
-	pixel_y = 0;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 0
 	},
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/effect/floor_decal/borderfloorblack{
@@ -37485,17 +34968,17 @@
 "coy" = (
 /obj/structure/table/marble,
 /obj/item/weapon/hand_labeler{
-	pixel_y = 8;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 8
 	},
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/item/weapon/reagent_containers/food/condiment/sugar{
-	pixel_y = 2;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 2
 	},
 /obj/item/weapon/reagent_containers/food/condiment/sugar{
-	pixel_y = 2;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 2
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -37507,8 +34990,8 @@
 	pixel_x = 28
 	},
 /obj/item/weapon/reagent_containers/food/condiment/carton/flour{
-	pixel_y = -2;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = -2
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/crew_quarters/coffee_shop)
@@ -37522,12 +35005,12 @@
 	},
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/item/weapon/storage/box/donkpockets{
-	pixel_y = -3;
-	pixel_x = 7
+	pixel_x = 7;
+	pixel_y = -3
 	},
 /obj/item/weapon/storage/box/donkpockets{
-	pixel_y = -3;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = -3
 	},
 /obj/item/weapon/storage/box/donut{
 	pixel_x = 3;
@@ -37738,59 +35221,24 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fore)
 "cpN" = (
-/turf/simulated/wall/r_wall,
-/area/medical/surgery)
-"cpO" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 10
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
 	},
-/obj/structure/table/standard,
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/weapon/surgical/retractor,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
-"cpP" = (
 /obj/machinery/camera/network/medbay{
-	c_tag = "MED - Operating Theatre 1";
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/pink/border,
-/obj/structure/table/standard,
-/obj/item/weapon/surgical/bonesetter,
-/obj/item/weapon/surgical/bonegel,
-/obj/item/weapon/surgical/bioregen,
 /turf/simulated/floor/tiled/white,
-/area/medical/surgery)
+/area/medical/foyer)
 "cpQ" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Surgery Observation";
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled,
-/area/medical/surgeryobs)
-"cpT" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 8
-	},
-/obj/machinery/chemical_analyzer,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
+/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
+/obj/item/weapon/reagent_containers/glass/bottle/stoxin,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "cpW" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -37799,6 +35247,12 @@
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"cpX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "cqf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38151,12 +35605,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fore)
-"cri" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "crk" = (
 /turf/simulated/floor/tiled,
 /area/storage/primary)
@@ -41108,6 +38556,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fore)
+"czT" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/surgical/bioregen,
+/obj/item/weapon/surgical/surgicaldrill,
+/obj/item/weapon/autopsy_scanner,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/black/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "czV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -41145,6 +38602,19 @@
 /obj/structure/janitorialcart,
 /turf/simulated/floor/tiled,
 /area/janitor)
+"cAo" = (
+/mob/living/simple_mob/animal/passive/cat/runtime{
+	vore_bump_chance = 1;
+	vore_bump_emote = "leaps at"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "cAq" = (
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
@@ -42695,25 +40165,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
-"cEH" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Equipment Storage";
-	dir = 8
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
 "cEI" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -43659,6 +41110,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
+"cPo" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "cPv" = (
 /obj/machinery/atmospherics/pipe/cap/visible{
 	color = "#444444";
@@ -43733,12 +41194,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
-"cSb" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "cSi" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -43751,22 +41206,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
-"cSC" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/item/weapon/clipboard,
-/obj/item/weapon/folder/blue,
-/obj/item/weapon/folder/red,
-/obj/item/weapon/folder/blue,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
 "cSF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -43780,12 +41219,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
-"cTb" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "cTj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
@@ -43810,38 +41243,6 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"cUx" = (
-/obj/item/stack/material/phoron{
-	amount = 5
-	},
-/obj/structure/table/glass,
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"cUR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "cUT" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -43866,6 +41267,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/chapel/office)
 "cVs" = (
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "MedbayLockdown"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/medical/medbay_emt_bay)
 "cVG" = (
@@ -43884,35 +41289,10 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/seconddeck/artgallery)
 "cVH" = (
-/obj/machinery/chem_master,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 8
-	},
+/obj/structure/table/darkglass,
+/obj/random/snack,
 /turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"cVI" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/area/medical/foyer)
 "cWj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -43927,6 +41307,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
+"cWm" = (
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "patienta"
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "cWU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -43942,20 +41329,16 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"cXd" = (
-/obj/structure/table/woodentable,
-/obj/machinery/computer/med_data/laptop{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
 "cXz" = (
-/obj/machinery/recharge_station,
-/obj/machinery/light/small{
+/obj/machinery/optable,
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "cXB" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -43986,6 +41369,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
+"cYj" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "cZy" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -44026,12 +41422,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/drone_fabrication)
-"day" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
 "dbg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -44052,6 +41442,14 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/coffee_shop)
+"dbD" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "dbK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/meter,
@@ -44077,6 +41475,26 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor,
 /area/engineering/drone_fabrication)
+"dcV" = (
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "patientb"
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
+"dda" = (
+/obj/machinery/disposal,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "ddf" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -44113,17 +41531,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/engineering/storage)
-"deQ" = (
-/obj/structure/table/steel,
-/obj/item/weapon/gun/launcher/syringe,
-/obj/item/weapon/storage/box/syringegun,
-/obj/random/medical,
-/obj/random/medical,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
 "dfc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
@@ -44137,19 +41544,33 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"dgM" = (
-/obj/structure/sign/examroom{
-	pixel_x = 32;
-	pixel_y = 32
+"dga" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_medical,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/sleeper)
+"dge" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay2)
 "dgU" = (
 /turf/simulated/wall/r_wall,
 /area/holodeck_control)
@@ -44192,6 +41613,28 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
+"dhS" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
+"dig" = (
+/obj/structure/closet/secure_closet/CMO,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/item/clothing/accessory/poncho/roles/cloak/cmo,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
+"diB" = (
+/obj/item/toy/katana,
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/sc/cmo)
 "djg" = (
 /obj/effect/floor_decal/sign/dock/one,
 /turf/simulated/floor/tiled,
@@ -44211,6 +41654,16 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/crew_quarters/coffee_shop)
+"djs" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood,
+/area/medical/psych)
+"djx" = (
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/masks,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "dkb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -44231,6 +41684,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/atmos_hallway)
+"dkI" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "dln" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 1
@@ -44270,25 +41735,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/hallway/atmos_hallway)
-"dlB" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/item/weapon/storage/box/nifsofts_medical,
-/obj/item/weapon/backup_implanter{
-	pixel_y = -6
-	},
-/obj/item/weapon/backup_implanter,
-/obj/item/weapon/backup_implanter{
-	pixel_y = 6
-	},
-/obj/item/weapon/backup_implanter{
-	pixel_y = 12
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "dlP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -44341,6 +41787,67 @@
 /obj/structure/bed/chair/comfy/purp,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"dmG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"dmO" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/transhuman/resleever,
+/obj/machinery/camera/network/medbay{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
+"dmP" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
+"dmT" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"dmY" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/medical_kiosk,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
+"dni" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/medical/sleeper)
 "doj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
@@ -44348,10 +41855,10 @@
 /turf/simulated/floor,
 /area/maintenance/engineering)
 "doR" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/foyer)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "dpN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44368,21 +41875,6 @@
 "dpO" = (
 /turf/simulated/wall,
 /area/hallway/primary/seconddeck/fscenter)
-"dpP" = (
-/obj/machinery/ai_status_display{
-	pixel_y = -32
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/pink/border,
-/obj/structure/table/standard,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/item/weapon/autopsy_scanner,
-/obj/item/weapon/surgical/FixOVein,
-/obj/item/weapon/surgical/surgicaldrill,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "dpQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/ai_status_display{
@@ -44425,35 +41917,34 @@
 "dqr" = (
 /turf/simulated/wall/r_wall,
 /area/medical/cryo/autoresleeve)
-"dqF" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "drD" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D2)
-"drJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "pr1_window_tint"
+"dsd" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/medical/patient_a)
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "dsj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -44498,6 +41989,18 @@
 /obj/item/weapon/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/fs_emergency)
+"dur" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "duE" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/loading{
@@ -44678,15 +42181,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/sc/hor)
-"dxh" = (
-/obj/structure/bed/chair/office/light{
-	dir = 8
+"dxw" = (
+/obj/item/toy/plushie/white_cat{
+	desc = "A small cat plushie. Why does it look so fat?";
+	name = "Frostella the Plushie";
+	pokephrase = "Feed Me!"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/patient_a)
 "dxR" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -44718,6 +42221,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/sc/hor)
+"dyG" = (
+/turf/simulated/wall/r_wall,
+/area/medical/patient_a)
 "dyK" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -44797,6 +42303,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/seconddeck/artgallery)
+"dAe" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/structure/sign/nosmoking_1{
+	pixel_x = 2;
+	pixel_y = 27
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "dBF" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck - Central Ring 7";
@@ -44810,6 +42330,22 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hallway/primary/seconddeck/apcenter)
+"dBO" = (
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/timer,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "dCb" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -44840,9 +42376,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/rnd/research)
-"dCI" = (
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "dDw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -44861,6 +42394,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"dDJ" = (
+/obj/structure/sign/warning/compressed_gas,
+/turf/simulated/wall,
+/area/medical/medbay_primary_storage)
 "dEa" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/corner/brown/diagonal,
@@ -44918,6 +42455,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/stairwell)
+"dFK" = (
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "patienta"
+	},
+/turf/simulated/floor/plating,
+/area/medical/patient_a)
 "dGs" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -45060,6 +42603,19 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
+"dKz" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
 "dKV" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -45147,18 +42703,23 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
-"dNI" = (
-/obj/structure/bed/chair{
-	dir = 8
+"dND" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/foyer)
+/area/medical/medbay2)
 "dOF" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
@@ -45170,22 +42731,6 @@
 /obj/random/junk,
 /turf/simulated/floor,
 /area/maintenance/bar)
-"dPW" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	name = "light switch ";
-	pixel_x = 36
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
 "dQc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -45193,6 +42738,24 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/rnd/storage)
+"dQW" = (
+/obj/structure/table/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/computer/med_data/laptop{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
+"dRl" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/donut,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "dRO" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/shield_diffuser,
@@ -45240,36 +42803,28 @@
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/docking_lounge)
 "dTh" = (
-/obj/machinery/disposal,
+/obj/machinery/chemical_analyzer,
 /obj/effect/floor_decal/borderfloor{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
-	},
-/obj/structure/window/reinforced/tinted/frosted{
 	dir = 4
 	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"dTs" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "dTv" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/library)
-"dTG" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "dTN" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/borderfloor{
@@ -45367,19 +42922,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
-"dVM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "dVT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -45444,6 +42986,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
+"dXc" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
+"dXn" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "dXD" = (
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
@@ -45482,21 +43051,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"dYS" = (
-/obj/machinery/reagentgrinder,
-/obj/structure/table/glass,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 8;
-	pixel_x = -21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "dYT" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1445;
@@ -45522,6 +43076,28 @@
 	},
 /turf/simulated/floor/airless,
 /area/engineering/engine_waste)
+"dZi" = (
+/obj/structure/closet/secure_closet/paramedic,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
+"dZt" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "dZA" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -45571,6 +43147,22 @@
 /obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
+"eaL" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/light/spot,
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
+"eaS" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/sleep_console,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "ebf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -45583,32 +43175,6 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"ebw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "ebA" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -45650,6 +43216,18 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
+"eer" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "eeQ" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin{
@@ -45705,6 +43283,17 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/secondary/entry/D2)
+"efu" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/item/weapon/book/manual/chemistry_guide,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "efz" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -45737,24 +43326,16 @@
 	},
 /turf/simulated/floor,
 /area/engineering/drone_fabrication)
-"egb" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	name = "Medical Restroom"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/medical_restroom)
+"efN" = (
+/obj/structure/table/rack/shelf,
+/obj/item/mecha_parts/mecha_equipment/tool/syringe_gun,
+/obj/item/weapon/storage/box/syringegun,
+/obj/item/weapon/storage/box/syringegun,
+/obj/item/weapon/storage/box/cdeathalarm_kit,
+/obj/item/weapon/storage/box/nifsofts_medical,
+/obj/item/weapon/disk/nifsoft/medical,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "ego" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -45790,11 +43371,26 @@
 	},
 /turf/simulated/floor,
 /area/engineering/drone_fabrication)
+"ehu" = (
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
 "ehE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/power/thermoregulator,
 /turf/simulated/floor,
 /area/engineering/storage)
+"ehH" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/item/weapon/circuitboard/medical_kiosk,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "eia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -45812,6 +43408,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"eig" = (
+/obj/machinery/door/window/holowindoor{
+	dir = 8
+	},
+/obj/structure/curtain/open/shower/medical,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/medical/patient_restroom)
+"eii" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "eiA" = (
 /obj/machinery/door/airlock/external{
 	icon_state = "door_locked";
@@ -45848,6 +43461,11 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor,
 /area/engineering/storage)
+"eiU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "ejk" = (
 /obj/machinery/door/window/southright{
 	name = "Bar";
@@ -45892,15 +43510,6 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
-"ekq" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/vending/wallmed1{
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "ekL" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -45921,27 +43530,6 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/carpet/oracarpet,
 /area/library)
-"elC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "emk" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/machinery/ai_status_display{
@@ -45979,6 +43567,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"emB" = (
+/obj/structure/table/reinforced,
+/obj/item/device/multitool,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/item/weapon/melee/umbrella,
+/obj/item/weapon/melee/umbrella,
+/obj/item/weapon/melee/umbrella,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "emI" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -46014,10 +43612,22 @@
 /turf/simulated/floor/lino,
 /area/chapel/office)
 "enc" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Reception";
+	req_access = list(5)
+	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/sleeper)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "end" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -46031,6 +43641,15 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/fp_emergency)
+"env" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "enG" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -46079,17 +43698,6 @@
 /obj/item/weapon/pen/multi,
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
-"eqD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/bodyscanner,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "eqL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -46149,12 +43757,40 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
 "esc" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/transhuman/resleever,
-/obj/machinery/light,
+/obj/structure/curtain/open/shower/medical,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/cryo)
+/area/medical/sleeper)
+"esg" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_x = 38
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
 "esm" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -46181,8 +43817,28 @@
 	name = "Medbay Maintenance Access";
 	req_access = list(5)
 	},
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "MedbayLockdown"
+	},
 /turf/simulated/floor/plating,
-/area/medical/medbay)
+/area/medical/medical_restroom)
+"etu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "etv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -46277,20 +43933,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/fs_emergency)
-"evM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/medical{
-	name = "Patient Room A"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/patient_a)
 "evZ" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -46331,6 +43973,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/fs_emergency)
+"exa" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/obj/machinery/vending/medical,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "exb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -46354,18 +44009,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
-"eyb" = (
-/obj/structure/table/woodentable,
-/obj/item/toy/plushie/therapy/blue,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -21
-	},
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
+"eyk" = (
+/turf/simulated/wall,
+/area/medical/foyer)
 "eyV" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/device/radio/intercom{
@@ -46374,6 +44020,45 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
+"ezb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
+"ezf" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
+"ezE" = (
+/obj/structure/curtain/open/shower/medical,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/medical/sleeper)
 "eAf" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -46388,6 +44073,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
+"eAF" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "eBi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -46480,23 +44177,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
-"eEj" = (
-/obj/structure/sink{
-	pixel_y = 16
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "surgeryobs2";
-	name = "Privacy Shutters";
-	pixel_x = -26
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "eEy" = (
 /obj/structure/closet/coffin,
 /obj/machinery/door/window/northleft{
@@ -46532,24 +44212,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/research)
-"eFj" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/westright{
-	name = "EVA Suit Storage";
-	req_access = list(5)
-	},
-/obj/item/device/suit_cooling_unit,
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "eFx" = (
 /obj/machinery/computer/mecha{
 	dir = 4
@@ -46737,6 +44399,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/quartermaster/delivery)
+"eHZ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
 "eIu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -46859,17 +44532,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"eKB" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/weapon/soap/nanotrasen,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
 "eKZ" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -46896,21 +44558,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/storage)
-"eLf" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "eLk" = (
 /obj/machinery/camera/network/research{
 	c_tag = "SCI - Toxins Gas Storage";
@@ -46930,19 +44577,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/apcenter)
-"eLH" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/obj/machinery/organ_printer/flesh/full,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
 "eLI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -46975,29 +44609,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
-"eMm" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "eMv" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/computer/area_atmos/tag{
@@ -47052,38 +44663,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"eNz" = (
-/obj/machinery/door/firedoor/glass,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/glass_medical{
-	id_tag = "Surgery";
-	name = "Patient Ward";
-	req_access = list(5)
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/ward)
 "eNJ" = (
 /turf/simulated/wall,
 /area/rnd/storage)
-"eNU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+"eOo" = (
+/turf/simulated/wall,
+/area/medical/medbay_primary_storage)
+"eOs" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
-"eOl" = (
-/obj/machinery/optable,
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
+/area/medical/medbay2)
 "eOG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -47190,6 +44788,16 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/rnd/mixing)
+"eRV" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "eSn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -47199,14 +44807,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"eSw" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_medical{
-	name = "Chemistry Laboratory";
-	req_access = list(33)
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/chemistry)
 "eSF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 4
@@ -47244,6 +44844,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/rnd/mixing)
+"eTp" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
 "eTt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -47263,6 +44877,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
+"eUW" = (
+/obj/structure/table/reinforced,
+/obj/item/device/radio/emergency,
+/obj/item/device/radio/emergency,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "eVw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -47303,22 +44934,6 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
-"eXp" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "eXq" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -47332,18 +44947,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
-"eXs" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
+"eXt" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/newscaster{
-	pixel_x = 30
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/beige/bordercorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
+/area/medical/sleeper)
 "eXF" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Cargo Substation Bypass"
@@ -47387,11 +45013,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
-"eYr" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/medical_lockerroom)
 "eYu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -47503,6 +45124,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
+"fbU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "fbZ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -47545,9 +45173,6 @@
 /obj/structure/table/bench/padded,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"fdB" = (
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
 "fdE" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -47567,17 +45192,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/genetics)
-"fdL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "fdO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -47603,26 +45217,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/hallway/atmos_hallway)
-"fek" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "ffB" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -47664,18 +45258,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"fgL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "fgN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -47784,6 +45366,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/fscenter)
+"fiJ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"fjg" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "fjp" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -47824,6 +45423,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/fs_emergency)
+"fjP" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/item/weapon/book/manual/medical_cloning,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
 "fld" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -47863,31 +45477,11 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/sc/hor)
 "flL" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/machinery/status_display{
-	pixel_x = 30
+/obj/structure/closet/walllocker_double{
+	name = "Chemistry Closet"
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"fma" = (
-/obj/structure/table/glass,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/medical_wall/pills{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/turf/simulated/wall,
+/area/medical/morgue)
 "fmH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -47904,6 +45498,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
+"fni" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/light/spot,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "fno" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -47921,26 +45521,6 @@
 "fnp" = (
 /turf/simulated/wall,
 /area/maintenance/chapel)
-"fnG" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "foc" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -47992,15 +45572,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/sc/hor)
-"foG" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "foZ" = (
 /obj/structure/table/standard,
 /obj/random/tech_supply,
@@ -48062,12 +45633,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_room)
-"fsn" = (
-/obj/machinery/smartfridge/secure/medbay{
-	req_one_access = list(33,66)
-	},
-/turf/simulated/wall/r_wall,
-/area/medical/chemistry)
 "fsr" = (
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 8
@@ -48096,19 +45661,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"fsC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+"fti" = (
+/obj/machinery/requests_console{
+	dir = 1;
+	name = "CMO RC"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/turf/simulated/wall/r_wall,
+/area/crew_quarters/heads/sc/cmo)
 "ftm" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/docking_lounge)
+"ftn" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "ftv" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/research)
@@ -48146,6 +45717,19 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
+"fuA" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "fuP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48163,18 +45747,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
-"fuU" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
 "fva" = (
 /obj/structure/railing,
 /turf/simulated/open,
@@ -48217,6 +45789,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
+"fvL" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/obj/structure/flora/pottedplant/orientaltree,
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "fvS" = (
 /obj/item/weapon/deck/cards,
 /obj/structure/table/hardwoodtable,
@@ -48341,32 +45926,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
-"fAl" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -21
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "fAD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -48378,6 +45937,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"fAG" = (
+/obj/structure/table/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/weapon/stamp/cmo{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/weapon/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "fAH" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -48497,6 +46071,21 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
+"fDo" = (
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "fDv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
@@ -48524,15 +46113,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_waste)
-"fEi" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/box/beakers,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/item/device/mass_spectrometer/adv,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "fEE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -48612,6 +46192,11 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/entry/D1)
+"fGC" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "fGG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 10
@@ -48691,6 +46276,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
+"fHT" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "fHV" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -48701,6 +46302,24 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
+"fIk" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "fIx" = (
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
@@ -48738,6 +46357,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/hallway/engineer_hallway)
+"fJf" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/paramedic,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "fJl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -48789,14 +46421,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
-"fJF" = (
-/obj/structure/bed/psych,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
 "fJX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
@@ -48806,6 +46430,28 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/engineering/hallway/engineer_hallway)
+"fKO" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
+"fLy" = (
+/obj/machinery/recharge_station,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/medical/patient_restroom)
 "fLN" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -48877,15 +46523,15 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D2)
 "fNB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
+/obj/structure/flora/pottedplant,
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/area/medical/medbay4)
 "fON" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48902,10 +46548,10 @@
 /area/maintenance/medbay)
 "fOV" = (
 /obj/machinery/button/remote/blast_door{
+	dir = 1;
 	id = "coffeeshop";
 	name = "Cafe Shutters";
 	pixel_y = -26;
-	dir = 1;
 	req_one_access = list(25,28)
 	},
 /obj/machinery/button/neonsign{
@@ -48971,18 +46617,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/seconddeck/fscenter)
-"fRK" = (
-/obj/machinery/vending/coffee{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "fRL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/network/second_deck{
@@ -48997,25 +46631,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
-"fRS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+"fRV" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"fSb" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/defib_kit/loaded,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/area/medical/sleeper)
 "fSk" = (
 /obj/structure/table/standard,
 /obj/item/toy/plushie/box,
@@ -49032,6 +46659,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
+"fSN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "fSQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -49048,6 +46689,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
+"fTm" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "fTt" = (
 /obj/structure/sign/directions/evac{
 	pixel_y = -10
@@ -49064,24 +46709,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
-"fVj" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 8;
-	pixel_x = -21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/iv_drip,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "fVu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -49138,6 +46765,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"fWh" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "fWj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -49159,36 +46800,39 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"fWS" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/weapon/soap/nanotrasen,
-/obj/machinery/firealarm{
-	pixel_y = 24
+"fWq" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = 21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "fXq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/docking_lounge)
-"fYw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
+"fXz" = (
+/obj/effect/landmark/start/fieldmedic,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/area/medical/medbay_emt_bay)
+"fXK" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/curtain/open/shower/medical,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/medical/patient_restroom)
 "fYH" = (
 /obj/structure/sign/warning/high_voltage{
 	pixel_y = 32
@@ -49221,6 +46865,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"fZh" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Operating Room B";
+	req_access = list(45)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/medbay2)
 "fZr" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -49233,9 +46896,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
 /turf/simulated/floor,
 /area/engineering/engine_waste)
-"fZU" = (
-/turf/simulated/wall,
-/area/medical/psych)
 "gar" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -49337,21 +46997,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/library)
-"gcc" = (
-/obj/structure/table/glass,
-/obj/item/roller,
-/obj/item/roller{
-	pixel_y = 8
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "gcd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable/green{
@@ -49495,6 +47140,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"gdX" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "gel" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -49562,19 +47216,42 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"geI" = (
-/obj/machinery/light{
-	dir = 1
+"gfa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 5
-	},
-/obj/machinery/vending/blood,
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/area/medical/reception)
+"gfm" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_x = 38
+	},
+/obj/machinery/button/windowtint{
+	id = "patientb";
+	pixel_x = 38;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_b)
 "gfQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -49630,22 +47307,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_waste)
-"ggV" = (
-/obj/structure/filingcabinet/medical{
-	desc = "A large cabinet with hard copy medical records.";
-	name = "Medical Records"
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
 "gho" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -49677,6 +47338,10 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/lino,
 /area/chapel/office)
+"giB" = (
+/obj/structure/closet/l3closet/virology,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "giQ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -49737,28 +47402,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"gjl" = (
-/obj/machinery/chem_master,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"gjr" = (
-/obj/structure/morgue{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "gju" = (
 /obj/machinery/door/airlock/glass{
 	name = "Cryogenic Storage"
@@ -49930,6 +47573,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
+"gnV" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_b)
 "got" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -50059,22 +47716,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"gro" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/medical_lockerroom)
-"grM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+"gqH" = (
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/area/medical/medbay4)
 "gsP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -50148,6 +47801,12 @@
 "guk" = (
 /turf/simulated/wall,
 /area/medical/medical_lockerroom)
+"guv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "guC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -50169,6 +47828,30 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"guU" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "gvv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -50268,11 +47951,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
-"gyD" = (
-/obj/machinery/door/airlock{
-	name = "Unit 2"
+"gyM" = (
+/obj/structure/bed/chair{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/freezer,
+/obj/effect/landmark/start/chemist,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/blue,
 /area/medical/medical_restroom)
 "gyT" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -50305,13 +47994,19 @@
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D2)
-"gAD" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
+"gAx" = (
+/obj/structure/filingcabinet/medical,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/foyer)
+/area/medical/reception)
 "gAK" = (
 /obj/structure/table/woodentable,
 /obj/machinery/librarycomp,
@@ -50387,60 +48082,23 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/rnd/mixing)
-"gCT" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -36
-	},
-/obj/random/medical,
-/obj/random/medical,
-/obj/random/medical,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "gDg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/apcenter)
+"gDp" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "gDr" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
 /turf/simulated/floor,
 /area/engineering/engine_waste)
 "gDA" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"gDC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/glass_medical,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/medbay2)
+/turf/simulated/wall/r_wall,
+/area/medical/surgeryobs)
 "gDF" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/lime/border,
@@ -50492,17 +48150,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_waste)
-"gEj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
 "gEM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
@@ -50514,12 +48161,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
-"gFH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "gFO" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/nullrod,
@@ -50544,6 +48185,15 @@
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
+"gGb" = (
+/obj/structure/table/rack/shelf,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/storage/firstaid/o2,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "gGj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -50586,25 +48236,18 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"gIc" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Medical Hallway Port 2";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+"gIx" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/patient_b)
+"gIJ" = (
+/obj/structure/table/darkglass,
+/obj/random/snack,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "gIM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -50643,6 +48286,12 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/locker)
+"gKj" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
 "gKx" = (
 /obj/structure/kitchenspike,
 /turf/simulated/floor/tiled/freezer,
@@ -50814,22 +48463,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/yellow,
 /area/crew_quarters/coffee_shop)
-"gPc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/surgery_storage)
 "gPh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -50953,18 +48586,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/hallway/engineer_hallway)
-"gQT" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/structure/morgue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "gRF" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -50976,44 +48597,17 @@
 /obj/item/weapon/book/manual/chef_recipes,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"gRL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/medbay2)
 "gRP" = (
 /obj/structure/sign/poster,
 /turf/simulated/wall,
 /area/quartermaster/delivery)
-"gSn" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+"gRV" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/unary/freezer{
+	icon_state = "freezer"
 	},
-/obj/machinery/door/window/westleft{
-	name = "EVA Suit Storage";
-	req_access = list(5)
-	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/helmet/space/void/medical,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/medical,
-/obj/item/weapon/tank/oxygen,
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.6
-	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/head/helmet/space/void/medical,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/suit/space/void/medical,
-/obj/item/weapon/tank/oxygen,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "gSJ" = (
 /obj/machinery/conveyor{
 	id = "recycler"
@@ -51043,6 +48637,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/engineer_hallway)
+"gTg" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "gTh" = (
 /obj/item/stack/tile/floor/yellow,
 /obj/item/frame/light,
@@ -51137,36 +48750,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"gVm" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
-"gVw" = (
-/turf/simulated/wall/r_wall,
-/area/medical/patient_a)
-"gWf" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/food/drinks/britcup,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "gWC" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 1;
@@ -51206,6 +48789,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/entry/D2/arrivals)
+"gXe" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "gXB" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/grass,
@@ -51259,51 +48851,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
-"hai" = (
-/obj/structure/table/glass,
-/obj/item/weapon/towel{
-	color = "#FF6666";
-	name = "light red towel"
-	},
-/obj/item/weapon/towel{
-	color = "#FF6666";
-	name = "light red towel"
-	},
-/obj/item/weapon/towel{
-	color = "#FF6666";
-	name = "light red towel"
-	},
-/obj/item/weapon/towel{
-	color = "#3fc0ea";
-	name = "light blue towel";
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/weapon/towel{
-	color = "#3fc0ea";
-	name = "light blue towel";
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/weapon/towel{
-	color = "#3fc0ea";
-	name = "light blue towel";
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/weapon/soap/nanotrasen,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -36
-	},
-/obj/structure/cable/green,
-/obj/random/soap,
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
 "hax" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -51337,30 +48884,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/seconddeck/artgallery)
-"haO" = (
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+"haH" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/area/medical/medbay4)
 "hbf" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/fscenter)
-"hcg" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/flora/pottedplant/overgrown,
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "hcA" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/firealarm{
@@ -51369,6 +48905,37 @@
 	},
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/fscenter)
+"hcB" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/computer/id_restorer{
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"hcJ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "hcP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -51408,47 +48975,10 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hallway/primary/seconddeck/fscenter)
-"hdj" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
+"hdM" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"hdI" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
+/area/medical/surgery2)
 "hdV" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck - Central Ring 1"
@@ -51499,25 +49029,17 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
-"hff" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "cmooffice"
+"heD" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/sc/cmo)
-"hft" = (
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/vending/wallmed1{
-	pixel_x = 25
-	},
-/obj/structure/flora/pottedplant/flower,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
 "hgn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -51558,22 +49080,22 @@
 /obj/structure/table/marble,
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/window/southright{
-	name = "Hydroponics";
-	dir = 4
+	dir = 4;
+	name = "Hydroponics"
 	},
 /obj/machinery/door/window/northleft{
+	dir = 8;
 	name = "Hydroponics";
-	req_one_access = list(35,28);
-	dir = 8
+	req_one_access = list(35,28)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/curtain/black{
+	dir = 2;
 	icon_state = "open";
 	layer = 2;
 	name = "privacy curtain";
-	opacity = 0;
-	dir = 2
+	opacity = 0
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hydroponics)
@@ -51632,6 +49154,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/genetics)
+"hko" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "hkr" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -51647,6 +49180,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
+"hkP" = (
+/obj/structure/table/rack/shelf,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/toxin,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "hkW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -51684,35 +49226,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
-"hlC" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+"hlq" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
 	},
-/obj/machinery/atm{
-	pixel_y = 30
+/obj/machinery/light/spot{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"hlN" = (
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/device/assembly/igniter,
-/obj/item/device/assembly/igniter,
-/obj/item/device/assembly/igniter,
-/obj/item/device/assembly/timer,
-/obj/item/device/assembly/timer,
-/obj/item/device/assembly/timer,
-/obj/structure/closet/crate{
-	name = "Grenade Crate"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/area/medical/chemistry)
 "hlX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51756,9 +49282,6 @@
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"hnG" = (
-/turf/simulated/wall,
-/area/medical/medbay2)
 "hnS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -51792,6 +49315,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"hox" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "hoK" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -51841,6 +49377,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
+"hqm" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_a)
 "hqq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51873,6 +49423,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
+"hrh" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
+"hri" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "hru" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51889,6 +49454,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"hrB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
+"hsE" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "hsI" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/space;
@@ -51903,6 +49488,29 @@
 /obj/structure/casino_table/roulette_chart,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
+"hsT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/obj/structure/mopbucket,
+/obj/item/weapon/mop,
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "hsW" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -51912,6 +49520,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"hsX" = (
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/black/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "hti" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -51927,27 +49541,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
-"hua" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+"hue" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay4)
 "hul" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -51967,6 +49571,35 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/disposal)
+"huU" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
+"huX" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/obj/structure/table/darkglass,
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "hvb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -52011,11 +49644,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/library)
-"hwJ" = (
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/plating,
-/area/medical/medbay_emt_bay)
 "hwR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -52061,28 +49689,6 @@
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"hyq" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/vending/medical,
-/turf/simulated/wall,
-/area/medical/medbay_primary_storage)
-"hzq" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Medical Hallway Starboard 3";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "hzr" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -52118,7 +49724,7 @@
 /area/rnd/research)
 "hzO" = (
 /turf/simulated/wall,
-/area/medical/biostorage)
+/area/medical/chemistry)
 "hzX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52131,21 +49737,41 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"hBg" = (
+"hAu" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
+"hBg" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"hBo" = (
-/turf/simulated/wall/r_wall,
-/area/medical/patient_wing)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "hBq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -52175,42 +49801,23 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"hBM" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 5
+"hCG" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id = "medbayrecquar";
-	name = "Medbay Emergency Quarantine Shutters";
-	opacity = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
-"hBX" = (
-/obj/structure/closet/secure_closet/paramedic,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/ai_status_display{
-	pixel_x = -32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "hCW" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	dir = 1;
@@ -52232,23 +49839,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D2/arrivals)
-"hCX" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/weapon/storage/box/pillbottles,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 4
-	},
-/obj/item/weapon/storage/box/syringes,
-/obj/item/weapon/tool/screwdriver,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "hDc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52267,6 +49857,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"hDg" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/photocopier/faxmachine,
+/obj/structure/sign/periodic{
+	pixel_y = 31
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "hDz" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -52389,12 +49993,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"hHj" = (
-/obj/machinery/sleep_console{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "hHG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorwhite/corner,
@@ -52404,6 +50002,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"hHS" = (
+/obj/structure/sign/warning{
+	name = "STERILE AREA"
+	},
+/turf/simulated/wall,
+/area/medical/sleeper)
 "hIh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52436,26 +50040,6 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hallway/primary/seconddeck/ascenter)
-"hIR" = (
-/obj/structure/closet/crate,
-/obj/item/weapon/storage/box/lights/mixed,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/item/device/radio{
-	frequency = 1487;
-	icon_state = "med_walkietalkie";
-	name = "Medbay Emergency Radio Link"
-	},
-/obj/item/device/radio{
-	frequency = 1487;
-	icon_state = "med_walkietalkie";
-	name = "Medbay Emergency Radio Link"
-	},
-/obj/item/weapon/tool/crowbar/red,
-/obj/item/weapon/tool/crowbar/red,
-/obj/item/weapon/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
 "hJg" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/shield_diffuser,
@@ -52586,6 +50170,18 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
+"hKC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/item/modular_computer/console/preset/medical{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "hKF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -52709,6 +50305,15 @@
 "hNv" = (
 /turf/simulated/wall,
 /area/storage/primary)
+"hNx" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "hNJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
@@ -52770,6 +50375,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
+"hOz" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_b)
 "hOK" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced/polarized{
@@ -52841,50 +50458,10 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/drone_fabrication)
-"hPS" = (
-/obj/structure/table/standard,
-/obj/item/roller,
-/obj/item/roller{
-	pixel_y = 8
-	},
-/obj/item/roller{
-	pixel_y = 16
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	name = "light switch ";
-	pixel_x = 36
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
 "hPV" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
-"hPZ" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
 "hQg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -52940,6 +50517,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
+"hRf" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
 "hRr" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -52999,19 +50588,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/locker)
-"hSQ" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Medbay";
-	sortType = "Medbay"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "hTs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53142,24 +50718,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/seconddeck/fscenter)
-"hVN" = (
-/obj/item/weapon/tool/wrench,
-/obj/structure/table/glass,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/item/device/sleevemate,
-/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -4
-	},
-/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/medical/cryo)
 "hVT" = (
 /turf/simulated/wall,
 /area/hallway/primary/seconddeck/dockhallway)
@@ -53197,17 +50755,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/fscenter)
-"hWO" = (
-/obj/structure/sink{
-	pixel_y = 16
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/surgery_storage)
 "hXo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
@@ -53218,18 +50765,6 @@
 "hXA" = (
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/fscenter)
-"hXY" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "hYp" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
@@ -53266,19 +50801,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
-"hYU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
 "hYY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -53330,14 +50852,38 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"ibK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "ibQ" = (
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
-"ibY" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/patient_wing)
+"ibU" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "ich" = (
 /turf/simulated/wall,
 /area/rnd/lab)
@@ -53399,39 +50945,29 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"idT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"ief" = (
-/obj/structure/table/glass,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/hand_labeler,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
-	name = "Chemistry Cleaner"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "iej" = (
 /turf/simulated/wall,
 /area/assembly/robotics)
+"ieF" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "ieG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -53441,31 +50977,27 @@
 "ifd" = (
 /turf/simulated/wall/r_wall,
 /area/assembly/robotics)
-"ifw" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 1
-	},
+"ifo" = (
+/obj/effect/landmark/start/paramedic,
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"ifD" = (
-/obj/structure/bed/chair/sofa/left/blue{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/vending/wallmed1{
-	pixel_y = -30
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
+/area/medical/medbay_emt_bay)
 "ifO" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/rnd/misc_lab)
+"ifU" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
+"igB" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "igH" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -53496,6 +51028,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/misc_lab)
+"igU" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
 "ihl" = (
 /obj/machinery/cryopod{
 	dir = 2
@@ -53511,21 +51049,22 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/cryo/station)
-"iho" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
+"ihw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 9
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "ihz" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -53535,25 +51074,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"ihG" = (
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/surgical/scalpel,
-/obj/item/weapon/surgical/circular_saw{
-	pixel_y = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "ihH" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
@@ -53618,6 +51138,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"iiL" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "iiQ" = (
 /obj/structure/sign/warning/server_room,
 /turf/simulated/wall/r_wall,
@@ -53643,21 +51175,9 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_room)
-"ijR" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/firstaid/toxin,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
-	},
+"ijM" = (
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
+/area/medical/medical_lockerroom)
 "ijU" = (
 /obj/random/trash,
 /turf/simulated/floor,
@@ -53693,13 +51213,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fpcenter)
-"ikX" = (
-/obj/machinery/vending/fitness,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay2)
 "ilk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
@@ -53716,14 +51229,29 @@
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "ilr" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/medical/cryo)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/button/remote/airlock{
+	id = "meddoor";
+	name = "Medbay Door";
+	pixel_x = -5;
+	pixel_y = 2;
+	req_access = list(5)
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "MedbayLockdown";
+	name = "MedBay Lockdown";
+	pixel_x = 5;
+	pixel_y = 2;
+	req_access = list(5)
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "ily" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -53755,29 +51283,51 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"ilX" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "ini" = (
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/purple/bordercorner,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"inE" = (
-/obj/structure/cable/green,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
+"inA" = (
+/obj/structure/bed/chair{
+	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = -24
+/obj/effect/landmark/start/chemist,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
+"inS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/patient_a)
+"ioD" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "ioL" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper,
@@ -53868,6 +51418,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
+"iqL" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "iqT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -53930,6 +51491,18 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
+"isz" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "isR" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced/polarized{
@@ -53943,6 +51516,29 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/rnd/mixing)
+"itv" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "itK" = (
 /obj/machinery/atmospherics/pipe/cap/visible{
 	color = "#444444";
@@ -53954,19 +51550,18 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_waste)
-"iuA" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
+"itZ" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
+	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "iuX" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -53986,28 +51581,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
-"ive" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "ivx" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -54021,6 +51594,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
+"ivX" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "iwp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -54112,22 +51698,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/engineer_hallway)
-"izw" = (
-/obj/effect/floor_decal/borderfloorwhite{
+"izy" = (
+/obj/structure/bed/chair/bay/comfy/teal{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/landmark/start/chemist,
 /turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"izx" = (
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/area/medical/chemistry)
 "izS" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -54143,6 +51720,16 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/workshop)
+"iAm" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "iAw" = (
 /obj/machinery/disposal,
 /obj/effect/floor_decal/corner/white/diagonal,
@@ -54175,6 +51762,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
+"iAR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
 "iBu" = (
 /obj/structure/sink/puddle,
 /turf/simulated/floor/grass,
@@ -54192,6 +51785,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fpcenter)
+"iCw" = (
+/obj/machinery/bodyscanner,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "iCy" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -54275,6 +51881,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
+"iFo" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "iFy" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -54284,6 +51899,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
+"iFS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "iGf" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -54293,6 +51914,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
+"iHc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "iHF" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -54356,6 +51986,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/seconddeck/artgallery)
+"iII" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "iJh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -54379,18 +52020,6 @@
 "iJG" = (
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
-"iJP" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "iJT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -54506,32 +52135,32 @@
 "iLA" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/fancy/crayons{
-	pixel_y = -3;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = -3
 	},
 /obj/item/weapon/storage/fancy/markers{
-	pixel_y = 6;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = 6
 	},
 /obj/item/weapon/storage/fancy/crayons{
-	pixel_y = -3;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = -3
 	},
 /obj/item/weapon/storage/fancy/markers{
-	pixel_y = 6;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = 6
 	},
 /obj/item/weapon/pen/multi{
-	pixel_y = -5;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -5
 	},
 /obj/item/weapon/pen/multi{
-	pixel_y = 7;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 7
 	},
 /obj/item/weapon/pen/multi{
-	pixel_y = 1;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 1
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -54629,6 +52258,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
+"iNz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "iOA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -54655,22 +52300,21 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
 "iOS" = (
-/obj/machinery/vending/medical,
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay2)
-"iOW" = (
-/obj/machinery/vending/coffee,
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
+/obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
 	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "iPq" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -54738,6 +52382,12 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
+"iSd" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/black/border,
+/obj/structure/bed/chair/bay/comfy/teal,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
 "iSo" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/space;
@@ -54792,21 +52442,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/docking_hallway2)
-"iSS" = (
-/obj/structure/bed/chair/sofa/blue{
-	dir = 1
+"iTv" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/light{
-	layer = 3
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
 	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -21
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "iUH" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green{
@@ -54824,6 +52468,12 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/library)
+"iUR" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "iUU" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
 	dir = 8
@@ -54833,17 +52483,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_waste)
-"iVk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "iVx" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -54948,20 +52587,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"iXo" = (
-/obj/structure/table/bench/glass,
-/obj/item/device/starcaster_news,
+"iWJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/sblucarpet,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
-"iXv" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
+"iWN" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "iXY" = (
 /obj/machinery/autolathe,
 /obj/machinery/alarm{
@@ -55045,6 +52684,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
+"iZe" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "iZh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -55066,16 +52714,10 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/secondary/docking_hallway2)
-"iZI" = (
-/obj/structure/closet/l3closet/medical,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+"iZA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/area/medical/morgue)
 "iZV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -55239,6 +52881,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
+"jez" = (
+/turf/simulated/wall/r_wall,
+/area/medical/patient_b)
+"jeC" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/turf/space,
+/area/space)
 "jeH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55349,18 +52999,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
-"jgt" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
 "jgx" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/glass,
@@ -55424,6 +53062,14 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
+"jhp" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/black/border,
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "jhW" = (
 /obj/structure/table/standard,
 /obj/item/device/assembly/igniter,
@@ -55464,9 +53110,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/server)
-"jjH" = (
-/turf/simulated/wall,
-/area/medical/medical_restroom)
 "jjL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -55514,26 +53157,15 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/primary/seconddeck/aft)
-"jlu" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/effect/floor_decal/borderfloorwhite{
+"jkV" = (
+/obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/pink/border{
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/turf/simulated/floor/glass/reinforced,
+/area/medical/sleeper)
 "jlD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1
@@ -55557,6 +53189,19 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/office)
+"jmf" = (
+/obj/structure/curtain/open/shower/medical,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/medical/sleeper)
 "jmh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
@@ -55564,6 +53209,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
+"jmq" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "jmu" = (
 /obj/machinery/computer/general_air_control{
 	dir = 4;
@@ -55592,24 +53252,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
-"jnc" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
 "jnl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -55639,6 +53281,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"jns" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "jnL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -55688,6 +53336,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_grid,
 /area/medical/genetics)
+"jpo" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_a)
 "jpF" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -55704,7 +53361,7 @@
 /area/maintenance/disposal)
 "jpX" = (
 /turf/simulated/wall/r_wall,
-/area/medical/medbay_primary_storage)
+/area/medical/morgue)
 "jqd" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -55728,6 +53385,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/aft)
+"jqm" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
 "jqu" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -55772,6 +53437,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
+"jre" = (
+/obj/structure/table/rack,
+/obj/machinery/door/window/southright{
+	dir = 1;
+	name = "CMO Suit";
+	req_one_access = list(30)
+	},
+/obj/item/weapon/rig/medical/equipped/fluff/saur,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "jrE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -55848,25 +53531,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"juu" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -21
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/surgical/scalpel,
-/obj/item/weapon/surgical/circular_saw{
-	pixel_y = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "jvl" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering Hallway"
@@ -55917,24 +53581,6 @@
 /obj/effect/map_helper/airlock/button/ext_button,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/entry/D2)
-"jwD" = (
-/obj/structure/bed/chair/wheelchair,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
 "jwJ" = (
 /obj/structure/table/rack,
 /obj/item/clothing/suit/storage/hazardvest,
@@ -55989,36 +53635,13 @@
 "jxs" = (
 /turf/simulated/wall,
 /area/crew_quarters/seconddeck/artgallery)
-"jxN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/obj/machinery/ai_status_display{
-	pixel_x = 32
+"jya" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"jyb" = (
-/turf/simulated/wall,
-/area/medical/surgery_storage)
-"jyp" = (
-/obj/item/device/radio/intercom/department/medbay{
-	pixel_y = -24
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/surgical/hemostat,
-/obj/item/weapon/surgical/cautery,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/pink/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/area/medical/sleeper)
 "jyC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -56040,6 +53663,20 @@
 /obj/item/weapon/storage/fancy/candle_box,
 /turf/simulated/floor/carpet,
 /area/chapel/main)
+"jzc" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "jzf" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -56047,18 +53684,34 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/workshop)
-"jzA" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+"jzk" = (
+/obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/area/medical/surgery)
+"jzA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 4
+	},
+/obj/effect/landmark/start/psych,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "jzV" = (
 /obj/effect/floor_decal/corner/white/diagonal,
 /obj/structure/noticeboard{
@@ -56158,6 +53811,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/fpcenter)
+"jDp" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "jDs" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -56172,26 +53829,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fpcenter)
-"jDw" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/westright{
-	name = "EVA Suit Storage";
-	req_access = newlist();
-	req_one_access = list(5,18)
-	},
-/obj/item/weapon/rig/medical/equipped,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "jEc" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable{
@@ -56216,18 +53853,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"jEj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
 "jEl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -56266,6 +53891,24 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/fscenter)
+"jEx" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"jFl" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "jFB" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/borderfloor{
@@ -56276,17 +53919,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"jFL" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
 "jGd" = (
 /obj/structure/table/marble,
 /obj/item/device/retail_scanner/civilian{
@@ -56366,6 +53998,19 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/fscenter)
+"jIe" = (
+/obj/machinery/vending/wardrobe/medidrobe,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "jIM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -56408,21 +54053,6 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
-"jKa" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "jKf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -56435,16 +54065,6 @@
 "jKu" = (
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/fscenter)
-"jKM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "jKO" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4
@@ -56564,13 +54184,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
-"jOR" = (
-/obj/structure/bedsheetbin,
-/obj/structure/table/steel,
-/obj/random/firstaid,
-/obj/random/firstaid,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
 "jPg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -56580,15 +54193,17 @@
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/port_emergency)
 "jPh" = (
-/obj/machinery/door/window/eastright{
-	name = "Medical Reception";
-	req_access = list(5)
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/holowindoor{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
+/obj/machinery/door/window/holowindoor{
+	dir = 2
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "MedbayLockdown"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
@@ -56617,18 +54232,6 @@
 /obj/machinery/computer/timeclock/premade/south,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"jPU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "jQa" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/recharger/wallcharger{
@@ -56650,20 +54253,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
-"jQo" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/blood/empty,
-/obj/item/weapon/reagent_containers/blood/empty,
-/obj/item/weapon/reagent_containers/blood/empty,
-/obj/item/weapon/reagent_containers/blood/empty,
-/obj/item/weapon/reagent_containers/blood/empty,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "jRr" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -56723,32 +54312,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
-"jSL" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -36
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Medical Hallway Starboard 2";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "jTu" = (
 /obj/machinery/door/airlock/glass_external{
 	frequency = null;
@@ -56820,6 +54383,15 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/lab)
+"jUI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "jUJ" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -56839,28 +54411,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
-"jVI" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
+"jVi" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
+/area/medical/patient_a)
 "jVL" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/wood,
@@ -56906,39 +54463,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"jXw" = (
-/obj/structure/table/steel,
-/obj/item/weapon/paper_bin{
-	pixel_y = -6
-	},
-/obj/item/device/camera{
-	name = "Autopsy Camera";
-	pixel_x = -2;
-	pixel_y = 7
-	},
-/obj/item/weapon/pen/red{
-	pixel_x = -1;
-	pixel_y = -9
-	},
-/obj/item/weapon/pen/blue{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer RC";
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "jXU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -57009,26 +54533,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
 "jYr" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/surgeryobs)
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/storage/box/monkeycubes,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "jYC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/ai_status_display{
@@ -57062,10 +54570,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"jZp" = (
-/obj/machinery/oxygen_pump/anesthetic,
-/turf/simulated/wall,
-/area/medical/surgery2)
 "jZy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -57121,26 +54625,6 @@
 /obj/effect/floor_decal/corner/green/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
-"kay" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/ai_status_display{
-	pixel_x = -32
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "kaM" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -57159,23 +54643,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
-"kcc" = (
-/obj/structure/filingcabinet/chestdrawer{
-	desc = "A large drawer filled with autopsy reports.";
-	name = "Autopsy Reports"
+"kaN" = (
+/obj/structure/table/woodentable,
+/obj/item/toy/plushie/marble_fox{
+	name = "Asa the Plush"
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/turf/simulated/floor/wood,
+/area/medical/psych)
+"kbf" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "kdg" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -57256,23 +54744,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
-"keY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "kff" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57512,23 +54983,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/secondary/docking_hallway2)
-"kke" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "klh" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -57575,31 +55029,6 @@
 "klR" = (
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/stairwell)
-"kmi" = (
-/obj/structure/closet/crate/medical,
-/obj/item/weapon/surgical/surgicaldrill,
-/obj/item/weapon/surgical/FixOVein,
-/obj/item/weapon/surgical/circular_saw,
-/obj/item/weapon/surgical/scalpel,
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/weapon/surgical/retractor,
-/obj/item/weapon/surgical/hemostat,
-/obj/item/weapon/surgical/cautery,
-/obj/item/weapon/surgical/bonesetter,
-/obj/item/weapon/surgical/bonegel,
-/obj/item/stack/nanopaste,
-/obj/item/weapon/autopsy_scanner,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/surgery_storage)
 "kmj" = (
 /obj/structure/cable/green,
 /obj/effect/wingrille_spawn/reinforced,
@@ -57622,6 +55051,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
+"kng" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "knz" = (
 /obj/structure/closet/crate,
 /obj/random/maintenance/engineering,
@@ -57704,6 +55137,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"kqk" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "kqp" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -57728,31 +55180,43 @@
 "kqI" = (
 /obj/structure/table/woodentable,
 /obj/item/paint_palette{
-	pixel_y = -6;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = -6
 	},
 /obj/item/paint_palette{
-	pixel_y = 0;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 0
 	},
 /obj/item/paint_palette{
-	pixel_y = 6;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /obj/item/paint_brush{
-	pixel_y = -5;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = -5
 	},
 /obj/item/paint_brush{
-	pixel_y = -1;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -1
 	},
 /obj/item/paint_brush{
-	pixel_y = 4;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/seconddeck/artgallery)
+"kri" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "krH" = (
 /obj/structure/dispenser,
 /obj/structure/extinguisher_cabinet{
@@ -57769,6 +55233,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"krY" = (
+/obj/structure/table/reinforced,
+/obj/item/organ/internal/lungs/erikLungs,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "krZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -57778,14 +55253,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"ksd" = (
-/obj/structure/bed/chair/sofa/blue{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
 "kse" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57862,6 +55329,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
+"kvL" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay,
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_a)
 "kwy" = (
 /obj/item/weapon/tool/wrench,
 /turf/simulated/floor/tiled,
@@ -57883,18 +55362,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"kwY" = (
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 2
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
+"kwV" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "kxM" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -57913,29 +55385,21 @@
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
 "kzp" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/structure/flora/pottedplant/orientaltree,
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/obj/item/clothing/glasses/fluff/science_proper,
+/obj/item/clothing/glasses/fluff/science_proper,
+/obj/item/clothing/glasses/fluff/science_proper,
 /turf/simulated/floor/tiled/white,
-/area/medical/foyer)
-"kzs" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/chemistry)
 "kzz" = (
 /obj/machinery/pipedispenser,
 /turf/simulated/floor/tiled,
@@ -58005,6 +55469,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/engineer_hallway)
+"kBM" = (
+/obj/structure/curtain/open/shower/medical,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "kBX" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -58019,20 +55490,29 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/workshop)
 "kCp" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_medical{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access = list(5)
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/foyer)
-"kCx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/effect/landmark/start/medical,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"kCB" = (
+/obj/machinery/chemical_dispenser/biochemistry,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "kDd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -58063,24 +55543,6 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/delivery)
-"kDK" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/blood/AMinus,
-/obj/item/weapon/reagent_containers/blood/APlus,
-/obj/item/weapon/reagent_containers/blood/BMinus,
-/obj/item/weapon/reagent_containers/blood/BPlus,
-/obj/item/weapon/reagent_containers/blood/OPlus,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "kEp" = (
 /obj/machinery/light{
 	dir = 4
@@ -58123,6 +55585,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/chapel/office)
+"kFB" = (
+/obj/structure/grille,
+/obj/structure/window/basic/full,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_restroom)
 "kFC" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -58305,6 +55773,17 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fpcenter)
+"kIG" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "kII" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58317,6 +55796,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fpcenter)
+"kIW" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "kJg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58431,6 +55921,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
+"kLC" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "kLD" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -58519,6 +56018,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"kOu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "kOM" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -58561,6 +56073,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
+"kPl" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/item/weapon/rig/medical/equipped,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "kPr" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -58573,21 +56104,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/fscenter)
-"kPH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Medical Hallway Starboard 1";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "kPK" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -58620,6 +56136,21 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/lab)
+"kQL" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
+"kQR" = (
+/obj/machinery/chemical_dispenser,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "kQV" = (
 /turf/simulated/floor/tiled,
 /area/rnd/lab)
@@ -58628,6 +56159,16 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/lab)
+"kRG" = (
+/obj/structure/closet/secure_closet/paramedic,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "kRR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 4
@@ -58700,12 +56241,23 @@
 /obj/effect/floor_decal/corner/purple/bordercorner,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"kTR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+"kTx" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/medbay2)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
 "kTT" = (
 /obj/structure/closet/wardrobe/robotics_black,
 /obj/item/device/radio/headset/headset_sci{
@@ -58730,21 +56282,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
-"kUt" = (
-/obj/structure/bed/chair/sofa/left/blue{
-	dir = 4
+"kUg" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
+"kUj" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
 "kUD" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -58795,19 +56350,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
 "kXd" = (
-/obj/machinery/chemical_dispenser/full,
-/obj/machinery/ai_status_display{
+/obj/structure/bed/chair/sofa/teal,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
+/area/medical/foyer)
 "kXk" = (
 /obj/structure/table/standard,
 /obj/random/tech_supply,
@@ -58825,6 +56379,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
+"kXG" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/black/bordercorner,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "kYA" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -58856,6 +56426,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D2/arrivals)
+"laa" = (
+/obj/structure/table/reinforced,
+/obj/item/device/gps/medical/cmo,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "lal" = (
 /obj/random/trash,
 /obj/random/trash,
@@ -58922,6 +56497,32 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
+"lbt" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
+"lbG" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance Access";
+	req_access = list(5)
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "MedbayLockdown"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
 "lbI" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
@@ -58983,6 +56584,26 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
+"lcS" = (
+/obj/machinery/iv_drip,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/black/border,
+/obj/structure/cable/green,
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = -24
+	},
+/obj/machinery/button/windowtint{
+	id = "or1";
+	pixel_x = -11;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "ldX" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -59007,6 +56628,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/server)
+"lfu" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "lgj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -59046,17 +56682,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/storage/primary)
-"lhc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "lhG" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge{
 	scrub_id = "Toxins"
@@ -59075,26 +56700,21 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
+"lin" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "liq" = (
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
 "liI" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/secondary/docking_hallway2)
-"ljh" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Chemistry";
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/beige/bordercorner,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "ljr" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Civilian Substation Bypass"
@@ -59106,25 +56726,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"ljE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Locker Room";
-	req_access = list(5)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/medical_lockerroom)
 "ljU" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -59146,6 +56747,22 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_room)
+"lku" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
 "lkw" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -59245,15 +56862,6 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
-"llv" = (
-/obj/item/device/radio/intercom/department/medbay{
-	pixel_y = -21
-	},
-/obj/machinery/clonepod/transhuman/full,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
 "llH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -59270,6 +56878,26 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/foyer)
+"lnk" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "lnq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -59300,19 +56928,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"lnJ" = (
-/obj/structure/table/steel,
-/obj/item/weapon/autopsy_scanner,
-/obj/item/weapon/surgical/scalpel,
-/obj/item/weapon/surgical/cautery,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "lnN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -59381,6 +56996,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"lqe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "lrp" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/wood/alt/parquet,
@@ -59542,70 +57163,51 @@
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "lvy" = (
-/obj/item/weapon/cane,
-/obj/item/weapon/cane{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/weapon/cane{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/gloves{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/box/rxglasses,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
-"lvF" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/item/weapon/storage/box/pillbottles,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
+/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
+/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
+/obj/item/weapon/reagent_containers/glass/bottle/antitoxin,
 /obj/effect/floor_decal/borderfloor{
-	dir = 5
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
 	},
-/obj/structure/morgue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "lvX" = (
 /obj/machinery/pointdefense{
 	id_tag = "PD Main"
 	},
 /turf/simulated/floor/airless,
 /area/space)
-"lwA" = (
-/obj/structure/closet/wardrobe/chemistry_white,
-/obj/item/device/radio/headset/headset_med,
+"lwn" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
 	},
+/obj/structure/cable/green,
 /obj/machinery/light_switch{
-	pixel_x = 11;
+	pixel_x = 12;
 	pixel_y = -24
 	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/item/weapon/storage/box/pillbottles,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 6
-	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
+/area/crew_quarters/heads/sc/cmo)
 "lxe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -59747,6 +57349,12 @@
 "lAv" = (
 /turf/simulated/wall,
 /area/maintenance/substation/central)
+"lAw" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/black/border,
+/obj/machinery/light/spot,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "lAW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 9
@@ -59756,6 +57364,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"lBC" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/black/border,
+/obj/structure/bed/chair/bay/comfy/teal,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
 "lBG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -59778,10 +57395,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
+"lCG" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "lCW" = (
 /obj/structure/sign/department/cargo,
 /turf/simulated/wall/r_wall,
 /area/maintenance/cargo)
+"lDL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "lEm" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -59799,6 +57432,16 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
+"lEA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "lFC" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -59878,35 +57521,10 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/aft)
-"lIk" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "lIC" = (
 /obj/machinery/computer/timeclock/premade/south,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/fscenter)
-"lIY" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "lJh" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
@@ -59934,6 +57552,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/fscenter)
+"lJU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/chemdrobe,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "lKa" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -60031,18 +57659,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"lMf" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "lMn" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -60095,19 +57711,18 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D1)
-"lNS" = (
-/obj/machinery/vending/snack,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+"lOb" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
 	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "lOw" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -60128,21 +57743,19 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/rnd/lab)
-"lPn" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
 "lPq" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/lab)
+"lPE" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
 "lPI" = (
 /obj/machinery/computer/rdconsole/core{
 	dir = 8
@@ -60163,24 +57776,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
-"lQC" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "lRj" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
@@ -60194,34 +57789,6 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
-"lRy" = (
-/obj/structure/closet/wardrobe/medic_white,
-/obj/item/device/flashlight/pen,
-/obj/item/device/flashlight/pen,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
-"lRD" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "lRF" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/material/kitchen/utensil/fork,
@@ -60321,19 +57888,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"lTw" = (
-/obj/structure/table/glass,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/hand_labeler,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
 "lTy" = (
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
@@ -60370,63 +57924,13 @@
 /obj/item/device/mmi/digital/robot,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
-"lUr" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"lUA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/bed/chair/office/light,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
-"lUC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
 "lUX" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/structure/curtain/open/privacy,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "or2"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 5
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/area/medical/surgery2)
 "lUZ" = (
 /obj/machinery/mecha_part_fabricator/pros,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -60462,6 +57966,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/seconddeck/artsupplies)
+"lVF" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_a)
 "lVX" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/borderfloor{
@@ -60481,9 +57990,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/foyer)
-"lWH" = (
-/turf/simulated/wall/r_wall,
-/area/medical/surgery2)
+"lWo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"lWv" = (
+/obj/structure/table/rack/shelf,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/fire,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "lWR" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -60541,6 +58063,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/ai_monitored/storage/emergency/eva)
+"lXy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "lXK" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -60586,16 +58121,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/robotics)
-"lZV" = (
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
+"lZo" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/morgue,
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
 "maC" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/robotics)
@@ -60666,22 +58202,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/misc_lab)
 "mco" = (
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/firealarm{
 	dir = 1;
-	icon_state = "pipe-c"
+	pixel_y = -26
 	},
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "mcs" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 8;
@@ -60718,13 +58246,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
-"mdj" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_medical{
-	name = "Patient Ward"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/patient_wing)
 "mdq" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/reinforced,
@@ -60743,53 +58264,10 @@
 /obj/random/junk,
 /turf/simulated/floor,
 /area/engineering/engine_room)
-"mff" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "mfz" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/aft)
-"mfB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "mga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -60845,26 +58323,15 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/locker)
-"mhL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner_steel_grid{
+"mhG" = (
+/obj/structure/table/rack/shelf,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/obj/item/weapon/storage/firstaid/adv,
+/obj/item/weapon/storage/firstaid/adv,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "mif" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -60917,32 +58384,32 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
-"mjw" = (
-/obj/structure/closet/l3closet/medical,
-/obj/item/device/radio/intercom{
+"mjm" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/black/bordercorner,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"mjn" = (
+/obj/machinery/power/apc{
 	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -21
+	name = "west bump";
+	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
-"mjR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_x = -36
 	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "mkd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -60959,10 +58426,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"mkW" = (
-/obj/structure/closet/secure_closet/psych,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
+"mkH" = (
+/obj/machinery/atmospherics/unary/cryo_cell,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "mkX" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -61003,19 +58477,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
-"mmn" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "mmq" = (
 /obj/machinery/atmospherics/omni/atmos_filter{
 	tag_east = 2;
@@ -61053,28 +58514,9 @@
 /turf/simulated/floor/tiled,
 /area/rnd/mixing)
 "mnu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 4
-	},
+/obj/machinery/computer/crew,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/reception)
 "mnB" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/landmark/start{
@@ -61134,6 +58576,14 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/cafeteria)
+"mot" = (
+/obj/structure/sign/redcross{
+	desc = "The Star of Life, a symbol of Medical Aid.";
+	icon_state = "lifestar";
+	name = "Medbay"
+	},
+/turf/simulated/wall,
+/area/medical/medbay4)
 "mou" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
 /turf/simulated/floor,
@@ -61159,17 +58609,14 @@
 /obj/item/device/geiger/wall/west,
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
-"mpx" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+"mpt" = (
+/obj/structure/table/reinforced,
+/obj/item/device/denecrotizer/medical,
+/obj/item/weapon/gun/energy/mouseray/medical,
+/obj/item/weapon/cane,
+/obj/item/weapon/cane,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "mqa" = (
 /obj/effect/landmark{
 	name = "JoinLateCyborg"
@@ -61199,33 +58646,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/engineer_hallway)
-"mre" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 36;
-	pixel_y = -6
-	},
-/obj/machinery/button/windowtint{
-	id = "pr2_window_tint";
-	pixel_x = 36;
-	pixel_y = 6
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
 "mrF" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -61270,27 +58690,20 @@
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
+"msw" = (
+/obj/structure/sign/warning,
+/turf/simulated/wall/r_wall,
+/area/medical/medbay_primary_storage)
 "msX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
 	},
 /turf/simulated/floor,
 /area/engineering/engine_room)
-"mti" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/ai_status_display{
-	pixel_x = 32
-	},
-/obj/structure/bed/chair/comfy/brown{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
+"mtf" = (
+/obj/machinery/vending/wallmed1,
+/turf/simulated/wall,
+/area/medical/chemistry)
 "mtC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61299,6 +58712,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/construction/seconddeck/construction1)
+"mup" = (
+/obj/structure/morgue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
 "mut" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/clothing/gloves/black,
@@ -61331,6 +58750,16 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/engineering/engi_restroom)
+"mws" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "myc" = (
 /obj/machinery/camera/network/engine{
 	c_tag = "ENG - Waste Handling Exterior 2";
@@ -61455,9 +58884,6 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
-"mAU" = (
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
 "mAZ" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /obj/structure/sink/kitchen{
@@ -61482,20 +58908,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/central)
-"mCf" = (
-/obj/machinery/chemical_dispenser/full,
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "mDJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/floor_decal/industrial/warning{
@@ -61550,10 +58962,28 @@
 /turf/simulated/floor/plating,
 /area/maintenance/central)
 "mEB" = (
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "MedbayLockdown"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
+"mEE" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/chemistry)
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "mEJ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -61580,26 +59010,6 @@
 /obj/machinery/vending/loadout,
 /turf/simulated/floor/tiled/white,
 /area/medical/cryo/autoresleeve)
-"mFN" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
 "mFY" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
@@ -61623,6 +59033,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
+"mGB" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/medical,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "mHl" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -61644,6 +59062,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/teleporter)
+"mIa" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "mId" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -61671,22 +59101,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/chapel/main)
-"mJB" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"mIC" = (
+/turf/simulated/wall,
+/area/medical/medbay2)
+"mIO" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
 	},
-/obj/machinery/door/airlock/glass_medical{
-	name = "Chemistry Laboratory";
-	req_access = list(33)
+/obj/effect/floor_decal/corner/black/border{
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/chemistry)
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "mKm" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -61755,18 +59184,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/fscenter)
-"mLK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "mLP" = (
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall,
@@ -61778,6 +59195,18 @@
 	},
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/fscenter)
+"mML" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "mNf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -61790,6 +59219,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
+"mNm" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "mNt" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -61822,6 +59266,20 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"mNS" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "mNU" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -61884,26 +59342,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
-"mOr" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
 "mOu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61919,12 +59357,15 @@
 "mOG" = (
 /turf/simulated/wall,
 /area/hydroponics)
-"mOZ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+"mOV" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/area/medical/surgery2)
 "mPt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -61949,9 +59390,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
-"mQY" = (
-/turf/simulated/wall/r_wall,
-/area/medical/medbay)
+"mQu" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_a)
 "mRD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -62053,26 +59505,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/sc/hop)
-"mTy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "mTO" = (
 /obj/machinery/computer/HolodeckControl{
 	dir = 1
@@ -62097,15 +59529,6 @@
 /obj/effect/floor_decal/spline/fancy/wood/cee,
 /turf/simulated/floor/carpet/oracarpet,
 /area/library)
-"mTV" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
 "mUi" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -62120,6 +59543,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_foyer)
+"mUF" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "mVe" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -62163,22 +59596,55 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
+"mWB" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Reception";
+	req_access = list(5)
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/medical_restroom)
 "mWD" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/storage/primary)
-"mWH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"mWI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/medbay2)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "mWR" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics)
+"mXa" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "mXo" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -62222,22 +59688,6 @@
 "mYU" = (
 /turf/simulated/wall/r_wall,
 /area/assembly/chargebay)
-"mZe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
 "mZG" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/alarm{
@@ -62311,18 +59761,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
-"naz" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+"nax" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/area/medical/medbay2)
 "naC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -62359,31 +59810,27 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
-"nby" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/glass_medical,
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/medbay2)
 "nbA" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id = "medbayrecquar";
-	name = "Medbay Emergency Quarantine Shutters";
-	opacity = 0
+	dir = 2;
+	id = "MedbayLockdown"
 	},
-/obj/effect/floor_decal/corner_steel_grid,
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
+/turf/simulated/floor/plating,
+/area/medical/reception)
+"nca" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/vending/fitness{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "ncb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -62416,11 +59863,6 @@
 	temperature = 80
 	},
 /area/server)
-"ncQ" = (
-/obj/item/toy/eight_ball,
-/obj/structure/table/bench/glass,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/medbay2)
 "ncU" = (
 /obj/structure/sign/directions/library{
 	dir = 5
@@ -62431,6 +59873,13 @@
 	},
 /turf/simulated/wall,
 /area/library)
+"ndr" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_b)
 "nev" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -62482,24 +59931,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"ngi" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_medical{
-	name = "Medbay Equipment";
-	req_access = list(5)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/medbay_primary_storage)
 "ngt" = (
 /turf/simulated/floor/airless,
 /area/medical/virology)
+"ngO" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/black/bordercorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "nhc" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
@@ -62536,6 +59980,27 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/workshop)
+"niR" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
+"njf" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "njG" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced/polarized{
@@ -62608,6 +60073,20 @@
 /obj/effect/floor_decal/industrial/warning/cee,
 /turf/simulated/shuttle/floor,
 /area/shuttle/cryo/station)
+"nmU" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/flora/skeleton,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "nns" = (
 /obj/structure/sign/directions/cryo{
 	dir = 8
@@ -62635,6 +60114,11 @@
 /obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/sc/chief)
+"nnW" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "noj" = (
 /obj/machinery/camera/network/engineering{
 	c_tag = "ENG - Chief Engineer's Office";
@@ -62782,6 +60266,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"npb" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "npf" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/cable/green,
@@ -62798,20 +60286,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
-"nql" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "nqs" = (
 /obj/structure/sign/warning/docking_area,
 /obj/effect/wingrille_spawn/reinforced,
@@ -62821,26 +60295,13 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/fpcenter)
-"nqY" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+"nrb" = (
+/obj/structure/curtain/open/shower/medical,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
-"nrg" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
+/area/medical/sleeper)
 "nrm" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -62866,6 +60327,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/central)
+"nsM" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/bookcase/manuals/medical,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "nsS" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 4
@@ -62899,11 +60382,11 @@
 	icon_state = "4-8"
 	},
 /obj/structure/curtain/black{
+	dir = 2;
 	icon_state = "open";
 	layer = 2;
 	name = "privacy curtain";
-	opacity = 0;
-	dir = 2
+	opacity = 0
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/seconddeck/artsupplies)
@@ -62924,6 +60407,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"nuO" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/black/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "nve" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -62938,24 +60426,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"nvr" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"nvi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre Storage";
-	req_access = list(45)
-	},
-/obj/structure/fans/hardlight/colorable{
-	light_color = "#D7D7D7"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/surgery_storage)
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "nvX" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/effect/floor_decal/spline/fancy/wood/cee{
@@ -62963,28 +60439,6 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/library)
-"nwc" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/structure/backup_implanter_ch{
-	pixel_y = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
 "nwl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -63019,32 +60473,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
-"nxR" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 1
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "chemcounter";
-	name = "Pharmacy Counter Lockdown Control";
-	pixel_x = 10;
-	pixel_y = 30
-	},
-/obj/machinery/button/remote/blast_door{
-	id = "chemwindow";
-	name = "Pharmacy Window Shutter Control";
-	pixel_x = -10;
-	pixel_y = 30
-	},
-/obj/machinery/chemical_dispenser/biochemistry/full,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "nxW" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/dark,
@@ -63084,23 +60512,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hydroponics)
-"nyO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "nzm" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/floor_decal/industrial/warning{
@@ -63169,10 +60580,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"nCH" = (
-/obj/structure/sign/nosmoking_1,
-/turf/simulated/wall,
-/area/medical/cryo)
 "nCU" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/lime/border,
@@ -63199,9 +60606,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/teleporter)
-"nDN" = (
-/turf/simulated/wall,
-/area/medical/patient_a)
 "nDS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -63259,24 +60663,24 @@
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/structure/table/marble,
 /obj/item/weapon/storage/box/glasses/coffeecup{
-	pixel_y = 1;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 1
 	},
 /obj/item/weapon/storage/box/glasses/coffeemug{
-	pixel_y = 12;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 12
 	},
 /obj/item/weapon/storage/box/glasses/square{
-	pixel_y = 1;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 1
 	},
 /obj/item/weapon/storage/box/buns{
-	pixel_y = 12;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 12
 	},
 /obj/item/weapon/storage/box/buns{
-	pixel_y = 12;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = 12
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack{
@@ -63319,13 +60723,28 @@
 /area/hallway/primary/seconddeck/fscenter)
 "nFF" = (
 /turf/simulated/wall/r_wall,
-/area/medical/medical_restroom)
+/area/medical/surgery2)
 "nGq" = (
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "nGr" = (
-/turf/simulated/wall/r_wall,
-/area/medical/patient_b)
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_x = -36
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/medical/patient_restroom)
 "nGH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -63383,16 +60802,25 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/oracarpet,
 /area/library)
-"nId" = (
-/obj/structure/morgue,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+"nIu" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "nIS" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box,
@@ -63567,28 +60995,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
-"nNL" = (
-/obj/structure/table/steel,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/item/device/gps/medical{
-	pixel_x = -8
-	},
-/obj/item/device/gps/medical{
-	pixel_x = -4
-	},
-/obj/item/device/gps/medical,
-/obj/item/device/gps/medical{
-	pixel_x = 4
-	},
-/obj/item/device/gps/medical{
-	pixel_x = 8
-	},
-/obj/item/device/defib_kit/compact/loaded,
-/turf/simulated/floor/tiled,
-/area/medical/medbay_emt_bay)
+"nOC" = (
+/turf/simulated/wall/r_wall,
+/area/medical/surgery)
 "nPc" = (
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
@@ -63710,52 +61119,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_foyer)
-"nSC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"nSF" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/window/westright{
-	name = "Chemistry Desk"
-	},
-/obj/machinery/door/window/eastright{
-	name = "Chemistry Desk";
-	req_access = list(33)
-	},
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "chemcounter";
-	name = "Pharmacy Counter Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "nSJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -63861,6 +61224,19 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/assembly/chargebay)
+"nWP" = (
+/obj/machinery/door/airlock/glass_medical,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/chemistry)
+"nXc" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "nXl" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -63872,6 +61248,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/assembly/chargebay)
+"nXw" = (
+/turf/simulated/wall,
+/area/medical/patient_b)
+"nXJ" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "nYb" = (
 /obj/structure/table/standard,
 /obj/random/maintenance/clean,
@@ -63939,12 +61328,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
-"nYH" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
 "nYU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -64004,29 +61387,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
 "nZA" = (
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
-"nZD" = (
-/obj/structure/bed/chair/sofa/blue{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
+/obj/structure/table/woodentable,
+/obj/machinery/light/spot,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "nZE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -64052,6 +61417,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/misc_lab)
+"nZO" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "nZY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -64133,24 +61511,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
-"oce" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "oct" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/reinforced,
@@ -64220,17 +61580,6 @@
 	temperature = 80
 	},
 /area/server)
-"oew" = (
-/obj/machinery/iv_drip,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "ofv" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark{
@@ -64247,31 +61596,38 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/airless,
 /area/chapel/main)
-"ogH" = (
-/obj/structure/bed/chair/wheelchair,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 8;
-	pixel_x = -21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+"ogL" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
+	dir = 1
+	},
+/obj/machinery/button/windowtint{
+	id = "cmooffice";
+	pixel_x = -2;
+	pixel_y = 34
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/machinery/button/remote{
+	id = "MedbayLockdown";
+	name = "Medbay Lockdown";
+	pixel_x = 5;
+	pixel_y = 34
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
+/area/crew_quarters/heads/sc/cmo)
 "ogN" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D2)
-"oht" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
+"ohm" = (
+/obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/area/medical/patient_a)
 "ohF" = (
 /obj/machinery/r_n_d/server/core,
 /turf/simulated/floor/bluegrid{
@@ -64353,6 +61709,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D2)
+"oji" = (
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "ojj" = (
 /obj/machinery/computer/rdconsole/core,
 /obj/effect/floor_decal/borderfloorblack{
@@ -64380,21 +61742,6 @@
 /obj/item/weapon/bikehorn/rubberducky,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/workshop)
-"ojP" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/vending/wallmed1{
-	pixel_x = 25
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
 "okh" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -64410,23 +61757,6 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/oracarpet,
 /area/library)
-"okt" = (
-/obj/machinery/iv_drip,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/surgery_storage)
 "oku" = (
 /obj/structure/table/steel,
 /obj/item/weapon/storage/bag/circuits/basic,
@@ -64469,24 +61799,9 @@
 /turf/simulated/wall,
 /area/rnd/workshop)
 "olj" = (
+/obj/machinery/vending/wardrobe/virodrobe,
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
-"olr" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "olH" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/shield_diffuser,
@@ -64510,6 +61825,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/entry/D2/arrivals)
+"omj" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 1
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "omq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -64600,38 +61927,6 @@
 "opM" = (
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
-"opU" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"oqh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "oqz" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -64648,27 +61943,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
-"oqS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Medical Restroom";
-	req_access = list(5)
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/medical_restroom)
-"oqY" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "oqZ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -64679,18 +61953,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/engineering/engine_room)
-"orf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "orq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/status_display{
@@ -64790,15 +62052,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/central)
-"otO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "ouo" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -64840,6 +62093,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/central)
+"ouS" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "ouT" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -64858,12 +62121,66 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/maintenance/central)
+"ovr" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "ovw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /obj/machinery/meter,
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/maintenance/central)
+"owe" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
+"owh" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
+"owp" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "MedbayLockdown";
+	name = "MedBay Lockdown";
+	pixel_x = -31;
+	req_access = list(5)
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
+"owr" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "owy" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -64880,24 +62197,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/central)
-"owQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "oxg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -64911,6 +62210,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"oxi" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "oxE" = (
 /obj/machinery/shieldwallgen,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -64919,6 +62225,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/teleporter)
+"oxI" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/machinery/cell_charger,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -30
+	},
+/obj/item/weapon/backup_implanter,
+/obj/item/weapon/backup_implanter,
+/obj/item/weapon/backup_implanter,
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "oxN" = (
 /obj/machinery/shieldwallgen,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -64954,6 +62278,15 @@
 /obj/item/weapon/reagent_containers/dropper,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"oyq" = (
+/obj/structure/table/darkglass,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "oyA" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4;
@@ -64987,6 +62320,26 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"oAi" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"oAq" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/item/weapon/book/manual/standard_operating_procedure,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "oAV" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -65063,6 +62416,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/first_aid_station/seconddeck/port)
+"oDD" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "oDE" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -65181,6 +62544,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
+"oIP" = (
+/obj/structure/curtain/open/shower/medical,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "oIX" = (
 /obj/item/weapon/folder/white,
 /obj/item/weapon/disk/tech_disk,
@@ -65241,13 +62615,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
-"oJW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
 "oKd" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -65267,33 +62634,44 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_foyer)
-"oKu" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
+"oMj" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
-"oKT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
-"oMg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/effect/floor_decal/corner/black/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
+"oMO" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/organ_printer/flesh/full,
+/obj/machinery/light_switch{
+	pixel_x = -36
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
 "oNr" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	dir = 4
@@ -65325,22 +62703,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_foyer)
-"oPy" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
 "oPJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -65380,6 +62742,17 @@
 /obj/effect/floor_decal/corner/purple/bordercorner2,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_foyer)
+"oRe" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "oRM" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -65388,33 +62761,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/assembly/robotics)
-"oRX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+"oRS" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/white,
-/area/medical/cryo)
+/area/medical/medbay2)
 "oSr" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -65424,9 +62781,6 @@
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
-"oSv" = (
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
 "oTe" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -65496,6 +62850,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/ap_emergency)
+"oUc" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "oUx" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
@@ -65714,23 +63072,57 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/assembly/chargebay)
-"oZp" = (
-/obj/structure/reagent_dispensers/water_cooler/full,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = 21
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
+"oYF" = (
+/obj/structure/closet/secure_closet/medical3,
 /obj/effect/floor_decal/borderfloor{
-	dir = 6
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/medical/surgeryobs)
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
+"oYJ" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_x = 38
+	},
+/obj/machinery/button/windowtint{
+	id = "patienta";
+	pixel_x = 38;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_a)
+"oZp" = (
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/weapon/tool/crowbar/red,
+/obj/item/weapon/tool/crowbar/red,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "oZL" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -65757,27 +63149,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"oZU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "pac" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
+"pag" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/device/defib_kit,
+/obj/structure/sign/biohazard{
+	name = "Chemical Exposure Zone";
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "paJ" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
@@ -65808,25 +63198,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
-"pbh" = (
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 8;
-	pixel_x = -21
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "pbi" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin{
@@ -65846,6 +63217,18 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/sc/hop)
+"pbp" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/medical/patient_restroom)
 "pbP" = (
 /obj/structure/closet/crate,
 /obj/random/contraband,
@@ -65882,6 +63265,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
+"pcv" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "pcD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65909,17 +63304,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/workshop)
-"pcH" = (
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
 "pda" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -65997,6 +63381,17 @@
 "peJ" = (
 /turf/simulated/floor/wood,
 /area/hallway/secondary/entry/docking_lounge)
+"peQ" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/mask/muzzle/ballgag,
+/obj/item/clothing/mask/muzzle/ballgag/ringgag,
+/obj/item/clothing/mask/muzzle/tape,
+/obj/item/weapon/handcuffs/legcuffs,
+/obj/item/weapon/handcuffs,
+/obj/item/clothing/under/rank/nursesuit,
+/obj/item/clothing/head/nursehat,
+/turf/simulated/floor/plating,
+/area/space)
 "peT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -66015,28 +63410,6 @@
 /obj/structure/closet/secure_closet/bar,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
-"pfB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "pfJ" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "MED - Autoresleeving Bay";
@@ -66050,6 +63423,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/cryo/autoresleeve)
+"pfU" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "pfY" = (
 /obj/structure/table/standard,
 /obj/item/weapon/soap/nanotrasen,
@@ -66107,16 +63488,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "phg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Chemistry";
-	sortType = "Chemistry"
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/turf/simulated/wall,
+/area/medical/psych)
 "pho" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -66138,6 +63511,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"pib" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Locker Room";
+	req_access = list(66)
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "pix" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -66198,15 +63579,35 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
-"pjG" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
+"pjv" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
 	},
-/obj/effect/landmark/start{
-	name = "Chemist"
+/obj/effect/floor_decal/corner/black/border{
+	dir = 6
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"pjG" = (
+/obj/structure/bed/chair/sofa/teal{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
+/area/medical/foyer)
 "pjT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -66225,24 +63626,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
-"pkK" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"pld" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/machinery/sleeper{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/area/medical/sleeper)
 "pli" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -66328,6 +63723,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
+"pmv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "pmJ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/engineering{
@@ -66379,6 +63781,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/apcenter)
+"poe" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "pog" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -66450,16 +63856,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/crew_quarters/coffee_shop)
-"ppc" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_emt_bay)
 "ppW" = (
 /obj/machinery/atmospherics/valve/shutoff{
 	name = "Deck 2 Starboard automatic shutoff valve"
@@ -66516,13 +63912,54 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
+"psB" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/machinery/iv_drip,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
+"psC" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/tiled/steel_grid,
+/area/awaymission/snowfield/medical/patient_restroom)
 "psR" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/research_foyer)
+"ptk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "ptE" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"put" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "pux" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -66565,16 +64002,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/rnd/research_foyer)
-"pvD" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/item/weapon/stool/padded,
-/obj/effect/landmark/start{
-	name = "Paramedic"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/medbay_emt_bay)
 "pvH" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/recharge_station,
@@ -66590,6 +64017,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/assembly/chargebay)
+"pvL" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "pwf" = (
 /obj/machinery/shield_diffuser,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -66617,6 +64054,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/entry/D3)
+"pwl" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/closet/secure_closet/psych,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "pwV" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -66674,6 +64122,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
+"pyj" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "pyN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66698,6 +64152,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_medical)
+"pyU" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "pzf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66707,22 +64183,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/apcenter)
-"pzi" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "pzF" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -66830,30 +64290,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"pDg" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/button/windowtint{
-	id = "psyco_tint";
-	pixel_x = 11;
-	pixel_y = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -11;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
 "pDh" = (
 /obj/structure/closet/crate,
 /obj/random/bomb_supply,
@@ -67167,18 +64603,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"pLC" = (
-/obj/machinery/door/window/westleft{
-	name = "Shower"
-	},
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/structure/curtain/open/shower/medical,
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
 "pMt" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -67226,44 +64650,13 @@
 /obj/random/cash,
 /turf/simulated/floor,
 /area/maintenance/cargo)
-"pMH" = (
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
+"pMJ" = (
+/turf/simulated/floor/glass/reinforced,
 /area/medical/sleeper)
-"pMI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "pMR" = (
 /obj/structure/sign/deck/second,
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/seconddeck/dockhallway)
-"pMZ" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/unary/cryo_cell,
-/turf/simulated/floor/tiled/techmaint,
-/area/medical/cryo)
 "pNa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -67306,11 +64699,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/entry/D3)
 "pOe" = (
-/obj/machinery/vending/loadout/uniform,
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "pOh" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -67355,20 +64757,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"pOQ" = (
-/obj/machinery/iv_drip,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
 "pOW" = (
 /obj/structure/table/steel,
 /obj/fiftyspawner/steel,
@@ -67437,6 +64825,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
+"pPL" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "pPU" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -67447,6 +64848,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/engineering/engine_room)
+"pPW" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "pQe" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -67458,19 +64872,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"pQo" = (
-/obj/machinery/disposal,
-/obj/effect/floor_decal/borderfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "pQD" = (
 /obj/machinery/computer/diseasesplicer{
 	dir = 8
@@ -67490,16 +64891,6 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
-"pRA" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "pRG" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -67539,6 +64930,26 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
+"pSD" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
+"pTC" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_b)
 "pTK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/machinery/meter,
@@ -67569,8 +64980,8 @@
 	},
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/item/weapon/storage/box/donut{
-	pixel_y = -4;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = -4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -67602,11 +65013,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/dockhallway)
 "pUX" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "rdoffice"
 	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"pVq" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -67614,34 +65027,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
-"pVe" = (
-/obj/structure/closet/secure_closet/paramedic,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -36
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medical_lockerroom)
 "pVG" = (
@@ -67659,10 +65044,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_airlock)
-"pVZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
 "pWn" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -67730,23 +65111,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/engineer_hallway)
-"pXr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "pXv" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -67900,6 +65264,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
+"qcs" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "qcZ" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -67978,6 +65352,19 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
+"qhr" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "qim" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -68015,6 +65402,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"qjR" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/surgical/hemostat/cyborg,
+/obj/item/weapon/surgical/retractor,
+/obj/item/weapon/surgical/cautery,
+/obj/item/weapon/surgical/scalpel,
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "qjZ" = (
 /obj/machinery/vending/coffee{
 	dir = 4
@@ -68284,6 +65685,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter)
+"qoK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "qoN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -68303,13 +65718,6 @@
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled,
 /area/teleporter)
-"qoZ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
 "qpz" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -68358,28 +65766,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
-"qrI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/medical{
-	name = "Morgue";
-	req_access = list(6)
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/morgue)
 "qrR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/floor_decal/industrial/warning,
@@ -68397,21 +65783,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
-"qsK" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "qtb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -68441,26 +65812,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/entry/D1)
-"qtn" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	layer = 4;
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
 "qtD" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -68522,20 +65873,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
-"qvr" = (
-/obj/item/weapon/stool/padded,
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Patient Ward Port";
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
+"qvI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/area/medical/foyer)
 "qvK" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -68553,26 +65898,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"qws" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/simulated/floor/tiled/freezer,
-/area/medical/surgery_storage)
-"qwB" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/command{
-	id_tag = "cmodoor";
-	name = "CMO's Office";
-	req_access = list(40)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/crew_quarters/heads/sc/cmo)
 "qwK" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/atmospherics/binary/pump/high_power/on{
@@ -68631,11 +65956,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/starboard)
-"qxs" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/medbay_primary_storage)
 "qxU" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -68648,6 +65968,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/starboard)
+"qxZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "qya" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -68681,6 +66011,23 @@
 /obj/structure/loot_pile/maint/technical,
 /turf/simulated/floor/plating,
 /area/maintenance/robotics)
+"qzp" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "qzu" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -68697,33 +66044,28 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/robotics)
-"qAA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+"qAJ" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_x = 38
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/cryo)
-"qAJ" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/patient_a)
+/area/medical/chemistry)
 "qAW" = (
 /obj/machinery/door/blast/shutters{
 	dir = 2;
@@ -68755,6 +66097,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_medical)
+"qBl" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "qBY" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -68769,6 +66133,21 @@
 	},
 /turf/simulated/wall,
 /area/hallway/primary/seconddeck/apcenter)
+"qCy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 1
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
 "qCZ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -68787,6 +66166,28 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
+"qDH" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_x = 38
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "qDV" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -68831,6 +66232,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"qFy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
 "qFB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -68977,26 +66388,50 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"qLq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+"qKJ" = (
+/obj/structure/toilet{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/medical/patient_restroom)
+"qLb" = (
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "patientb"
 	},
+/turf/simulated/floor/plating,
+/area/medical/patient_b)
+"qLq" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Chemistry Laboratory";
+	req_access = list(33)
+	},
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/chemistry)
+"qLw" = (
+/obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/area/medical/medbay_emt_bay)
 "qLC" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -69030,13 +66465,27 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/research_medical)
+"qNd" = (
+/obj/machinery/chemical_dispenser,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "qNz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry/D3)
 "qNE" = (
 /turf/simulated/wall/r_wall,
-/area/medical/medical_lockerroom)
+/area/medical/medical_restroom)
 "qOl" = (
 /obj/structure/table/bench/wooden,
 /obj/structure/flora/pottedplant/small{
@@ -69173,6 +66622,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D2)
+"qTL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "qUd" = (
 /obj/structure/flora/pottedplant/decorative,
 /turf/simulated/floor/tiled/dark,
@@ -69193,6 +66651,37 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/workshop)
+"qUr" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
+"qVK" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/medical/sleeper)
 "qVR" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/cups,
@@ -69215,18 +66704,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"qWb" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "qWW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -69256,6 +66733,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"qXJ" = (
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "qXP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
@@ -69342,16 +66829,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"qZK" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+"qZw" = (
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "or1"
 	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "qZT" = (
@@ -69389,22 +66871,23 @@
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D2/arrivals)
-"raN" = (
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 1
-	},
-/mob/living/simple_mob/animal/passive/cat/runtime,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
 "raZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
+"rbu" = (
+/mob/living/simple_mob/animal/space/carp{
+	butchery_loot = null;
+	desc = "A ferocious, fang-bearing creature that resembles a fish. This one looks at you cutely with their cute fish eyes.";
+	faction = "neutral";
+	meat_amount = 0;
+	meat_type = null;
+	name = "Phora"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "rby" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -69432,8 +66915,8 @@
 "rbZ" = (
 /obj/structure/closet/emcloset,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = -30;
-	dir = 1
+	dir = 1;
+	pixel_y = -30
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
@@ -69471,6 +66954,11 @@
 "rev" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/cryo/autoresleeve)
+"reA" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "reH" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -69488,52 +66976,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/port)
-"reJ" = (
-/obj/structure/table/steel,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	name = "light switch ";
-	pixel_x = 36
-	},
-/obj/item/device/sleevemate,
-/obj/item/weapon/storage/box/bodybags,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
-"rfd" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/folder/white,
-/obj/item/weapon/pen,
-/turf/simulated/floor/tiled/white,
-/area/medical/reception)
-"rfQ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "rfR" = (
 /turf/simulated/wall,
 /area/library)
@@ -69731,6 +67173,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/medical/genetics)
+"rmL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "rmM" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -69741,6 +67190,54 @@
 /obj/machinery/light,
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/fscenter)
+"rob" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/multi_tile/glass{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
+"rom" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "roo" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 1;
@@ -69780,6 +67277,16 @@
 /obj/structure/loot_pile/maint/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
+"rqf" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "rqw" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck - Aft Hallway 5";
@@ -69801,24 +67308,6 @@
 /obj/effect/floor_decal/carpet,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/coffee_shop)
-"rra" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 25
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
 "rrh" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -69860,15 +67349,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"rsK" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "rsM" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -69912,6 +67392,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
+"rtC" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/spot,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "rtL" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -70017,6 +67507,27 @@
 	},
 /turf/simulated/floor/tiled,
 /area/holodeck_control)
+"rwk" = (
+/obj/machinery/door/window/holowindoor{
+	dir = 1;
+	name = "Medical Storage";
+	req_access = list(66)
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "rwl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -70051,14 +67562,17 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/cryo/station)
 "rxD" = (
-/obj/structure/bed/chair{
+/obj/random/vendordrink{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = 30
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "rxI" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -70066,23 +67580,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
-"ryn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
-"ryI" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery)
 "rzk" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -70173,24 +67670,27 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/robotics)
-"rCx" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
+"rCf" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych)
+"rCA" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/area/medical/foyer)
 "rCN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -70277,13 +67777,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
-"rEb" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "pr2_window_tint"
-	},
-/turf/simulated/floor/plating,
-/area/medical/patient_b)
 "rEd" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/borderfloor{
@@ -70298,8 +67791,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
 "rEl" = (
-/turf/simulated/wall/r_wall,
-/area/medical/biostorage)
+/obj/machinery/suit_cycler/medical,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "rEq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -70379,23 +67882,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/seconddeck/aft)
+"rGJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_b)
 "rGT" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/locker)
-"rGX" = (
-/obj/structure/table/standard,
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/weapon/surgical/retractor,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "rHm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/conveyor_switch{
@@ -70454,13 +67951,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/apcenter)
-"rIN" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/pink/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
 "rIW" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -70469,6 +67959,21 @@
 /obj/machinery/power/solar,
 /turf/simulated/floor/airless,
 /area/space)
+"rJa" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
+"rJd" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "rJB" = (
 /turf/simulated/floor/plating,
 /area/maintenance/research_medical)
@@ -70481,48 +67986,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"rKm" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
+"rLl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/structure/curtain/open/privacy,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/cryo)
-"rKn" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
-"rKQ" = (
 /obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/medical/surgeryobs)
+/obj/effect/landmark/start/fieldmedic,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "rLs" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/disposalpipe/segment{
@@ -70531,15 +68005,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
-"rLH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "rLZ" = (
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Holodeck Port";
@@ -70549,11 +68014,40 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/alphadeck)
+"rMf" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "rMh" = (
 /obj/structure/closet/emcloset,
 /obj/random/maintenance/research,
 /turf/simulated/floor,
 /area/maintenance/research_medical)
+"rMq" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "rMJ" = (
 /obj/machinery/atmospherics/tvalve/digital{
 	dir = 8;
@@ -70609,6 +68103,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
+"rNm" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "rNn" = (
 /obj/structure/table/standard,
 /obj/fiftyspawner/plastic,
@@ -70636,15 +68148,6 @@
 /obj/item/device/starcaster_news,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"rOO" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "rOX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -70663,16 +68166,24 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
-"rPr" = (
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/structure/table/steel,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+"rPq" = (
+/obj/machinery/camera/network/medbay{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/turf/simulated/floor/wood,
+/area/medical/psych)
+"rPx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
+"rPy" = (
+/turf/simulated/wall,
+/area/medical/surgery2)
 "rPK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -70735,11 +68246,11 @@
 /area/hallway/secondary/entry/D1)
 "rRc" = (
 /obj/structure/curtain/black{
+	dir = 2;
 	icon_state = "open";
 	layer = 2;
 	name = "privacy curtain";
-	opacity = 0;
-	dir = 2
+	opacity = 0
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/seconddeck/artgallery)
@@ -70797,6 +68308,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"rSa" = (
+/obj/machinery/vending/medical,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "rSd" = (
 /obj/structure/reagent_dispensers/water_cooler/full,
 /obj/machinery/light{
@@ -70810,27 +68331,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"rSH" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Surgery Storage";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/surgery_storage)
 "rTr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"rTw" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "rTO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -70894,40 +68399,9 @@
 /obj/structure/closet/coffin,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"rXR" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Medical Foyer";
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/foyer)
 "rXY" = (
 /turf/simulated/wall/r_wall,
 /area/chapel/main)
-"rYk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "rYB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -70956,13 +68430,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/seconddeck/artgallery)
-"rYP" = (
-/obj/machinery/door/airlock/glass_medical{
-	name = "Patient Ward"
+"rYX" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/patient_wing)
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/obj/machinery/keycard_auth{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "rZA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -71013,24 +68495,27 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/medical/genetics)
-"saz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+"sah" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /turf/simulated/floor/tiled/white,
-/area/medical/cryo)
+/area/medical/resleeving)
+"saz" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/light/spot,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "saJ" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -71160,6 +68645,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_room)
+"scG" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/papershredder,
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "scT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/vending/cigarette,
@@ -71174,6 +68672,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"sdo" = (
+/obj/machinery/bodyscanner,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "sdq" = (
 /obj/structure/sign/directions/medical{
 	dir = 4
@@ -71244,21 +68755,6 @@
 	},
 /turf/simulated/wall,
 /area/hallway/primary/seconddeck/fpcenter)
-"seX" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "sfi" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -71335,21 +68831,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"shy" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "shB" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -71365,66 +68846,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
-"shD" = (
-/obj/machinery/disposal,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = -32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/cryo)
-"shQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "shU" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/starboard)
-"sib" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
 "siq" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -71443,23 +68868,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/chapel/main)
-"skp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "skB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71468,27 +68876,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
-"slm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "smo" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -71503,14 +68890,9 @@
 "smA" = (
 /turf/simulated/floor/plating,
 /area/maintenance/locker)
-"snu" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
+"smK" = (
+/turf/simulated/wall,
+/area/medical/medbay4)
 "snD" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -71524,24 +68906,6 @@
 /obj/item/weapon/storage/rollingpapers/blunt,
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
-"soy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/glass_medical{
-	name = "Patient Ward"
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/patient_wing)
 "soz" = (
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
@@ -71602,6 +68966,36 @@
 "sql" = (
 /turf/unsimulated/mask,
 /area/hallway/primary/seconddeck/starboard)
+"sqp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
+"sqw" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "sqI" = (
 /obj/machinery/light{
 	dir = 8
@@ -71620,10 +69014,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/construction/seconddeck/construction1)
-"srt" = (
-/obj/structure/table/glass,
-/turf/simulated/floor/tiled/dark,
-/area/medical/patient_wing)
 "srF" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -71639,6 +69029,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/ascenter)
+"srS" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "srU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -71650,6 +69051,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research_medical)
+"ssb" = (
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "ssC" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythree_nineteen,
@@ -71659,6 +69073,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/seconddeck/artgallery)
+"ssD" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/bookcase/manuals/medical,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "ssH" = (
 /obj/effect/floor_decal/carpet{
 	dir = 8
@@ -71744,25 +69172,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"stu" = (
-/obj/machinery/optable,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"stG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
 "stH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 8
@@ -71771,19 +69180,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "sup" = (
-/obj/machinery/papershredder,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "svD" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -71800,6 +69198,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fpcenter)
+"swJ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "sxa" = (
 /obj/structure/sign/warning/hot_exhaust,
 /turf/simulated/wall/r_wall,
@@ -71849,6 +69260,24 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/seconddeck/artgallery)
+"syj" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "syk" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/closet/emcloset,
@@ -71956,19 +69385,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/hallway/engineer_hallway)
-"sAC" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/food/drinks/britcup,
-/obj/item/weapon/storage/box/glasses/square,
-/obj/effect/floor_decal/corner/paleblue/diagonal{
+"sAs" = (
+/obj/structure/bed/chair/bay/comfy/teal{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/item/weapon/storage/box/body_record_disk,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/area/medical/foyer)
 "sAH" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -72003,6 +69427,28 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D2)
+"sCf" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/medical,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "sCg" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/blast/regular{
@@ -72066,12 +69512,12 @@
 /obj/structure/table/marble,
 /obj/effect/floor_decal/corner/brown/diagonal,
 /obj/item/weapon/reagent_containers/food/drinks/shaker{
-	pixel_y = 8;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 8
 	},
 /obj/item/weapon/reagent_containers/food/drinks/teapot{
-	pixel_y = 1;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/crew_quarters/coffee_shop)
@@ -72108,6 +69554,16 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/port)
+"sDn" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "sEv" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment,
@@ -72116,6 +69572,15 @@
 "sEx" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/bar)
+"sEO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "sFt" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -72215,14 +69680,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/port)
-"sHK" = (
-/obj/structure/bed/chair/wheelchair,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+"sHZ" = (
+/obj/structure/table/reinforced,
+/obj/random/medical,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "sIk" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -72285,12 +69748,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
-"sKv" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/sleeper)
 "sKG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72318,6 +69775,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fpcenter)
+"sLO" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/obj/effect/floor_decal/sign/cmo,
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "sLS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -72369,6 +69850,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fpcenter)
+"sMy" = (
+/obj/machinery/recharger/wallcharger,
+/turf/simulated/wall,
+/area/medical/medbay_emt_bay)
 "sMJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72393,6 +69878,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fpcenter)
+"sNu" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/obj/structure/flora/pottedplant/orientaltree,
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
+"sNT" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_b)
 "sOC" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
@@ -72432,16 +69932,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/ascenter)
-"sPy" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
+"sPj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "sPZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72478,37 +69972,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
-"sRD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"sRL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "sRN" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -72536,30 +69999,28 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
 "sSp" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/glass/beaker/large,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"sTb" = (
-/obj/structure/morgue,
+/obj/structure/bed/chair/sofa/corner/teal,
 /obj/effect/floor_decal/borderfloor{
-	dir = 1
+	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
+"sSz" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_b)
 "sUh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72587,28 +70048,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
-"sUz" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Patient Room B";
-	dir = 8
+"sUI" = (
+/obj/machinery/optable,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/obj/machinery/newscaster{
-	pixel_x = 30
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	layer = 4;
-	pixel_y = -32
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 6
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/surgery)
 "sVp" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/space;
@@ -72619,6 +70068,15 @@
 	},
 /turf/space,
 /area/space)
+"sVP" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
 "sWi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72631,6 +70089,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
+"sWm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"sWy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "sWJ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -72641,6 +70123,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
+"sXf" = (
+/obj/structure/table/reinforced,
+/obj/random/plushie,
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_b)
 "sXo" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -72650,6 +70137,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
+"sXq" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/black/bordercorner,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "sXG" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_grid,
@@ -72696,16 +70191,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
-"sZj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "sZC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/floor_decal/industrial/warning,
@@ -72736,13 +70221,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
-"tbL" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "psyco_tint"
-	},
-/turf/simulated/floor/plating,
-/area/medical/psych)
 "tce" = (
 /obj/machinery/camera/network/second_deck{
 	c_tag = "Second Deck - Starboard Hallway 3"
@@ -72755,6 +70233,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
+"tcU" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "tdm" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -72769,6 +70255,17 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
+"tdu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/structure/table/darkglass,
+/obj/random/maintenance/foodstuff,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "tdv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72783,6 +70280,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/apcenter)
+"tdH" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "tdJ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
@@ -72807,6 +70313,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/coffee_shop)
+"tej" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "tfd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72970,40 +70488,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
-"thu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"thF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "thH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -73051,6 +70535,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
+"tkr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "tku" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -73081,6 +70572,17 @@
 "tkH" = (
 /turf/simulated/wall,
 /area/engineering/engi_restroom)
+"tle" = (
+/obj/structure/mirror{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/awaymission/snowfield/medical/patient_restroom)
+"tll" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/black/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "tlw" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -73088,26 +70590,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D3)
-"tlx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "tmd" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light{
@@ -73127,6 +70609,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"tmG" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "tna" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
@@ -73142,6 +70636,10 @@
 	},
 /turf/simulated/open,
 /area/maintenance/substation/cargo)
+"tnH" = (
+/obj/machinery/body_scanconsole,
+/turf/simulated/floor/glass/reinforced,
+/area/medical/sleeper)
 "tnO" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -73156,6 +70654,18 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/cargo)
+"tnY" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/turf/simulated/floor/glass/reinforced,
+/area/medical/sleeper)
+"toe" = (
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "cmooffice"
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/sc/cmo)
 "toq" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -73166,6 +70676,7 @@
 /obj/effect/floor_decal/corner/purple/bordercorner{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/genedrobe,
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
 "tos" = (
@@ -73228,33 +70739,41 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
-"tpu" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"tpj" = (
+/obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/medbay2)
 "tpy" = (
-/obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "MedbayLockdown"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
+"tpC" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "MedbayLockdown"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "tpH" = (
 /obj/structure/sink{
 	dir = 8;
@@ -73267,22 +70786,20 @@
 /turf/simulated/floor/tiled/steel,
 /area/medical/virology)
 "tpX" = (
-/obj/effect/floor_decal/industrial/warning{
+/obj/machinery/door/window/holowindoor{
+	dir = 2
+	},
+/obj/machinery/door/window/holowindoor{
 	dir = 1
 	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/blast/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id = "medbayrecquar";
-	name = "Medbay Emergency Quarantine Shutters";
-	opacity = 0
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 10
+	dir = 2;
+	id = "MedbayLockdown"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/foyer)
+/area/medical/reception)
 "tqH" = (
 /obj/item/weapon/stool/padded,
 /obj/effect/floor_decal/carpet{
@@ -73304,6 +70821,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
+"trF" = (
+/obj/structure/bed/chair/sofa/left/teal,
+/turf/simulated/floor/carpet/blue,
+/area/medical/psych)
 "trL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/item/device/radio/intercom{
@@ -73348,14 +70869,19 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "ttQ" = (
-/obj/structure/toilet{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/weapon/surgical/hemostat/cyborg,
+/obj/item/weapon/surgical/retractor,
+/obj/item/weapon/surgical/cautery,
+/obj/item/weapon/surgical/scalpel,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/floor_decal/corner/black/border{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "ttW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -73396,26 +70922,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
-"tuX" = (
-/obj/structure/bed/padded,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Examination Room";
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
 "tvh" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -73490,6 +70996,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"twY" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "txi" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -73500,10 +71019,6 @@
 "txk" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/locker)
-"txI" = (
-/obj/machinery/door/firedoor/border_only,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/sleeper)
 "txX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -73516,31 +71031,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
-"tye" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/medical/surgeryobs)
 "tyL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
@@ -73570,6 +71060,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"tzA" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
+	},
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "tzP" = (
 /obj/machinery/disease2/isolator,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -73600,8 +71102,9 @@
 /turf/simulated/floor/greengrid/nitrogen,
 /area/engineering/engine_room)
 "tAA" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
+/obj/structure/morgue,
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
 "tBz" = (
 /obj/machinery/air_sensor{
 	frequency = 1438;
@@ -73675,6 +71178,24 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D2/arrivals)
+"tBY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
+"tCB" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/black/border,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "tCI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73796,8 +71317,8 @@
 "tHc" = (
 /obj/structure/table/bench/wooden,
 /obj/structure/flora/pottedplant/flower{
-	pixel_y = 10;
-	name = "pietra"
+	name = "pietra";
+	pixel_y = 10
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -73810,17 +71331,8 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
 "tHk" = (
-/obj/machinery/vending/wallmed1{
-	pixel_x = 25
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "tHp" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/floor_decal/borderfloor{
@@ -73850,23 +71362,25 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
 "tHW" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/o2{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/weapon/storage/firstaid/o2,
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
+/area/medical/medbay2)
 "tIv" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -73928,23 +71442,6 @@
 /obj/item/device/toner,
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
-"tMo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Patient Hallway Starboard";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "tMs" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -73994,6 +71491,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
+"tPG" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/obj/machinery/computer/med_data/laptop{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "tQh" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -74013,6 +71523,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/seconddeck/port)
+"tQF" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/item/weapon/book/manual/medical_diagnostics_manual,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "tRm" = (
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
@@ -74072,6 +71593,12 @@
 "tTx" = (
 /turf/space,
 /area/shuttle/arrival/station)
+"tUm" = (
+/obj/machinery/body_scanconsole{
+	dir = 4
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/medical/sleeper)
 "tUA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74115,6 +71642,13 @@
 	},
 /turf/simulated/wall,
 /area/hallway/secondary/entry/D2)
+"tWs" = (
+/turf/simulated/wall,
+/area/crew_quarters/heads/sc/cmo)
+"tWw" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
 "tXm" = (
 /obj/structure/sign/poster/nanotrasen{
 	dir = 1
@@ -74130,6 +71664,15 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/security_starboard)
+"tXL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "tXV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74220,29 +71763,6 @@
 /obj/effect/floor_decal/corner/brown/bordercorner,
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
-"uau" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/medical{
-	id_tag = "mentaldoor";
-	name = "Mental Health";
-	req_access = list(64)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/psych)
 "uay" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -74289,8 +71809,8 @@
 	dir = 8
 	},
 /obj/machinery/vending/wallmed1{
-	pixel_x = -25;
-	dir = 4
+	dir = 4;
+	pixel_x = -25
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cafeteria)
@@ -74321,15 +71841,28 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/central)
-"ueM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_medical{
-	name = "Patient Ward"
+"ueu" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/patient_wing)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
+"ueM" = (
+/turf/simulated/wall,
+/area/medical/medical_restroom)
 "ueP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74432,33 +71965,22 @@
 /turf/simulated/floor/tiled/yellow,
 /area/crew_quarters/coffee_shop)
 "ufJ" = (
-/obj/structure/sign/chemistry{
-	icon_state = "chemistry2";
-	pixel_y = 32
+/obj/structure/bed/chair/sofa/right/teal,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "chemwindow";
-	name = "Chemistry Window Shutters";
-	opacity = 0
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/medical/chemistry)
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "ufT" = (
 /obj/effect/shuttle_landmark/southern_cross/arrivals_station,
 /turf/space,
 /area/shuttle/arrival/station)
-"ugC" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "cryo_tint"
-	},
-/turf/simulated/floor/plating,
-/area/medical/cryo)
 "ugD" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -74544,6 +72066,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
+"uhw" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "uhC" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/landmark/start{
@@ -74558,28 +72095,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/library)
-"uhE" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
-"uhF" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "uhO" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -74628,6 +72143,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
+"uiw" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "uiD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -74663,6 +72202,12 @@
 	},
 /turf/space,
 /area/space)
+"ukS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "ukV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -74681,25 +72226,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
-"ulX" = (
-/obj/structure/flora/pottedplant/smalltree{
-	pixel_y = 11
-	},
+"ulo" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 6
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
+	dir = 8
 	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"ulX" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_a)
 "umh" = (
 /obj/machinery/shield_diffuser,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -74724,15 +72274,21 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"umI" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+"umL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/paleblue{
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/foyer)
+/area/crew_quarters/heads/sc/cmo)
 "umZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -74910,6 +72466,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/seconddeck/research_medical)
+"utI" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "utJ" = (
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 4
@@ -74946,6 +72516,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/seconddeck/research_medical)
+"uvl" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "uvq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74983,8 +72573,20 @@
 	name = "Medsci and Autoresleeving";
 	req_one_access = null
 	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "mbld"
+	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
+"uwp" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "uwy" = (
 /obj/machinery/ai_status_display{
 	pixel_y = -32
@@ -75082,6 +72684,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
+"uyf" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "MedbayLockdown"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "uzy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -75113,16 +72723,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
-"uzX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "uAt" = (
 /obj/machinery/door/airlock/glass_external{
 	frequency = null;
@@ -75187,6 +72787,10 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/white,
 /area/medical/genetics)
+"uAV" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "uAZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75293,36 +72897,36 @@
 	name = "Art supplies"
 	},
 /obj/item/weapon/storage/fancy/crayons{
-	pixel_y = -3;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = -3
 	},
 /obj/item/weapon/storage/fancy/crayons{
-	pixel_y = -3;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = -3
 	},
 /obj/item/weapon/storage/fancy/crayons{
-	pixel_y = -3;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = -3
 	},
 /obj/item/weapon/storage/fancy/crayons{
-	pixel_y = -3;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = -3
 	},
 /obj/item/weapon/storage/fancy/markers{
-	pixel_y = 6;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = 6
 	},
 /obj/item/weapon/storage/fancy/markers{
-	pixel_y = 6;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = 6
 	},
 /obj/item/weapon/storage/fancy/markers{
-	pixel_y = 6;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = 6
 	},
 /obj/item/weapon/storage/fancy/markers{
-	pixel_y = 6;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = 6
 	},
 /obj/item/weapon/tape_roll,
 /obj/item/weapon/tape_roll,
@@ -75339,20 +72943,20 @@
 /obj/item/weapon/hand_labeler,
 /obj/item/weapon/hand_labeler,
 /obj/item/weapon/pen/multi{
-	pixel_y = 1;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 1
 	},
 /obj/item/weapon/pen/multi{
-	pixel_y = 1;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 1
 	},
 /obj/item/weapon/pen/multi{
-	pixel_y = 1;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 1
 	},
 /obj/item/weapon/pen/multi{
-	pixel_y = 1;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 1
 	},
 /obj/item/device/lightpainter,
 /obj/item/device/lightpainter,
@@ -75466,27 +73070,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/qm)
-"uGj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"uGB" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/area/medical/surgery)
 "uHc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -75495,6 +73088,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"uHn" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "uHz" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/lockbox/vials,
@@ -75529,6 +73135,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"uIv" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "uJq" = (
 /obj/structure/sign/warning/airlock{
 	pixel_y = -32
@@ -75593,21 +73213,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
-"uLm" = (
-/obj/structure/bed/chair/sofa/corner/blue{
-	dir = 1
-	},
+"uLr" = (
 /obj/effect/floor_decal/borderfloor{
-	dir = 10
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 10
+/obj/effect/floor_decal/corner/black/border{
+	dir = 5
 	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 8;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled,
+/obj/structure/sink/kitchen,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "uMn" = (
 /obj/structure/table/glass,
@@ -75623,12 +73237,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "uMy" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
 /turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
+/area/medical/reception)
 "uNh" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -75656,26 +73275,6 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D1)
-"uOA" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start{
-	name = "Psychiatrist"
-	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control-switch for the office door.";
-	id = "mentaldoor";
-	name = "office door control";
-	pixel_y = 24
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Mental Health";
-	dir = 6
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/psych)
 "uOF" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -75683,45 +73282,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D2)
-"uOH" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/belt/medical,
-/obj/item/weapon/storage/belt/medical,
-/obj/item/weapon/storage/belt/medical,
-/obj/item/weapon/storage/belt/medical,
-/obj/item/weapon/storage/belt/medical,
-/obj/item/clothing/accessory/stethoscope,
-/obj/item/clothing/accessory/stethoscope,
-/obj/item/clothing/accessory/stethoscope,
-/obj/item/clothing/accessory/stethoscope,
-/obj/item/clothing/accessory/stethoscope,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
-"uOL" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
 "uOZ" = (
 /obj/effect/floor_decal/chapel{
 	dir = 8
@@ -75757,6 +73317,19 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/entry/D1)
+"uRa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "uRk" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/wingrille_spawn/reinforced,
@@ -75775,9 +73348,16 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
 "uSo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/holowindoor{
+	dir = 8
+	},
+/obj/machinery/door/window/holowindoor,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "MedbayLockdown"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "uSG" = (
@@ -75806,17 +73386,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/chapel/main)
-"uTu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/alarm/freezer{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/surgery_storage)
 "uTA" = (
 /obj/structure/table/steel,
 /obj/random/maintenance/clean,
@@ -75836,27 +73405,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
-"uVg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+"uVi" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/area/medical/sleeper)
 "uVm" = (
 /obj/machinery/appliance/cooker/oven,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -75876,16 +73447,6 @@
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor,
 /area/engineering/engine_room)
-"uVT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "uVZ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -75933,29 +73494,28 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/secondary/entry/D2)
-"uXT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
+"uXt" = (
+/obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+/obj/machinery/camera/network/medbay{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
+/area/medical/foyer)
 "uYd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D3)
-"uYj" = (
-/obj/effect/floor_decal/industrial/loading{
-	dir = 1
+"uYJ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/area/medical/medbay4)
 "uYZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -75969,36 +73529,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_waste)
-"uZc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"uZr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = 21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "uZx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -76053,6 +73583,29 @@
 /obj/random/trash_pile,
 /turf/simulated/floor,
 /area/maintenance/cargo)
+"vbK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "vbL" = (
 /obj/machinery/door/firedoor,
 /obj/effect/wingrille_spawn/reinforced,
@@ -76109,28 +73662,14 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/airless,
 /area/medical/genetics)
-"vda" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Patient Room A";
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
 "vdd" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/port)
+"vdN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
 "vdV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -76140,27 +73679,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"vei" = (
-/obj/item/weapon/stool/padded,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
+"veg" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"vff" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/corner/beige/border{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
-"veJ" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
+/area/medical/reception)
 "vfn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -76220,6 +73756,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
+"vgv" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "vgH" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -76277,8 +73818,8 @@
 /area/quartermaster/warehouse)
 "viP" = (
 /obj/machinery/door/window/southleft{
-	name = "Library Desk Door";
 	dir = 8;
+	name = "Library Desk Door";
 	req_access = list(37)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -76358,6 +73899,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
+"vli" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "vlz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -76381,20 +73938,38 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/ascenter)
 "vmR" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/structure/curtain/open/privacy,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
+/obj/structure/closet/secure_closet/medical3,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/obj/machinery/ai_status_display{
-	pixel_y = 32
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/area/medical/medical_lockerroom)
+"vmX" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "vnc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76428,6 +74003,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/chapel/office)
+"vok" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 5
+	},
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "vor" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76458,15 +74045,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/hallway/secondary/entry/docking_lounge)
-"vpD" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_medical{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access = list(5)
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/foyer)
 "vpH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -76479,27 +74057,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
-"vqv" = (
-/obj/machinery/atmospherics/unary/cryo_cell,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techmaint,
-/area/medical/cryo)
-"vqA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+"vqj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
+"vqv" = (
+/obj/random/vendorfood{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "vqB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -76509,6 +74084,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
+"vra" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "vrg" = (
 /turf/simulated/shuttle/wall/no_join,
 /area/shuttle/cryo/station)
@@ -76580,17 +74164,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
-"vvd" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "vvh" = (
 /obj/item/device/radio/intercom/locked/confessional{
 	pixel_y = -21
@@ -76678,32 +74251,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "vxB" = (
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Secondary Storage";
-	dir = 8
-	},
+/obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
-"vxF" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/bed/chair/office/light,
-/obj/machinery/vending/wallmed1{
-	pixel_x = -25
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/morgue)
 "vxG" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -76747,6 +74302,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cafeteria)
+"vyy" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "MedbayLockdown"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "vyA" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -76761,18 +74329,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
-"vzz" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
 "vzL" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -76788,6 +74344,10 @@
 "vzM" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry/D3)
+"vzQ" = (
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall,
+/area/medical/medbay4)
 "vAp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -76865,6 +74425,10 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D3)
+"vCE" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/medbay4)
 "vCI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light{
@@ -76900,24 +74464,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"vDT" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "vDV" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/blast/regular{
@@ -76991,95 +74537,64 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/seconddeck/research_medical)
+"vFY" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "vGd" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/glass/bottle/stoxin{
-	pixel_x = -6;
-	pixel_y = 10
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/medical{
+	name = "Morgue";
+	req_access = list(6)
 	},
-/obj/item/weapon/reagent_containers/glass/bottle/antitoxin{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline{
-	pixel_x = 1
-	},
-/obj/random/medical,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/firstaid/regular,
-/obj/random/medical,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/weapon/storage/box/gloves{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/box/masks,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
-"vGp" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Locker Room";
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
-"vGJ" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/bar)
-"vGS" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/patient_b)
-"vHd" = (
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/hallway/secondary/seconddeck/research_medical)
-"vHe" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/curtain/open/privacy,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/cryo)
-"vIb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
+/area/medical/morgue)
+"vGD" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
+"vGJ" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/bar)
+"vHd" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/hallway/secondary/seconddeck/research_medical)
 "vIj" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -77094,21 +74609,6 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
-"vIn" = (
-/obj/item/weapon/storage/box/cdeathalarm_kit,
-/obj/item/bodybag/cryobag{
-	pixel_x = -3
-	},
-/obj/item/bodybag/cryobag{
-	pixel_x = -3
-	},
-/obj/structure/table/steel,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/obj/item/device/sleevemate,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
 "vIB" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -77162,6 +74662,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
+"vJe" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/surgical/FixOVein/cyborg,
+/obj/item/weapon/surgical/bonesetter,
+/obj/item/weapon/surgical/circular_saw,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/black/border,
+/obj/machinery/light/spot,
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "vJh" = (
 /obj/random/plushielarge,
 /turf/simulated/floor/plating,
@@ -77177,6 +74687,13 @@
 /obj/structure/sign/warning/radioactive,
 /turf/simulated/wall/r_wall,
 /area/engineering/engine_waste)
+"vJQ" = (
+/obj/structure/table/rack/shelf,
+/obj/item/wheelchair,
+/obj/item/wheelchair,
+/obj/item/wheelchair,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "vJS" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -77221,6 +74738,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/locker)
+"vKK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "vKX" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/floor_decal/industrial/warning{
@@ -77266,6 +74792,18 @@
 /obj/machinery/vending/loadout/clothing,
 /turf/simulated/floor/tiled/white,
 /area/medical/cryo/autoresleeve)
+"vLP" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/awaymission/snowfield/medical/patient_restroom)
 "vMl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 6
@@ -77288,6 +74826,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"vMI" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "vMO" = (
 /turf/simulated/floor/reinforced{
 	name = "Holodeck Projector Floor"
@@ -77295,7 +74842,15 @@
 /area/holodeck/alphadeck)
 "vNi" = (
 /turf/simulated/wall/r_wall,
-/area/medical/surgery_storage)
+/area/medical/medbay_primary_storage)
+"vNj" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
 "vNr" = (
 /obj/machinery/vending/nifsoft_shop,
 /turf/simulated/floor/tiled/dark,
@@ -77315,27 +74870,47 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/civilian)
-"vOR" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"vOh" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = -10
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
+/area/medical/chemistry)
+"vOJ" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 1
+	},
+/obj/structure/sign/biohazard{
+	name = "Chemical Exposure Zone";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "vOY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/white,
@@ -77352,6 +74927,34 @@
 /obj/effect/floor_decal/corner/lime/bordercorner,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"vPt" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_x = 38
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "vPP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -77424,21 +75027,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
-"vRU" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/adv{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/firstaid/adv,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
 "vSv" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/borderfloor{
@@ -77470,19 +75058,26 @@
 "vSR" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/engine_monitoring)
-"vUd" = (
-/obj/machinery/papershredder,
-/obj/effect/floor_decal/corner/paleblue/diagonal{
-	dir = 4
+"vTg" = (
+/obj/structure/table/reinforced,
+/obj/item/device/defib_kit/compact,
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 10
+	},
+/obj/item/clothing/gloves/sterile/fluff/jiao_gloves,
+/obj/item/clothing/gloves/sterile/fluff/jiao_gloves,
+/obj/machinery/light/spot{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/area/medical/medbay_emt_bay)
 "vUf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/medbay2)
+/obj/machinery/oxygen_pump/anesthetic,
+/turf/simulated/wall/r_wall,
+/area/medical/surgery)
 "vUp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_grid,
@@ -77611,11 +75206,16 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/delivery)
 "vXB" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
 	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay,
 /turf/simulated/floor/tiled/white,
-/area/medical/medical_lockerroom)
+/area/medical/medbay_emt_bay)
 "vYL" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 2;
@@ -77627,15 +75227,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
 "vZc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
+/obj/structure/grille,
+/obj/structure/window/basic/full,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
+"vZm" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/surgeryobs)
 "vZE" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
@@ -77683,17 +75287,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
-"wbc" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "wbx" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/effect/landmark/start{
@@ -77718,21 +75311,15 @@
 /turf/simulated/wall,
 /area/hallway/primary/seconddeck/port)
 "wbS" = (
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Operating Theatre 2";
+/obj/machinery/vending/blood,
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed1{
-	pixel_y = -30
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
 	},
-/obj/structure/table/standard,
-/obj/item/weapon/surgical/bonesetter,
-/obj/item/weapon/surgical/bonegel,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/pink/border,
-/obj/item/weapon/surgical/bioregen,
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
+/turf/simulated/floor/glass/reinforced,
+/area/medical/sleeper)
 "wco" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77778,49 +75365,34 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "wdd" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/medical{
-	name = "Secondary Storage";
-	req_access = list(5)
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/biostorage)
-"wdx" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 9
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/exam_room)
+/area/medical/medbay_emt_bay)
+"wdC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "wec" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/airless,
 /area/medical/genetics)
-"wer" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+"weI" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "weK" = (
 /obj/machinery/vending/nifsoft_shop{
 	dir = 1
@@ -77844,6 +75416,20 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
+"wfC" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "wfV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack,
@@ -77854,12 +75440,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/central)
-"whb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/surgery_storage)
 "whh" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -77873,22 +75453,29 @@
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/delivery)
-"whv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"wht" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/reagent_dispensers/water_cooler/full,
+/obj/machinery/light_switch{
+	name = "light switch ";
+	pixel_x = 38
+	},
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/area/medical/surgeryobs)
 "wiE" = (
 /obj/structure/sign/directions/engineering{
 	pixel_y = 10
@@ -77900,6 +75487,21 @@
 	},
 /turf/simulated/wall,
 /area/hallway/primary/seconddeck/ascenter)
+"wiL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
 "wjc" = (
 /obj/structure/bed/chair,
 /obj/machinery/camera/network/second_deck{
@@ -77987,17 +75589,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/ascenter)
-"wlf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "wlg" = (
 /obj/structure/sign/directions/medical,
 /obj/structure/sign/directions/security{
@@ -78010,54 +75601,6 @@
 	},
 /turf/simulated/wall,
 /area/maintenance/medbay_fore)
-"wls" = (
-/obj/machinery/iv_drip,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	pixel_x = -36;
-	pixel_y = -6
-	},
-/obj/machinery/button/windowtint{
-	id = "pr1_window_tint";
-	pixel_x = -36;
-	pixel_y = 6
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
-"wmj" = (
-/turf/simulated/wall,
-/area/medical/patient_b)
-"wmE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "wni" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -78085,6 +75628,23 @@
 "wnB" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry/D1)
+"wnI" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
 "woi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -78121,24 +75681,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
-"wpH" = (
-/obj/machinery/disposal,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -21
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
 "wqa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/monotile,
@@ -78178,6 +75720,21 @@
 /obj/effect/floor_decal/corner/green/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
+"wqp" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/device/defib_kit,
+/obj/structure/sign/biohazard{
+	name = "Chemical Exposure Zone";
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "wqq" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -78210,32 +75767,19 @@
 /obj/random/tech_supply,
 /turf/simulated/floor/plating,
 /area/maintenance/research_medical)
+"wrp" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/black/bordercorner,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay2)
 "wry" = (
 /turf/simulated/wall/r_wall,
 /area/medical/medbay2)
-"wrz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "wrK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -78269,7 +75813,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "MedbayLockdown"
+	},
+/turf/simulated/floor/plating,
 /area/medical/medbay2)
 "wsU" = (
 /obj/effect/floor_decal/steeldecal/monofloor,
@@ -78302,6 +75850,21 @@
 "wtP" = (
 /turf/simulated/wall/r_wall,
 /area/quartermaster/lockerroom)
+"wua" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "wuf" = (
 /obj/effect/floor_decal/industrial/loading,
 /obj/machinery/door/firedoor/border_only,
@@ -78311,40 +75874,17 @@
 /obj/machinery/navbeacon/delivery/south{
 	location = "Medbay"
 	},
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
-"wum" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "cryo_tint"
-	},
 /turf/simulated/floor/plating,
-/area/medical/cryo)
+/area/medical/medbay2)
 "wup" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Patient Hallway Port"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
+/area/medical/medbay4)
 "wuu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78376,6 +75916,12 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
+"wuU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "wuX" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Substation - Medical"
@@ -78408,18 +75954,49 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/dockhallway)
-"wvS" = (
+"wwe" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgeryobs)
+"wwM" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/chemistry)
+"wwN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
@@ -78447,6 +76024,28 @@
 "wxP" = (
 /turf/simulated/wall,
 /area/maintenance/substation/civilian)
+"wyi" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "wyl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/industrial/warning,
@@ -78457,6 +76056,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D2)
+"wza" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/morgue)
+"wzc" = (
+/obj/machinery/requests_console/preset/medical{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/medical/reception)
 "wzj" = (
 /obj/effect/decal/warning_stripes,
 /obj/machinery/atmospherics/tvalve/mirrored/bypass,
@@ -78483,20 +76098,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "wzV" = (
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/glass/hidden/steel,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/medical/medbay2)
-"wAw" = (
-/obj/structure/table/glass,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/medical/medbay2)
+/turf/simulated/wall,
+/area/medical/sleeper)
 "wAG" = (
 /obj/item/weapon/storage/secure/safe{
 	pixel_x = 5;
@@ -78523,6 +76126,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"wAO" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "wAZ" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/grass,
@@ -78546,21 +76159,6 @@
 /obj/effect/floor_decal/corner/beige/border,
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/crew_quarters/coffee_shop)
-"wCh" = (
-/turf/simulated/floor/tiled/white,
-/area/medical/surgery2)
-"wCl" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
 "wCB" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin{
@@ -78698,9 +76296,46 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/port)
+"wGK" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
+"wHm" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "wIa" = (
 /turf/simulated/floor/carpet,
 /area/chapel/main)
+"wIs" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "wJa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78729,10 +76364,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/apcenter)
-"wKf" = (
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/white,
-/area/crew_quarters/heads/sc/cmo)
 "wKg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -78764,19 +76395,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/port)
-"wKQ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced,
-/obj/machinery/door/blast/shutters{
-	density = 0;
-	dir = 8;
-	icon_state = "shutter0";
-	id = "chemwindow";
-	name = "Chemistry Window Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/medical/chemistry)
 "wLh" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -78805,20 +76423,17 @@
 /turf/simulated/floor/grass,
 /area/hydroponics)
 "wML" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
+/obj/machinery/light/spot{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/turf/simulated/floor/carpet/blue,
+/area/medical/medical_restroom)
 "wMO" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -78880,27 +76495,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/locker)
-"wNw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "wNx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -78929,6 +76523,9 @@
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
+"wOD" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "wPa" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/glass{
@@ -78936,11 +76533,40 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/seconddeck/aft)
+"wPn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "wPD" = (
 /obj/structure/closet/emcloset,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
+"wPE" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
+"wQd" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/foyer)
 "wQP" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -78948,21 +76574,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
-"wQR" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre 2";
-	req_access = list(45)
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/surgery2)
 "wQZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79020,6 +76631,13 @@
 /obj/structure/grille,
 /turf/space,
 /area/space)
+"wSG" = (
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/obj/machinery/vitals_monitor,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "wSU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -79032,6 +76650,36 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/central)
+"wSW" = (
+/obj/structure/table/rack,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window,
+/obj/item/clothing/head/helmet/space/void/medical,
+/obj/item/clothing/head/helmet/space/void/medical,
+/obj/item/clothing/suit/space/void/medical,
+/obj/item/clothing/suit/space/void/medical,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/weapon/tank/oxygen,
+/obj/item/weapon/tank/oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/device/suit_cooling_unit,
+/obj/item/device/suit_cooling_unit,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_emt_bay)
 "wSZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
@@ -79064,60 +76712,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
-"wTK" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
-"wTX" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "CMO Office";
-	sortType = "CMO Office"
-	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
-"wUp" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/pink/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
 "wUN" = (
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/tiled/hydro,
@@ -79163,29 +76757,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
-"wVM" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+"wVK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
+	dir = 5
 	},
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/clonepod/transhuman,
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
+/area/medical/resleeving)
 "wWd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79216,23 +76797,6 @@
 /obj/structure/grille/broken,
 /turf/space,
 /area/space)
-"wXc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner_steel_grid{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "wXh" = (
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/airlock/external{
@@ -79250,23 +76814,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/entry/D1)
-"wXx" = (
-/obj/structure/bed/chair/wheelchair,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
-"wXZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
 "wYq" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -79281,11 +76828,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
-"wZh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
 "wZn" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -79324,45 +76866,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/library)
-"xaD" = (
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -21
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Acute";
-	dir = 1
-	},
-/obj/item/device/defib_kit/loaded,
-/obj/item/device/defib_kit/loaded,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
-"xaT" = (
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
+"xap" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
+/area/medical/medbay4)
+"xaQ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_b)
 "xaY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79372,26 +76899,18 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
-"xbq" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
+"xbj" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/landmark/start{
-	name = "Medical Doctor"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/reception)
+/area/medical/chemistry)
 "xbV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79415,6 +76934,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
+"xcn" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "xcE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
@@ -79468,21 +77007,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
-"xdw" = (
-/obj/structure/morgue{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
 "xdX" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable{
@@ -79513,11 +77037,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
 "xeH" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/patient_wing)
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/heads/sc/cmo)
 "xeT" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -79542,20 +77063,33 @@
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "xff" = (
-/obj/machinery/door/airlock{
-	name = "Unit 1"
+/obj/machinery/iv_drip,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
-"xft" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
+	},
+/obj/machinery/button/windowtint{
+	id = "or2";
+	pixel_x = -11;
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/foyer)
+/area/medical/surgery2)
 "xfH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -79576,13 +77110,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"xgD" = (
-/obj/structure/undies_wardrobe,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
 "xgL" = (
 /turf/simulated/shuttle/wall,
 /area/shuttle/cryo/station)
@@ -79612,29 +77139,8 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "xhh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay)
+/area/medical/reception)
 "xhM" = (
 /turf/simulated/wall,
 /area/maintenance/research_medical)
@@ -79655,6 +77161,14 @@
 	},
 /turf/simulated/floor/lino,
 /area/chapel/office)
+"xiq" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/structure/filingcabinet/medical,
+/turf/simulated/floor/wood,
+/area/medical/psych)
 "xiE" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -79667,6 +77181,20 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/research_medical)
+"xjl" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "xjv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79679,6 +77207,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
+"xjx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "xjG" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -79688,19 +77223,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/apcenter)
-"xjT" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "xka" = (
 /obj/structure/lattice,
 /obj/machinery/shield_diffuser,
@@ -79743,7 +77265,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/plating,
 /area/medical/medbay2)
 "xlj" = (
 /obj/machinery/door/firedoor/border_only,
@@ -79768,6 +77290,15 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/warehouse)
+"xlz" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/medical/sleeper)
 "xlF" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -79783,26 +77314,18 @@
 /obj/structure/sign/warning/docking_area,
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry/D1)
-"xnd" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/firstaid/fire,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+"xmG" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
+/area/medical/medbay4)
 "xnj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -79819,7 +77342,7 @@
 	name = "Medical Delivery";
 	req_access = list(5)
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/medical/medbay2)
 "xnS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79894,21 +77417,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/crew_quarters/coffee_shop)
-"xpb" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/machinery/door/window/westright{
-	name = "Shower"
-	},
-/obj/structure/window/basic{
-	dir = 1
-	},
-/obj/structure/curtain/open/shower/medical,
-/turf/simulated/floor/tiled/freezer,
-/area/medical/medical_restroom)
 "xpf" = (
 /obj/machinery/transhuman/autoresleever{
 	ghost_spawns = 1
@@ -79980,6 +77488,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
+"xsw" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/surgical/FixOVein/cyborg,
+/obj/item/weapon/surgical/bonesetter,
+/obj/item/weapon/surgical/circular_saw,
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
 "xsK" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -80031,6 +77555,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/genetics)
+"xtV" = (
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 1
+	},
+/obj/machinery/sleep_console{
+	dir = 4
+	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "xuy" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 1
@@ -80187,21 +77723,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/storage/primary)
-"xxU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
+"xxS" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
+/obj/effect/floor_decal/corner/black/bordercorner{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/camera/network/medbay{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/sleeper)
+/area/medical/surgery)
+"xxU" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "xyg" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/virusdish/random,
@@ -80217,6 +77754,28 @@
 /obj/item/weapon/storage/briefcase/inflatable,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"xzk" = (
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/weapon/storage/belt/medical,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/accessory/stethoscope,
+/obj/item/clothing/accessory/stethoscope,
+/obj/item/clothing/accessory/stethoscope,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/item/weapon/storage/pouch/medical,
+/obj/item/weapon/storage/pouch/medical,
+/obj/item/weapon/storage/pouch/medical,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medical_lockerroom)
 "xzm" = (
 /obj/structure/sign/warning/vent_port,
 /turf/simulated/wall/r_wall,
@@ -80304,11 +77863,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
 "xBk" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/floor_decal/borderfloorwhite/corner,
-/obj/effect/floor_decal/corner/paleblue/bordercorner,
-/turf/simulated/floor/tiled/white,
-/area/medical/patient_wing)
+/obj/structure/largecrate/animal/catgirl,
+/turf/simulated/floor/plating,
+/area/crew_quarters/heads/sc/cmo)
 "xBQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80362,10 +77919,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
 "xDi" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/patient_wing)
+/turf/simulated/wall/r_wall,
+/area/crew_quarters/heads/sc/cmo)
 "xDl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -80398,11 +77953,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D1)
-"xDM" = (
-/obj/structure/closet/crate/freezer,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/freezer,
-/area/medical/surgery_storage)
+"xDQ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "xDR" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -80417,24 +77981,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
-"xEj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
+"xEl" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	layer = 3
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
@@ -80498,14 +78055,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
-"xFC" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "xGd" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
@@ -80538,15 +78087,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/stairwell)
 "xGZ" = (
-/obj/machinery/mech_recharger,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 8;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/floor/tiled/white,
 /area/medical/medbay_emt_bay)
 "xHj" = (
 /obj/structure/table/wooden_reinforced,
@@ -80595,23 +78136,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
-"xIp" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "xIB" = (
 /obj/machinery/lapvend,
 /obj/machinery/light{
@@ -80631,9 +78155,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/apcenter)
 "xLt" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/smartfridge/chemistry,
+/turf/simulated/wall,
 /area/medical/chemistry)
 "xLD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -80648,6 +78171,19 @@
 /mob/living/simple_mob/animal/passive/dog/corgi/Ian,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/sc/hop)
+"xLM" = (
+/obj/machinery/vending/loadout/uniform,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/resleeving)
 "xLN" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -80688,6 +78224,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/ascenter)
+"xME" = (
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "xNd" = (
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder,
@@ -80709,27 +78253,24 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/as_emergency)
+"xNH" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
 "xNV" = (
 /obj/structure/loot_pile/maint/technical,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"xOe" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "xOD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/industrial/warning{
@@ -80792,17 +78333,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "xQy" = (
-/obj/structure/bed/chair{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/medical/surgeryobs)
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "xQF" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
 	dir = 8
@@ -80812,15 +78348,6 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_waste)
-"xRa" = (
-/obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/glass_medical{
-	id_tag = "Surgery";
-	name = "Patient Ward";
-	req_access = list(5)
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/ward)
 "xRo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80910,6 +78437,15 @@
 	},
 /turf/space,
 /area/space)
+"xTd" = (
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery2)
+"xTK" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/surgery)
 "xTR" = (
 /obj/machinery/door/airlock/glass_external{
 	frequency = null;
@@ -80935,13 +78471,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/entry/D3)
-"xTW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "st2_tint"
-	},
-/turf/simulated/floor/plating,
-/area/medical/surgery2)
 "xTX" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/sign/redcross{
@@ -80985,18 +78514,15 @@
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
-"xVJ" = (
-/obj/structure/sink{
-	pixel_y = 16
+"xVP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
+/turf/simulated/floor/tiled/white,
+/area/medical/reception)
 "xWT" = (
 /obj/machinery/camera/network/civilian{
 	c_tag = "CIV - Chapel Aft";
@@ -81020,18 +78546,15 @@
 /area/maintenance/medbay)
 "xYs" = (
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/medical/ward)
+/area/medical/resleeving)
 "xYN" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -81042,6 +78565,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
+"xYT" = (
+/obj/structure/curtain/open/shower/medical,
+/turf/simulated/floor/glass/reinforced,
+/area/medical/sleeper)
 "xZu" = (
 /obj/random/trash,
 /obj/structure/loot_pile/surface/medicine_cabinet{
@@ -81060,36 +78587,36 @@
 	name = "Art supplies"
 	},
 /obj/item/paint_palette{
-	pixel_y = 6;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /obj/item/paint_palette{
-	pixel_y = 6;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /obj/item/paint_palette{
-	pixel_y = 6;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /obj/item/paint_palette{
-	pixel_y = 6;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 6
 	},
 /obj/item/paint_brush{
-	pixel_y = 4;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /obj/item/paint_brush{
-	pixel_y = 4;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /obj/item/paint_brush{
-	pixel_y = 4;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /obj/item/paint_brush{
-	pixel_y = 4;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = 4
 	},
 /obj/item/device/camera_film,
 /obj/item/device/camera_film,
@@ -81132,6 +78659,19 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
+"ybI" = (
+/obj/structure/curtain/open/shower/medical,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "ycd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -81148,20 +78688,16 @@
 /turf/simulated/floor,
 /area/engineering/engine_waste)
 "ycm" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
+/turf/simulated/floor/tiled/white,
+/area/medical/sleeper)
+"ycr" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Morgue"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/medical/morgue)
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 "ydm" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_mining{
@@ -81182,6 +78718,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research_medical)
+"yei" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -36
+	},
+/obj/machinery/vitals_monitor,
+/turf/simulated/floor/reinforced,
+/area/medical/medbay_primary_storage)
 "yet" = (
 /obj/machinery/computer/security/mining,
 /obj/effect/floor_decal/borderfloor{
@@ -81251,31 +78806,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/research_medical)
-"ygD" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/paleblue/bordercorner2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay2)
 "yhq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81284,12 +78814,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"yhv" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/chemistry)
 "yij" = (
 /obj/structure/table/rack,
 /obj/item/device/suit_cooling_unit,
@@ -81300,19 +78824,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/ai_monitored/storage/emergency/eva)
 "yiw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/device/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "yiX" = (
@@ -81351,6 +78862,16 @@
 "ylt" = (
 /turf/simulated/floor/tiled/white,
 /area/medical/genetics)
+"ymg" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay4)
 
 (1,1,1) = {"
 aaa
@@ -120177,9 +117698,9 @@ hIE
 beX
 bwR
 aPk
-xGZ
-nNL
-aKG
+rEl
+wSW
+kPl
 aPk
 aPk
 aPk
@@ -120187,8 +117708,8 @@ bKk
 bKk
 bKk
 bBH
-bGZ
-bGZ
+bBH
+bBH
 bGZ
 bGZ
 hIE
@@ -120434,16 +117955,16 @@ sSl
 hIE
 beY
 hIE
-aPk
-bkc
-pvD
-cTb
-bpa
-gCT
-aPk
-mQY
+aKP
+qLw
+xGZ
+ifU
+aru
+vTg
+bwh
+qNE
 ets
-mQY
+qNE
 bBH
 qya
 jkg
@@ -120693,15 +118214,15 @@ beZ
 aDd
 bgW
 aFT
-aHB
-aKH
-aKH
-bpb
-aNB
-aPm
-buJ
-bwo
-aWj
+xGZ
+gDp
+cpX
+ifo
+emB
+sMy
+tdu
+sup
+fWq
 aYq
 bBF
 sQN
@@ -120951,15 +118472,15 @@ wkF
 aDd
 xLT
 cVs
-bka
-ppc
-aKJ
-bpc
-aNC
-aPn
-aRg
-bwp
-byj
+xGZ
+kQL
+tXL
+xGZ
+eUW
+bra
+huX
+fTm
+ssD
 bGZ
 bBG
 wuX
@@ -121209,22 +118730,22 @@ bhj
 bfa
 bhj
 aPk
-eFj
-gSn
-aKK
-jDw
-bDG
-hwJ
-aRh
-bwq
-byk
+vXB
+fXz
+qoK
+qcs
+qcs
+bSo
+dTs
+wGK
+nsM
 bBH
 bBH
 bBH
 bBH
 bBH
-bKn
-bKn
+qNE
+qNE
 bLX
 bNE
 bPs
@@ -121467,22 +118988,22 @@ bhj
 bfb
 aEk
 aPk
-aHD
+wdd
+qDH
+isz
+swJ
+pvL
 bra
-bra
-bra
-bra
-bra
-orf
-rYk
-tpu
-hff
-wpH
-sup
-bFm
-bHd
-bIJ
-bKn
+lOb
+tkr
+huU
+pOe
+sWy
+rxD
+vqv
+nca
+uHn
+qNE
 bLY
 bNF
 bPt
@@ -121724,23 +119245,23 @@ vrh
 bhj
 bfc
 bgZ
-biv
-wdx
-fma
-jwD
-aMm
-aND
-bso
-aRi
-bws
-bym
-bHh
-raN
-bDH
-bFn
-bHe
-bnr
-bKn
+aPk
+bra
+bra
+bra
+bra
+bra
+bra
+wML
+rLl
+fJf
+mGB
+wAO
+jFl
+jFl
+uRa
+dZt
+qNE
 bLZ
 bNG
 bPu
@@ -121982,23 +119503,23 @@ vrr
 bhj
 wVa
 bha
-biv
-bkd
-dxh
-bnl
-aMn
-aNE
-bAc
-buK
-aTe
-pfB
-qwB
-mZe
-bfD
-biB
-fRS
-bns
-bKn
+buN
+aNI
+aPR
+xiq
+bNU
+tHk
+phg
+itZ
+dRl
+oyq
+gIJ
+rPx
+sup
+sup
+sqp
+rtC
+qNE
 btE
 bNH
 jlD
@@ -122240,23 +119761,23 @@ bbM
 bhj
 wVw
 bhb
-biv
-bke
-tuX
-tHk
-bpf
-aND
+buN
+aen
+kUj
+owr
+jzA
+lDL
 bth
-dgM
-pMI
-byu
-bHh
-bKs
-wKf
-bFo
-bHf
-nZA
-bKn
+wua
+inA
+sCf
+gyM
+ueu
+weI
+weI
+ezf
+uwp
+qNE
 btE
 aSP
 bNZ
@@ -122499,22 +120020,22 @@ bdA
 bfc
 bhc
 buN
-buN
-bti
-bti
-bti
-bti
-bti
-bti
-bwu
-byp
-bIL
-bBL
-bDJ
-biC
-bHg
-bnu
-bKn
+trF
+bTQ
+rCf
+kaN
+nZA
+phg
+uhw
+eiU
+iAm
+oxi
+vPt
+bGF
+vra
+hCG
+vgv
+qNE
 bTz
 bNJ
 bPx
@@ -122756,28 +120277,28 @@ aUy
 bhj
 wWd
 bhd
-bti
-bkf
-aIY
-fRK
-bph
-brc
-btj
-bti
-bwz
-byq
-bKn
-bIL
-bDK
-bIL
-bHh
-bIL
-bKn
-bSm
-bSm
+buN
+tHk
+hri
+wPn
+tHk
+rPq
+phg
+ueM
+kFB
+mWB
+kFB
+ueM
+ueM
+mEE
+ptk
+guv
+qNE
+bTz
+bwR
 bPy
-bSm
-bSm
+bwR
+bTz
 aaa
 aaa
 aaa
@@ -123015,33 +120536,33 @@ bhj
 bfh
 bhe
 aFW
-bkk
-blN
-blN
-bpi
-blN
-btk
+jUI
+ilX
+lEA
+fjg
+tHk
+phg
+tQF
+tPG
+tcU
+nnW
 bti
-nSC
-byr
-bKu
-bBN
-bDL
-bFq
-bkJ
-bIM
-bKu
-bMb
-bNL
-bPz
-kDK
+bIO
+cck
+mXa
+wup
+uYJ
+smK
 bSm
-cpN
-cpN
-cpN
-cpN
-cpN
-cpN
+lbG
+bSm
+bSm
+blS
+tle
+blS
+blS
+blS
+blS
 aaf
 aaa
 aaa
@@ -123272,34 +120793,34 @@ bbN
 bhj
 wWW
 bhf
+buN
+hBg
+pwl
+ihw
+djs
+iqL
+phg
+buM
+kng
+fiJ
+aiY
 bti
-bkh
-sAC
-aKM
-bpk
-aNG
-bbE
-bti
-hua
-bys
-txI
-bKt
 fNB
-wXZ
-pMH
-bcR
-bKu
-btU
-bNM
-bCM
-bHC
-cpN
-bTG
+ovr
+syj
+fIk
+wup
+pUX
+xLM
+igU
+oMO
+sah
+cfO
 bUS
-bWl
-juu
-cpO
-cpN
+nGr
+psC
+qKJ
+blS
 wWX
 wWX
 aag
@@ -123530,34 +121051,34 @@ vtu
 bhj
 wYq
 bhg
+buN
+phg
+phg
+phg
+aKQ
+phg
+phg
+gAx
+xhh
+srS
+wfC
 bti
-bki
-dlB
-aKN
-bpk
-brd
-vUd
-buM
-wrz
-byt
-sKv
-bMc
-bIO
-hHj
-bHo
-oew
-bKu
-btH
-bNY
-bDd
-jQo
-bSo
-bTH
-bUT
+eRV
+gqH
+vMI
+dsd
+hue
+ybI
+xYs
+wiL
+lku
+eTp
+pbp
+vLP
+bmq
 cfO
-cSb
-caZ
-cpN
+cfO
+blS
 aaa
 aaa
 aag
@@ -123788,34 +121309,34 @@ bbP
 bhj
 xaY
 bhh
-bti
-bkj
-btq
+bwB
 bno
-aMo
-aNH
-whv
-buL
-xhh
-bys
-txI
-bBQ
-bDO
-bIP
-mOZ
-xaD
-bKu
-bPG
-bNX
-bPA
-qvr
+kOu
+fDo
+eMV
+sAs
+bti
+scG
+poe
+xVP
+nnW
+wzc
+bti
+smK
+hcB
+mXa
+fGC
+pUX
+sVP
+iAR
+gKj
 bSq
-bXF
+cfO
 cct
 cfP
-cct
-cpP
-cpN
+psC
+fLy
+blS
 aaa
 aaa
 aaa
@@ -124046,34 +121567,34 @@ vtO
 bhj
 xbV
 bhi
-bti
-ggV
-xbq
-aKO
-bpl
-rfd
-izx
-buM
-pMI
-byu
-bKu
-bBR
+bwB
+qBl
+nXc
+qvI
+eMV
+wPE
+nbA
+uMy
 xxU
-rsK
-rsK
-bIQ
-bKu
-lUX
-bNO
-xYs
+gfa
+iTv
+oAq
+krY
+smK
+pyU
+agb
+xME
+smK
+wVK
+dmO
 aMg
-bSp
-bTI
-ccu
-bWm
-ryI
-bYF
-cpN
+fjP
+cfO
+fXK
+eig
+cfO
+cfO
+blS
 aaa
 aaa
 aaa
@@ -124305,34 +121826,34 @@ wlg
 xch
 bhj
 aGd
-bkl
-blR
-aKP
-bpm
-bre
+dmY
+eMV
+pSD
+jns
+wPE
 jPh
-buN
-byv
-mLK
-bKu
-bKu
-txI
-bFv
-txI
-bKu
-bKu
-bNV
-bNV
-bPC
-ekq
-bSq
-bTJ
-bUU
-bWn
-qZK
-cdr
-cpN
-aaa
+kCp
+xhh
+qTL
+iHc
+xhh
+ioD
+smK
+xmG
+mXa
+veg
+smK
+guk
+guk
+guk
+bLz
+eOo
+eOo
+eOo
+eOo
+dDJ
+msw
+aan
 aaa
 aaa
 aag
@@ -124563,34 +122084,34 @@ wom
 xcQ
 bAi
 bwB
-brb
-blS
-aKQ
-bpn
-brf
-nbA
-doR
+fvL
+eMV
+dXc
+eMV
+uXt
+aEa
+ilr
 mnu
-jKa
-bKu
-bQN
-gDA
-gDA
-qWb
-gcc
-bSu
-btJ
-bNQ
-rfQ
-bQZ
-bSu
-bTO
-cfQ
-cfQ
-cfQ
+xhh
+dmG
+kwV
+saz
+smK
+tmG
+mXa
+haH
+smK
+rSa
+mjn
+kRG
+mhG
+blj
+jYr
+yei
+wSG
 bYH
-bYH
-aaf
+hrh
+aan
 aaf
 aaf
 aag
@@ -124821,34 +122342,34 @@ wpq
 xdX
 xPe
 pXX
-aNI
-blT
-lPn
-gAD
-aNI
+jDp
+jDp
+wQd
+pmv
+wPE
 tpX
 kCp
-wTX
-dqF
-bAj
-uGj
-bfW
-eqD
-jPU
-hdj
-eNz
-pUX
-bNR
-eLf
-jzA
-fVj
-bTO
-tye
+xhh
+xhh
+dmG
+xxU
+ehH
+bti
+hNx
+mXa
+veg
+smK
+jIe
+kIW
+dZi
+hkP
 xQy
-rKQ
+efN
+wIs
 bYI
-bYH
-aaa
+bYI
+psB
+aan
 aaa
 aaa
 aag
@@ -125078,35 +122599,35 @@ vvJ
 vvJ
 xeF
 xPX
-doR
-kzp
-blU
-brg
-aMp
-day
-aXf
-doR
-wXc
-otO
-bFv
-bVa
-bDT
-bFy
-bHo
-bIS
-bNV
-bNM
-bNS
-bUY
-bHD
-bSt
-bTM
-bUX
-bWp
-bXv
-cpQ
-bYH
-aaa
+wDy
+eMV
+eMV
+dXc
+wuU
+wPE
+nbA
+tzA
+dmT
+hko
+vff
+lCG
+nmU
+smK
+lXy
+iNz
+vGD
+vzQ
+bPD
+itv
+pVq
+rwk
+lnk
+dXn
+rNm
+vqj
+bYI
+aWS
+aan
 aaa
 aaa
 wWX
@@ -125338,33 +122859,33 @@ xeT
 xPX
 wDy
 eMV
-nrg
-umI
 eMV
-eMV
-avH
-vpD
-nql
+dXc
+wuU
+eaL
+eyk
+bti
+bti
 vZc
 enc
-ifw
-bDU
-bVc
-bkZ
-bPK
-xRa
+vZc
+bti
+smK
+xmG
+hcJ
+qhr
 btL
-bNT
-rfQ
-bQY
-rCx
-bTO
-jYr
-bWq
-bWq
-oZp
-bYH
-aaa
+iII
+fHT
+bGY
+lWv
+xQy
+cpQ
+tdH
+pyj
+bYI
+oxI
+aan
 aaa
 aaa
 aag
@@ -125595,34 +123116,34 @@ aWf
 xeV
 xTX
 bwB
-nwc
-rXR
-xft
-dNI
-jnc
-hBM
-doR
-mhL
-gIc
-bKu
-geI
-bDV
-ajf
-bHp
-bIT
-bSu
-bMf
-bNU
-rfQ
-bQZ
-bSu
-bTO
-bWr
-bWr
-bWr
-bYH
-bYH
-aaf
+sNu
+iWN
+kbf
+wuU
+rCA
+owp
+mEB
+mot
+xap
+bUX
+sDn
+ulo
+smK
+cck
+xjl
+ycr
+smK
+vmR
+bFb
+iUR
+gGb
+xQy
+djx
+ftn
+oZp
+sHZ
+mpt
+aan
 aaf
 aaf
 aag
@@ -125852,38 +123373,38 @@ tdm
 wqL
 xhM
 xhM
-eCW
+aGd
 ufJ
-wKQ
-nSF
-wKQ
-wKQ
-eCW
-eCW
+eMV
+wHm
+nZO
+oDD
+oDD
+tpC
 ccK
-inE
-bKF
-bKF
-rKm
-vHe
-bHq
-bKF
-bKF
-bNV
-bNV
-bPC
-bRa
-lWH
-eEj
-izw
-iho
-vzz
-mmn
-lWH
+mWI
+qzp
+ymg
+dur
+bvY
+fSN
+nIu
+pfU
+smK
+oYF
+ijM
+rqf
+guk
+dbD
+dBO
+ftn
+giB
+vNi
+vNi
+aan
 aaa
 aaa
 aaa
-aag
 aaa
 aaa
 aaa
@@ -126110,38 +123631,38 @@ tdq
 rEJ
 xhM
 xZu
-eCW
+bwB
 kXd
 cVH
-vei
-cpT
-ief
-dYS
-mEB
-oZU
-fdL
-nCH
-hVN
-bWt
-bVb
-bHr
-shD
-bKF
-vmR
-bNW
-bUY
-bRb
-wQR
-bTQ
-pRA
-naz
-cgg
-dpP
-lWH
+eMV
+bQT
+jDp
+jDp
+uyf
+vCE
+uAV
+rJd
+uAV
+xjx
+uAV
+fbU
+sqw
+gXe
+smK
+ouS
+ijM
+xzk
+guk
+owh
+vJQ
+hsE
+giB
+vNi
+peQ
+aan
 aaa
 aaa
-aag
-aag
+aaa
 aaa
 aaa
 aaa
@@ -126368,37 +123889,37 @@ vAp
 wrf
 xhM
 rJB
-eCW
+bwB
 sSp
 pjG
-rHH
-yhv
-rHH
-cUx
-mEB
-tlx
-fdL
-wum
-pMZ
-bfE
-jEj
-bHs
-bnw
-bKF
-bPG
-bNX
-hBg
-bHE
+aKO
+cpN
+vKK
+vKK
+vyy
+mot
+nXJ
+vFY
+qxZ
+tej
+smK
+vMI
+mXa
+veg
+smK
+guk
+pib
+guk
 bSx
-bTR
-wCh
-uhF
-wCh
-wbS
-lWH
+bSx
+bSx
+bSx
+bSx
+dyG
+aan
+aan
 aaa
 aaa
-aag
 aaa
 aaa
 aaa
@@ -126627,36 +124148,36 @@ aWf
 xiE
 ydn
 eCW
-nxR
-fEi
+hzO
+hzO
 xLt
 tpy
 uSo
-keY
-mJB
-ive
-phg
-ugC
-apP
-oJW
-bFD
-bHt
+tpy
+hzO
+hzO
+hzO
+wzV
+wzV
+wzV
+wzV
+oIP
 esc
-bKF
-btH
-bNY
-vqA
-bHF
-xTW
-bTS
-bVd
-stu
-uYj
-jyp
-lWH
-aaf
-aaf
-aaf
+kBM
+wzV
+etu
+aHU
+eer
+cWm
+blT
+jpo
+jVi
+dxw
+dFK
+aaa
+aaa
+aaa
+aAs
 aaa
 aaa
 aaa
@@ -126885,36 +124406,36 @@ sqd
 pzW
 qHW
 eCW
-seX
-pjG
-rHH
-gFH
-rHH
-ljh
-fsn
-lMf
-foG
-wum
-vqv
-qAA
-saz
-bAk
-llv
-bKF
-btU
-bNM
-rfQ
-xFC
-bSx
-flL
-jlu
-jZp
-ihG
-rGX
-lWH
+ahx
+aPm
+iFo
+iFo
+iFo
+mws
+qNd
+kCB
+hzO
+mNm
+mIa
+sdo
+bOP
+owe
+bcz
+uiw
+mUF
+xNH
+twY
+fRV
+cWm
+kvL
+hqm
+inS
+lVF
+dFK
 aaa
 aaa
-aag
+aaa
+aAs
 aaa
 aaa
 aaa
@@ -127143,36 +124664,36 @@ sql
 pzW
 qHW
 eCW
-mCf
-gjl
-uMy
-eXs
-hCX
-lwA
-eCW
-wML
-fAl
-bKF
-ilr
-oRX
-pOe
-bHu
-eLH
-bKF
-bMh
-bOa
-rfQ
-iuA
-jyb
-jyb
-jyb
-jyb
-vNi
-lWH
-lWH
+pPL
+bbE
+rHH
+oUc
+wdC
+avH
+izy
+tCB
+hzO
+eaS
+pMJ
+tnH
+xYT
+pMJ
+pMJ
+qUr
+niR
+eii
+vbK
+lfu
+dga
+mQu
+oYJ
+ulX
+ohm
+dFK
 aaa
 aaa
-aag
+aaa
+aAs
 aaa
 aaa
 aaa
@@ -127401,36 +124922,36 @@ sql
 pzW
 qJk
 eCW
-mEB
-mEB
-eSw
-eCW
-eCW
-eCW
-eCW
-gDC
-nby
-bOb
-bOb
-qrI
-bOb
-bOb
-bOb
-bOb
-bOb
-bOb
-eMm
-cVI
-nvr
-gPc
-uTu
-kmi
-vNi
-aaa
-aaa
-aaa
+aMo
+avH
+aUb
+rbu
+sWm
+rHH
+rHH
+hsX
+mtf
+ezb
+pMJ
+pMJ
+xYT
+pMJ
+pMJ
+xcn
+put
+jya
+rom
+guU
+wzV
+nXw
+nXw
+nXw
+nXw
+jez
 aaf
-wWX
+aaf
+aaf
+aAs
 aaa
 aaa
 aaa
@@ -127658,37 +125179,37 @@ sql
 sql
 pzW
 qHW
-jpX
-vRU
-hPZ
-ccj
-wXx
-ogH
-uOL
-qxs
-xIp
-pXr
-bOb
-sTb
-thF
-lZV
-nId
-kcc
-rOO
-jXw
-bOb
-soy
-rYP
-jyb
-hWO
-whb
-xDM
-vNi
+eCW
+dAe
+bfD
+xbj
+cPo
+ivX
+oRe
+oRe
+vOh
+hzO
+pag
+pMJ
+pMJ
+xYT
+pMJ
+pMJ
+kqk
+wzV
+mkH
+pPW
+wyi
+dcV
+gIx
+sSz
+ndr
+sXf
+qLb
 aaa
 aaa
 aaa
-aaf
-aaa
+aAs
 aaa
 aaa
 aaa
@@ -127916,36 +125437,36 @@ sql
 sql
 pzW
 qHW
-jpX
-tHW
-tAA
-eNU
-mTV
-wZh
-uhE
-ngi
-shQ
-lUr
-bOb
-xVJ
-mjR
-dCI
-cri
-dCI
-dCI
-eOl
-bOb
-ebw
-wbc
-jyb
-okt
-rSH
-qws
-vNi
+eCW
+kQR
+qXJ
+qAJ
+blR
+hlq
+dTh
+wwM
+wnI
+nWP
+ycm
+pMJ
+tnY
+jmf
+jkV
+pMJ
+eXt
+wzV
+gRV
+cjY
+uVi
+dcV
+hOz
+xaQ
+rGJ
+sNT
+qLb
 aaa
 aaa
 aaa
-aag
 aaa
 aaa
 aaa
@@ -128175,36 +125696,36 @@ sql
 pzW
 qHW
 jpX
-ijR
-xnd
-vGd
-cEH
-rra
-hPS
-hyq
-lQC
-hSQ
-bOb
+aql
+aql
+aql
+aql
+aql
+aql
+iOS
+wnI
+xLt
 ycm
-mfB
-lhc
-qsK
-jKM
-wer
-lnJ
-bOb
-wVM
-snu
-nDN
-nDN
-nDN
-nDN
-gVw
-aaf
-aaf
-aaf
-aag
+pMJ
+qVK
+wzV
+wbS
+pMJ
+kqk
+wzV
+aNy
+bMM
+bcz
+dga
+gnV
+gfm
+pTC
+bHU
+qLb
 aaa
+aaa
+aaa
+wxw
 aaa
 aaa
 aaa
@@ -128433,35 +125954,35 @@ pzW
 pzW
 ydH
 jpX
-aql
-aql
-aql
-aql
-aql
-aql
-aql
-wNw
-lUr
-bOb
-lvF
-gQT
-xdw
-gjr
-reJ
-hcg
-pQo
-bOb
-fek
-nqY
-drJ
-wls
-lUA
-vda
-cda
+tAA
+tAA
+tAA
+tAA
+wza
+flL
+lvy
+wnI
+nWP
+ycm
+pMJ
+dni
+ezE
+xlz
+pMJ
+eXt
+tWs
+toe
+toe
+toe
+nXw
+jez
+jez
+jez
+jez
+jez
 aaa
 aaa
 aaa
-aag
 aaa
 aaa
 aaa
@@ -128690,36 +126211,36 @@ vAY
 wrn
 qHW
 yeN
-rEl
-jOR
-mjw
-iZI
-rPr
-deQ
-fSb
+jpX
+vxB
+vdN
+qFy
+tWw
+hrB
+aql
+kzp
+wnI
 hzO
-kke
-kPH
-bOb
-bOb
-bOb
-bOb
-bOb
-bOb
-bOb
-bOb
-bOb
-mff
-vDT
-evM
-lUC
-stG
-rIN
-qAJ
+wqp
+pMJ
+pMJ
+xYT
+pMJ
+pMJ
+uVi
+toe
+lin
+lin
+lin
+jzc
+xDi
+diB
+xDi
 aaa
 aaa
 aaa
-aaf
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -128948,39 +126469,39 @@ vBP
 rJB
 xiX
 rJB
-rEl
-vIn
-oSv
-oMg
-fsC
-kCx
-oPy
-wdd
-elC
-lUr
-bMW
-hdI
-kUt
-uLm
-fZU
-cSC
-aDv
-eyb
-fZU
-gVm
+jpX
+dhS
+iZA
+kTx
+vNj
+lPE
+aql
+lJU
+wnI
+mtf
+ezb
+pMJ
+pMJ
+xYT
+pMJ
+pMJ
+sLO
+bDJ
+heD
+hAu
+umL
+lwn
+xDi
 xBk
-drJ
-wUp
-ojP
-qtn
-cda
+xDi
+aaa
+aaa
+aaf
+aaa
+aAs
 aaa
 aaa
 aaa
-aab
-aaa
-aaa
-wxw
 aaa
 aaa
 aaa
@@ -129206,36 +126727,36 @@ ooT
 ooT
 xkS
 ygz
-rEl
-lvy
-hlN
-hIR
-vxB
-sHK
-dPW
+jpX
+mup
+mup
+fKO
+esg
+ehu
+aql
+efu
+wnI
 hzO
-wmE
-thu
-lNS
-vUf
-ncQ
-nZD
-fZU
-uOA
-cXd
-nYH
-tbL
-wup
-skp
-wmj
-wmj
-wmj
-wmj
-nGr
-aaa
-aaa
-aaa
-wWX
+xtV
+pMJ
+tUm
+xYT
+pMJ
+pMJ
+gTg
+toe
+acc
+sEO
+cAo
+fni
+xDi
+xDi
+xDi
+aaf
+aaf
+aaf
+aaf
+jeC
 aaa
 aaa
 aaa
@@ -129464,36 +126985,36 @@ vDl
 wry
 wry
 wry
-rEl
-hzO
-hzO
-hzO
-hzO
-hzO
-hzO
+jpX
+aql
+aql
+vGd
+aql
+aql
+aql
 hzO
 qLq
-idT
-iOW
-vUf
-wAw
-iSS
-fZU
-pDg
-aFA
-oKT
-uau
-vOR
-lIY
-rEb
-pOQ
-vxF
-rKn
-bup
+hzO
+pld
+dkI
+iCw
+nrb
+rmL
+jmq
+ieF
+tWs
+hDg
+laa
+fAG
+rJa
+xDi
 aaa
 aaa
 aaa
-aag
+aaa
+aaa
+aAs
+aAs
 aaa
 aaa
 aaa
@@ -129721,37 +127242,37 @@ utJ
 vDV
 wsB
 xkY
-ygD
-kay
-pbh
-oqY
-mpx
-jSL
-opU
-uVT
-uVT
-wvS
-sRL
+ccj
+ccj
+lWo
+tBY
+nax
+rMq
+vli
+env
+vOJ
+dND
 wzV
-mWH
-iXo
-ksd
-fZU
-mkW
-fdB
-iXv
-tbL
-jVI
-oce
-bsC
-sib
-gEj
-avI
-vGS
+wzV
+wzV
+wzV
+hHS
+mML
+rob
+hHS
+tWs
+ogL
+oji
+dQW
+mco
+xDi
+aan
 aaa
 aaa
 aaa
-aag
+aAs
+aAs
+aaa
 aaa
 aaa
 aaa
@@ -129979,39 +127500,39 @@ utZ
 vFV
 wuf
 xnj
-yiw
-wTK
-mTy
-uVg
-nyO
-slm
-fnG
-sZj
-sZj
-cUR
-lRD
-mco
-kTR
-gRL
-ifD
-fZU
-hft
-fJF
-mti
-fZU
-oqh
-xBk
-rEb
-mre
-kzs
-sUz
-bup
+doR
+doR
+doR
+ngO
+uvl
+sPj
+iWJ
+igB
+igB
+bJC
+eOs
+iiL
+cYj
+env
+iZe
+nvi
+utI
+nuO
+tWs
+rYX
+xeH
+aKt
+reA
+jre
+aan
+aaa
+aaa
+aAs
+aAs
 aaa
 aaa
 aaa
-aag
-xka
-xka
+aaa
 aaa
 aaa
 aaa
@@ -130240,36 +127761,36 @@ xom
 xom
 xom
 xom
-xom
-hnG
-hlC
-iJP
-rTw
-rTw
-grM
-rLH
-dTh
-kwY
-pcH
-ulX
-fZU
-fZU
-fZU
-fZU
-fZU
-fgL
-uXT
-hBo
-hBo
-aan
-aan
+mIC
+hsT
+njf
+kri
+rMf
+kUg
+wwN
+vmX
+kIG
+kIG
+tHW
+kIG
+dge
+xEl
+lAw
+tWs
+pcv
+hKC
+dda
+dig
+fti
 aan
 aaf
 aaf
-aaf
-aaf
-lvX
-xka
+aAs
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130498,36 +128019,36 @@ xqf
 yiX
 nSo
 bsx
-xom
-ikX
-dTG
-pzi
-gWf
-haO
-iVk
-uZc
-wlf
-lIk
-dVM
-oqY
-sRD
-hXY
-eXp
-xaT
-mdj
-wCl
-vvd
-xeH
-ibY
+mIC
+exa
+npb
+lqe
+utI
+yiw
+yiw
+oRS
+yiw
+yiw
+utI
+yiw
+yiw
+yiw
+jhp
+xDi
+xDi
+xDi
+xDi
+xDi
+xDi
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aag
-xka
-xka
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -130756,34 +128277,34 @@ xte
 ykL
 ylt
 odi
-xom
-iOS
-xjT
-pkK
-oht
-rxD
-hzq
-jxN
-olr
-owQ
-fYw
-shy
-uzX
-xOe
-uZr
-xEj
-ueM
-tMo
-cde
-srt
-xDi
+mIC
+uLr
+oAi
+tpj
+utI
+mjm
+tpj
+oRS
+wrp
+hox
+utI
+sXq
+oAi
+oAi
+kLC
+wry
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aag
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -131014,34 +128535,34 @@ xtR
 ylt
 uAF
 gDF
-xom
-jjH
-jjH
-egb
-jjH
-jjH
-jjH
-guk
-guk
-ljE
-guk
-guk
-qNE
+mIC
+mIC
+mIC
+mIC
+fZh
+mIC
+mIC
+aXt
+mIC
+mIC
+bsB
+mIC
+mIC
+mIC
 wry
 wry
-wry
-hBo
-xDi
-ibY
-xDi
-hBo
-aaf
 aaa
 aaa
 aaa
 aaa
-aag
-aag
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -131272,19 +128793,24 @@ xuy
 uwS
 jEl
 tJZ
-xom
-aAu
-veJ
-mFN
-hai
-xgD
-jjH
-hBX
-pVe
-mOr
-fuU
-lRy
-qNE
+rPy
+ssb
+fWh
+omj
+lbt
+lUX
+qCy
+lZo
+lBC
+qZw
+xDQ
+xxS
+uIv
+oMj
+nOC
+aaa
+aaf
+aaa
 aaa
 aaa
 aaa
@@ -131293,12 +128819,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
 aaa
-aaa
-aaa
-aag
-aag
 aaa
 aaa
 aaa
@@ -131530,19 +129051,24 @@ xuM
 eBZ
 fdK
 rwm
-xom
-qoZ
-pVZ
-hYU
-vIb
-jgt
-oqS
-oKu
-aZf
-ryn
-vXB
-lTw
-qNE
+rPy
+xff
+mOV
+eAF
+kXG
+lUX
+dKz
+eHZ
+iSd
+qZw
+ibU
+uGB
+mNS
+lcS
+nOC
+aaa
+aaf
+aaa
 aaa
 aaa
 aaa
@@ -131551,11 +129077,6 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aaa
-aaa
-wWX
-aag
 aaa
 aaa
 aaa
@@ -131788,21 +129309,21 @@ xvt
 oIc
 hjH
 dqp
-xom
-mAU
-sPy
-mAU
-xpb
-pLC
-jjH
-fWS
-jFL
-vGp
-eKB
-uOH
-qNE
-aaa
-aaa
+rPy
+bkl
+xTd
+ukS
+tll
+lUX
+hRf
+vZm
+iSd
+qZw
+gdX
+dmP
+iFS
+czT
+nOC
 aaa
 aaf
 aaa
@@ -131811,8 +129332,8 @@ aag
 aag
 aag
 aag
-aaf
-cuR
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -132046,21 +129567,21 @@ xvw
 jgx
 joH
 vcY
-xom
-xff
-jjH
-gyD
-nFF
-nFF
-nFF
-qNE
-eYr
-gro
-eYr
-qNE
-qNE
-aaa
-aaa
+rPy
+xsw
+hdM
+ibK
+tll
+lUX
+wwe
+jqm
+iSd
+qZw
+gdX
+xTK
+wOD
+vJe
+nOC
 cuR
 cuR
 wWX
@@ -132304,21 +129825,21 @@ xwa
 lWR
 pUs
 lod
-xom
+rPy
 ttQ
-jjH
+fuA
 cXz
-nFF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
+mIO
+lUX
+wht
+jEx
+pjv
+qZw
+vok
+sUI
+jzk
+qjR
+nOC
 aaa
 aaa
 aaa
@@ -132562,21 +130083,21 @@ xwr
 efB
 nHi
 rZK
-wuH
 nFF
 nFF
 nFF
+bOb
 nFF
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
+nFF
+gDA
+gDA
+gDA
+nOC
+nOC
+vUf
+nOC
+nOC
+nOC
 aaa
 aaa
 aaa
@@ -132824,15 +130345,15 @@ wec
 lYK
 aaa
 aaa
-aaf
-aaa
-aaa
-wxw
 aaa
 aaa
 aaa
 aaa
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -134117,7 +131638,7 @@ aaa
 aab
 aaa
 aaa
-aaa
+wxw
 aaa
 aaa
 aaa


### PR DESCRIPTION
- Full overhaul of the Medbay Department for both look and functionality.

- Adds 1 more full body scanner and sleeper

- Separates into a general and sterile section of Medbay for both realism and organization.

- Better breakroom for our lovely medical staff.

- New Medbay Pet (Runtime is still there) Phora the Chemistry Carp (Butchering loot is disabled, no easy Carpotoxin)

- EMT Bay expanded slightly and given an O2 tank.

- Mental Health Office moved into a logical location, better access by the public in hopes to encourage Phych RP

- Some new equipment as well as Wardrobe vendors.

- Public Chem vendor for chems that Medbay is okay with giving to any who need it. (Still access locked)

Overhaul was made with RP, Functionality, and Visuals in mind, in that order.