### PR TITLE
Allow all mobs and punpun to be spontaneously vored

### DIFF
--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -12,3 +12,4 @@
 	real_name = name
 	w_uniform = new /obj/item/clothing/under/punpun(src)
 	regenerate_icons()
+	can_be_drop_prey = TRUE //CHOMP Add

--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -5,7 +5,6 @@
 	worn_state = "punpun"
 	has_sensor = 0
 	species_restricted = list("Monkey")
-	can_be_drop_prey = TRUE //CHOMP Add
 
 /mob/living/carbon/human/monkey/punpun/Initialize()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -5,6 +5,7 @@
 	worn_state = "punpun"
 	has_sensor = 0
 	species_restricted = list("Monkey")
+	can_be_drop_prey = TRUE //CHOMP Add
 
 /mob/living/carbon/human/monkey/punpun/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -54,6 +54,7 @@
 	var/obj/item/device/radio/headset/mob_radio		//Adminbus headset for simplemob shenanigans.
 	does_spin = FALSE
 	can_be_drop_pred = TRUE				// Mobs are pred by default.
+	can_be_drop_prey = TRUE				//CHOMP Add This also counts for spontaneous prey for telenoms and phase noms.
 	var/damage_threshold  = 0 //For some mobs, they have a damage threshold required to deal damage to them.
 
 


### PR DESCRIPTION
All mobs and punpun can be spontaneously vored. That includes drop, tele, and phase noms.

Remember that vore is an RP tool, not a mechanics tool. If you telenom a boss monster, you will be bwoinked, possibly gibbed (especially because that's funny).