### PR TITLE
Updating POIs

### DIFF
--- a/AmbushBase.dmm
+++ b/AmbushBase.dmm
@@ -1,0 +1,2748 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aN" = (
+/obj/structure/railing/grey,
+/turf/simulated/floor/water/deep,
+/area/submap/DugOutMercs)
+"aQ" = (
+/obj/machinery/porta_turret/poi{
+	faction = "syndicate"
+	},
+/turf/simulated/floor/plating,
+/area/submap/DugOutMercs)
+"bg" = (
+/obj/random/landmine,
+/turf/template_noop,
+/area/template_noop)
+"bk" = (
+/obj/structure/table/rack/shelf,
+/obj/random/toolbox,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"bl" = (
+/obj/random/landmine,
+/turf/simulated/floor/outdoors/rocks,
+/area/submap/DugOutMercs)
+"bo" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"bz" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 10
+	},
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"bF" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/gun/projectile/revolver/nova,
+/obj/item/weapon/strangerock,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"bS" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/oar,
+/obj/item/weapon/oar,
+/turf/simulated/floor/wood,
+/area/submap/DugOutMercs)
+"cd" = (
+/obj/structure/cliff/automatic{
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"cj" = (
+/obj/machinery/light,
+/turf/simulated/floor/wood,
+/area/submap/DugOutMercs)
+"cu" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/surgical/surgicaldrill/alien,
+/obj/item/weapon/strangerock,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"db" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/toolbox/lunchbox/syndicate/filled,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
+"dh" = (
+/obj/structure/cliff/automatic{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"do" = (
+/obj/effect/floor_decal/borderfloor,
+/mob/living/simple_mob/humanoid/merc/melee/sword,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"dI" = (
+/obj/structure/table/rack,
+/obj/random/energy,
+/obj/random/energy,
+/obj/random/energy,
+/obj/random/energy,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"el" = (
+/obj/random/mob/merc/all,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"eC" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/woodentable,
+/obj/item/stolenpackage,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"fq" = (
+/obj/item/weapon/mine/phoron,
+/turf/template_noop,
+/area/submap/DugOutMercs)
+"fw" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/jellyfishcore,
+/obj/item/weapon/reagent_containers/food/snacks/monkfishfillet,
+/obj/item/weapon/reagent_containers/food/snacks/monkfishfillet,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
+"fx" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/gun/magnetic/gasthrower,
+/obj/item/weapon/strangerock,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"fL" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/item/stack/cable_coil/alien,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"fP" = (
+/obj/vehicle/boat/dragon,
+/turf/simulated/floor/water,
+/area/submap/DugOutMercs)
+"fR" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/water,
+/area/submap/DugOutMercs)
+"fS" = (
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"go" = (
+/turf/template_noop,
+/area/template_noop)
+"hH" = (
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"hZ" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/item/stolenpackage,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"iq" = (
+/obj/random/mob/merc/armored,
+/turf/simulated/floor/wood,
+/area/submap/DugOutMercs)
+"iG" = (
+/obj/structure/table/bench/padded,
+/mob/living/simple_mob/humanoid/merc/ranged/deagle,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"iL" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/random/pottedplant,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"jb" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"jf" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"jz" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/head/helmet/laserproof,
+/obj/item/clothing/gloves/arm_guard/laserproof,
+/obj/item/clothing/shoes/leg_guard/laserproof,
+/obj/item/clothing/suit/armor/pcarrier/laserproof,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"kg" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"kF" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/device/radio,
+/obj/item/weapon/storage/mre/random,
+/obj/item/device/binoculars,
+/turf/simulated/floor/outdoors/rocks,
+/area/submap/DugOutMercs)
+"kN" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/template_noop,
+/area/submap/DugOutMercs)
+"kW" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/random/material/precious,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"lq" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/mob/living/simple_mob/animal/space/carp/large/huge{
+	faction = "syndicate"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"md" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/mob/living/simple_mob/humanoid/merc/ranged/ionrifle,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"ml" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"mv" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
+"my" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/item/weapon/weldingtool/alien,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"mY" = (
+/obj/structure/bed/chair,
+/mob/living/simple_mob/humanoid/merc/ranged/sniper,
+/turf/simulated/floor/outdoors/rocks,
+/area/submap/DugOutMercs)
+"nZ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"oq" = (
+/obj/structure/ledge/ledge_stairs,
+/mob/living/simple_mob/humanoid/merc/melee/sword,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"oC" = (
+/obj/structure/table/rack/shelf,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 9
+	},
+/obj/random/energy,
+/obj/item/clothing/suit/space/syndicate/black/blue,
+/obj/item/clothing/head/helmet/space/syndicate/black/blue,
+/obj/item/weapon/tank/oxygen/welded,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"oN" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey,
+/turf/simulated/floor/water/deep,
+/area/submap/DugOutMercs)
+"oU" = (
+/obj/machinery/door/airlock/engineering,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/DugOutMercs)
+"pf" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/random/toolbox,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"pg" = (
+/obj/machinery/door/airlock/external/bolted,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"po" = (
+/turf/simulated/floor/water/deep,
+/area/submap/DugOutMercs)
+"qR" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"rd" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"rk" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"rl" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/random/cash/huge,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"rn" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"rr" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"ry" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"rV" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/cliff/automatic{
+	dir = 6
+	},
+/obj/structure/railing/grey,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"sc" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
+"so" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/woodentable,
+/obj/item/weapon/material/fishing_net,
+/obj/item/weapon/material/fishing_net,
+/obj/item/weapon/material/fishing_net,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
+"sO" = (
+/obj/machinery/power/smes/buildable/point_of_interest,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/DugOutMercs)
+"sZ" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/oar,
+/turf/simulated/floor/wood,
+/area/submap/DugOutMercs)
+"tS" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"tT" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 5
+	},
+/obj/random/material/refined,
+/obj/random/material,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"uk" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/item/clothing/head/wizard/amp,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"ul" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/woodentable,
+/obj/item/weapon/material/fishing_rod/modern/built,
+/obj/item/weapon/material/fishing_rod/modern/built,
+/obj/item/weapon/material/fishing_rod/modern/built,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
+"uv" = (
+/turf/simulated/wall/r_wall,
+/area/submap/DugOutMercs)
+"uF" = (
+/obj/structure/barricade,
+/turf/simulated/floor/wood,
+/area/submap/DugOutMercs)
+"uQ" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
+"vh" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"vR" = (
+/obj/structure/cliff/automatic/ramp{
+	dir = 9
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"wU" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/mob/living/simple_mob/humanoid/merc/ranged/laser,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"xe" = (
+/obj/structure/table/rack/shelf,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 5
+	},
+/obj/random/energy,
+/obj/item/clothing/suit/space/syndicate/black/blue,
+/obj/item/clothing/head/helmet/space/syndicate/black/blue,
+/obj/item/weapon/tank/oxygen/welded,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"xC" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/random/janusmodule,
+/obj/item/weapon/surgical/bone_clamp/alien,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"yc" = (
+/obj/machinery/door/airlock/highsecurity,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"yr" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/pcarrier/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/head/helmet/laserproof,
+/obj/item/clothing/gloves/arm_guard/laserproof,
+/obj/item/clothing/shoes/leg_guard/laserproof,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"yA" = (
+/mob/living/simple_mob/humanoid/merc/ranged/technician,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"yG" = (
+/obj/effect/floor_decal/borderfloor,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"zG" = (
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "PAPC";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/mob/living/simple_mob/mechanical/viscerator/mercenary,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/DugOutMercs)
+"Ag" = (
+/obj/structure/ledge/ledge_stairs,
+/turf/simulated/floor/outdoors/rocks,
+/area/submap/DugOutMercs)
+"AV" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Bq" = (
+/obj/structure/table/reinforced,
+/obj/random/cigarettes,
+/obj/item/weapon/flame/lighter/random,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"BY" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/template_noop,
+/area/submap/DugOutMercs)
+"Ca" = (
+/obj/structure/table/rack,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"Cl" = (
+/obj/structure/ledge/ledge_stairs,
+/obj/structure/ledge/ledge_stairs,
+/obj/structure/barricade,
+/turf/simulated/floor/outdoors/rocks,
+/area/submap/DugOutMercs)
+"Cp" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/water/deep,
+/area/submap/DugOutMercs)
+"Cr" = (
+/obj/effect/floor_decal/corner/blue/border,
+/mob/living/simple_mob/humanoid/merc/ranged/ionrifle,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"CA" = (
+/obj/structure/cliff/automatic/corner{
+	dir = 6
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"CQ" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"Da" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"De" = (
+/obj/random/landmine,
+/turf/template_noop,
+/area/submap/DugOutMercs)
+"DB" = (
+/obj/structure/cliff/automatic/corner,
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"DJ" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey,
+/obj/structure/cliff/automatic{
+	dir = 10
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"DR" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/material/fishing_rod/modern/built,
+/turf/simulated/floor/wood,
+/area/submap/DugOutMercs)
+"DV" = (
+/obj/structure/table/marble,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/mob/living/simple_mob/mechanical/viscerator/mercenary,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/DugOutMercs)
+"Ed" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/material/fishing_net,
+/turf/simulated/floor/wood,
+/area/submap/DugOutMercs)
+"Eh" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Eo" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/rocks,
+/area/submap/DugOutMercs)
+"Ex" = (
+/obj/structure/table/rack/shelf,
+/obj/random/firstaid,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"EQ" = (
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"EY" = (
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/water/deep,
+/area/submap/DugOutMercs)
+"Fr" = (
+/obj/effect/floor_decal/corner/blue/border,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"FQ" = (
+/obj/machinery/power/terminal{
+	dir = 1;
+	icon_state = "term"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/DugOutMercs)
+"FZ" = (
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/DugOutMercs)
+"Gv" = (
+/obj/structure/table/marble,
+/obj/item/stack/material/phoron,
+/obj/item/stack/material/phoron,
+/mob/living/simple_mob/mechanical/viscerator/mercenary,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/DugOutMercs)
+"GL" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Ha" = (
+/obj/item/frame/noticeboard,
+/turf/simulated/wall/r_wall,
+/area/submap/DugOutMercs)
+"Hb" = (
+/obj/random/landmine,
+/obj/random/landmine,
+/turf/template_noop,
+/area/submap/DugOutMercs)
+"Hk" = (
+/obj/structure/cliff/automatic/corner{
+	dir = 9
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"HX" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/carpmeat/sif/murkfish,
+/obj/item/weapon/reagent_containers/food/snacks/carpmeat/sif/murkfish,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
+"Ia" = (
+/obj/structure/railing/grey,
+/turf/simulated/floor/outdoors/rocks,
+/area/submap/DugOutMercs)
+"Ig" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/telecube/randomized,
+/obj/item/weapon/strangerock,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"IA" = (
+/mob/living/simple_mob/humanoid/merc/ranged/ionrifle,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"IM" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"IQ" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 9
+	},
+/obj/random/material/refined,
+/obj/random/material,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Jh" = (
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Jp" = (
+/obj/structure/table/woodentable,
+/obj/random/cash/big,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Jz" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"JC" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey,
+/turf/simulated/floor/water,
+/area/submap/DugOutMercs)
+"JJ" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/water,
+/area/submap/DugOutMercs)
+"Ks" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 5
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"KA" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"Lg" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/woodentable,
+/obj/item/stolenpackage,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Mh" = (
+/mob/living/simple_mob/humanoid/merc/ranged/grenadier/poi,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
+"Mi" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"Ng" = (
+/obj/structure/cliff/automatic,
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"Nl" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
+"Nr" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloor,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"NJ" = (
+/obj/structure/table/marble,
+/obj/item/stack/material/phoron{
+	amount = 10
+	},
+/mob/living/simple_mob/mechanical/viscerator/mercenary,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/DugOutMercs)
+"NM" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"OP" = (
+/turf/simulated/floor/water,
+/area/submap/DugOutMercs)
+"OU" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/water/deep,
+/area/submap/DugOutMercs)
+"Pe" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"PB" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"PO" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/structure/table/woodentable,
+/obj/random/projectile/scrapped_gun,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Qf" = (
+/turf/template_noop,
+/area/submap/DugOutMercs)
+"Qm" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/structure/table/standard,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/random/medical,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"QM" = (
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/water,
+/area/submap/DugOutMercs)
+"QN" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Rz" = (
+/turf/simulated/floor/outdoors/rocks,
+/area/submap/DugOutMercs)
+"RS" = (
+/obj/structure/railing/grey,
+/turf/simulated/floor/water,
+/area/submap/DugOutMercs)
+"Sj" = (
+/obj/structure/table/rack/shelf,
+/obj/structure/plushie/drone,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Sn" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"SN" = (
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 1
+	},
+/obj/random/mob/merc/all,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Tf" = (
+/obj/structure/grille,
+/turf/simulated/floor/water/deep,
+/area/submap/DugOutMercs)
+"Tw" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/water,
+/area/submap/DugOutMercs)
+"TO" = (
+/obj/machinery/light,
+/mob/living/simple_mob/mechanical/viscerator/mercenary,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/DugOutMercs)
+"TQ" = (
+/obj/structure/cliff/automatic/corner{
+	dir = 10
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"Uo" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"UA" = (
+/obj/structure/railing/grey,
+/turf/template_noop,
+/area/submap/DugOutMercs)
+"UP" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Vl" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 6
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"Vn" = (
+/obj/structure/cliff/automatic/ramp,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/dirt,
+/area/submap/DugOutMercs)
+"VQ" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/device/radio,
+/obj/item/weapon/storage/mre/random,
+/obj/item/device/binoculars,
+/turf/simulated/floor/wood,
+/area/submap/DugOutMercs)
+"VX" = (
+/mob/living/simple_mob/mechanical/viscerator/mercenary,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/DugOutMercs)
+"VZ" = (
+/obj/structure/railing/grey,
+/obj/vehicle/boat/dragon,
+/turf/simulated/floor/outdoors/rocks,
+/area/submap/DugOutMercs)
+"Wa" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"Wx" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"WF" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/carpmeat/fish/sharkmeat,
+/obj/item/weapon/reagent_containers/food/snacks/carpmeat/fish/sharkmeat,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
+"WY" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"XP" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/obj/item/weapon/archaeological_find,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"Yg" = (
+/turf/simulated/floor/wood,
+/area/submap/DugOutMercs)
+"Yx" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"YD" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/machinery/portable_atmospherics/canister/empty/oxygen,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"YE" = (
+/obj/effect/floor_decal/corner/mauve/diagonal,
+/mob/living/simple_mob/humanoid/merc/ranged/technician,
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"YF" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/mob/living/simple_mob/humanoid/merc/ranged/technician,
+/turf/simulated/floor/wood,
+/area/submap/DugOutMercs)
+"YW" = (
+/obj/structure/table/rack/shelf,
+/obj/random/medical,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"Zg" = (
+/mob/living/simple_mob/humanoid/merc/ranged/sniper,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/submap/DugOutMercs)
+"Zt" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"ZS" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+
+(1,1,1) = {"
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+bg
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+"}
+(2,1,1) = {"
+go
+Qf
+Qf
+Qf
+Qf
+De
+Qf
+Qf
+Qf
+De
+Qf
+Hb
+Qf
+bl
+Rz
+bl
+Rz
+Qf
+De
+Qf
+De
+Qf
+Qf
+Qf
+Qf
+De
+Qf
+Qf
+Qf
+Qf
+De
+Qf
+Qf
+Qf
+Qf
+CA
+dh
+dh
+DB
+go
+"}
+(3,1,1) = {"
+go
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+De
+Qf
+Qf
+Rz
+Rz
+Rz
+OP
+OP
+OP
+OP
+Rz
+Rz
+Qf
+Qf
+Qf
+De
+Qf
+De
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Vn
+rV
+Rz
+Rz
+Ng
+go
+"}
+(4,1,1) = {"
+go
+Qf
+Qf
+Qf
+Qf
+Qf
+De
+Qf
+Qf
+Rz
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+Rz
+Rz
+Qf
+Qf
+Qf
+Qf
+Qf
+De
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+oq
+Ag
+Cl
+mY
+kF
+Ng
+go
+"}
+(5,1,1) = {"
+go
+Qf
+Qf
+Qf
+De
+Qf
+Qf
+Rz
+Rz
+OP
+OP
+OP
+OP
+po
+po
+OP
+OP
+OP
+OP
+OP
+OP
+Rz
+aQ
+Qf
+Qf
+Qf
+Qf
+Qf
+aQ
+Qf
+Qf
+Qf
+Qf
+Qf
+vR
+DJ
+Rz
+Rz
+Ng
+go
+"}
+(6,1,1) = {"
+go
+Qf
+Qf
+De
+Qf
+Qf
+Rz
+OP
+OP
+OP
+OP
+OP
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+OP
+OP
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+aQ
+Qf
+Qf
+TQ
+cd
+cd
+Hk
+go
+"}
+(7,1,1) = {"
+go
+Qf
+Hb
+Qf
+Qf
+bl
+OP
+OP
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+OP
+RS
+Rz
+sc
+sc
+sc
+sc
+uv
+IM
+jf
+uv
+Qf
+Qf
+Qf
+Qf
+Qf
+De
+Qf
+go
+"}
+(8,1,1) = {"
+go
+Qf
+Qf
+Qf
+Rz
+OP
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+OP
+OP
+QM
+Rz
+sc
+Mh
+sc
+uv
+nZ
+yG
+Da
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+De
+go
+"}
+(9,1,1) = {"
+go
+Qf
+De
+Rz
+OP
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+OP
+JJ
+OP
+fP
+OP
+JJ
+JC
+Rz
+sc
+sc
+sc
+uv
+Wx
+yG
+uv
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+go
+"}
+(10,1,1) = {"
+bg
+Qf
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+RS
+bS
+Yg
+Yg
+Yg
+Yg
+Yg
+Yg
+Yg
+sc
+Nl
+uv
+nZ
+yG
+uv
+aQ
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+bg
+"}
+(11,1,1) = {"
+go
+Qf
+Qf
+bl
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+RS
+Yg
+Yg
+Yg
+Yg
+Yg
+Yg
+Yg
+Yg
+sc
+sc
+uv
+nZ
+Nr
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+aQ
+go
+"}
+(12,1,1) = {"
+go
+De
+Rz
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+OP
+RS
+Yg
+Yg
+Yg
+Yg
+Yg
+Yg
+Yg
+iq
+sc
+sc
+Da
+nZ
+do
+uv
+Jz
+GL
+Jz
+Jp
+Jz
+uv
+Qf
+go
+"}
+(13,1,1) = {"
+go
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+OP
+OP
+RS
+Yg
+Yg
+Yg
+Yg
+Yg
+Yg
+Yg
+Yg
+sc
+sc
+uv
+Wx
+yG
+uv
+Eh
+md
+Eh
+Eh
+Eh
+uv
+Qf
+go
+"}
+(14,1,1) = {"
+go
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+OP
+fR
+fR
+fR
+fR
+fR
+Tw
+Rz
+sc
+sc
+sc
+uv
+nZ
+yG
+pg
+Eh
+Eh
+el
+Eh
+Lg
+uv
+Qf
+go
+"}
+(15,1,1) = {"
+go
+De
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+Rz
+uv
+Rz
+sc
+sc
+sc
+uQ
+uv
+nZ
+Nr
+uv
+Eh
+QN
+Eh
+Eh
+Eh
+uv
+De
+go
+"}
+(16,1,1) = {"
+go
+Qf
+De
+Rz
+OP
+po
+po
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+Rz
+Rz
+Qf
+uv
+WF
+sc
+sc
+sc
+so
+uv
+nZ
+yG
+uv
+Jz
+eC
+Jz
+PO
+Jz
+uv
+Qf
+bg
+"}
+(17,1,1) = {"
+bg
+Qf
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+OP
+OP
+OP
+Rz
+Rz
+Rz
+Rz
+Rz
+Rz
+Qf
+Qf
+Qf
+Ha
+fw
+sc
+sc
+sc
+db
+uv
+nZ
+yG
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+aQ
+go
+"}
+(18,1,1) = {"
+go
+Qf
+bl
+OP
+OP
+po
+po
+po
+po
+OP
+OP
+OP
+Rz
+kN
+kN
+kN
+Qf
+Qf
+Qf
+Qf
+Qf
+aQ
+uv
+HX
+mv
+sc
+sc
+ul
+uv
+nZ
+yG
+uv
+dI
+PB
+Yx
+Uo
+yr
+uv
+Qf
+go
+"}
+(19,1,1) = {"
+bg
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+OP
+OP
+OP
+VZ
+VQ
+DR
+Ed
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+yc
+uv
+uv
+uv
+IA
+yG
+uv
+KA
+vh
+hH
+bo
+Wa
+uv
+De
+go
+"}
+(20,1,1) = {"
+go
+Qf
+De
+Rz
+OP
+OP
+po
+po
+OP
+OP
+OP
+Rz
+UA
+sZ
+Zg
+cj
+uv
+NJ
+DV
+Gv
+VX
+VX
+uv
+uk
+WY
+WY
+WY
+fx
+uv
+nZ
+yG
+uv
+ml
+ZS
+rd
+ry
+qR
+uv
+Qf
+go
+"}
+(21,1,1) = {"
+go
+Qf
+Rz
+OP
+OP
+OP
+po
+po
+OP
+OP
+Rz
+Qf
+Qf
+uF
+Yg
+Yg
+oU
+VX
+VX
+VX
+VX
+VX
+uv
+pf
+WY
+CQ
+WY
+cu
+uv
+nZ
+yG
+uv
+jz
+Ks
+Mi
+Vl
+Ca
+uv
+Qf
+go
+"}
+(22,1,1) = {"
+go
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+OP
+Rz
+Qf
+Qf
+uF
+Yg
+Yg
+uv
+zG
+VX
+VX
+VX
+TO
+uv
+xC
+lq
+fL
+YE
+XP
+uv
+nZ
+yG
+uv
+uv
+uv
+yc
+uv
+uv
+uv
+aQ
+go
+"}
+(23,1,1) = {"
+go
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+OP
+Rz
+Qf
+UA
+sZ
+YF
+cj
+uv
+sO
+FQ
+FZ
+VX
+VX
+uv
+Qm
+WY
+CQ
+WY
+bF
+uv
+nZ
+Nr
+uv
+YW
+Pe
+Pe
+Pe
+Pe
+uv
+Qf
+bg
+"}
+(24,1,1) = {"
+go
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+OP
+OP
+Rz
+Ia
+VQ
+DR
+Ed
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+my
+wU
+WY
+WY
+Ig
+uv
+AV
+yG
+uv
+Sn
+Pe
+Pe
+iL
+Pe
+uv
+Qf
+go
+"}
+(25,1,1) = {"
+go
+Qf
+De
+Rz
+OP
+OP
+po
+po
+po
+po
+OP
+OP
+OP
+Eo
+BY
+BY
+Qf
+Qf
+Qf
+Qf
+Qf
+aQ
+uv
+uv
+uv
+yc
+uv
+uv
+uv
+nZ
+yG
+uv
+bk
+Pe
+Pe
+Bq
+Pe
+uv
+Qf
+go
+"}
+(26,1,1) = {"
+go
+De
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+Rz
+Rz
+Rz
+Qf
+Qf
+Qf
+Qf
+Qf
+uv
+IQ
+Zt
+Zt
+Zt
+bz
+uv
+Wx
+yG
+pg
+Pe
+Pe
+tS
+hZ
+iG
+uv
+De
+go
+"}
+(27,1,1) = {"
+bg
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+OP
+Rz
+Rz
+Rz
+Qf
+Qf
+uv
+kW
+fS
+fS
+Jh
+YD
+uv
+nZ
+yG
+uv
+Ex
+Pe
+Pe
+rl
+Pe
+uv
+Qf
+bg
+"}
+(28,1,1) = {"
+go
+Qf
+bl
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+Rz
+Rz
+uv
+kW
+yA
+fS
+fS
+YD
+uv
+nZ
+Nr
+uv
+Sn
+Pe
+Pe
+iL
+Pe
+uv
+Qf
+go
+"}
+(29,1,1) = {"
+go
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+uv
+tT
+kg
+kg
+EQ
+Fr
+uv
+nZ
+do
+uv
+Sj
+Pe
+Pe
+Pe
+Pe
+uv
+Qf
+go
+"}
+(30,1,1) = {"
+go
+De
+Rz
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+OP
+OP
+OP
+po
+po
+Tf
+OU
+OU
+oN
+rr
+Fr
+Da
+nZ
+yG
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+aQ
+go
+"}
+(31,1,1) = {"
+go
+Qf
+Rz
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+Tf
+po
+po
+aN
+rr
+Cr
+uv
+Wx
+yG
+uv
+aQ
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+bg
+"}
+(32,1,1) = {"
+go
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+Tf
+Cp
+po
+EY
+rr
+Fr
+uv
+nZ
+yG
+uv
+Qf
+Qf
+Qf
+Qf
+Qf
+De
+Qf
+go
+"}
+(33,1,1) = {"
+go
+Qf
+bl
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+OP
+uv
+oC
+NM
+Zt
+SN
+Fr
+uv
+nZ
+Nr
+Da
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+De
+go
+"}
+(34,1,1) = {"
+go
+De
+Qf
+Rz
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+uv
+xe
+kg
+kg
+rk
+UP
+uv
+jb
+rn
+uv
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+bg
+"}
+(35,1,1) = {"
+go
+Qf
+Qf
+bl
+OP
+OP
+po
+po
+po
+po
+po
+po
+po
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+Rz
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+uv
+aQ
+Qf
+Qf
+CA
+dh
+dh
+DB
+go
+"}
+(36,1,1) = {"
+go
+De
+Qf
+Qf
+Rz
+OP
+OP
+OP
+po
+po
+po
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+Rz
+De
+aQ
+Qf
+Qf
+Qf
+Qf
+Qf
+aQ
+Qf
+Qf
+Qf
+Qf
+Qf
+Vn
+rV
+Rz
+Rz
+Ng
+go
+"}
+(37,1,1) = {"
+go
+Qf
+Qf
+De
+Qf
+Rz
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+OP
+bl
+Rz
+OP
+OP
+Rz
+Rz
+Qf
+Qf
+Qf
+De
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+oq
+Ag
+Cl
+mY
+kF
+Ng
+go
+"}
+(38,1,1) = {"
+go
+Qf
+Qf
+Qf
+Qf
+Qf
+Rz
+OP
+OP
+OP
+OP
+OP
+OP
+bl
+Qf
+Qf
+Rz
+bl
+Qf
+De
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+fq
+Qf
+Qf
+Qf
+Qf
+Qf
+De
+Qf
+vR
+DJ
+Rz
+Rz
+Ng
+go
+"}
+(39,1,1) = {"
+go
+De
+Qf
+Qf
+De
+Qf
+De
+Rz
+Rz
+bl
+Rz
+Rz
+Rz
+De
+Qf
+De
+Qf
+Qf
+Qf
+Qf
+De
+Qf
+Qf
+Qf
+De
+Qf
+Qf
+Qf
+De
+Qf
+De
+Qf
+Qf
+Qf
+Qf
+TQ
+cd
+cd
+Hk
+go
+"}
+(40,1,1) = {"
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+bg
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+go
+bg
+go
+go
+go
+go
+go
+"}

--- a/CultBar.dmm
+++ b/CultBar.dmm
@@ -1,0 +1,2491 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"at" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"aH" = (
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/anomaly_spectroscopy,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"aN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"bs" = (
+/obj/structure/simple_door/sifwood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"bt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"bv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/fancyblack,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/cargo,
+/obj/item/weapon/spellbook/oneuse/charge,
+/obj/random/maintenance/research,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"cq" = (
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/cook_guide,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"cv" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"cH" = (
+/obj/structure/table/fancyblack,
+/obj/random/firstaid,
+/obj/random/maintenance/morestuff,
+/obj/random/maintenance/misc,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"cJ" = (
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/water/ocean,
+/area/submap/CultBar)
+"cL" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/random/maintenance/morestuff,
+/obj/random/maintenance/foodstuff,
+/obj/item/clothing/glasses/thermal/syndi,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"cT" = (
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/head/helmet/space/cult,
+/obj/item/clothing/suit/space/cult,
+/obj/structure/closet/grave{
+	opened = 0
+	},
+/obj/structure/gravemarker,
+/turf/simulated/floor/outdoors/grass,
+/area/submap/CultBar)
+"cX" = (
+/obj/structure/table/gamblingtable,
+/obj/random/cash,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"cY" = (
+/obj/structure/table/standard,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/item/weapon/deck/cards,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"dh" = (
+/obj/structure/flora/lily1,
+/turf/simulated/floor/water/ocean,
+/area/template_noop)
+"dt" = (
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"dO" = (
+/obj/item/stolenpackage,
+/obj/structure/table/rack,
+/obj/machinery/light/small/emergency/flicker{
+	dir = 1
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/CultBar)
+"dY" = (
+/obj/machinery/light/small/emergency/flicker,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"ea" = (
+/obj/structure/table/marble,
+/obj/random/meat,
+/obj/item/weapon/reagent_containers/food/snacks/sharkmeatcubes,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"ei" = (
+/turf/simulated/floor/outdoors/grass,
+/area/template_noop)
+"ez" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"eM" = (
+/obj/structure/table/bench/sifwooden,
+/mob/living/simple_mob/humanoid/cultist/hunter,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"eT" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/cans/orange_cola,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"eW" = (
+/obj/structure/table/marble,
+/obj/random/meat,
+/obj/item/weapon/reagent_containers/food/snacks/stewedsoymeat,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"fe" = (
+/obj/structure/table/marble,
+/obj/item/weapon/reagent_containers/food/snacks/taco,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"fq" = (
+/obj/structure/table/bench/sifwooden,
+/mob/living/simple_mob/humanoid/cultist/caster,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"fs" = (
+/obj/structure/flora/lily1,
+/turf/simulated/floor/water/ocean,
+/area/submap/CultBar)
+"fB" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"fD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/humanoid/cultist/human/bloodjaunt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"fF" = (
+/turf/simulated/floor/outdoors/grass,
+/area/submap/CultBar)
+"fR" = (
+/obj/structure/table/bench/sifwooden,
+/mob/living/simple_mob/humanoid/cultist/human,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"gh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/fancyblack,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/security,
+/obj/item/weapon/melee/energy/sword/ionic_rapier,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"go" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/table/sifwooden_reinforced,
+/obj/random/maintenance/misc,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/research,
+/obj/item/clothing/gloves/ring/material/diamond,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"gu" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"gP" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"he" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner/red/diagonal,
+/mob/living/simple_mob/humanoid/cultist/castertesh,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"hm" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/humanoid/cultist/hunter,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"ht" = (
+/obj/structure/table/standard,
+/obj/item/weapon/gun/projectile/revolver/cerberus,
+/obj/item/weapon/gun/projectile/revolver/judge,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"hu" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"hN" = (
+/obj/structure/kitchenspike,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"ij" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/light/small/emergency/flicker{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"io" = (
+/obj/structure/table/bench/sifwooden,
+/mob/living/simple_mob/humanoid/cultist/castertesh,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"iJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"jk" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/decaf,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"jy" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/outdoors/grass,
+/area/submap/CultBar)
+"jJ" = (
+/mob/living/simple_mob/humanoid/cultist/human/bloodjaunt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"jM" = (
+/obj/machinery/appliance/cooker/oven,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"kD" = (
+/mob/living/simple_mob/humanoid/cultist/castertesh,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"kK" = (
+/obj/effect/rune,
+/obj/item/clothing/head/culthood/magus,
+/obj/item/weapon/melee/cultblade,
+/obj/item/clothing/suit/cultrobes/magusred,
+/obj/item/clothing/shoes/cult,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shield_projector/rectangle/automatic/magus,
+/obj/item/device/soulstone,
+/turf/simulated/floor/gorefloor2,
+/area/submap/CultBar)
+"kY" = (
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/outdoors/grass,
+/area/submap/CultBar)
+"kZ" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"lg" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/item/weapon/melee/energy/sword/red,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"lm" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/stolenpackage,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"lu" = (
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/nuclear,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"lV" = (
+/obj/structure/loot_pile/surface/bones,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"ma" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/CultBar)
+"mt" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/humanoid/cultist/hunter,
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"mz" = (
+/obj/effect/gibspawner/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"mD" = (
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/water/ocean,
+/area/template_noop)
+"mQ" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"mT" = (
+/obj/structure/table/bench/sifwooden,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"na" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/contraband,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"nj" = (
+/obj/structure/table/marble,
+/obj/random/meat,
+/obj/item/weapon/reagent_containers/food/snacks/turkeyslice,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"nu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"nO" = (
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "PAPC";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/CultBar)
+"nU" = (
+/mob/living/simple_mob/humanoid/cultist/tesh,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"ok" = (
+/turf/template_noop,
+/area/template_noop)
+"oo" = (
+/mob/living/simple_mob/humanoid/cultist/human/bloodjaunt,
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"or" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"ov" = (
+/obj/item/clothing/head/helmet/bulletproof,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"oH" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"oZ" = (
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual/anomaly_testing,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"pd" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/champagne,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"pi" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/gorefloor,
+/area/submap/CultBar)
+"pj" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"pv" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/random/maintenance/misc,
+/obj/random/maintenance/cargo,
+/obj/item/stack/nanopaste/advanced,
+/obj/random/maintenance/security,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"pE" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/cans/redarmy,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"pG" = (
+/turf/simulated/floor/gorefloor,
+/area/submap/CultBar)
+"pX" = (
+/obj/structure/table/bench/sifwooden,
+/mob/living/simple_mob/vore/demonAI/avarn{
+	faction = "cult"
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"qh" = (
+/obj/machinery/appliance/cooker/grill,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"qG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"qP" = (
+/obj/structure/table/sifwooden_reinforced,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"rH" = (
+/obj/structure/flora/lily2,
+/turf/simulated/floor/water/ocean,
+/area/submap/CultBar)
+"rJ" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"sh" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/cans/shambler,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"tE" = (
+/obj/structure/table/standard,
+/obj/random/cash/big,
+/obj/random/cash/big,
+/obj/random/cash/big,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"tO" = (
+/obj/structure/table/bench/sifwooden,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/humanoid/cultist/lizard,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"ug" = (
+/obj/structure/table/marble,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"va" = (
+/obj/structure/flora/lily2,
+/turf/simulated/floor/water/ocean,
+/area/template_noop)
+"wr" = (
+/mob/living/simple_mob/humanoid/cultist/hunter,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"wt" = (
+/turf/simulated/floor/outdoors/mud,
+/area/submap/CultBar)
+"wA" = (
+/obj/structure/table/marble,
+/obj/random/meat,
+/obj/item/weapon/reagent_containers/food/snacks/waffles,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"xb" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/random/maintenance/foodstuff,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"xz" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"xQ" = (
+/obj/machinery/light/small/emergency/flicker{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"xX" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stolenpackage,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"yI" = (
+/obj/structure/table/standard,
+/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
+/obj/item/clothing/shoes/boots/winter/climbing,
+/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
+/obj/item/clothing/shoes/boots/winter/climbing,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"yP" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"yV" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"zk" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/outdoors/grass,
+/area/submap/CultBar)
+"zy" = (
+/obj/structure/table/bench/sifwooden,
+/mob/living/simple_mob/humanoid/cultist/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"zU" = (
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Ah" = (
+/obj/structure/table/bench/sifwooden,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Ak" = (
+/mob/living/simple_mob/vore/demonAI{
+	faction = "cult"
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"AO" = (
+/obj/machinery/power/smes/buildable/point_of_interest,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/CultBar)
+"Br" = (
+/mob/living/simple_mob/humanoid/cultist/caster,
+/obj/structure/table/bench/sifwooden,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"BV" = (
+/obj/structure/table/bench/sifwooden,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/humanoid/cultist/lizard,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"BW" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/stolenpackage,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Cf" = (
+/mob/living/simple_mob/humanoid/cultist/magus,
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"Ch" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/machinery/chemical_dispenser/bar_soft/full,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"Co" = (
+/obj/structure/cult/pylon,
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"Cp" = (
+/turf/simulated/floor/water/ocean,
+/area/submap/CultBar)
+"CC" = (
+/obj/structure/flora/ausbushes/genericbush,
+/turf/simulated/floor/outdoors/grass,
+/area/submap/CultBar)
+"CY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"Dm" = (
+/obj/structure/loot_pile/surface/bones,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Dp" = (
+/obj/structure/table/fancyblack,
+/obj/item/weapon/melee/energy/sword/ionic_rapier/lance,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/maintenance/morestuff,
+/obj/random/maintenance/misc,
+/obj/random/maintenance/research,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"Dt" = (
+/obj/machinery/light/small/flicker,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Dw" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/machinery/chemical_dispenser/bar_alc/full,
+/obj/machinery/light/small/emergency/flicker{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"DS" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/water/ocean,
+/area/template_noop)
+"DY" = (
+/obj/effect/gibspawner/human,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"EH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"EJ" = (
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"EM" = (
+/turf/simulated/floor/water/ocean,
+/area/template_noop)
+"EY" = (
+/obj/machinery/power/terminal{
+	dir = 1;
+	icon_state = "term"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/CultBar)
+"Fb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"Gb" = (
+/obj/machinery/light/small/emergency/flicker{
+	dir = 1
+	},
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"Gd" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"Gp" = (
+/obj/effect/gibspawner/human,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"Gy" = (
+/obj/machinery/light/small/emergency/flicker{
+	dir = 1
+	},
+/obj/structure/kitchenspike,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"GO" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/random/contraband,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Hw" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"HK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"HP" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"Ip" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/item/weapon/reagent_containers/food/snacks/pancakes/berry,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"ID" = (
+/turf/simulated/floor/outdoors/mud,
+/area/template_noop)
+"IU" = (
+/mob/living/simple_mob/vore/demonAI/wendigo{
+	faction = "cult"
+	},
+/turf/simulated/floor/outdoors/grass,
+/area/submap/CultBar)
+"Jj" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/food/snacks/ribplate,
+/obj/item/weapon/reagent_containers/food/snacks/ribplate,
+/obj/effect/floor_decal/corner/red/diagonal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"JE" = (
+/mob/living/simple_mob/vore/demonAI/wendigo{
+	faction = "cult"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/CultBar)
+"JJ" = (
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"Ka" = (
+/obj/structure/table/gamblingtable,
+/obj/random/cash/big,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Kb" = (
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/CultBar)
+"Ki" = (
+/obj/structure/grille/cult,
+/obj/structure/bonfire/permanent,
+/obj/item/weapon/gun/magic/firestaff,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Ks" = (
+/obj/machinery/light/small/emergency/flicker{
+	dir = 1
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"KB" = (
+/obj/structure/table/bench/sifwooden,
+/mob/living/simple_mob/humanoid/cultist/human,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"KF" = (
+/obj/structure/table/marble,
+/obj/item/weapon/reagent_containers/food/snacks/meat,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"KV" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/item/device/soulstone,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"Le" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/random/gun/random,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Lp" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/table/sifwooden_reinforced,
+/obj/random/maintenance/misc,
+/obj/random/maintenance/foodstuff,
+/obj/item/clothing/gloves/regen,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"LD" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/vore/demonAI{
+	faction = "cult"
+	},
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"LV" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"LY" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/reagent_containers/food/drinks/cans/kvass,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Mw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/submap/CultBar)
+"Mx" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/superbiteburger,
+/obj/item/weapon/reagent_containers/food/snacks/superbiteburger,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"MF" = (
+/obj/structure/table/marble,
+/obj/item/weapon/reagent_containers/food/snacks/pancakes,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"MH" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"MJ" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/random/energy,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"MO" = (
+/mob/living/simple_mob/humanoid/cultist/human/bloodjaunt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"MS" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/firstaid,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Nw" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/water/ocean,
+/area/submap/CultBar)
+"NJ" = (
+/obj/structure/closet/grave,
+/turf/simulated/floor/outdoors/grass,
+/area/submap/CultBar)
+"NZ" = (
+/mob/living/simple_mob/humanoid/cultist/human,
+/obj/structure/table/bench/sifwooden,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Om" = (
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/outdoors/mud,
+/area/submap/CultBar)
+"Op" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"Oq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"Ot" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/maintenance/foodstuff,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"OO" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/random/maintenance/morestuff,
+/obj/random/maintenance/foodstuff,
+/obj/random/maintenance/engineering,
+/obj/item/clothing/glasses/meson,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"OZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/humanoid/cultist/human/bloodjaunt,
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"Px" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/water/ocean,
+/area/submap/CultBar)
+"QO" = (
+/obj/structure/cult/pylon,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"QX" = (
+/obj/structure/simple_door/sifwood,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Rc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/gorefloor,
+/area/submap/CultBar)
+"Rk" = (
+/obj/structure/flora/ausbushes,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/outdoors/grass,
+/area/submap/CultBar)
+"RO" = (
+/obj/structure/table/fancyblack,
+/obj/random/contraband,
+/obj/machinery/light/small/flicker,
+/obj/random/maintenance/misc,
+/obj/random/mainttoyloot/nofail,
+/obj/item/weapon/telecube/randomized,
+/turf/simulated/floor/carpet,
+/area/submap/CultBar)
+"Sn" = (
+/obj/structure/grille/cult,
+/obj/structure/bonfire/permanent,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"ST" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"Ti" = (
+/turf/template_noop,
+/area/submap/CultBar)
+"TV" = (
+/obj/machinery/light/small/emergency/flicker,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/suit/storage/hooded/wintercoat/narsie,
+/obj/item/clothing/suit/storage/hooded/wintercoat/narsie,
+/obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
+/obj/item/clothing/shoes/boots/winter,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"Ub" = (
+/obj/machinery/light/small/emergency/flicker,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Uy" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/humanoid/cultist/castertesh,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"UB" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/item/stolenpackage,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/CultBar)
+"UJ" = (
+/obj/structure/table/bench/sifwooden,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"UT" = (
+/obj/structure/table/marble,
+/obj/random/meat,
+/obj/random/meat,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"Vk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"Vr" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Vs" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"VC" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/cultrobes/alt,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/head/culthood/alt,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/head/culthood/alt,
+/obj/item/clothing/suit/cultrobes/alt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"VJ" = (
+/obj/structure/table/bench/sifwooden,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"VZ" = (
+/turf/simulated/wall/log_sif,
+/area/submap/CultBar)
+"Wc" = (
+/obj/structure/table/standard,
+/obj/machinery/microwave,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"Wf" = (
+/mob/living/simple_mob/vore/demonAI/wendigo{
+	faction = "cult"
+	},
+/turf/simulated/floor/outdoors/mud,
+/area/submap/CultBar)
+"Wq" = (
+/obj/structure/table/marble,
+/obj/machinery/light/small/flicker,
+/obj/random/meat,
+/obj/random/meat,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"Ww" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/outdoors/grass,
+/area/template_noop)
+"WL" = (
+/obj/machinery/light/small/flicker,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/standard,
+/obj/item/clothing/head/culthood,
+/obj/item/clothing/suit/cultrobes,
+/obj/item/clothing/shoes/cult,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"WO" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/humanoid/cultist/elite,
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"WT" = (
+/obj/structure/table/gamblingtable,
+/obj/random/cash/huge,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"WW" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/gorefloor,
+/area/submap/CultBar)
+"Xa" = (
+/obj/structure/table/gamblingtable,
+/obj/item/weapon/deck/cards,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Xs" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"XI" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/water/ocean,
+/area/template_noop)
+"Yk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/cult,
+/area/submap/CultBar)
+"YM" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/random/maintenance/misc,
+/obj/random/maintenance/morestuff,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/research,
+/obj/random/firstaid,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"YU" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/item/weapon/reagent_containers/food/snacks/stew,
+/obj/item/weapon/reagent_containers/food/snacks/stew,
+/obj/item/weapon/reagent_containers/food/snacks/stew,
+/obj/item/weapon/reagent_containers/food/snacks/bloodsoup,
+/obj/item/weapon/reagent_containers/food/snacks/bloodsoup,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"YZ" = (
+/obj/structure/table/bench/sifwooden,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Zl" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/melee/energy/sword/red,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+"Zx" = (
+/obj/structure/table/marble,
+/obj/item/weapon/reagent_containers/food/snacks/sharkmeatcooked,
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/turf/simulated/floor/tiled/freezer,
+/area/submap/CultBar)
+"Zz" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"ZG" = (
+/obj/machinery/light/small/emergency/flicker{
+	dir = 1
+	},
+/turf/simulated/floor/wood/sif/broken,
+/area/submap/CultBar)
+"ZZ" = (
+/obj/structure/window/basic,
+/obj/structure/curtain,
+/turf/simulated/floor/wood/sif,
+/area/submap/CultBar)
+
+(1,1,1) = {"
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+"}
+(2,1,1) = {"
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ID
+ID
+ok
+ID
+ID
+ID
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+"}
+(3,1,1) = {"
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ID
+ei
+ei
+ID
+ei
+Ww
+ei
+ID
+ID
+ok
+ok
+ok
+ok
+ID
+ID
+ID
+ID
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+"}
+(4,1,1) = {"
+ok
+ok
+ok
+Wf
+wt
+wt
+wt
+wt
+wt
+wt
+zk
+fF
+fF
+fF
+fF
+fF
+CC
+fF
+wt
+wt
+wt
+wt
+fF
+zk
+fF
+fF
+Wf
+wt
+Ti
+wt
+wt
+ok
+ok
+ok
+ok
+"}
+(5,1,1) = {"
+ok
+ok
+ok
+wt
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+fF
+fF
+Om
+wt
+wt
+ID
+ok
+ok
+ok
+"}
+(6,1,1) = {"
+ok
+ok
+ID
+wt
+VZ
+Sn
+dt
+zU
+Xs
+EJ
+yP
+Sn
+VZ
+lu
+JJ
+bv
+VZ
+go
+OO
+Lp
+YM
+cL
+pv
+VZ
+TV
+VZ
+fF
+wt
+wt
+Cp
+Cp
+ID
+ID
+ok
+ok
+"}
+(7,1,1) = {"
+ok
+ok
+ID
+fF
+VZ
+EJ
+Ak
+Gp
+zU
+or
+Zz
+zU
+VZ
+cq
+CY
+Dp
+VZ
+Ks
+zU
+or
+or
+dt
+ez
+QX
+zU
+QX
+wt
+wt
+Cp
+Px
+Cp
+EM
+ID
+ID
+ok
+"}
+(8,1,1) = {"
+ok
+ID
+Ww
+fF
+VZ
+zU
+LV
+or
+iJ
+bt
+or
+zU
+QX
+CY
+jJ
+RO
+VZ
+dt
+zU
+at
+zU
+or
+zU
+VZ
+VC
+VZ
+wt
+Cp
+Cp
+Nw
+Cp
+EM
+XI
+ID
+ok
+"}
+(9,1,1) = {"
+ok
+ID
+ei
+fF
+VZ
+HK
+lV
+Rc
+MO
+HK
+mz
+zU
+VZ
+oZ
+CY
+cH
+VZ
+Ks
+tO
+lm
+xb
+mT
+zU
+VZ
+VZ
+VZ
+wt
+Cp
+Cp
+Cp
+Cp
+va
+EM
+ID
+ok
+"}
+(10,1,1) = {"
+ok
+ok
+ID
+CC
+VZ
+yP
+Fb
+Co
+Fb
+QO
+Vk
+EJ
+VZ
+aH
+mQ
+gh
+VZ
+zU
+or
+qP
+qP
+HK
+iJ
+VZ
+CC
+wt
+wt
+Cp
+Cp
+Cp
+fs
+EM
+EM
+ID
+ok
+"}
+(11,1,1) = {"
+ok
+ok
+ID
+fF
+VZ
+dt
+Cf
+WO
+kK
+mt
+OZ
+zU
+VZ
+VZ
+QX
+VZ
+VZ
+zU
+Ah
+GO
+Le
+KB
+zU
+VZ
+fF
+wt
+wt
+Cp
+cJ
+Cp
+Cp
+EM
+EM
+ID
+ok
+"}
+(12,1,1) = {"
+ok
+ok
+ok
+wt
+VZ
+zU
+bt
+QO
+Yk
+Co
+or
+or
+VZ
+pi
+HP
+HP
+gu
+Ah
+zU
+qP
+rJ
+HK
+zU
+ZZ
+fF
+wt
+wt
+Cp
+Cp
+rH
+Cp
+DS
+EM
+ID
+ok
+"}
+(13,1,1) = {"
+ok
+ok
+ID
+fF
+VZ
+Fb
+Oq
+DY
+oo
+or
+Dm
+aN
+VZ
+Dw
+EH
+yV
+qP
+or
+mT
+xb
+eT
+mT
+zU
+ZZ
+fF
+wt
+wt
+Cp
+Cp
+Cp
+Cp
+EM
+EM
+ID
+ok
+"}
+(14,1,1) = {"
+ok
+ID
+ei
+fF
+VZ
+Xs
+ov
+or
+or
+Fb
+bt
+pG
+VZ
+UB
+nu
+HP
+pd
+Ah
+cv
+zU
+zU
+zU
+or
+ZZ
+fF
+fF
+wt
+wt
+Cp
+Cp
+Px
+EM
+ID
+ID
+ok
+"}
+(15,1,1) = {"
+ok
+ok
+ID
+zk
+VZ
+zU
+Fb
+zU
+MH
+DY
+LD
+yP
+VZ
+KV
+HP
+wr
+qP
+zU
+or
+LD
+pG
+yP
+dt
+VZ
+fF
+fF
+wt
+wt
+Cp
+Cp
+Cp
+ID
+ID
+ok
+ok
+"}
+(16,1,1) = {"
+ok
+ok
+ID
+fF
+VZ
+Sn
+Xs
+dt
+zU
+or
+Fb
+Ki
+VZ
+Ch
+HP
+HP
+gu
+NZ
+zU
+or
+iJ
+or
+dY
+VZ
+jy
+fF
+fF
+wt
+wt
+Cp
+Cp
+ID
+ID
+ok
+ok
+"}
+(17,1,1) = {"
+ok
+ok
+ID
+fF
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+lg
+EH
+qG
+gu
+or
+YZ
+MJ
+LY
+mT
+zU
+VZ
+fF
+fF
+fF
+fF
+wt
+wt
+wt
+ID
+ok
+ok
+ok
+"}
+(18,1,1) = {"
+ok
+ok
+ok
+Wf
+VZ
+dO
+Mw
+ma
+VZ
+ht
+yI
+WL
+VZ
+Gb
+qG
+he
+jk
+mT
+zU
+qP
+qP
+zU
+at
+VZ
+fF
+Rk
+fF
+IU
+cT
+wt
+Om
+ID
+ID
+ok
+ok
+"}
+(19,1,1) = {"
+ok
+ok
+ok
+wt
+VZ
+nO
+JE
+Mw
+QX
+or
+fD
+or
+bs
+EH
+yV
+EH
+qP
+yP
+mT
+GO
+xX
+Br
+or
+ZZ
+fF
+fF
+fF
+fF
+fF
+wt
+wt
+EM
+ID
+ID
+ok
+"}
+(20,1,1) = {"
+ok
+ok
+ok
+wt
+VZ
+AO
+EY
+Kb
+VZ
+Vr
+iJ
+Dt
+VZ
+xQ
+HP
+EH
+VZ
+dt
+or
+qP
+gP
+iJ
+zU
+ZZ
+fF
+fF
+fF
+fF
+wt
+wt
+Cp
+dh
+EM
+ID
+ok
+"}
+(21,1,1) = {"
+ok
+ok
+ok
+wt
+VZ
+VZ
+VZ
+VZ
+VZ
+QX
+VZ
+VZ
+VZ
+Ip
+HP
+tE
+VZ
+Ks
+fR
+Ot
+Ot
+UJ
+zU
+ZZ
+fF
+fF
+fF
+wt
+wt
+Cp
+Cp
+EM
+EM
+ID
+ok
+"}
+(22,1,1) = {"
+ok
+ok
+ok
+wt
+VZ
+MF
+Gd
+oH
+Hw
+pj
+Gd
+UT
+VZ
+cY
+xz
+Jj
+VZ
+at
+zU
+zU
+zU
+or
+zU
+VZ
+fF
+fF
+fF
+wt
+wt
+Cp
+Cp
+mD
+EM
+ID
+ok
+"}
+(23,1,1) = {"
+ok
+ok
+ID
+fF
+VZ
+Gy
+Gd
+hm
+KF
+oH
+Gd
+eW
+VZ
+VZ
+QX
+VZ
+VZ
+VZ
+VZ
+VZ
+QX
+VZ
+VZ
+VZ
+zk
+NJ
+wt
+wt
+Px
+Cp
+Cp
+EM
+EM
+ID
+ok
+"}
+(24,1,1) = {"
+ok
+ok
+ID
+zk
+VZ
+hN
+ST
+oH
+fe
+nU
+oH
+Wq
+VZ
+Vs
+zU
+io
+zU
+or
+zU
+iJ
+or
+zU
+dY
+VZ
+fF
+fF
+wt
+wt
+Cp
+Nw
+Cp
+EM
+ID
+ID
+ok
+"}
+(25,1,1) = {"
+ok
+ID
+ei
+fF
+VZ
+ug
+oH
+nU
+Zx
+Hw
+pj
+nj
+VZ
+Ks
+Ah
+Ka
+UJ
+or
+mT
+sh
+pE
+fq
+zU
+VZ
+jy
+wt
+wt
+Cp
+Cp
+Cp
+Cp
+ID
+ID
+ok
+ok
+"}
+(26,1,1) = {"
+ok
+ID
+Ww
+fF
+QX
+Gd
+oH
+oH
+KF
+oH
+kZ
+UT
+VZ
+zU
+HK
+Xa
+zU
+HK
+at
+qP
+qP
+zU
+or
+ZZ
+wt
+wt
+rH
+Cp
+Cp
+Cp
+wt
+ID
+ok
+ok
+ok
+"}
+(27,1,1) = {"
+ok
+ID
+ei
+fF
+VZ
+Mx
+kZ
+oH
+fe
+kD
+oH
+wA
+VZ
+or
+eM
+WT
+pX
+HK
+BV
+na
+Zl
+Ah
+zU
+ZZ
+wt
+wt
+Cp
+cJ
+Cp
+Px
+wt
+ID
+ok
+ok
+ok
+"}
+(28,1,1) = {"
+ok
+ok
+ID
+zk
+VZ
+YU
+oH
+Uy
+KF
+Gd
+Gd
+Wq
+VZ
+or
+or
+Xa
+or
+ez
+HK
+gP
+gP
+HK
+or
+ZZ
+wt
+wt
+Cp
+Cp
+Cp
+Px
+wt
+ID
+ok
+ok
+ok
+"}
+(29,1,1) = {"
+ok
+ok
+ok
+wt
+VZ
+ij
+hu
+oH
+oH
+Op
+oH
+ea
+VZ
+ZG
+VJ
+cX
+Ah
+dt
+Ah
+MS
+BW
+zy
+HK
+VZ
+fF
+wt
+wt
+Cp
+wt
+wt
+wt
+ok
+ok
+ok
+ok
+"}
+(30,1,1) = {"
+ok
+ok
+ok
+wt
+VZ
+fB
+Gd
+WW
+qh
+jM
+Wc
+UT
+VZ
+or
+pG
+fR
+Xs
+or
+iJ
+ez
+or
+or
+Ub
+VZ
+kY
+fF
+wt
+wt
+wt
+Om
+Ti
+ok
+ok
+ok
+ok
+"}
+(31,1,1) = {"
+ok
+ok
+ok
+wt
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+VZ
+CC
+fF
+fF
+wt
+Ti
+Ti
+Ti
+ok
+ok
+ok
+ok
+"}
+(32,1,1) = {"
+ok
+ok
+ok
+Wf
+wt
+wt
+zk
+fF
+jy
+fF
+wt
+wt
+wt
+Ti
+wt
+wt
+wt
+Ti
+Ti
+wt
+wt
+wt
+wt
+jy
+IU
+fF
+wt
+Ti
+Ti
+Ti
+Ti
+ok
+ok
+ok
+ok
+"}
+(33,1,1) = {"
+ok
+ok
+ok
+ok
+ok
+ok
+ID
+ID
+ID
+ID
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ID
+ID
+ID
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+"}
+(34,1,1) = {"
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+"}
+(35,1,1) = {"
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+ok
+"}

--- a/RaidedMechBunker.dmm
+++ b/RaidedMechBunker.dmm
@@ -1,0 +1,887 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ac" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/loot_pile/mecha/durand,
+/turf/simulated/floor/tiled/red,
+/area/submap/MechHangar)
+"af" = (
+/turf/template_noop,
+/area/submap/MechHangar)
+"aR" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8;
+	icon_state = "bordercolor"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"di" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8;
+	icon_state = "bordercolor"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"fB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/floor/outdoors/rocks{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"fL" = (
+/obj/structure/table/bench/padded,
+/obj/structure/loot_pile/surface/bones,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"ha" = (
+/turf/simulated/wall/r_wall,
+/area/submap/MechHangar)
+"hg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/rocks{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"hW" = (
+/obj/random/outcrop,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"jF" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/red,
+/area/submap/MechHangar)
+"mP" = (
+/obj/structure/boulder,
+/turf/simulated/floor/tiled,
+/area/submap/MechHangar)
+"nC" = (
+/obj/structure/filingcabinet,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"nV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/rocks{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"ob" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/loot_pile/mecha/odysseus,
+/turf/simulated/floor/tiled/red,
+/area/submap/MechHangar)
+"qr" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/mineral/ignore_mapgen,
+/area/submap/MechHangar)
+"rn" = (
+/obj/random/outcrop,
+/turf/simulated/floor/outdoors/rocks{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"rF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains,
+/turf/simulated/floor/outdoors/rocks{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"sD" = (
+/turf/simulated/mineral/ignore_mapgen,
+/area/submap/MechHangar)
+"sX" = (
+/obj/structure/boulder,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"tt" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/random/mob/merc/armored,
+/turf/simulated/floor/tiled/red,
+/area/submap/MechHangar)
+"tF" = (
+/turf/simulated/mineral/ignore_mapgen,
+/area/template_noop)
+"ua" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"uy" = (
+/turf/template_noop,
+/area/template_noop)
+"uK" = (
+/mob/living/simple_mob/mechanical/mecha/combat/phazon,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"vy" = (
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/template_noop)
+"vP" = (
+/obj/structure/boulder,
+/turf/simulated/floor/outdoors/rocks{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"wf" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4;
+	icon_state = "bordercolor"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"yB" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/decal/mecha_wreckage/janus,
+/turf/simulated/floor/tiled/red,
+/area/submap/MechHangar)
+"yG" = (
+/obj/structure/boulder,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/template_noop)
+"zs" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/submap/MechHangar)
+"Aj" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"AF" = (
+/obj/effect/decal/remains,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"AW" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/decal/mecha_wreckage/marauder,
+/turf/simulated/floor/tiled/red,
+/area/submap/MechHangar)
+"BZ" = (
+/obj/structure/boulder,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/rocks{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"CO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"Fd" = (
+/obj/structure/filingcabinet,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"FS" = (
+/obj/structure/table/standard,
+/obj/random/firstaid,
+/obj/random/toolbox,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4;
+	icon_state = "bordercolor"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"Hz" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/turf/simulated/floor/tiled,
+/area/submap/MechHangar)
+"Ix" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"IM" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/red,
+/area/submap/MechHangar)
+"Ju" = (
+/turf/simulated/floor/outdoors/rocks{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"JI" = (
+/obj/structure/filingcabinet,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"Kh" = (
+/obj/random/outcrop,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/rocks{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"Kp" = (
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"KW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/mechanical/mecha/combat/phazon,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"Le" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/submap/MechHangar)
+"LE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"Nh" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/effect/decal/remains,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/submap/MechHangar)
+"RH" = (
+/obj/structure/door_assembly,
+/turf/simulated/floor/tiled,
+/area/submap/MechHangar)
+"RK" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"Sk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"So" = (
+/obj/random/outcrop,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"VA" = (
+/obj/effect/decal/remains,
+/turf/simulated/floor/outdoors/rocks{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"WZ" = (
+/obj/structure/table/standard,
+/obj/item/weapon/telecube/randomized,
+/turf/simulated/floor/tiled/dark,
+/area/submap/MechHangar)
+"XS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/rocks{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+"Ze" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/loot_pile/mecha/deathripley,
+/turf/simulated/floor/tiled/red,
+/area/submap/MechHangar)
+"ZC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/dirt{
+	outdoors = 0
+	},
+/area/submap/MechHangar)
+
+(1,1,1) = {"
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+"}
+(2,1,1) = {"
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+"}
+(3,1,1) = {"
+uy
+uy
+uy
+tF
+tF
+tF
+tF
+tF
+tF
+uy
+uy
+uy
+uy
+uy
+tF
+tF
+uy
+uy
+uy
+uy
+"}
+(4,1,1) = {"
+uy
+uy
+tF
+sD
+sD
+sD
+sD
+sD
+sD
+sD
+af
+af
+Kp
+sD
+sD
+sD
+sD
+uy
+uy
+uy
+"}
+(5,1,1) = {"
+uy
+uy
+tF
+ha
+ha
+ha
+ha
+ha
+ha
+sD
+af
+Kp
+Ju
+sD
+sD
+sD
+sD
+tF
+uy
+uy
+"}
+(6,1,1) = {"
+uy
+uy
+tF
+ha
+JI
+di
+aR
+RK
+ha
+sD
+hW
+ua
+XS
+sD
+sD
+sD
+sD
+uy
+uy
+uy
+"}
+(7,1,1) = {"
+uy
+tF
+tF
+ha
+Fd
+CO
+WZ
+fL
+ha
+sD
+sD
+LE
+LE
+vP
+sD
+sD
+rn
+uy
+uy
+uy
+"}
+(8,1,1) = {"
+uy
+tF
+tF
+ha
+nC
+wf
+FS
+Ix
+ha
+sD
+sD
+LE
+KW
+Sk
+Sk
+LE
+LE
+vy
+uy
+uy
+"}
+(9,1,1) = {"
+uy
+tF
+tF
+ha
+ha
+RH
+ha
+ha
+ha
+sD
+sD
+vP
+nV
+LE
+LE
+XS
+VA
+vy
+vy
+uy
+"}
+(10,1,1) = {"
+uy
+tF
+tF
+ha
+AW
+Le
+Le
+yB
+ha
+sD
+sD
+sD
+XS
+Kp
+hW
+LE
+sX
+tF
+tF
+uy
+"}
+(11,1,1) = {"
+uy
+tF
+tF
+ha
+Hz
+Le
+vP
+Le
+ha
+sD
+sD
+sD
+LE
+Kp
+LE
+Kp
+sD
+tF
+tF
+tF
+"}
+(12,1,1) = {"
+uy
+tF
+tF
+ha
+ac
+Hz
+Le
+jF
+ha
+sD
+sD
+sD
+sD
+Sk
+Kp
+sX
+sD
+tF
+tF
+tF
+"}
+(13,1,1) = {"
+uy
+uy
+tF
+ha
+mP
+Le
+Le
+Hz
+ha
+sD
+sD
+sD
+fB
+ZC
+Sk
+sD
+sD
+tF
+tF
+uy
+"}
+(14,1,1) = {"
+uy
+uy
+tF
+ha
+ob
+Hz
+Le
+IM
+ha
+sD
+sD
+Kh
+Ju
+LE
+LE
+hW
+sD
+tF
+uy
+uy
+"}
+(15,1,1) = {"
+uy
+uy
+tF
+ha
+Hz
+Hz
+Le
+Hz
+ha
+sD
+BZ
+XS
+hg
+Aj
+LE
+Kp
+Kp
+yG
+uy
+uy
+"}
+(16,1,1) = {"
+uy
+tF
+tF
+ha
+tt
+Hz
+Nh
+Hz
+Hz
+Kp
+LE
+nV
+Sk
+Sk
+XS
+rF
+Kp
+uy
+uy
+uy
+"}
+(17,1,1) = {"
+uy
+tF
+tF
+ha
+Hz
+vP
+Hz
+Le
+zs
+Sk
+LE
+So
+qr
+Ju
+sX
+LE
+af
+uy
+uy
+uy
+"}
+(18,1,1) = {"
+uy
+tF
+tF
+ha
+Ze
+Hz
+Hz
+Hz
+vP
+LE
+Kp
+sD
+sD
+sD
+sD
+Kp
+af
+uy
+uy
+uy
+"}
+(19,1,1) = {"
+uy
+uy
+tF
+ha
+ha
+ha
+ha
+ha
+ha
+vP
+sD
+sD
+sD
+sD
+Sk
+LE
+Kp
+uy
+uy
+uy
+"}
+(20,1,1) = {"
+uy
+uy
+tF
+sD
+sD
+sD
+sD
+sD
+sD
+AF
+vP
+sD
+sD
+sD
+uK
+LE
+vP
+tF
+uy
+uy
+"}
+(21,1,1) = {"
+uy
+uy
+uy
+sD
+sD
+sD
+sD
+sD
+sD
+af
+Kp
+hW
+sD
+sX
+LE
+Kp
+sD
+tF
+tF
+uy
+"}
+(22,1,1) = {"
+uy
+uy
+uy
+sD
+sD
+sD
+sD
+sD
+sD
+af
+af
+af
+af
+af
+Ju
+sD
+sD
+tF
+tF
+uy
+"}
+(23,1,1) = {"
+uy
+uy
+uy
+uy
+tF
+tF
+tF
+tF
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+tF
+tF
+uy
+uy
+"}
+(24,1,1) = {"
+uy
+uy
+uy
+uy
+uy
+tF
+tF
+tF
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+"}
+(25,1,1) = {"
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+uy
+"}


### PR DESCRIPTION
Attempting to update my POIs. To make them bearable to look at, up the difficultly, but also to increase the shinnies.

Ambush Base
Lore: After finding some strange artifacts in the water, a smaller company hired out contractors to try and salvage as much useful loot as they can, preferably undetected, but not witnesses. Changes
-Added more foes, including a mercenary trained giant fish. -Swapped the cafe for a 'diving' room, changed the old living quarters to a 'xenoarch' room, shifted the location of the 'leader' room, putting the armory between it and the new living quarters area. -Made it so the mercenaries are trying to fish out artifacts from the lack. -Added 3rd sniper spot, but the APC is much easier to access. The person who built the base was shortly fired. -A team of 4 can be equipped with armor and weaponry.

Cult Bar
-The demons and cultists shouldn't fight now. At least this POI's demons. So also added more of them. -Made the 'boss' room quite a bit rougher, but two new goodies lay within. -There is now a large table of random items they took from their previous victims...although their body is sprawled throughout most of the facility. -The bar is now split up into further sections. Well, the 'gambling' area is now properly separated. -Added creepy grass, and some plant life.
-Theoretically a team of 4 could roleplay as cultists. -Kitchen has food.

Mech Bunker
-Made the bunker more carved into a cave.
-Added a 3rd mech.
-Made the some wrecked mechs loot piles.
-Changed the loot inside the small room.

Now, in the high likely hood I messed something up, I'll try to fix it as soon as I can. And if needed, do feel free to close this one if it gets in the way.