### PR TITLE
Fix a pair of carbonkin job bugs

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -547,6 +547,10 @@
 			// Checks for jobs with minimum age requirements
 			if((job.minimum_character_age || job.min_age_by_species) && (client.prefs.age < job.get_min_age(client.prefs.species, client.prefs.organ_data["brain"])))
 				continue
+			//CHOMPEdit Begin - Check species job bans... (Only used for shadekin)
+			if(job.is_species_banned(client.prefs.species, client.prefs.organ_data["brain"]))
+				continue
+			//CHOMPEdit End
 			// Checks for jobs set to "Never" in preferences	//TODO: Figure out a better way to check for this
 			if(!(client.prefs.GetJobDepartment(job, 1) & job.flag))
 				if(!(client.prefs.GetJobDepartment(job, 2) & job.flag))

--- a/modular_chomp/code/game/jobs/job/silicon.dm
+++ b/modular_chomp/code/game/jobs/job/silicon.dm
@@ -1,0 +1,7 @@
+/datum/job/ai/is_species_banned(species_name, brain_type)
+    // Any species can join as AI, including shadekin.
+    return FALSE
+
+/datum/job/cyborg/is_species_banned(species_name, brain_type)
+    // Any species can join as cyborgs, including shadekin.
+    return FALSE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4509,6 +4509,7 @@
 #include "modular_chomp\code\datums\outfits\jobs\noncrew.dm"
 #include "modular_chomp\code\game\jobs\job\department.dm"
 #include "modular_chomp\code\game\jobs\job\noncrew.dm"
+#include "modular_chomp\code\game\jobs\job\silicon.dm"
 #include "modular_chomp\code\game\machinery\airconditioner_ch.dm"
 #include "modular_chomp\code\game\objects\structures\watercloset_ch.dm"
 #include "modular_chomp\code\game\objects\structures\crate_lockers\largecrate.dm"


### PR DESCRIPTION
Shadekin could still pick any job they wanted before this fix, and I have made the change to allow carbonkin slots to pick AI or Cyborg jobs as well as non-crew. (Since they don't get to be carbonkin anyways as either of those jobs.)