### PR TITLE
Earlyports fix for cleanbot runtime spam

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -297,7 +297,8 @@
 	return
 
 /mob/living/bot/proc/handleFrustrated(var/targ)
-	obstacle = targ ? target_path[1] : patrol_path[1]
+	if((targ && LAZYLEN(target_path)) || LAZYLEN(patrol_path))
+		obstacle = targ ? target_path[1] : patrol_path[1]
 	target_path = list()
 	patrol_path = list()
 	return


### PR DESCRIPTION
Not gonna find an obstacle in a nonexistent path.