### PR TITLE
Fixes wilderness active edge issues with ceilings!

### DIFF
--- a/code/game/machinery/casino_ch.dm
+++ b/code/game/machinery/casino_ch.dm
@@ -277,7 +277,7 @@
 		"sodawater", "lemon_lime", "sugar", "orangejuice", "limejuice", "watermelonjuice", "thirteenloko", "grapesoda",
 		"coffee", "cafe_latte", "soy_latte", "hot_coco", "milk", "cream", "tea", "ice", "orangejuice", "lemonjuice",
 		"limejuice", "berryjuice", "mint", "lemon_lime", "sugar", "orangejuice", "limejuice", "sodawater",
-		"tonic", "beer", "kahlua", "whiskey", "wine", "vodka", "gin", "rum", "tequilla", "vermouth", "cognac",
+		"tonic", "beer", "kahlua", "whiskey", "redwine", "vodka", "gin", "rum", "tequilla", "vermouth", "cognac",
 		"ale", "mead", "bitters", "champagne", "singulo", "doctorsdelight", "nothing", "banana", "honey", "egg",
 		"coco", "cherryjelly", "carrotjuice", "applejuice", "tomatojuice", "peanutbutter", "soymilk", "grenadine", "gingerale", "roy_rogers",
 		"patron", "goldschlager", "gelatin", "melonliquor", "bluecuracao", "thirteenloko", "deadrum", "sake", "acidspit",

--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -418,6 +418,12 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 	if(orientation != 0) // 0 means no rotation
 		var/atom/A = .
 		A.set_dir(turn(A.dir, orientation))
+	if(istype(crds, /turf/simulated/floor)) //CHOMPAdd: Wilderness ceilings!
+		var/turf/simulated/floor/F = crds
+		if(istype(F.loc, /area/submap) && F.outdoors != 1)
+			var/turf/above = GetAbove(F)
+			if(above && istype(above, /turf/simulated/open))
+				above.ChangeTurf(get_base_turf_by_area(F), FALSE, TRUE)
 
 /dmm_suite/proc/create_atom(path, crds)
 	set waitfor = FALSE

--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -420,12 +420,18 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 		A.set_dir(turn(A.dir, orientation))
 	if(istype(crds, /turf/simulated/floor)) //CHOMPAdd: Wilderness ceilings!
 		var/turf/simulated/floor/F = crds
-		if(istype(F.loc, /area/submap) && F.outdoors != 1)
-			for(var/obj/effect/zone_divider/ZD in F.contents)
-				qdel(ZD)
-			var/turf/above = GetAbove(F)
-			if(above && istype(above, /turf/simulated/open))
-				above.ChangeTurf(get_base_turf_by_area(F), FALSE, TRUE) //CHOMPAdd End
+		if(istype(F.loc, /area/submap))
+			var/turf/B = get_base_turf(F.z)
+			if(istype(B, /turf_simulated)) //If I have to force standardized POI atmos, I will.
+				F.oxygen = B.oxygen
+				F.nitrogen = B.nitrogen
+				F.temperature = B.temperature
+			if(F.outdoors != 1)
+				for(var/obj/effect/zone_divider/ZD in F.contents)
+					qdel(ZD)
+				var/turf/above = GetAbove(F)
+				if(above && istype(above, /turf/simulated/open))
+					above.ChangeTurf(get_base_turf_by_area(F), FALSE, TRUE) //CHOMPAdd End
 
 /dmm_suite/proc/create_atom(path, crds)
 	set waitfor = FALSE

--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -421,6 +421,8 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 	if(istype(crds, /turf/simulated/floor)) //CHOMPAdd: Wilderness ceilings!
 		var/turf/simulated/floor/F = crds
 		if(istype(F.loc, /area/submap) && F.outdoors != 1)
+			for(var/obj/effect/zone_divider/ZD in F.contents)
+				qdel(ZD)
 			var/turf/above = GetAbove(F)
 			if(above && istype(above, /turf/simulated/open))
 				above.ChangeTurf(get_base_turf_by_area(F), FALSE, TRUE) //CHOMPAdd End

--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -420,18 +420,12 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 		A.set_dir(turn(A.dir, orientation))
 	if(istype(crds, /turf/simulated/floor)) //CHOMPAdd: Wilderness ceilings!
 		var/turf/simulated/floor/F = crds
-		if(istype(F.loc, /area/submap))
-			var/turf/B = get_base_turf(F.z)
-			if(istype(B, /turf/simulated)) //If I have to force standardized POI atmos, I will.
-				F.oxygen = B.oxygen
-				F.nitrogen = B.nitrogen
-				F.temperature = B.temperature
-			if(F.outdoors != 1)
-				for(var/obj/effect/zone_divider/ZD in F.contents)
-					qdel(ZD)
-				var/turf/above = GetAbove(F)
-				if(above && istype(above, /turf/simulated/open))
-					above.ChangeTurf(get_base_turf_by_area(F), FALSE, TRUE) //CHOMPAdd End
+		if(istype(F.loc, /area/submap) && F.outdoors != 1)
+			for(var/obj/effect/zone_divider/ZD in F.contents)
+				qdel(ZD)
+			var/turf/above = GetAbove(F)
+			if(above && istype(above, /turf/simulated/open))
+				above.ChangeTurf(get_base_turf_by_area(F), FALSE, TRUE) //CHOMPAdd End
 
 /dmm_suite/proc/create_atom(path, crds)
 	set waitfor = FALSE

--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -423,7 +423,7 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 		if(istype(F.loc, /area/submap) && F.outdoors != 1)
 			var/turf/above = GetAbove(F)
 			if(above && istype(above, /turf/simulated/open))
-				above.ChangeTurf(get_base_turf_by_area(F), FALSE, TRUE)
+				above.ChangeTurf(get_base_turf_by_area(F), FALSE, TRUE) //CHOMPAdd End
 
 /dmm_suite/proc/create_atom(path, crds)
 	set waitfor = FALSE

--- a/code/modules/maps/tg/reader.dm
+++ b/code/modules/maps/tg/reader.dm
@@ -422,7 +422,7 @@ GLOBAL_DATUM_INIT(_preloader, /dmm_suite/preloader, new)
 		var/turf/simulated/floor/F = crds
 		if(istype(F.loc, /area/submap))
 			var/turf/B = get_base_turf(F.z)
-			if(istype(B, /turf_simulated)) //If I have to force standardized POI atmos, I will.
+			if(istype(B, /turf/simulated)) //If I have to force standardized POI atmos, I will.
 				F.oxygen = B.oxygen
 				F.nitrogen = B.nitrogen
 				F.temperature = B.temperature

--- a/code/modules/xenobio/items/slime_objects.dm
+++ b/code/modules/xenobio/items/slime_objects.dm
@@ -141,9 +141,10 @@
 	light_range = 6
 	on = 1 //Bio-luminesence has one setting, on.
 	power_use = 0
+	light_system = STATIC_LIGHT
 
-/obj/item/device/flashlight/slime/New()
-	..()
+/obj/item/device/flashlight/slime/Initialize()
+	.=..()
 	set_light(light_range, light_power, light_color)
 
 /obj/item/device/flashlight/slime/update_brightness()


### PR DESCRIPTION
The maploader/reader/thingy now generates "roofs" for open indoors POIs if there is open space above. Also yeets the dividers out of the way for the indoor turfs.

Also fixes casino/vr drink dispenser runtime and glow slime runtime.