### PR TITLE
Fixes fire spread runtime spam

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -170,7 +170,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 					continue
 
 				//Spread the fire.
-				if(prob( 50 + 50 * (firelevel/vsc.fire_firelevel_multiplier) ) && my_tile.CanPass(null, enemy_tile, 0,0) && enemy_tile.CanPass(null, my_tile, 0,0))
+				if(prob( 50 + 50 * (firelevel/vsc.fire_firelevel_multiplier) ) && my_tile.CanPass(src, enemy_tile, 0,0) && enemy_tile.CanPass(src, my_tile, 0,0))
 					enemy_tile.create_fire(firelevel)
 
 			else


### PR DESCRIPTION
apparently had been fixed on virgo over a year ago but completely ignored by the mirrorbot