### PR TITLE
A survival pod in a superposition, just for Kassc

### DIFF
--- a/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
+++ b/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
@@ -1,0 +1,125 @@
+// Unique areas were requested for each superpose map for future use. The plain superpose area is for future varedits to all superpose submaps.
+/area/survivalpod/superpose
+
+/area/survivalpod/superpose/CrashedInfestedShip
+
+/area/survivalpod/superpose/CrashedQurantineShip
+
+/area/survivalpod/superpose/CultShip
+
+/area/survivalpod/superpose/DemonPool
+
+/area/survivalpod/superpose/Dinner
+
+/area/survivalpod/superpose/ExplorerHome
+
+/area/survivalpod/superpose/Farm
+
+/area/survivalpod/superpose/FieldLab
+
+/area/survivalpod/superpose/HellCave
+
+/area/survivalpod/superpose/HydroCave
+
+/area/survivalpod/superpose/LargeAlienShip
+
+/area/survivalpod/superpose/LoneHome
+
+/area/survivalpod/superpose/MechFabShip
+
+/area/survivalpod/superpose/MechStorageFab
+
+/area/survivalpod/superpose/MercShip
+
+/area/survivalpod/superpose/MethLab
+
+/area/survivalpod/superpose/OldHotel
+
+/area/survivalpod/superpose/ScienceShip
+
+/area/survivalpod/superpose/SmallCombatShip
+
+/area/survivalpod/superpose/SurvivalBarracks
+
+/area/survivalpod/superpose/SurvivalCargo
+
+/area/survivalpod/superpose/SurvivalDIY_11x11
+
+/area/survivalpod/superpose/SurvivalDIY_7x7
+
+/area/survivalpod/superpose/SurvivalDIY_9x9
+
+/area/survivalpod/superpose/SurvivalDinner
+
+/area/survivalpod/superpose/SurvivalEngineering
+
+/area/survivalpod/superpose/SurvivalHome
+
+/area/survivalpod/superpose/SurvivalHydro
+
+/area/survivalpod/superpose/SurvivalJanitor
+
+/area/survivalpod/superpose/SurvivalLeisure
+
+/area/survivalpod/superpose/SurvivalLuxuryBar
+
+/area/survivalpod/superpose/SurvivalLuxuryHome
+
+/area/survivalpod/superpose/SurvivalMedical
+
+/area/survivalpod/superpose/SurvivalPool
+
+/area/survivalpod/superpose/SurvivalQuarters
+
+/area/survivalpod/superpose/SurvivalScience
+
+/area/survivalpod/superpose/SurvivalSecurity
+
+/area/survivalpod/superpose/TinyCombatShip
+
+/area/survivalpod/superpose/TradingShip
+
+/area/survivalpod/superpose/WoodenCamp
+
+/obj/item/device/survivalcapsule/superpose
+	name = "superposed surfluid shelter capsule"
+	desc = "A proprietary hyperstructure of many three-dimensional spaces superposed around a supermatter nano crystal; use a pen to reach the reset button. There's a license for use printed on the bottom."
+	description_info = "The capsule contains pockets of compressed space in a super position stabilized by a miniscule supermatter crystal. \
+	NanoTrasen stresses the safety of this model over previous prototypes but assumes no liability for sub-kiloton explosions."
+	template_id = null
+	var/list/template_ids = list()
+	var/pod_initialized = FALSE
+
+// Override since the parent proc has a sanity check to delete the capsule if no template is found, which doesn't exactly work with this item considering examining calls this proc.
+/obj/item/device/survivalcapsule/superpose/get_template()
+	if(template)
+		return
+	template = SSmapping.shelter_templates[template_id]
+	if(!template)
+		template = null
+
+/obj/item/device/survivalcapsule/superpose/attack_self()
+	if(!pod_initialized) // Populate list after round start as map templates might not exist when this item is created.
+		for(var/datum/map_template/shelter/superpose/shelter_type as anything in subtypesof(/datum/map_template/shelter))
+			if(!(initial(shelter_type.mappath)) || !(initial(shelter_type.superpose))) // Limits map templates to those marked for the superpose capsule.
+				continue
+			template_ids += initial(shelter_type.shelter_id)
+		pod_initialized = TRUE
+	if(!template_id)
+		var/answer = tgui_input_list(usr, "Which template would you like to load?","Available Templates", template_ids)
+		if(!answer)
+			return
+		else
+			src.template_id = answer
+			return // Return here or the pod will activate as soon as a selection is made.
+
+	// Now we call super to run the rest of the parent proc since the choice has been handled.
+	..()
+
+// Allows resetting the capsule if the wrong template is chosen.
+/obj/item/device/survivalcapsule/superpose/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/weapon/pen) && !used)
+		template_id = null
+		template = null // Important to reset both, otherwise the template cannot be reset once the pod has been deployed.
+		to_chat(user, "<span class='notice'>You reset the pod's selection.</span>")
+	..()

--- a/modular_chomp/code/modules/mining/shelters_ch.dm
+++ b/modular_chomp/code/modules/mining/shelters_ch.dm
@@ -1,0 +1,169 @@
+/datum/map_template/shelter
+	var/superpose = FALSE
+
+// Subtype to mark maps for use with the superpose capsule. This is mostly to prevent automatic additions from upstream changes.
+/datum/map_template/shelter/superpose
+	superpose = TRUE
+	name = "ERROR: string 'name' cannot be null!"
+	description = "ERROR: string 'description' cannot be null!"
+	mappath = null
+
+/datum/map_template/shelter/superpose/CrashedInfestedShip
+	shelter_id = "CrashedInfestedShip"
+	mappath = "modular_chomp/maps/submaps/shelters/CrashedInfestedShip-60x29.dmm"
+
+/datum/map_template/shelter/superpose/CrashedQurantineShip
+	shelter_id = "CrashedQurantineShip"
+	mappath = "modular_chomp/maps/submaps/shelters/CrashedQurantineShip-25x25.dmm"
+
+/datum/map_template/shelter/superpose/CultShip
+	shelter_id = "CultShip"
+	mappath = "modular_chomp/maps/submaps/shelters/CultShip-28x17.dmm"
+
+/datum/map_template/shelter/superpose/DemonPool
+	shelter_id = "DemonPool"
+	mappath = "modular_chomp/maps/submaps/shelters/DemonPool-21x21.dmm"
+
+/datum/map_template/shelter/superpose/Dinner
+	shelter_id = "Dinner"
+	mappath = "modular_chomp/maps/submaps/shelters/Dinner-25x25.dmm"
+
+/datum/map_template/shelter/superpose/ExplorerHome
+	shelter_id = "ExplorerHome"
+	mappath = "modular_chomp/maps/submaps/shelters/ExplorerHome-17x20.dmm"
+
+/datum/map_template/shelter/superpose/Farm
+	shelter_id = "Farm"
+	mappath = "modular_chomp/maps/submaps/shelters/Farm-32x32.dmm"
+
+/datum/map_template/shelter/superpose/FieldLab
+	shelter_id = "FieldLab"
+	mappath = "modular_chomp/maps/submaps/shelters/FieldLab-20x20.dmm"
+
+/datum/map_template/shelter/superpose/HellCave
+	shelter_id = "HellCave"
+	mappath = "modular_chomp/maps/submaps/shelters/HellCave-40x25.dmm"
+
+/datum/map_template/shelter/superpose/HydroCave
+	shelter_id = "HydroCave"
+	mappath = "modular_chomp/maps/submaps/shelters/HydroCave-40x40.dmm"
+
+/datum/map_template/shelter/superpose/LargeAlienShip
+	shelter_id = "LargeAlienShip"
+	mappath = "modular_chomp/maps/submaps/shelters/LargeAlienShip-60x29.dmm"
+
+/datum/map_template/shelter/superpose/LoneHome
+	shelter_id = "LoneHome"
+	mappath = "modular_chomp/maps/submaps/shelters/LoneHome-20x25.dmm"
+
+/datum/map_template/shelter/superpose/MechFabShip
+	shelter_id = "MechFabShip"
+	mappath = "modular_chomp/maps/submaps/shelters/MechFabShip-27x24.dmm"
+
+/datum/map_template/shelter/superpose/MechStorageFab
+	shelter_id = "MechStorageFab"
+	mappath = "modular_chomp/maps/submaps/shelters/MechStorageFab-32x24.dmm"
+
+/datum/map_template/shelter/superpose/MercShip
+	shelter_id = "MercShip"
+	mappath = "modular_chomp/maps/submaps/shelters/MercShip-60x29.dmm"
+
+/datum/map_template/shelter/superpose/MethLab
+	shelter_id = "MethLab"
+	mappath = "modular_chomp/maps/submaps/shelters/MethLab-20x20.dmm"
+
+/datum/map_template/shelter/superpose/OldHotel
+	shelter_id = "OldHotel"
+	mappath = "modular_chomp/maps/submaps/shelters/OldHotel-25x25.dmm"
+
+/datum/map_template/shelter/superpose/ScienceShip
+	shelter_id = "ScienceShip"
+	mappath = "modular_chomp/maps/submaps/shelters/ScienceShip-25x33.dmm"
+
+/datum/map_template/shelter/superpose/SmallCombatShip
+	shelter_id = "SmallCombatShip"
+	mappath = "modular_chomp/maps/submaps/shelters/SmallCombatShip-9x11.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalBarracks
+	shelter_id = "SurvivalBarracks"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalBarracks-11x11.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalCargo
+	shelter_id = "SurvivalCargo"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalCargo-11x11.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalDIY_11x11
+	shelter_id = "SurvivalDIY_11x11"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalDIY-11x11.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalDIY_7x7
+	shelter_id = "SurvivalDIY_7x7"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalDIY-7x7.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalDIY_9x9
+	shelter_id = "SurvivalDIY_9x9"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalDIY-9x9.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalDinner
+	shelter_id = "SurvivalDinner"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalDinner-11x11.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalEngineering
+	shelter_id = "SurvivalEngineering"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalEngineering-9x9.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalHome
+	shelter_id = "SurvivalHome"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalHome-9x9.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalHydro
+	shelter_id = "SurvivalHydro"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalHydro-9x9.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalJanitor
+	shelter_id = "SurvivalJanitor"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalJanitor-7x7.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalLeisure
+	shelter_id = "SurvivalLeisure"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalLeisure-9x9.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalLuxuryBar
+	shelter_id = "SurvivalLuxuryBar"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalLuxuryBar-11x11.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalLuxuryHome
+	shelter_id = "SurvivalLuxuryHome"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalLuxuryHome-11x11.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalMedical
+	shelter_id = "SurvivalMedical"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalMedical-9x9.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalPool
+	shelter_id = "SurvivalPool"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalPool-11x11.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalQuarters
+	shelter_id = "SurvivalQuarters"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalQuarters-9x9.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalScience
+	shelter_id = "SurvivalScience"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalScience-9x9.dmm"
+
+/datum/map_template/shelter/superpose/SurvivalSecurity
+	shelter_id = "SurvivalSecurity"
+	mappath = "modular_chomp/maps/submaps/shelters/SurvivalSecurity-9x9.dmm"
+
+/datum/map_template/shelter/superpose/TinyCombatShip
+	shelter_id = "TinyCombatShip"
+	mappath = "modular_chomp/maps/submaps/shelters/TinyCombatShip-9x7.dmm"
+
+/datum/map_template/shelter/superpose/TradingShip
+	shelter_id = "TradingShip"
+	mappath = "modular_chomp/maps/submaps/shelters/TradingShip-40x22.dmm"
+
+/datum/map_template/shelter/superpose/WoodenCamp
+	shelter_id = "WoodenCamp"
+	mappath = "modular_chomp/maps/submaps/shelters/WoodenCamp-10x10.dmm"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4505,6 +4505,8 @@
 #include "modular_chomp\code\modules\emotes\definitions\audiable.dm"
 #include "modular_chomp\code\modules\food\drinkgglass\metaglass.dm"
 #include "modular_chomp\code\modules\food\food\drinks\bottle.dm"
+#include "modular_chomp\code\modules\mining\shelter_atoms_ch.dm"
+#include "modular_chomp\code\modules\mining\shelters_ch.dm"
 #include "modular_chomp\code\modules\mob\holder.dm"
 #include "modular_chomp\code\modules\mob\mob.dm"
 #include "modular_chomp\code\modules\mob\living\emote.dm"


### PR DESCRIPTION
Request from Kassc, I don't entirely know what he'll be using it for.
-Adds a survival pod capable of selecting any map template from the superpose subtype.
-Adds Kassc's 40 maps to said subtype.
-Adds areas for said maps.

The superposition pod allows the user to choose from a selection of map templates. If you change your mind after picking one, use a pen to reset the pod.

"BUT NADYYYYYYYYR, THIS IS unFiNIshEdddDDD"
Yes, this is largely skeleton code for Kassc to fill in the details later. That's also why the maps were merged, so I could make this so he can use it for his current project. 