### PR TITLE
Revert "[MIRROR] Makes wounds disappear"

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -595,8 +595,6 @@ This function completely restores a damaged organ to perfect condition.
 		return 1
 	else
 		last_dam = brute_dam + burn_dam
-	if (number_wounds != 0)
-		return 1
 	if(germ_level)
 		return 1
 	return 0
@@ -733,8 +731,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		return
 
 	for(var/datum/wound/W in wounds)
-		// wounds used to be able to disappear after 10 minutes at the earliest, for now just remove them as soon as there is no damage
-		if(W.damage <= 0)
+		// wounds can disappear after 10 minutes at the earliest
+		if(W.damage <= 0 && W.created + 10 * 10 * 60 <= world.time)
 			wounds -= W
 			continue
 			// let the GC handle the deletion of the wound


### PR DESCRIPTION
Reverts CHOMPStation2/CHOMPStation2#4680

I think this might be causing a recent issue where you can't clamp bleeders from shrapnel wounds. Taking a blind guess with this.
This is also an upstream issue.