### PR TITLE
Rename grit pathname

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -216,7 +216,7 @@
 	varchange_type = TRAIT_VARCHANGE_MORE_BETTER
 */
 
-/datum/trait/positive/pain_tolerance
+/datum/trait/positive/trauma_tolerance //CHOMPEdit renamed because we already have pain_tolerance pathname for halloss damage resistance.
 	name = "Grit"
 	desc = "You can keep going a little longer, a little harder when you get hurt, Injuries only inflict 85% as much pain, and slowdown from pain is 85% as effective."
 	cost = 2


### PR DESCRIPTION
Renamed Grit pathname because we already have pain_tolerance pathname for halloss damage resistance. It was overwriting Grit.