### PR TITLE
Defib Buff

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -308,8 +308,8 @@
 		return bad_vital_organ
 
 	//this needs to be last since if any of the 'other conditions are met their messages take precedence
-	if(!H.client && !H.teleop)
-		return "buzzes, \"Resuscitation failed - Mental interface error. Further attempts may be successful.\""
+	//if(!H.client && !H.teleop)
+	//	return "buzzes, \"Resuscitation failed - Mental interface error. Further attempts may be successful.\""// CHOMPEdit, removing this check to allow revival through bad internet connections.
 
 	return null
 


### PR DESCRIPTION
Removes the mental interface error on defibs.

Nothing is more annoying for players, medical and patient alike, for an OOC issue to bleed into an in-character one.

A brief bout of afk frustration or loss of internet leading medical to try and revive you using many chems, then giving up an leaving you for dead... A Search and Rescue going out to rescue someone in such a state... Why punish players of medical for doing their job with a no-sale at the absolute last step?

Bonus points, monkey's are now revivable. Yay!