### PR TITLE
Adds gradual corpse digestion

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -55,6 +55,8 @@
 	var/next_emote = 0						// When we're supposed to print our next emote, as a world.time
 	var/selective_preference = DM_DIGEST	// Which type of selective bellymode do we default to?
 	var/special_entrance_sound				// CHOMPEdit: Mob specific custom entry sound set by mob's init_vore when applicable
+	var/slow_digestion = FALSE				// CHOMPEdit: Gradual corpse digestion
+	var/slow_brutal = FALSE					// CHOMPEdit: Gradual corpse digestion: Stumpy's Special
 
 	// Generally just used by AI
 	var/autotransferchance = 0 				// % Chance of prey being autotransferred to transfer location
@@ -266,7 +268,9 @@
 	"autotransferlocation",
 	"autotransfer_enabled",
 	"autotransfer_min_amount",
-	"autotransfer_max_amount", //CHOMP end of variables from CHOMP
+	"autotransfer_max_amount",
+	"slow_digestion",
+	"slow_brutal", //CHOMP end of variables from CHOMP
 	"egg_type",
 	"save_digest_mode"
 	)
@@ -1308,7 +1312,9 @@
 	dupe.autotransferlocation = autotransferlocation
 	dupe.autotransfer_enabled = autotransfer_enabled
 	dupe.autotransfer_min_amount = autotransfer_min_amount
-	dupe.autotransfer_max_amount = autotransfer_max_amount //CHOMP end of variables from CHOMP
+	dupe.autotransfer_max_amount = autotransfer_max_amount
+	dupe.slow_digestion = slow_digestion
+	dupe.slow_brutal = slow_brutal //CHOMP end of variables from CHOMP
 
 	dupe.belly_fullscreen = belly_fullscreen
 	dupe.disable_hud = disable_hud

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -29,15 +29,20 @@ GLOBAL_LIST_INIT(digest_modes, list())
 
 	//Person just died in guts!
 	if(L.stat == DEAD)
-		if(L.is_preference_enabled(/datum/client_preference/digestion_noises))
+		if(!L.digestion_in_progress) //CHOMPEdit Start
+			if(L.is_preference_enabled(/datum/client_preference/digestion_noises))
+				if(!B.fancy_vore)
+					SEND_SOUND(L, sound(get_sfx("classic_death_sounds")))
+				else
+					SEND_SOUND(L, sound(get_sfx("fancy_death_prey")))
+			B.handle_digestion_death(L)
 			if(!B.fancy_vore)
-				SEND_SOUND(L, sound(get_sfx("classic_death_sounds")))
-			else
-				SEND_SOUND(L, sound(get_sfx("fancy_death_prey")))
-		B.handle_digestion_death(L)
-		if(!B.fancy_vore)
-			return list("to_update" = TRUE, "soundToPlay" = sound(get_sfx("classic_death_sounds")))
-		return list("to_update" = TRUE, "soundToPlay" = sound(get_sfx("fancy_death_pred")))
+				return list("to_update" = TRUE, "soundToPlay" = sound(get_sfx("classic_death_sounds")))
+			return list("to_update" = TRUE, "soundToPlay" = sound(get_sfx("fancy_death_pred")))
+		else
+			B.handle_digestion_death(L)
+	if(!L)
+		return //CHOMPEdit End
 
 		//CHOMPEDIT: Parasitic digestion immunity hook, used to be a synx istype check but this is more optimized.
 	if(L.parasitic)
@@ -68,7 +73,8 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	var/actual_tox = L.getToxLoss() - old_tox
 	var/actual_clone = L.getCloneLoss() - old_clone
 	var/damage_gain = (actual_brute + actual_burn + actual_oxy/2 + actual_tox + actual_clone*2)*(B.nutrition_percent / 100)
-
+	if(B.slow_digestion) //CHOMPEdit
+		damage_gain = damage_gain * 0.5
 	var/offset = (1 + ((L.weight - 137) / 137)) // 130 pounds = .95 140 pounds = 1.02
 	var/difference = B.owner.size_multiplier / L.size_multiplier
 	if(isrobot(B.owner))

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -297,6 +297,8 @@
 	if(slow_digestion) //CHOMPAdd Start: Gradual corpse digestion
 		if(!M.digestion_in_progress)
 			M.digestion_in_progress = TRUE
+			if(M.health > -36 || (ishuman(M) && M.health > -136))
+				to_chat(M, "<span class='notice'>(Your predator has enabled gradual body digestion. Stick around for a second round of churning to reach the true finisher.)</span>")
 		if(M.health < M.maxHealth * -1) //Siplemobs etc
 			if(ishuman(M))
 				if(M.health < (M.maxHealth * -1) -100) //Spacemans can go much deeper. Jank but maxHealth*-2 doesn't work with flat standard -100hp death threshold.

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -294,6 +294,31 @@
 	return did_an_item
 
 /obj/belly/proc/handle_digestion_death(mob/living/M)
+	if(slow_digestion) //CHOMPAdd Start: Gradual corpse digestion
+		if(!M.digestion_in_progress)
+			M.digestion_in_progress = TRUE
+		if(M.health < M.maxHealth * -1) //Siplemobs etc
+			if(ishuman(M))
+				if(M.health < (M.maxHealth * -1) -100) //Spacemans can go much deeper. Jank but maxHealth*-2 doesn't work with flat standard -100hp death threshold.
+					if(slow_brutal)
+						var/mob/living/carbon/human/P = M
+						var/vitals_only = TRUE
+						for(var/obj/item/organ/external/E in P.organs)
+							if(!E.vital)
+								vitals_only = FALSE
+								if(!LAZYLEN(E.children))
+									E.droplimb(TRUE, DROPLIMB_EDGE)
+									qdel(E)
+									break
+							continue
+						if(vitals_only)
+							M.digestion_in_progress = FALSE
+					else
+						M.digestion_in_progress = FALSE
+			else
+				M.digestion_in_progress = FALSE
+		if(M.digestion_in_progress)
+			return //CHOMPAdd End
 	var/digest_alert_owner = pick(digest_messages_owner)
 	var/digest_alert_prey = pick(digest_messages_prey)
 	var/compensation = M.maxHealth / 5 //Dead body bonus.

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -51,6 +51,7 @@
 	var/selective_preference = DM_DEFAULT	// Preference for selective bellymode
 	var/appendage_color = "#e03997" //Default pink. Used for the 'long_vore' trait.
 	var/appendage_alt_setting = FALSE	// Dictates if 'long_vore' user pulls prey to them or not. 1 = user thrown towards target.
+	var/digestion_in_progress = FALSE	// CHOMPEdit: Gradual corpse gurgles
 	var/regen_sounds = list(
 		'sound/effects/mob_effects/xenochimera/regen_1.ogg',
 		'sound/effects/mob_effects/xenochimera/regen_2.ogg',


### PR DESCRIPTION
Adds a belly setting option to enable gradual corpse digestion. With this feature, a pred can digest their prey for longer even after death instead of instantly deleting the body upon expiring. Prey's body will finish digesting when the dead body has been given another dose of their maxhealth's worth of glorpin (total nutri gain halved due to double round). Also comes with an extra option for humanmobs to digest individual body parts one by one before the grand finish. (Why? Simply because I had a brainfart and a mood to chase it for no reason other than personal flex to see if i can code it so the code simply exists now. Why not? That's up for you to decide lol)

Currently lacking vorepanel buttons though. Haven't got the TGUI baking equipments set up on this compy yet and got maybe offered some assistance with it. (Per-belly settings for "slow_digestion" var (main feature toggle button) and "slow_brutal" var (that humanmob extra option toggle button)