### PR TITLE
Comment out var/map_name because we don't use it

### DIFF
--- a/code/modules/tgs/v5/chat_commands.dm
+++ b/code/modules/tgs/v5/chat_commands.dm
@@ -8,7 +8,7 @@
 	var/afks = 0
 	var/active = 0
 	var/bellied = 0
-	var/map_name = "n/a"
+//	var/map_name = "n/a" //CHOMP Remove we don't use this and it is causing problems with the dmb compiler.
 	if(using_map && using_map.full_name)
 		map_name = using_map.full_name
 

--- a/code/modules/tgs/v5/chat_commands.dm
+++ b/code/modules/tgs/v5/chat_commands.dm
@@ -9,8 +9,8 @@
 	var/active = 0
 	var/bellied = 0
 //	var/map_name = "n/a" //CHOMP Remove we don't use this and it is causing problems with the dmb compiler.
-	if(using_map && using_map.full_name)
-		map_name = using_map.full_name
+//	if(using_map && using_map.full_name)
+//		map_name = using_map.full_name
 
 	for(var/X in GLOB.clients)
 		var/client/C = X


### PR DESCRIPTION
And it is causing a warning for the compiler.