### PR TITLE
Prevents simple_mobs from using emergency_shutdown, eject_usb and eject_id

### DIFF
--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -12,7 +12,7 @@
 	set category = "Object"
 	set src in view(1)
 
-	if(usr.incapacitated() || !istype(usr, /mob/living))
+	if(usr.incapacitated() || !istype(usr, /mob/living) || istype(usr, /mob/living/simple_mob)) //CHOMPEdit - Preventing simple_mobs from interacting
 		to_chat(usr, "<span class='warning'>You can't do that.</span>")
 		return
 
@@ -36,7 +36,7 @@
 	set category = "Object"
 	set src in view(1)
 
-	if(usr.incapacitated() || !istype(usr, /mob/living))
+	if(usr.incapacitated() || !istype(usr, /mob/living) || istype(usr, /mob/living/simple_mob)) //CHOMPEdit - Preventing simple_mobs from interacting
 		to_chat(usr, "<span class='warning'>You can't do that.</span>")
 		return
 
@@ -52,7 +52,7 @@
 	set category = "Object"
 	set src in view(1)
 
-	if(usr.incapacitated() || !istype(usr, /mob/living))
+	if(usr.incapacitated() || !istype(usr, /mob/living) || istype(usr, /mob/living/simple_mob)) //CHOMPEdit - Preventing simple_mobs from interacting
 		to_chat(usr, "<span class='warning'>You can't do that.</span>")
 		return
 


### PR DESCRIPTION
Changed modular_computers interactions to prevent mouse (and any possessed/player-controlled simple_mobs) from using the `Forced shutdown`, `Eject ID` and `Eject Portable Storage` verbs on computers.

Now, I will admit I was unsure if I should create the PR here or in one of the upstreams, but I have decided to use CHOMPEdit because the issue that inspired this change is from here.

Unrelated, but hiya, it's my first PR! 👋 