### PR TITLE
Minor non-crew tweaks 1

### DIFF
--- a/code/__defines/misc_ch.dm
+++ b/code/__defines/misc_ch.dm
@@ -1,6 +1,9 @@
 //Department defines
 #define DEPARTMENT_NONCREW      "Non crew"
 
+//Job defines
+#define JOB_OUTSIDER            "Outsider"
+
 //Material defines
 #define MAT_CARPET				"red carpet"
 #define MAT_CARPET_TEAL			"teal carpet"

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -41,7 +41,7 @@ var/list/spawntypes = list()
 /datum/spawnpoint/arrivals
 	display_name = "Arrivals Shuttle"
 	msg = "will arrive to the station shortly by shuttle"
-	disallow_job = list("Non-Crew") //CHOMPEdit add
+	disallow_job = list(JOB_OUTSIDER) //CHOMPEdit add
 
 /datum/spawnpoint/arrivals/New()
 	..()
@@ -67,7 +67,7 @@ var/list/spawntypes = list()
 	display_name = "Cryogenic Storage"
 	msg = "has completed cryogenic revival"
 	allowed_mob_types = JOB_CARBON
-	disallow_job = list("Non-Crew") //CHOMPEdit add
+	disallow_job = list(JOB_OUTSIDER) //CHOMPEdit add
 
 /datum/spawnpoint/cryo/New()
 	..()
@@ -77,7 +77,7 @@ var/list/spawntypes = list()
 	display_name = "Cyborg Storage"
 	msg = "has been activated from storage"
 	allowed_mob_types = JOB_SILICON
-	disallow_job = list("Non-Crew") //CHOMPEdit add
+	disallow_job = list(JOB_OUTSIDER) //CHOMPEdit add
 
 /datum/spawnpoint/cyborg/New()
 	..()
@@ -104,7 +104,7 @@ var/global/list/latejoin_tram   = list()
 /datum/spawnpoint/tram
 	display_name = "Tram Station"
 	msg = "will arrive to the station shortly by shuttle"
-	disallow_job = list("Non-Crew") //CHOMPEdit add
+	disallow_job = list(JOB_OUTSIDER) //CHOMPEdit add
 
 /datum/spawnpoint/tram/New()
 	..()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -483,7 +483,7 @@
 	ticker.mode.latespawn(character)
 
 	//CHOMPEdit Begin - non-crew join don't get a message
-	if(rank == "Non-Crew")
+	if(rank == JOB_OUTSIDER)
 		log_and_message_admins("has joined the round as non-crew. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)",character)
 		if(!(J.mob_type & JOB_SILICON))
 			ticker.minds += character.mind

--- a/maps/southern_cross/southern_cross-5.dmm
+++ b/maps/southern_cross/southern_cross-5.dmm
@@ -11629,7 +11629,7 @@
 	name = "JoinLateSifPlains"
 	},
 /obj/effect/landmark/start{
-	name = "Non-Crew"
+	name = "Outsider"
 	},
 /turf/simulated/shuttle/floor/voidcraft/external,
 /area/surface/outpost/wall)
@@ -24031,7 +24031,7 @@
 	name = "JoinLateSifPlains"
 	},
 /obj/effect/landmark/start{
-	name = "Non-Crew"
+	name = "Outsider"
 	},
 /turf/simulated/shuttle/floor/voidcraft/external,
 /area/surface/outpost/wall)

--- a/modular_chomp/code/datums/outfits/jobs/noncrew.dm
+++ b/modular_chomp/code/datums/outfits/jobs/noncrew.dm
@@ -1,10 +1,14 @@
 /decl/hierarchy/outfit/noncrew
-	name = OUTFIT_JOB_NAME("Non-Crew")
+	name = OUTFIT_JOB_NAME(JOB_OUTSIDER)
 	//hierarchy_type = /decl/hierarchy/outfit/noncrew
 	uniform = /obj/item/clothing/under/primitive
 	shoes = /obj/item/clothing/shoes/primitive
 	r_pocket = /obj/item/weapon/spacecash/ewallet
 	l_pocket = /obj/item/device/survivalcapsule/superpose
+
+	id_slot = slot_wear_id
+	id_type = /obj/item/weapon/card/id/external // No access, allows activating PDA's.
+
 	flags = OUTFIT_HAS_BACKPACK|OUTFIT_EXTENDED_SURVIVAL|OUTFIT_COMPREHENSIVE_SURVIVAL
 
 /decl/hierarchy/outfit/noncrew/post_equip(mob/living/carbon/human/H)

--- a/modular_chomp/code/game/jobs/job/noncrew.dm
+++ b/modular_chomp/code/game/jobs/job/noncrew.dm
@@ -1,9 +1,9 @@
 /datum/job/noncrew
-    title = "Non-Crew"
+    title = JOB_OUTSIDER
     disallow_jobhop = TRUE
     total_positions = 3
     spawn_positions = 6
-    supervisors = "no one."
+    supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property"
 
     flag = NONCREW
     departments = list(DEPARTMENT_NONCREW)
@@ -14,16 +14,16 @@
     offmap_spawn = TRUE
 
     outfit_type = /decl/hierarchy/outfit/noncrew
-    job_description = {"Players taking a role of a visitor outside of NT property with no special mechanics or items outside of the item loadout. Excluding one superpose pod.
-		-----Goes without saying, server rules still apply to the fullest
-		-----Neutral-crew are considered unauthorized personnel on SouthernCross.
-		-----Neutral-crew are not allowed to take part in events and mini-event areas unless the EM says otherwise.
-		-----Neutral-crew are not allowed to take station jobs.
-		-----Neutral-crew are not allowed to know more than two department jobs.
-		-----Neutral-crew are expected to behave and respect station SOP and Corp.Reg regardless of their IC knowledge.
-		-----Neutral-crew are not allowed to log-off with station key items.  (Captain spare, Station Blueprints, Nuke-key, Bluespace harpoon, any valuable or large amount of materials, chems, guns, etc. . .). Please discard these items on station or crew with relevant job roles.
-		-----We encourage Neutral-crew to take on exploration content as a group, staff will not help you for any hardships of solo play.
-		-----Notice: Not all of "Neutral-crew play" bugs have been fixed but we are aware of some of them that still need fixing, if you do encounter one that can be abused mechanically, please notify the staff member and be mindful of the exploit itself."}
+    job_description = {"Players taking a role of an outsider not employed by NT with no special mechanics. One superpose pod is provided.
+		-----Server rules still apply to the fullest
+		-----Outsiders are considered unauthorized personnel on Southern Cross.
+		-----Outsiders are not allowed to take part in events and mini-event areas unless the EM says otherwise.
+		-----Outsiders are not allowed to take station jobs.
+		-----Outsiders are not allowed to know more than two department jobs.
+		-----Outsiders are expected to behave in accordance with Unauthorized Personnel SOP regardless of their IC knowledge.
+		-----Outsiders are not allowed to log-off with station key items (e.g. Captain's spare, station blueprints, nuclear authentication disk, bluespace harpoon, large quantities of station goods, etc). Please leave these items on station or with relevant crew.
+		-----We encourage outsiders to take on exploration content as a group, staff will not help you for any hardships of solo play.
+		-----Notice: The outsider role is relatively new; if you encounter bugs, please notify a staff member and avoid using exploits."}
 
 /datum/job/noncrew/is_species_banned(species_name, brain_type)
     // Any species can join as non-crew, including shadekin.

--- a/modular_chomp/code/modules/client/preferences_spawnpoints.dm
+++ b/modular_chomp/code/modules/client/preferences_spawnpoints.dm
@@ -1,7 +1,7 @@
 /datum/spawnpoint/stationgateway
 	display_name = "Station gateway"
 	msg = "has completed translation from station gateway"
-	disallow_job = list("Non-Crew")
+	disallow_job = list(JOB_OUTSIDER)
 
 /datum/spawnpoint/stationgateway/New()
 	..()
@@ -23,7 +23,7 @@
 /datum/spawnpoint/plainspath
 	display_name = "Sif plains"
 	msg = "has checked in at the plains gate"
-	restrict_job = list("Non-Crew")
+	restrict_job = list(JOB_OUTSIDER)
 
 /datum/spawnpoint/plainspath/New()
 	..()


### PR DESCRIPTION
-Renames "non-crew" to "outsider."
-Adds reference to NT Unauthorized Personnel SOP to round-join mini-paragraph since we really shouldn't assume everybody checks the wiki. 
-Provides an external ID to outsiders, allowing PDA use. No access or NT accounts on said ID.
-Improves grammar in outsider job description
-Re-formats outsider to use a define for the job name, replaces hard-coded uses of "non-crew" with said define. Should make it easier if we change the name again. 