### PR TITLE
Fix broken tesh mechanics + nerf underwater diving

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/teshari.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/teshari.dm
@@ -1,2 +1,29 @@
 /datum/species/teshari
     vore_belly_default_variant = "T"
+
+// allow teshari to always be scooped, as long as pref is enabled
+/mob/living/MouseDrop(var/atom/over_object)
+	// make sure src (The dragged) is human
+	if(!istype(src, /mob/living/carbon/human))
+		return ..()
+
+	var/mob/living/carbon/human/DraggedH = src
+
+	//make sure src (the dragged) is a teshari
+	if(DraggedH.species.name == SPECIES_TESHARI)
+		var/mob/living/M = over_object
+		// only perform the grab if; grabber and grabbed adjacent, caller is grabbed OR grabber, and the grabbed's grab preference is true.
+		if(holder_type && istype(M) && Adjacent(M) && (usr == M || usr == DraggedH) && DraggedH != M && !M.incapacitated() && DraggedH.pickup_pref && (M != usr || (M == usr && M.pickup_active)) && (DraggedH.a_intent == I_HELP && M.a_intent == I_HELP)) //VOREStation Edit
+			get_scooped(M, (usr == DraggedH))
+			return
+	return ..()
+
+
+//allow teshari permission to pass plastic flaps.
+/obj/structure/plasticflaps/CanPass(atom/A, turf/T)
+	var/mob/living/carbon/human/H = A
+	if(istype(H))
+		if(H.species.name == SPECIES_TESHARI)
+			return 1
+
+	return ..()

--- a/modular_chomp/code/modules/projectiles/gun.dm
+++ b/modular_chomp/code/modules/projectiles/gun.dm
@@ -1,0 +1,9 @@
+// prevent gun activation when stealth swimming. The low alpha hides you from NPC AI, which allows you to cheese mobs.
+/obj/item/weapon/gun/special_check(var/mob/user)
+	var/mob/living/L = user
+	if(istype(L))
+		if(L.has_modifier_of_type(/datum/modifier/underwater_stealth))
+			to_chat(user,"<span class='warning'>You cannot use guns whilst hiding underwater!</span>")
+			return 0
+
+	return ..()

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4566,6 +4566,7 @@
 #include "modular_chomp\code\modules\power\cells\device_cells.dm"
 #include "modular_chomp\code\modules\power\cells\esoteric_cells.dm"
 #include "modular_chomp\code\modules\power\cells\power_cells.dm"
+#include "modular_chomp\code\modules\projectiles\gun.dm"
 #include "modular_chomp\code\modules\reagents\machinery\dispenser\chem_synthesizer_ch.dm"
 #include "modular_chomp\code\modules\reagents\reactions\instant\drinks.dm"
 #include "modular_chomp\code\modules\reagents\reagents\food_drinks.dm"


### PR DESCRIPTION
Fixes teshgrabbing and tesh running under plastic flaps without touching the mob size.

Teshgrabbing now respects the pref setting of micro grabbing mechanics AS WELL AS the toggle for intent to pick micros up.
Same as previous, clickdrag with both on green intent to do it.
The grabbed must have the pref enabled.
The grabber must have pickup pref on. 

Also nerfs being able to shoot whilst dived underwater. The alpha change prevents mob AI locking onto you which is cheesey. 