### PR TITLE
Lets non-crew show up in char directory

### DIFF
--- a/code/modules/client/verbs/character_directory.dm
+++ b/code/modules/client/verbs/character_directory.dm
@@ -59,11 +59,12 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 
 		if(ishuman(C.mob))
 			var/mob/living/carbon/human/H = C.mob
+			var/strangername = H.real_name //CHOMPEdit
 			if(data_core && data_core.general)
 				if(!find_general_record("name", H.real_name))
 					if(!find_record("name", H.real_name, data_core.hidden_general))
-						continue
-			name = H.real_name
+						strangername = "unknown" //CHOMPEdit
+			name = strangername //CHOMPEdit
 			species = "[H.custom_species ? H.custom_species : H.species.name]"
 			ooc_notes = H.ooc_notes
 			flavor_text = H.flavor_texts["general"]


### PR DESCRIPTION
Humanmobs without crew record will however show up as "unknown" in the directory. However, with this addition, any antag who wants to stay completely sneaky will need to toggle their directory visibility manually, which should probably be added to event guidelines.