### PR TITLE
Fixes missing concrete material sprite.

### DIFF
--- a/code/modules/materials/sheets/stone.dm
+++ b/code/modules/materials/sheets/stone.dm
@@ -26,7 +26,7 @@
 
 /obj/item/stack/material/concrete
 	name = "concrete brick"
-	icon_state = "brick"
+	icon_state = "sheet-brick"
 	default_type = "concrete"
 	no_variants = FALSE
 	apply_colour = 1


### PR DESCRIPTION
Turns out it was not the parent file, but a file a folder DEEPER.
![dreamseeker_C6KibjGDMa](https://user-images.githubusercontent.com/10555869/200147478-f8fbc830-3be0-43b0-b9bd-323ea4a7e867.png)

You got brick now.