### PR TITLE
Multiple Bugfixes for Live Runtimes

### DIFF
--- a/code/game/turfs/simulated/wall_types.dm
+++ b/code/game/turfs/simulated/wall_types.dm
@@ -79,17 +79,12 @@
 	. = ..(mapload, "resin",null,"resin")
 
 /turf/simulated/wall/concrete
-	desc = "A wall made out of concrete bricks"
-	material = MAT_CONCRETE
 	icon_state = "brick"
 
 /turf/simulated/wall/concrete/Initialize(mapload)
 	. = ..(mapload, "concrete") //3strong
 
 /turf/simulated/wall/r_concrete
-	desc = "A sturdy wall made of concrete and reinforced with plasteel rebar"
-	material = MAT_CONCRETE
-	reinf_material = MAT_PLASTEELREBAR
 	icon_state = "rbrick"
 
 /turf/simulated/wall/r_concrete/Initialize(mapload)
@@ -431,7 +426,7 @@
 					if(decided_to_blend)
 						dirs += direction
 						break blend_obj_loop // breaks outer loop
-						
+
 /turf/simulated/wall/eris/r_wall
 	icon_state = "rgeneric"
 /turf/simulated/wall/eris/r_wall/Initialize(mapload)
@@ -444,7 +439,7 @@
 	wall_masks = 'icons/turf/wall_masks_bay.dmi'
 	var/list/blend_objects = list(/obj/machinery/door)
 	var/list/noblend_objects = list(/obj/machinery/door/window, /obj/machinery/door/firedoor)
-	
+
 	var/stripe_color // Adds a colored stripe to the walls
 
 /turf/simulated/wall/bay/can_join_with_low_wall(var/obj/structure/low_wall/WF)
@@ -458,7 +453,7 @@
 			I = image(wall_masks, "stripe[wall_connections[i]]", dir = 1<<(i-1))
 			I.color = stripe_color
 			add_overlay(I)
-			
+
 /turf/simulated/wall/bay/special_wall_connections(list/dirs, list/inrange)
 	..()
 	for(var/direction in cardinal)

--- a/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
+++ b/maps/submaps/surface_submaps/wilderness/wilderness_areas.dm
@@ -48,8 +48,8 @@
 /area/submap/ChemSpill2
 	name = "POI Wilderness - Acrid Lake"
 	ambience = AMBIENCE_FOREBODING
- 
- /area/submap/CultBar
+
+/area/submap/CultBar
 	name = "POI - Cult Bar"
 	ambience = AMBIENCE_GHOSTLY
 
@@ -80,9 +80,9 @@
 /area/submap/Drugd
 	name = "POI Wilderness - Drug Den"
 	ambience = AMBIENCE_FOREBODING
- 
- /area/submap/DugOutMercs
-	name = "POI - Dug Out Mercanries"
+
+/area/submap/DugOutMercs
+	name = "POI - Dug Out Mercenaries"
 	ambience = AMBIENCE_HIGHSEC
 
 /area/submap/Cragzone1
@@ -156,8 +156,8 @@
 /area/submap/Manor1
 	name = "POI Wilderness - Manor House"
 	ambience = AMBIENCE_FOREBODING
- 
- /area/submap/MechHanger
+
+/area/submap/MechHanger
 	name = "POI - Mech Hanger"
 	ambience = AMBIENCE_SIF
 


### PR DESCRIPTION
* Fixes relative path warning due to errant spaces added in wilderness_areas.dm
* Fixes concrete mat runtime in pre-mapped walls. Big thanks to Heroman for identifying it in https://github.com/VOREStation/VOREStation/pull/13792
