### PR TITLE
Tiny Incorporeal fix

### DIFF
--- a/modular_chomp/code/modules/mob/mob.dm
+++ b/modular_chomp/code/modules/mob/mob.dm
@@ -1,3 +1,8 @@
 /mob
 	var/voice_freq = 42500	// Preference for character voice frequency
 	var/list/voice_sounds_list = list()	// The sound list containing our voice sounds!
+
+/mob/is_incorporeal()
+	if(incoporeal_move)
+		return 1
+	..()

--- a/modular_chomp/code/modules/mob/mob.dm
+++ b/modular_chomp/code/modules/mob/mob.dm
@@ -3,6 +3,6 @@
 	var/list/voice_sounds_list = list()	// The sound list containing our voice sounds!
 
 /mob/is_incorporeal()
-	if(incoporeal_move)
+	if(incorporeal_move)
 		return 1
 	..()


### PR DESCRIPTION
tl;dr Carbon Shadekin's are coded in a way that employ's the use of spawn(), such that if they phase twice between those spawns, the incorporeal_move var gets set twice. Allowing them to have incorporeal_move = 1 while not having the phase shift flag.

is_incorporeal() only checked for the phase shift flag.
My lazy fix is making it check for incorporeal_move too.