### PR TITLE
Fix some POI atmospherics

### DIFF
--- a/maps/southern_cross/southern_cross-12.dmm
+++ b/maps/southern_cross/southern_cross-12.dmm
@@ -102,7 +102,7 @@
 "dd" = (
 /obj/effect/zone_divider,
 /obj/effect/zone_divider,
-/turf/simulated/open{
+/turf/simulated/open/sif{
 	temperature = 243.15
 	},
 /area/surface/outside/wilderness/skylands/empty)
@@ -343,7 +343,7 @@
 /area/surface/outside/wilderness/skylands)
 "jM" = (
 /obj/effect/zone_divider,
-/turf/simulated/open{
+/turf/simulated/open/sif{
 	temperature = 243.15
 	},
 /area/surface/outside/wilderness/skylands/empty)
@@ -432,7 +432,7 @@
 /obj/machinery/camera/network/exploration{
 	c_tag = "WILD - Shelter Second Floor Utilities"
 	},
-/turf/simulated/open{
+/turf/simulated/open/sif{
 	temperature = 243.15
 	},
 /area/surface/outpost/shelter/utilityroom)
@@ -1007,7 +1007,7 @@
 /turf/simulated/floor/outdoors/grass,
 /area/surface/outside/wilderness/skylands)
 "ye" = (
-/turf/simulated/open{
+/turf/simulated/open/sif{
 	temperature = 243.15
 	},
 /area/surface/outpost/shelter/exterior)
@@ -1259,7 +1259,7 @@
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
 "DD" = (
-/turf/simulated/open{
+/turf/simulated/open/sif{
 	temperature = 243.15
 	},
 /area/surface/outside/wilderness/skylands)
@@ -2068,7 +2068,7 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/wilderness/skylands)
 "WO" = (
-/turf/simulated/open{
+/turf/simulated/open/sif{
 	temperature = 243.15
 	},
 /area/surface/outside/wilderness/skylands/empty)

--- a/maps/southern_cross/turfs/outdoors.dm
+++ b/maps/southern_cross/turfs/outdoors.dm
@@ -137,6 +137,11 @@
 	oxygen		= MOLES_O2SIF
 	nitrogen	= MOLES_N2SIF
 	temperature	= TEMPERATURE_ALTSIF
+	
+/turf/simulated/floor/tiled/asteroid_steel //CHOMP Edit now I'm adding shit here now too. Abandoned temple.
+	oxygen		= MOLES_O2SIF
+	nitrogen	= MOLES_N2SIF
+	temperature	= TEMPERATURE_ALTSIF
 
 // Space mineral tiles are now not the default, so they get demoted to subtype status.
 

--- a/maps/southern_cross/turfs/outdoors.dm
+++ b/maps/southern_cross/turfs/outdoors.dm
@@ -83,6 +83,11 @@
 	nitrogen	= MOLES_N2SIF
 	temperature	= TEMPERATURE_SIF
 
+/turf/simulated/open/sif //CHOMP Edit now I'm adding shit here now too. Skylands
+	oxygen		= MOLES_O2SIF
+	nitrogen	= MOLES_N2SIF
+	temperature	= TEMPERATURE_ALTSIF
+
 // PoI compatability, to stop active edges.
 // In hindsight it would've been better to do this first instead of making a billion /sif subtypes above,
 // but maybe we can transition to this instead now and over time get rid of the /sif subtypes.

--- a/maps/submaps/surface_submaps/mountains/crashed_ufo.dmm
+++ b/maps/submaps/surface_submaps/mountains/crashed_ufo.dmm
@@ -345,7 +345,7 @@
 /turf/simulated/shuttle/floor/alienplating,
 /area/submap/cave/crashed_ufo)
 "bv" = (
-/turf/simulated/mineral/floor/ignore_mapgen,
+/turf/simulated/mineral/floor/ignore_mapgen/sif,
 /area/template_noop)
 
 (1,1,1) = {"

--- a/maps/submaps/surface_submaps/mountains/crashed_ufo_frigate.dmm
+++ b/maps/submaps/surface_submaps/mountains/crashed_ufo_frigate.dmm
@@ -530,6 +530,9 @@
 "ch" = (
 /turf/simulated/shuttle/wall/alien/hard_corner,
 /area/submap/cave/crashed_ufo_frigate)
+"xX" = (
+/turf/simulated/shuttle/floor/alienplating/external,
+/area/submap/cave/crashed_ufo_frigate)
 
 (1,1,1) = {"
 aa
@@ -1986,7 +1989,7 @@ ad
 ad
 ad
 aZ
-ae
+xX
 aZ
 ad
 ad

--- a/maps/submaps/surface_submaps/mountains/temple.dmm
+++ b/maps/submaps/surface_submaps/mountains/temple.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/submap/cave/AbandonedTemple)
 "b" = (
-/turf/simulated/mineral/floor,
+/turf/simulated/mineral/floor/ignore_mapgen/sif,
 /area/submap/cave/AbandonedTemple)
 "c" = (
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -206,7 +206,7 @@
 /area/submap/cave/AbandonedTemple)
 "O" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/mineral/floor,
+/turf/simulated/mineral/floor/ignore_mapgen/sif,
 /area/submap/cave/AbandonedTemple)
 
 (1,1,1) = {"

--- a/maps/submaps/surface_submaps/wilderness/Blackshuttledown.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Blackshuttledown.dmm
@@ -143,13 +143,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/submap/Blackshuttledown)
-"av" = (
-/turf/simulated/floor/tiled/steel,
-/turf/simulated/shuttle/wall/dark{
-	icon_state = "dark5";
-	name = "Unknown Shuttle"
-	},
-/area/submap/Blackshuttledown)
 "aw" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/submap/Blackshuttledown)
@@ -200,20 +193,6 @@
 	icon_state = "bordercolor"
 	},
 /turf/simulated/floor/tiled/white,
-/area/submap/Blackshuttledown)
-"aG" = (
-/turf/simulated/floor/tiled/steel,
-/turf/simulated/shuttle/wall/dark{
-	icon_state = "dark9";
-	name = "Unknown Shuttle"
-	},
-/area/submap/Blackshuttledown)
-"aH" = (
-/turf/simulated/floor/tiled/steel,
-/turf/simulated/shuttle/wall/dark{
-	icon_state = "dark6";
-	name = "Unknown Shuttle"
-	},
 /area/submap/Blackshuttledown)
 "aI" = (
 /mob/living/simple_mob/mechanical/viscerator,
@@ -366,13 +345,6 @@
 "be" = (
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/tiled/white,
-/area/submap/Blackshuttledown)
-"bf" = (
-/turf/simulated/floor/tiled/steel,
-/turf/simulated/shuttle/wall/dark{
-	icon_state = "dark10";
-	name = "Unknown Shuttle"
-	},
 /area/submap/Blackshuttledown)
 "bg" = (
 /obj/machinery/computer/communications,
@@ -1028,14 +1000,14 @@ ab
 ab
 ab
 ab
-aH
+ai
 aj
 bq
 bx
 bx
 bG
 aj
-av
+cp
 ab
 ab
 ab
@@ -1064,7 +1036,7 @@ ab
 ab
 ab
 ab
-aH
+ai
 aj
 bg
 br
@@ -1073,7 +1045,7 @@ br
 br
 bJ
 aj
-av
+cp
 ab
 ab
 ab
@@ -1099,8 +1071,8 @@ ad
 ai
 aj
 aj
-av
-aH
+cp
+ai
 aj
 bb
 bh
@@ -1111,8 +1083,8 @@ bl
 bF
 bT
 aj
-av
-aH
+cp
+ai
 aj
 aj
 cp
@@ -1840,18 +1812,18 @@ aj
 aj
 aj
 aj
-aG
+cq
 ab
-bf
+ak
 aj
 bw
 bK
 bK
 bI
 aj
-aG
+cq
 ab
-bf
+ak
 aj
 aj
 aj
@@ -1876,20 +1848,20 @@ ab
 aj
 aj
 aj
-aG
+cq
 ab
 ab
 ab
-bf
+ak
 al
 al
 al
 al
-aG
+cq
 ab
 ab
 ab
-bf
+ak
 al
 al
 cq

--- a/maps/submaps/surface_submaps/wilderness/DecoupledEngine.dmm
+++ b/maps/submaps/surface_submaps/wilderness/DecoupledEngine.dmm
@@ -28,19 +28,19 @@
 "ah" = (
 /obj/item/weapon/arrow/rod,
 /obj/item/stack/material/steel,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DecoupledEngine)
 "ai" = (
 /obj/item/stack/material/steel,
 /turf/template_noop,
 /area/submap/DecoupledEngine)
 "aj" = (
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DecoupledEngine)
 "ak" = (
 /obj/structure/lattice,
 /obj/structure/girder/displaced,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DecoupledEngine)
 "am" = (
 /obj/item/weapon/arrow/rod,
@@ -51,12 +51,12 @@
 /area/submap/DecoupledEngine)
 "ao" = (
 /obj/structure/lattice,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DecoupledEngine)
 "ap" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aq" = (
 /obj/structure/girder,
@@ -92,12 +92,12 @@
 "ax" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DecoupledEngine)
 "ay" = (
 /obj/effect/floor_decal/rust,
 /obj/item/stack/material/steel,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "az" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -105,14 +105,14 @@
 	icon_state = "intact"
 	},
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aA" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aB" = (
 /obj/structure/shuttle/engine/heater{
@@ -124,7 +124,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aD" = (
 /obj/structure/lattice,
@@ -150,19 +150,19 @@
 /obj/machinery/fusion_fuel_compressor,
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aH" = (
 /obj/machinery/fusion_fuel_injector/mapped,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aI" = (
 /obj/effect/decal/cleanable/blood/oil/streak{
 	amount = 0
 	},
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aJ" = (
 /obj/machinery/power/rad_collector,
@@ -171,7 +171,7 @@
 	dir = 9;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aK" = (
 /obj/effect/floor_decal/rust,
@@ -179,7 +179,7 @@
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aL" = (
 /obj/structure/grille/broken,
@@ -189,12 +189,12 @@
 	},
 /obj/item/weapon/material/shard/phoron,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aM" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aN" = (
 /obj/structure/shuttle/engine/heater{
@@ -205,7 +205,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aO" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -216,7 +216,7 @@
 /area/submap/DecoupledEngine)
 "aP" = (
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aQ" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -225,7 +225,7 @@
 	name = "Engine Access";
 	req_one_access = list(11)
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aR" = (
 /obj/structure/closet/crate/oldreactor{
@@ -236,14 +236,14 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aS" = (
 /obj/structure/closet/crate/oldreactor{
 	anchored = 1
 	},
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aT" = (
 /obj/item/poi/brokenoldreactor{
@@ -254,12 +254,12 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aU" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aV" = (
 /obj/structure/grille,
@@ -271,7 +271,7 @@
 	dir = 8;
 	icon_state = "phoronrwindow"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aW" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -279,11 +279,11 @@
 	icon_state = "intact"
 	},
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aX" = (
 /obj/structure/shuttle/engine/router,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "aY" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -293,11 +293,11 @@
 /area/submap/DecoupledEngine)
 "aZ" = (
 /obj/item/stack/material/steel,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DecoupledEngine)
 "ba" = (
 /obj/item/stack/rods,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bb" = (
 /obj/structure/lattice,
@@ -327,7 +327,7 @@
 "bd" = (
 /obj/machinery/atmospherics/pipe/tank/carbon_dioxide,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "be" = (
 /obj/machinery/power/rad_collector,
@@ -340,14 +340,14 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bf" = (
 /obj/machinery/power/rad_collector,
 /obj/structure/window/phoronreinforced,
 /obj/effect/floor_decal/rust,
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bg" = (
 /obj/machinery/power/rad_collector,
@@ -360,32 +360,32 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bh" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bi" = (
 /obj/machinery/atmospherics/tvalve/digital{
 	dir = 8
 	},
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bj" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bk" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bl" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -401,30 +401,30 @@
 	dir = 8;
 	icon_state = "phoronrwindow"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bm" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4;
 	icon_state = "propulsion_l"
 	},
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bn" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/closet/crate/radiation,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bo" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/effect/floor_decal/rust,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bp" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/rcd,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bq" = (
 /obj/structure/sign/warning/radioactive,
@@ -475,11 +475,11 @@
 /area/submap/DecoupledEngine)
 "bw" = (
 /obj/structure/girder,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DecoupledEngine)
 "bx" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DecoupledEngine)
 
 (1,1,1) = {"

--- a/maps/submaps/surface_submaps/wilderness/derelictengine.dmm
+++ b/maps/submaps/surface_submaps/wilderness/derelictengine.dmm
@@ -83,7 +83,7 @@
 /area/submap/DerelictEngine)
 "bl" = (
 /obj/item/weapon/material/shard/phoron,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/template_noop)
 "bn" = (
 /obj/structure/girder/reinforced,
@@ -113,7 +113,7 @@
 	pixel_x = -9;
 	pixel_y = -7
 	},
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/template_noop)
 "bH" = (
 /obj/machinery/power/emitter/gyrotron,
@@ -146,7 +146,7 @@
 	pixel_x = 7;
 	pixel_y = 10
 	},
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/template_noop)
 "db" = (
 /obj/effect/floor_decal/techfloor{
@@ -184,7 +184,7 @@
 "dy" = (
 /obj/structure/shuttle/engine/propulsion/burst,
 /obj/structure/shuttle/engine/propulsion/burst,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DerelictEngine)
 "dC" = (
 /mob/living/simple_mob/mechanical/hivebot/ranged_damage/laser,
@@ -302,7 +302,7 @@
 /area/submap/DerelictEngine)
 "fJ" = (
 /mob/living/simple_mob/mechanical/hivebot/tank,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/template_noop)
 "fO" = (
 /turf/simulated/shuttle/wall/alien,
@@ -374,7 +374,7 @@
 	health = 15;
 	maxHealth = 15
 	},
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/template_noop)
 "ht" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -891,7 +891,7 @@
 	health = 15;
 	maxHealth = 15
 	},
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/template_noop)
 "ql" = (
 /obj/item/device/gps/internal/poi,
@@ -1304,7 +1304,7 @@
 /area/submap/DerelictEngine)
 "wK" = (
 /obj/structure/shuttle/engine/propulsion/burst,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DerelictEngine)
 "wM" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -1434,7 +1434,7 @@
 /area/submap/DerelictEngine)
 "yk" = (
 /mob/living/simple_mob/mechanical/hivebot/swarm,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/template_noop)
 "yA" = (
 /obj/structure/table/alien,
@@ -2198,6 +2198,9 @@
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/plating,
 /area/submap/DerelictEngine)
+"KU" = (
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
+/area/template_noop)
 "Lb" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 4
@@ -2321,7 +2324,7 @@
 /area/submap/DerelictEngine)
 "Nr" = (
 /mob/living/simple_mob/mechanical/hivebot/swarm,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/template_noop)
 "Ns" = (
 /mob/living/simple_mob/mechanical/hivebot/tank/armored,
@@ -2496,6 +2499,9 @@
 /obj/item/clothing/under/psysuit,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DerelictEngine)
+"Qv" = (
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
+/area/template_noop)
 "QJ" = (
 /obj/effect/floor_decal/techfloor/orange,
 /obj/structure/window/titanium/full,
@@ -2534,6 +2540,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
+/area/submap/DerelictEngine)
+"QY" = (
+/obj/structure/shuttle/engine/propulsion/burst,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/submap/DerelictEngine)
 "Rk" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -2632,7 +2642,7 @@
 /area/submap/DerelictEngine)
 "SW" = (
 /obj/effect/gibspawner/robot,
-/turf/simulated/floor/outdoors/rocks,
+/turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/template_noop)
 "Tt" = (
 /turf/simulated/floor/outdoors/dirt,
@@ -3074,22 +3084,22 @@ SF
 ap
 SF
 SF
-Tt
-Tt
-bN
-bN
+Qv
+Qv
+KU
+KU
 jl
-bN
-jl
-jl
+KU
 jl
 jl
 jl
-bN
 jl
 jl
-bN
-bN
+KU
+jl
+jl
+KU
+KU
 jl
 SF
 SF
@@ -3121,13 +3131,13 @@ SF
 jl
 SF
 SF
-Tt
-Tt
-bN
-bN
-bN
+Qv
+Qv
+KU
+KU
+KU
 jl
-bN
+KU
 jl
 jl
 zH
@@ -3142,10 +3152,10 @@ gy
 EC
 wK
 SF
-bN
-bN
+KU
+KU
 SF
-Tt
+Qv
 SF
 SF
 SF
@@ -3169,11 +3179,11 @@ SF
 SF
 SF
 Xp
-Tt
-bN
+Qv
+KU
 jl
-bN
-bN
+KU
+KU
 jl
 jl
 jl
@@ -3189,16 +3199,16 @@ fO
 zH
 Ja
 EC
-Bz
-Tt
-Tt
-Tt
-bN
+wK
+Qv
+Qv
+Qv
+KU
 Nr
 SF
-Tt
+Qv
 SF
-Tt
+Qv
 SF
 SF
 SF
@@ -3219,8 +3229,8 @@ ap
 SF
 fJ
 jl
-bN
-bN
+KU
+KU
 jl
 jl
 jl
@@ -3239,17 +3249,17 @@ fO
 fO
 EC
 wK
-bN
-bN
-bN
-bN
-Tt
-bN
+KU
+KU
+KU
+KU
+Qv
+KU
 fJ
 hb
-Tt
-Tt
-Tt
+Qv
+Qv
+Qv
 SF
 SF
 SF
@@ -3266,9 +3276,9 @@ SF
 (5,1,1) = {"
 jl
 SF
-Tt
-bN
-bN
+Qv
+KU
+KU
 jl
 jl
 jl
@@ -3289,21 +3299,21 @@ fO
 EC
 wK
 SF
-Tt
-bN
-Tt
-bN
-Tt
-bN
-bN
-Tt
-bN
-bN
-bN
+Qv
+KU
+Qv
+KU
+Qv
+KU
+KU
+Qv
+KU
+KU
+KU
 SF
-Tt
+Qv
 SF
-Tt
+Qv
 SF
 SF
 SF
@@ -3314,8 +3324,8 @@ SF
 "}
 (6,1,1) = {"
 SF
-Tt
-bN
+Qv
+KU
 jl
 jl
 jl
@@ -3340,20 +3350,20 @@ gy
 SF
 SF
 SF
-bN
+KU
 SF
-bN
+KU
 SF
-bN
+KU
 ap
-bN
+KU
 SF
-Tt
-bN
-Tt
+Qv
+KU
+Qv
 SF
-Tt
-Tt
+Qv
+Qv
 SF
 SF
 SF
@@ -3362,9 +3372,9 @@ SF
 SF
 "}
 (7,1,1) = {"
-Tt
+Qv
 jl
-bN
+KU
 jl
 jl
 jl
@@ -3400,10 +3410,10 @@ SF
 SF
 SF
 yk
-bN
+KU
 SF
-Tt
-Tt
+Qv
+Qv
 SF
 SF
 SF
@@ -3412,8 +3422,8 @@ SF
 "}
 (8,1,1) = {"
 jl
-bN
-bN
+KU
+KU
 jl
 jl
 fO
@@ -3445,22 +3455,22 @@ zH
 BR
 fO
 EC
-wK
+QY
 SF
-Tt
-Tt
-bN
-Tt
-bN
-Tt
-bN
+Qv
+Qv
+KU
+Qv
+KU
+Qv
+KU
 SF
 SF
 SF
 SF
 "}
 (9,1,1) = {"
-Tt
+Qv
 jl
 jl
 jl
@@ -3496,21 +3506,21 @@ Yr
 EC
 dy
 SF
-bN
+KU
 SF
-Tt
+Qv
 Xp
 fJ
 SF
+KU
 bN
-bN
-Tt
+Qv
 SF
 SF
 "}
 (10,1,1) = {"
-bN
-bN
+KU
+KU
 jl
 jl
 jl
@@ -3543,22 +3553,22 @@ fO
 jE
 Eu
 EC
-wK
-bN
-bN
-bN
-bN
-bN
-Tt
+QY
+KU
+KU
+KU
+KU
+KU
+Qv
 Nr
 SF
-Tt
-bN
-bN
+Qv
+KU
+KU
 SF
 "}
 (11,1,1) = {"
-bN
+KU
 jl
 jl
 zH
@@ -3592,19 +3602,19 @@ fO
 fO
 fO
 EC
-Bz
+QY
 SF
 SF
 SF
 SF
-bN
-bN
-bN
-Tt
-Tt
+KU
+KU
+KU
+Qv
+Qv
 SF
-bN
-Tt
+KU
+Qv
 "}
 (12,1,1) = {"
 jl
@@ -3649,8 +3659,8 @@ SF
 SF
 SF
 SF
-bN
-bN
+KU
+KU
 SF
 SF
 SF
@@ -3700,9 +3710,9 @@ jU
 EC
 wK
 SF
-bN
-bN
-bN
+KU
+KU
+KU
 "}
 (14,1,1) = {"
 jl
@@ -3747,11 +3757,11 @@ zH
 gy
 gy
 EC
-Bz
+QY
 SF
 SF
 SW
-bN
+KU
 "}
 (15,1,1) = {"
 jl
@@ -3849,7 +3859,7 @@ fH
 fp
 fO
 zH
-bN
+KU
 "}
 (17,1,1) = {"
 jl
@@ -3897,8 +3907,8 @@ db
 yZ
 Vb
 Bd
-Tt
-bN
+Qv
+KU
 "}
 (18,1,1) = {"
 jl
@@ -3947,7 +3957,7 @@ QS
 ib
 ab
 Xq
-Tt
+Qv
 "}
 (19,1,1) = {"
 jl
@@ -3996,7 +4006,7 @@ Ku
 YJ
 VX
 SF
-Tt
+Qv
 "}
 (20,1,1) = {"
 bG
@@ -4045,7 +4055,7 @@ fH
 wM
 zH
 zH
-bN
+KU
 "}
 (21,1,1) = {"
 cX
@@ -4189,10 +4199,10 @@ jG
 jG
 EC
 Bz
-Tt
+Qv
 SW
-bN
-Tt
+KU
+Qv
 "}
 (24,1,1) = {"
 SF
@@ -4240,7 +4250,7 @@ SF
 SF
 SF
 SF
-bN
+KU
 SF
 "}
 (25,1,1) = {"
@@ -4278,9 +4288,9 @@ fO
 fO
 fO
 EC
-Bz
+QY
 SF
-Tt
+Qv
 SF
 SF
 SF
@@ -4327,11 +4337,11 @@ fO
 RG
 RG
 EC
-wK
-bN
-bN
-bN
-Tt
+QY
+KU
+KU
+KU
+Qv
 SF
 SF
 SF
@@ -4339,7 +4349,7 @@ ap
 SF
 SF
 SF
-Tt
+Qv
 "}
 (27,1,1) = {"
 SF
@@ -4376,19 +4386,19 @@ Vs
 Vk
 Yr
 EC
-Bz
+QY
 SF
-bN
+KU
 SF
-bN
+KU
 Nr
 SF
-Tt
+Qv
 SF
 SF
 SF
 SF
-bN
+KU
 "}
 (28,1,1) = {"
 SF
@@ -4425,15 +4435,15 @@ fO
 BR
 fO
 EC
-Bz
+QY
 SF
 SF
-Tt
-bN
-bN
+Qv
+KU
+KU
 pR
-Tt
-Tt
+Qv
+Qv
 SF
 SF
 SF
@@ -4479,10 +4489,10 @@ SF
 SF
 SF
 SF
-bN
+KU
 SF
-bN
-bN
+KU
+KU
 Tt
 SF
 SF
@@ -4514,11 +4524,11 @@ fO
 gy
 zH
 SF
-bN
-bN
-Tt
+KU
+KU
+Qv
 SF
-Tt
+Qv
 SF
 SF
 SF
@@ -4529,11 +4539,11 @@ SF
 SF
 ap
 SF
-Tt
-bN
-bN
+Qv
+KU
+KU
 SF
-bN
+KU
 SF
 SF
 "}
@@ -4561,15 +4571,15 @@ iZ
 Ng
 fO
 EC
-Bz
-bN
+wK
+KU
 SF
 SF
-bN
-bN
+KU
+KU
 SF
 SF
-Tt
+Qv
 SF
 Nr
 SF
@@ -4580,10 +4590,10 @@ SF
 SF
 SF
 SF
-bN
-bN
+KU
+KU
 SF
-bN
+KU
 SF
 "}
 (32,1,1) = {"
@@ -4612,28 +4622,28 @@ fO
 EC
 wK
 SF
-bN
-bN
-bN
+KU
+KU
+KU
 SF
 ap
-bN
+KU
 SF
 SF
 SF
-bN
-bN
+KU
+KU
 SF
 SF
 SF
 SF
 SF
 SF
-Tt
-Tt
+Qv
+Qv
 SF
 SF
-bN
+KU
 "}
 (33,1,1) = {"
 SF
@@ -4660,28 +4670,28 @@ fO
 GU
 EC
 wK
-bN
-Tt
-Tt
-Tt
+KU
+Qv
+Qv
+Qv
 SF
-bN
+KU
 SF
 hb
 bX
-bN
+KU
 SF
 SF
 SF
-bN
-Tt
-bN
+KU
+Qv
+KU
 SF
 SF
 SF
-Tt
-bN
-bN
+Qv
+KU
+KU
 SF
 "}
 (34,1,1) = {"
@@ -4713,22 +4723,22 @@ SF
 SF
 SF
 SF
+Qv
+SF
+SF
+KU
 Tt
 SF
-SF
-bN
-Tt
-SF
-bN
-bN
+KU
+KU
 SF
 SF
 SF
 SF
 SF
-bN
+KU
 SF
-bN
+KU
 SF
 SF
 SF
@@ -4764,13 +4774,13 @@ SF
 SF
 SF
 SF
-Tt
+Qv
 SF
 SF
 SF
 SF
 SF
-bN
+KU
 SF
 SF
 SF
@@ -4778,7 +4788,7 @@ SF
 SF
 SF
 SF
-bN
-bN
-bN
+KU
+KU
+KU
 "}

--- a/maps/submaps/surface_submaps/wilderness/dogbase.dmm
+++ b/maps/submaps/surface_submaps/wilderness/dogbase.dmm
@@ -20,7 +20,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "ay" = (
 /obj/structure/dogbed,
@@ -28,7 +28,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/tajaran,
 /obj/random/maintenance/medical,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "aF" = (
 /obj/structure/sign/securearea,
@@ -42,7 +42,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/bone,
 /obj/random/maintenance/security,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "bl" = (
 /obj/machinery/light{
@@ -51,7 +51,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DogBase)
 "bw" = (
 /obj/item/weapon/storage/belt/janitor,
@@ -121,7 +121,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/cargo,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "hl" = (
 /obj/effect/floor_decal/borderfloor/corner,
@@ -158,7 +158,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/bone/ribs,
 /obj/random/maintenance/research,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "jz" = (
 /obj/machinery/vending/cigarette,
@@ -184,14 +184,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/security,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "kl" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/cargo,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "km" = (
 /obj/effect/decal/remains/human,
@@ -222,7 +222,7 @@
 "lk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "lm" = (
 /obj/structure/table/woodentable,
@@ -235,7 +235,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DogBase)
 "lN" = (
 /obj/machinery/porta_turret/poi{
@@ -262,7 +262,7 @@
 "oW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/template_noop)
 "pR" = (
 /obj/structure/bed,
@@ -298,7 +298,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/bone,
 /obj/random/maintenance/security,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "qO" = (
 /obj/structure/bed,
@@ -337,7 +337,7 @@
 /area/submap/DogBase)
 "tp" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DogBase)
 "tt" = (
 /obj/machinery/power/smes/buildable/point_of_interest,
@@ -431,7 +431,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
 /obj/random/contraband/nofail,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "yl" = (
 /obj/structure/dogbed,
@@ -439,7 +439,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/contraband/nofail,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "yx" = (
 /obj/machinery/door/airlock/external,
@@ -457,7 +457,7 @@
 "Am" = (
 /obj/machinery/door/blast/gate/thin,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "AJ" = (
 /obj/machinery/door/airlock/engineering,
@@ -515,7 +515,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/bone,
 /obj/random/contraband/nofail,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "Dt" = (
 /obj/effect/floor_decal/borderfloor{
@@ -546,7 +546,7 @@
 "FD" = (
 /obj/structure/fence,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "FO" = (
 /obj/machinery/light{
@@ -573,14 +573,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/cargo,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "GB" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "GJ" = (
 /obj/structure/closet/secure_closet/guncabinet,
@@ -594,7 +594,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/submap/DogBase)
 "Hl" = (
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DogBase)
 "HF" = (
 /obj/random/mob/merc/all,
@@ -610,12 +610,18 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/dark,
 /area/submap/DogBase)
+"IE" = (
+/obj/machinery/porta_turret/poi{
+	faction = "syndicate"
+	},
+/turf/simulated/floor/plating/sif/planetuse,
+/area/submap/DogBase)
 "Jm" = (
 /obj/structure/dogbed,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/research,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "Ki" = (
 /obj/machinery/power/port_gen/pacman,
@@ -710,7 +716,7 @@
 	faction = "syndicate";
 	name = "syndicate guard dog"
 	},
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "OR" = (
 /mob/living/simple_mob/animal/wolf/direwolf/dog/sec{
@@ -721,7 +727,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DogBase)
 "OS" = (
 /obj/effect/floor_decal/corner/red/border,
@@ -773,7 +779,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/template_noop)
 "Rz" = (
 /obj/structure/table/woodentable,
@@ -791,14 +797,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/submap/DogBase)
 "SW" = (
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/template_noop)
 "To" = (
 /obj/structure/fence/corner{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "UW" = (
 /obj/effect/floor_decal/borderfloor{
@@ -811,7 +817,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/security,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "Vm" = (
 /obj/structure/loot_pile/maint/technical,
@@ -822,7 +828,7 @@
 /obj/effect/decal/remains/unathi,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "VG" = (
 /obj/structure/bed/chair,
@@ -865,7 +871,7 @@
 /area/submap/DogBase)
 "Xz" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/template_noop)
 "Ya" = (
 /mob/living/simple_mob/animal/wolf/direwolf/dog/sec{
@@ -891,7 +897,7 @@
 /area/submap/DogBase)
 "YJ" = (
 /obj/random/mob/merc/all,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/sif/planetuse,
 /area/submap/DogBase)
 "YX" = (
 /obj/structure/dogbed,
@@ -899,7 +905,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/maintenance/medical,
-/turf/simulated/floor/outdoors/dirt,
+/turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/submap/DogBase)
 "ZK" = (
 /obj/machinery/power/apc{
@@ -1020,13 +1026,13 @@ hp
 hp
 hp
 hp
-lN
+IE
 Hl
 hp
 hp
 hp
 Hl
-lN
+IE
 hp
 hp
 hp
@@ -1198,7 +1204,7 @@ hp
 Qp
 Qp
 tp
-lN
+IE
 hp
 hp
 hp
@@ -1366,7 +1372,7 @@ hp
 "}
 (15,1,1) = {"
 hp
-lN
+IE
 Hl
 Bk
 qO
@@ -1559,7 +1565,7 @@ hp
 (21,1,1) = {"
 hp
 hp
-lN
+IE
 Hl
 hp
 hp
@@ -1582,7 +1588,7 @@ hp
 hp
 hp
 Hl
-lN
+IE
 hp
 hp
 hp
@@ -1724,13 +1730,13 @@ hp
 hp
 hp
 hp
-lN
+IE
 Hl
 hp
 hp
 hp
 Hl
-lN
+IE
 hp
 hp
 hp


### PR DESCRIPTION
Because most of the POIs tiles don't match the sif atmos parameters. Some have sif subtypes, others are just added in outdoors.dm https://github.com/CHOMPStation2/CHOMPStation2/blob/master/maps/southern_cross/turfs/outdoors.dm

I would actually recommend continuing with sif subtypes, especially if we start adding more planets.