### PR TITLE
Adds a toggle for vorgan entrance chatlogs

### DIFF
--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -19,12 +19,13 @@
 	verbs |= /mob/living/proc/lick
 	verbs |= /mob/living/proc/smell
 	verbs |= /mob/living/proc/switch_scaling
+	verbs |= /mob/living/proc/mute_entry //CHOMPEdit
 
 	if(!no_vore)
 		verbs |= /mob/living/proc/vorebelly_printout
 		if(!vorePanel)
 			AddComponent(/datum/component/vore_panel)
-			
+
 	verbs += /mob/living/proc/vore_transfer_reagents //CHOMP If mob doesnt have bellies it cant use this verb for anything
 	verbs += /mob/living/proc/vore_check_reagents //CHOMP If mob doesnt have bellies it cant use this verb for anything
 	verbs += /mob/living/proc/vore_bellyrub //CHOMP If mob doesnt have bellies it probably won't be needing this anyway

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -311,7 +311,8 @@
 		return //Someone dropping something (or being stripdigested)
 
 	//Generic entered message
-	to_chat(owner,"<span class='notice'>[thing] slides into your [lowertext(name)].</span>")
+	if(!owner.mute_entry) //CHOMPEdit
+		to_chat(owner,"<span class='notice'>[thing] slides into your [lowertext(name)].</span>")
 
 	//Sound w/ antispam flag setting
 	if(vore_sound && !recent_sound)

--- a/code/modules/vore/eating/living_ch.dm
+++ b/code/modules/vore/eating/living_ch.dm
@@ -6,7 +6,7 @@
 	var/vore_footstep_volume = 0			//Variable volume for a mob, updated every 5 steps where a footstep hasnt occurred.
 	var/vore_footstep_chance = 0
 	var/vore_footstep_volume_cooldown = 0	//goes up each time a step isnt heard, and will proc update of list of viable bellies to determine the most filled and loudest one to base audio on.
-
+	var/mute_entry = FALSE				//Toggleable vorgan entry logs.
 	var/parasitic = FALSE //Digestion immunity and nutrition leeching variable
 
 	// CHOMP vore icons refactor (Now on living)
@@ -270,3 +270,9 @@
 			return TRUE
 	to_chat(src, "<span class='warning'>There is no suitable belly for rubs.</span>")
 	return FALSE
+
+/mob/living/proc/mute_entry()
+	set name = "Mute Vorgan Entrance"
+	set category = "Preferences"
+	set desc = "Mute the chatlog messages when something enters a vore belly."
+	mute_entry = !mute_entry


### PR DESCRIPTION
Only in ingame preferences tab as a non-persistent setting for now. Might make a proper pref later if folks want that, but currently it's just a niche thing I wanted to try out for some extra level of mystery with rng autotransfer setups. Basically just makes it so that things entering a vorgan don't print out "thing slides into your vorgan" into the chat every time it happens.