### PR TITLE
[WIP] Updated Promethean Revive

### DIFF
--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -280,7 +280,7 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 	name = "Promethean Revival"
 	id = "prom_revival"
 	result = null
-	required_reagents = list("phoron" = 40)
+	required_reagents = list("phoron" = 20) // CHOMPEdit Cost reduction from 40 to 20 to match other mobs cost
 	result_amount = 1
 
 /decl/chemical_reaction/instant/promethean_brain_revival/can_happen(var/datum/reagents/holder)
@@ -293,7 +293,8 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 	if(brain.reviveBody())
 		brain.visible_message("<span class='notice'>[brain] bubbles, surrounding itself with a rapidly expanding mass of slime!</span>")
 	else
-		brain.visible_message("<span class='warning'>[brain] shifts strangely, but falls still.</span>")
+		brain.visible_message("<span class='warning'>[brain] shifts strangely, solidifying the injected phoron into a crystal before becoming dormant.</span>") // CHOMPEdit Changed message
+		new /obj/item/stack/material/phoron(holder.my_atom) // CHOMPAdd Allow the phoron from the failed attempt to be used when client reconnects
 
 /obj/item/organ/internal/brain/golem
 	name = "chem"


### PR DESCRIPTION
Promethean revival reaction will now leave a solid chunk of phoron in the slime core on failure, allowing the Promethean to revive themselves in the future when/if they reconnect for that session.

WIP TO-DO LIST:
Add verb to allow post-failure phoron crystal check and revival.

Allow examining the core to determine if it's got a crystal in it already, so we don't use up even more phoron. Possible spritework?

Fix bug where gibbed prommie's -genesis networks splatter with default human blood instead of inheriting the prommie's blood.