### PR TITLE
MuchSpiders and Minour Changes

### DIFF
--- a/maps/submaps/surface_submaps/wilderness/AmbushBase.dmm
+++ b/maps/submaps/surface_submaps/wilderness/AmbushBase.dmm
@@ -93,11 +93,26 @@
 /area/submap/DugOutMercs)
 "dI" = (
 /obj/structure/table/rack,
+/obj/item/weapon/gun/energy/vepr,
+/obj/item/weapon/gun/energy/laser,
 /obj/random/energy,
 /obj/random/energy,
-/obj/random/energy,
-/obj/random/energy,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
 /turf/simulated/floor/tiled/techmaint,
+/area/submap/DugOutMercs)
+"eg" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/random/material/precious,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/submap/DugOutMercs)
 "el" = (
 /obj/random/mob/merc/all,
@@ -127,6 +142,7 @@
 /obj/structure/table/standard,
 /obj/item/weapon/gun/magnetic/gasthrower,
 /obj/item/weapon/strangerock,
+/obj/item/weapon/cell/device/weapon/recharge/alien/omni,
 /turf/simulated/floor/tiled/techmaint,
 /area/submap/DugOutMercs)
 "fL" = (
@@ -171,6 +187,7 @@
 /obj/structure/table/bench/padded,
 /mob/living/simple_mob/humanoid/merc/ranged/deagle,
 /obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/submap/DugOutMercs)
 "iL" = (
@@ -188,6 +205,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/submap/DugOutMercs)
 "jz" = (
@@ -242,6 +260,13 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
 	},
+/obj/structure/table/rack,
+/obj/item/weapon/card/id/silver{
+	access = list(103)
+	},
+/obj/item/weapon/card/id/silver{
+	access = list(103)
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/submap/DugOutMercs)
 "mv" = (
@@ -255,6 +280,7 @@
 /obj/random/maintenance/research,
 /obj/random/maintenance/research,
 /obj/item/weapon/weldingtool/alien,
+/obj/item/weapon/cell/device/weapon/recharge/alien/hybrid,
 /turf/simulated/floor/tiled/techmaint,
 /area/submap/DugOutMercs)
 "mY" = (
@@ -266,6 +292,12 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
+"op" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/machinery/portable_atmospherics/canister/empty/oxygen,
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/submap/DugOutMercs)
 "oq" = (
@@ -282,6 +314,9 @@
 /obj/item/clothing/suit/space/syndicate/black/blue,
 /obj/item/clothing/head/helmet/space/syndicate/black/blue,
 /obj/item/weapon/tank/oxygen/welded,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/submap/DugOutMercs)
 "oN" = (
@@ -292,7 +327,9 @@
 /turf/simulated/floor/water/deep,
 /area/submap/DugOutMercs)
 "oU" = (
-/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/airlock/engineering{
+	locked = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/submap/DugOutMercs)
 "pf" = (
@@ -310,9 +347,23 @@
 "po" = (
 /turf/simulated/floor/water/deep,
 /area/submap/DugOutMercs)
+"qN" = (
+/obj/effect/floor_decal/corner/lightgrey/diagonal,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/submap/DugOutMercs)
 "qR" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
+	},
+/obj/structure/table/rack,
+/obj/item/weapon/card/id/silver{
+	access = list(103)
+	},
+/obj/item/weapon/card/id/silver{
+	access = list(103)
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/submap/DugOutMercs)
@@ -338,6 +389,7 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/submap/DugOutMercs)
 "rr" = (
@@ -459,6 +511,12 @@
 /obj/item/weapon/tank/oxygen/welded,
 /turf/simulated/floor/tiled,
 /area/submap/DugOutMercs)
+"xy" = (
+/obj/machinery/door/airlock/highsecurity{
+	locked = 1
+	},
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
 "xC" = (
 /obj/effect/floor_decal/corner/mauve/diagonal,
 /obj/structure/table/standard,
@@ -532,10 +590,14 @@
 /area/submap/DugOutMercs)
 "Ca" = (
 /obj/structure/table/rack,
-/obj/item/weapon/cell/device/weapon,
-/obj/item/weapon/cell/device/weapon,
-/obj/item/weapon/cell/device/weapon,
-/obj/item/weapon/cell/device/weapon,
+/obj/random/projectile/shotgun,
+/obj/random/projectile/shotgun,
+/obj/item/weapon/gun/projectile/automatic/as24,
+/obj/item/ammo_magazine/ammo_box/b12g/flechette,
+/obj/item/ammo_magazine/ammo_box/b12g/flechette,
+/obj/item/ammo_magazine/ammo_box/b12g/flechette,
+/obj/item/ammo_magazine/ammo_box/b12g/flechette,
+/obj/item/weapon/gun/projectile/shotgun/compact,
 /turf/simulated/floor/tiled/techmaint,
 /area/submap/DugOutMercs)
 "Cl" = (
@@ -774,6 +836,9 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
 	},
+/obj/structure/table/rack,
+/obj/item/weapon/rig/pmc/security,
+/obj/item/weapon/rig/pmc/medical,
 /turf/simulated/floor/tiled/techmaint,
 /area/submap/DugOutMercs)
 "Lg" = (
@@ -890,6 +955,11 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
 /area/submap/DugOutMercs)
+"Sl" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/submap/DugOutMercs)
 "Sn" = (
 /obj/machinery/light{
 	dir = 1
@@ -984,6 +1054,9 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
 	},
+/obj/structure/table/rack,
+/obj/item/weapon/rig/pmc/security,
+/obj/item/weapon/rig/pmc/medical,
 /turf/simulated/floor/tiled/techmaint,
 /area/submap/DugOutMercs)
 "Wx" = (
@@ -1021,6 +1094,11 @@
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/ammo_box/b145,
+/obj/item/ammo_magazine/ammo_box/b145,
+/obj/item/ammo_magazine/ammo_box/b145,
+/obj/item/ammo_magazine/ammo_box/b145/highvel,
 /turf/simulated/floor/tiled/techmaint,
 /area/submap/DugOutMercs)
 "YD" = (
@@ -1344,7 +1422,7 @@ OP
 RS
 Rz
 sc
-sc
+qN
 sc
 sc
 uv
@@ -1848,7 +1926,7 @@ uv
 uv
 uv
 uv
-yc
+xy
 uv
 uv
 uv
@@ -2100,7 +2178,7 @@ aQ
 uv
 uv
 uv
-yc
+xy
 uv
 uv
 uv
@@ -2182,11 +2260,11 @@ Rz
 Qf
 Qf
 uv
-kW
+eg
 fS
 fS
 Jh
-YD
+op
 uv
 nZ
 yG
@@ -2438,10 +2516,10 @@ oC
 NM
 Zt
 SN
-Fr
+Sl
 uv
 nZ
-Nr
+yG
 Da
 Qf
 Qf

--- a/maps/submaps/surface_submaps/wilderness/CultBar.dmm
+++ b/maps/submaps/surface_submaps/wilderness/CultBar.dmm
@@ -85,10 +85,6 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/CultBar)
-"dh" = (
-/obj/structure/flora/lily1,
-/turf/simulated/floor/water/ocean,
-/area/template_noop)
 "dt" = (
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/CultBar)
@@ -114,9 +110,6 @@
 /obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/freezer,
 /area/submap/CultBar)
-"ei" = (
-/turf/simulated/floor/outdoors/grass,
-/area/template_noop)
 "ez" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -339,11 +332,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/sif,
 /area/submap/CultBar)
-"mD" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/water/ocean,
-/area/template_noop)
 "mQ" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/simulated/floor/carpet,
@@ -508,10 +496,6 @@
 /obj/structure/loot_pile/surface/bones,
 /turf/simulated/floor/tiled/freezer,
 /area/submap/CultBar)
-"va" = (
-/obj/structure/flora/lily2,
-/turf/simulated/floor/water/ocean,
-/area/template_noop)
 "wr" = (
 /mob/living/simple_mob/humanoid/cultist/hunter,
 /obj/effect/decal/cleanable/dirt,
@@ -674,10 +658,6 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/CultBar)
-"DS" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/water/ocean,
-/area/template_noop)
 "DY" = (
 /obj/effect/gibspawner/human,
 /turf/simulated/floor/wood/sif,
@@ -1095,10 +1075,6 @@
 /obj/effect/floor_decal/corner/lightgrey/diagonal,
 /turf/simulated/floor/tiled/freezer,
 /area/submap/CultBar)
-"Ww" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/turf/simulated/floor/outdoors/grass,
-/area/template_noop)
 "WL" = (
 /obj/machinery/light/small/flicker,
 /obj/effect/decal/cleanable/blood,
@@ -1189,7 +1165,7 @@
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/CultBar)
 "ZZ" = (
-/obj/structure/window/basic,
+/obj/structure/window/plastitanium,
 /obj/structure/curtain,
 /turf/simulated/floor/wood/sif,
 /area/submap/CultBar)
@@ -1271,36 +1247,36 @@ ok
 (3,1,1) = {"
 ok
 ok
-ok
-ok
-ok
-ok
-ok
-ok
-ok
-ID
-ei
-ei
-ID
-ei
-Ww
-ei
-ID
-ID
-ok
-ok
-ok
-ok
-ID
-ID
-ID
-ID
-ok
-ok
-ok
-ok
-ok
-ok
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
+wt
+fF
+fF
+wt
+fF
+jy
+fF
+wt
+wt
+Ti
+Ti
+Ti
+Ti
+wt
+wt
+wt
+wt
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
 ok
 ok
 ok
@@ -1308,7 +1284,7 @@ ok
 (4,1,1) = {"
 ok
 ok
-ok
+Ti
 Wf
 wt
 wt
@@ -1337,7 +1313,7 @@ wt
 Ti
 wt
 wt
-ok
+Ti
 ok
 ok
 ok
@@ -1345,7 +1321,7 @@ ok
 (5,1,1) = {"
 ok
 ok
-ok
+Ti
 wt
 VZ
 VZ
@@ -1374,7 +1350,7 @@ fF
 Om
 wt
 wt
-ID
+wt
 ok
 ok
 ok
@@ -1382,7 +1358,7 @@ ok
 (6,1,1) = {"
 ok
 ok
-ID
+wt
 wt
 VZ
 Sn
@@ -1411,7 +1387,7 @@ wt
 wt
 Cp
 Cp
-ID
+wt
 ID
 ok
 ok
@@ -1419,7 +1395,7 @@ ok
 (7,1,1) = {"
 ok
 ok
-ID
+wt
 fF
 VZ
 EJ
@@ -1448,7 +1424,7 @@ wt
 Cp
 Px
 Cp
-EM
+Cp
 ID
 ID
 ok
@@ -1456,7 +1432,7 @@ ok
 (8,1,1) = {"
 ok
 ID
-Ww
+jy
 fF
 VZ
 zU
@@ -1485,7 +1461,7 @@ Cp
 Cp
 Nw
 Cp
-EM
+Cp
 XI
 ID
 ok
@@ -1493,7 +1469,7 @@ ok
 (9,1,1) = {"
 ok
 ID
-ei
+fF
 fF
 VZ
 HK
@@ -1522,7 +1498,7 @@ Cp
 Cp
 Cp
 Cp
-va
+rH
 EM
 ID
 ok
@@ -1530,7 +1506,7 @@ ok
 (10,1,1) = {"
 ok
 ok
-ID
+wt
 CC
 VZ
 yP
@@ -1559,7 +1535,7 @@ Cp
 Cp
 Cp
 fs
-EM
+Cp
 EM
 ID
 ok
@@ -1567,7 +1543,7 @@ ok
 (11,1,1) = {"
 ok
 ok
-ID
+wt
 fF
 VZ
 dt
@@ -1596,7 +1572,7 @@ Cp
 cJ
 Cp
 Cp
-EM
+Cp
 EM
 ID
 ok
@@ -1604,7 +1580,7 @@ ok
 (12,1,1) = {"
 ok
 ok
-ok
+Ti
 wt
 VZ
 zU
@@ -1633,7 +1609,7 @@ Cp
 Cp
 rH
 Cp
-DS
+Nw
 EM
 ID
 ok
@@ -1641,7 +1617,7 @@ ok
 (13,1,1) = {"
 ok
 ok
-ID
+wt
 fF
 VZ
 Fb
@@ -1670,7 +1646,7 @@ Cp
 Cp
 Cp
 Cp
-EM
+Cp
 EM
 ID
 ok
@@ -1678,7 +1654,7 @@ ok
 (14,1,1) = {"
 ok
 ID
-ei
+fF
 fF
 VZ
 Xs
@@ -1707,7 +1683,7 @@ wt
 Cp
 Cp
 Px
-EM
+Cp
 ID
 ID
 ok
@@ -1715,7 +1691,7 @@ ok
 (15,1,1) = {"
 ok
 ok
-ID
+wt
 zk
 VZ
 zU
@@ -1744,7 +1720,7 @@ wt
 Cp
 Cp
 Cp
-ID
+wt
 ID
 ok
 ok
@@ -1752,7 +1728,7 @@ ok
 (16,1,1) = {"
 ok
 ok
-ID
+wt
 fF
 VZ
 Sn
@@ -1781,7 +1757,7 @@ wt
 wt
 Cp
 Cp
-ID
+wt
 ID
 ok
 ok
@@ -1789,7 +1765,7 @@ ok
 (17,1,1) = {"
 ok
 ok
-ID
+wt
 fF
 VZ
 VZ
@@ -1818,7 +1794,7 @@ fF
 wt
 wt
 wt
-ID
+wt
 ok
 ok
 ok
@@ -1826,7 +1802,7 @@ ok
 (18,1,1) = {"
 ok
 ok
-ok
+Ti
 Wf
 VZ
 dO
@@ -1855,7 +1831,7 @@ IU
 cT
 wt
 Om
-ID
+wt
 ID
 ok
 ok
@@ -1863,7 +1839,7 @@ ok
 (19,1,1) = {"
 ok
 ok
-ok
+Ti
 wt
 VZ
 nO
@@ -1892,7 +1868,7 @@ fF
 fF
 wt
 wt
-EM
+Cp
 ID
 ID
 ok
@@ -1900,7 +1876,7 @@ ok
 (20,1,1) = {"
 ok
 ok
-ok
+Ti
 wt
 VZ
 AO
@@ -1929,7 +1905,7 @@ fF
 wt
 wt
 Cp
-dh
+fs
 EM
 ID
 ok
@@ -1937,7 +1913,7 @@ ok
 (21,1,1) = {"
 ok
 ok
-ok
+Ti
 wt
 VZ
 VZ
@@ -1966,7 +1942,7 @@ wt
 wt
 Cp
 Cp
-EM
+Cp
 EM
 ID
 ok
@@ -1974,7 +1950,7 @@ ok
 (22,1,1) = {"
 ok
 ok
-ok
+Ti
 wt
 VZ
 MF
@@ -2003,7 +1979,7 @@ wt
 wt
 Cp
 Cp
-mD
+cJ
 EM
 ID
 ok
@@ -2011,7 +1987,7 @@ ok
 (23,1,1) = {"
 ok
 ok
-ID
+wt
 fF
 VZ
 Gy
@@ -2040,7 +2016,7 @@ wt
 Px
 Cp
 Cp
-EM
+Cp
 EM
 ID
 ok
@@ -2048,7 +2024,7 @@ ok
 (24,1,1) = {"
 ok
 ok
-ID
+wt
 zk
 VZ
 hN
@@ -2077,7 +2053,7 @@ wt
 Cp
 Nw
 Cp
-EM
+Cp
 ID
 ID
 ok
@@ -2085,7 +2061,7 @@ ok
 (25,1,1) = {"
 ok
 ID
-ei
+fF
 fF
 VZ
 ug
@@ -2114,7 +2090,7 @@ Cp
 Cp
 Cp
 Cp
-ID
+wt
 ID
 ok
 ok
@@ -2122,7 +2098,7 @@ ok
 (26,1,1) = {"
 ok
 ID
-Ww
+jy
 fF
 QX
 Gd
@@ -2151,7 +2127,7 @@ Cp
 Cp
 Cp
 wt
-ID
+wt
 ok
 ok
 ok
@@ -2159,7 +2135,7 @@ ok
 (27,1,1) = {"
 ok
 ID
-ei
+fF
 fF
 VZ
 Mx
@@ -2188,7 +2164,7 @@ cJ
 Cp
 Px
 wt
-ID
+wt
 ok
 ok
 ok
@@ -2196,7 +2172,7 @@ ok
 (28,1,1) = {"
 ok
 ok
-ID
+wt
 zk
 VZ
 YU
@@ -2225,7 +2201,7 @@ Cp
 Cp
 Px
 wt
-ID
+wt
 ok
 ok
 ok
@@ -2233,7 +2209,7 @@ ok
 (29,1,1) = {"
 ok
 ok
-ok
+Ti
 wt
 VZ
 ij
@@ -2262,7 +2238,7 @@ Cp
 wt
 wt
 wt
-ok
+Ti
 ok
 ok
 ok
@@ -2270,7 +2246,7 @@ ok
 (30,1,1) = {"
 ok
 ok
-ok
+Ti
 wt
 VZ
 fB
@@ -2299,7 +2275,7 @@ wt
 wt
 Om
 Ti
-ok
+Ti
 ok
 ok
 ok
@@ -2307,7 +2283,7 @@ ok
 (31,1,1) = {"
 ok
 ok
-ok
+Ti
 wt
 VZ
 VZ
@@ -2336,7 +2312,7 @@ wt
 Ti
 Ti
 Ti
-ok
+Ti
 ok
 ok
 ok
@@ -2344,7 +2320,7 @@ ok
 (32,1,1) = {"
 ok
 ok
-ok
+Ti
 Wf
 wt
 wt
@@ -2373,7 +2349,7 @@ Ti
 Ti
 Ti
 Ti
-ok
+Ti
 ok
 ok
 ok
@@ -2381,36 +2357,36 @@ ok
 (33,1,1) = {"
 ok
 ok
-ok
-ok
-ok
-ok
-ID
-ID
-ID
-ID
-ok
-ok
-ok
-ok
-ok
-ok
-ok
-ok
-ok
-ok
-ok
-ok
-ok
-ID
-ID
-ID
-ok
-ok
-ok
-ok
-ok
-ok
+Ti
+Ti
+Ti
+Ti
+wt
+wt
+wt
+wt
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
+wt
+wt
+wt
+Ti
+Ti
+Ti
+Ti
+Ti
+Ti
 ok
 ok
 ok

--- a/maps/submaps/surface_submaps/wilderness/DoomP.dmm
+++ b/maps/submaps/surface_submaps/wilderness/DoomP.dmm
@@ -364,26 +364,36 @@
 "bo" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/box/smokes,
-/turf/simulated/floor/tiled/techfloor,
-/area/submap/DoomP)
-"bp" = (
-/obj/structure/table/rack,
 /obj/item/weapon/storage/box/handcuffs,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DoomP)
 "bq" = (
 /obj/structure/table/rack,
-/obj/item/weapon/cell/device/weapon,
-/obj/item/weapon/cell/device/weapon,
+/obj/item/clothing/gloves/tactical,
+/obj/item/clothing/gloves/tactical,
+/obj/item/clothing/head/helmet/tactical,
+/obj/item/clothing/accessory/armor/armorplate/tactical,
+/obj/item/clothing/suit/storage/vest/tactical,
+/obj/item/clothing/shoes/boots/tactical,
+/obj/item/clothing/shoes/boots/tactical,
+/obj/item/clothing/head/helmet/tactical,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DoomP)
 "br" = (
 /obj/structure/table/rack,
 /obj/random/energy,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/obj/item/weapon/cell/device/weapon,
+/obj/random/energy,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/DoomP)
 "bs" = (
 /obj/structure/table/rack,
+/obj/item/weapon/gun/projectile/contender,
+/obj/item/ammo_magazine/s357,
+/obj/item/ammo_magazine/s357,
 /obj/item/weapon/gun/projectile/contender,
 /obj/item/ammo_magazine/s357,
 /obj/item/ammo_magazine/s357,
@@ -2206,7 +2216,7 @@ aN
 bg
 be
 at
-bp
+bq
 bL
 at
 ac

--- a/maps/submaps/surface_submaps/wilderness/Manor1.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Manor1.dmm
@@ -19,6 +19,7 @@
 "ae" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/random/medical,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "af" = (
@@ -43,11 +44,15 @@
 /obj/structure/table/woodentable,
 /obj/item/clothing/mask/smokable/cigarette/cigar,
 /obj/item/weapon/material/ashtray/glass,
+/obj/effect/spider/stickyweb,
+/obj/random/medical,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "ak" = (
 /obj/structure/flora/pottedplant/dead,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "al" = (
@@ -57,6 +62,7 @@
 "am" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "an" = (
@@ -93,6 +99,8 @@
 /obj/structure/bed,
 /obj/item/weapon/bedsheet,
 /obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/animal/giant_spider/pepper,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "av" = (
@@ -107,10 +115,14 @@
 /area/submap/Manor1)
 "ax" = (
 /obj/structure/closet/cabinet,
+/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
+/obj/item/clothing/shoes/boots/winter/climbing,
+/obj/random/projectile/random,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "ay" = (
 /obj/effect/decal/cleanable/blood/gibs/robot/limb,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "az" = (
@@ -132,6 +144,7 @@
 "aC" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/maglight,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "aD" = (
@@ -143,13 +156,14 @@
 /obj/structure/closet/cabinet,
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/clothing/head/hood/winter,
-/obj/item/clothing/shoes/boots/winter,
-/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/shoes/boots/winter/climbing,
+/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "aF" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/cobweb,
+/obj/item/stack/material/void_opal,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "aG" = (
@@ -185,7 +199,7 @@
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "aN" = (
-/obj/effect/decal/cleanable/cobweb2,
+/mob/living/simple_mob/animal/giant_spider/nurse,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "aO" = (
@@ -212,6 +226,8 @@
 "aT" = (
 /obj/structure/closet/cabinet,
 /obj/random/projectile/shotgun,
+/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
+/obj/item/clothing/shoes/boots/winter/climbing,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "aU" = (
@@ -270,14 +286,16 @@
 "bf" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/head/hood/winter,
-/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/shoes/boots/winter/climbing,
 /obj/item/clothing/suit/storage/hooded/wintercoat,
 /obj/random/contraband,
+/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bg" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bh" = (
@@ -295,6 +313,7 @@
 /area/submap/Manor1)
 "bj" = (
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bk" = (
@@ -344,6 +363,7 @@
 	icon_state = "wooden_chair"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bu" = (
@@ -357,6 +377,7 @@
 "bv" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/food/condiment/small/sugar,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bw" = (
@@ -372,9 +393,9 @@
 /area/submap/Manor1)
 "by" = (
 /obj/structure/closet/cabinet,
-/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
 /obj/item/clothing/head/hood/winter,
-/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/shoes/boots/winter/climbing,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bz" = (
@@ -386,16 +407,19 @@
 /obj/structure/table/standard,
 /obj/item/weapon/material/kitchen/utensil/fork,
 /obj/item/weapon/material/kitchen/utensil/fork,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bB" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/weapon/reagent_containers/food/snacks/stew,
 /obj/item/weapon/reagent_containers/food/snacks/stew,
+/obj/item/weapon/reagent_containers/food/snacks/meat/worm,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bC" = (
 /obj/item/weapon/shovel,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bD" = (
@@ -404,6 +428,7 @@
 	icon_state = "wooden_chair"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bE" = (
@@ -423,16 +448,20 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/weapon/reagent_containers/food/snacks/sausage,
 /obj/item/weapon/reagent_containers/food/snacks/sausage,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/pottedplant/drooping,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/pottedplant/dead,
+/obj/effect/spider/stickyweb,
+/obj/item/weapon/material/sword,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bJ" = (
@@ -444,6 +473,7 @@
 "bK" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/glass/bottle/stoxin,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bL" = (
@@ -461,11 +491,16 @@
 /area/submap/Manor1)
 "bO" = (
 /obj/machinery/icecream_vat,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet/blucarpet,
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bQ" = (
 /obj/effect/decal/cleanable/blood,
@@ -488,11 +523,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/purcarpet,
 /area/submap/Manor1)
-"bV" = (
-/turf/simulated/floor/holofloor/wood{
-	icon_state = "wood_broken6"
-	},
-/area/submap/Manor1)
 "bW" = (
 /obj/machinery/washing_machine,
 /turf/simulated/floor/holofloor/wood,
@@ -505,12 +535,19 @@
 /area/submap/Manor1)
 "bY" = (
 /obj/structure/table/rack,
+/obj/random/carp_plushie,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "bZ" = (
 /obj/structure/closet/crate,
 /obj/item/stack/cable_coil/random_belt,
 /obj/random/cash,
+/obj/random/contraband,
+/obj/random/contraband/nofail,
+/obj/random/cash/huge,
+/obj/item/stack/material/gold{
+	amount = 18
+	},
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "ca" = (
@@ -521,13 +558,15 @@
 "cb" = (
 /obj/structure/closet/cabinet,
 /obj/random/gun/random,
+/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
+/obj/item/clothing/shoes/boots/winter/climbing,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "cc" = (
 /obj/structure/closet/cabinet,
 /obj/item/weapon/cell/device/weapon,
 /obj/item/weapon/cell/device/weapon,
-/obj/random/medical,
+/obj/item/weapon/storage/firstaid/combat,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "cd" = (
@@ -544,11 +583,14 @@
 "cf" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/wallet/random,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "cg" = (
 /obj/structure/flora/pottedplant/dead,
 /obj/effect/decal/cleanable/cobweb2,
+/mob/living/simple_mob/animal/giant_spider/lurker,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "ch" = (
@@ -560,18 +602,24 @@
 /obj/structure/closet/crate,
 /obj/item/weapon/flame/lighter/random,
 /obj/random/powercell,
+/obj/random/contraband,
+/obj/random/contraband/nofail,
+/obj/random/cash/huge,
+/obj/item/stack/material/durasteel{
+	amount = 18
+	},
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "cj" = (
 /obj/structure/closet/cabinet,
-/obj/item/clothing/shoes/boots/winter,
-/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/shoes/boots/winter/climbing,
+/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
 /obj/item/clothing/head/hood/winter,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "ck" = (
-/obj/effect/decal/cleanable/spiderling_remains,
-/turf/simulated/floor/holofloor/wood,
+/mob/living/simple_mob/animal/giant_spider/carrier,
+/turf/simulated/floor/carpet/turcarpet,
 /area/submap/Manor1)
 "cl" = (
 /turf/simulated/floor/carpet/turcarpet,
@@ -587,6 +635,12 @@
 "cn" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/storage/wallet/random,
+/obj/random/contraband,
+/obj/random/contraband/nofail,
+/obj/random/cash/huge,
+/obj/item/stack/material/tritium{
+	amount = 20
+	},
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "co" = (
@@ -612,12 +666,15 @@
 /area/submap/Manor1)
 "cs" = (
 /obj/item/weapon/material/twohanded/spear,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "ct" = (
 /obj/structure/closet/cabinet{
 	opened = 1
 	},
+/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
+/obj/item/clothing/shoes/boots/winter/climbing,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "cu" = (
@@ -637,6 +694,7 @@
 "cx" = (
 /obj/structure/table/standard,
 /obj/effect/decal/cleanable/cobweb2,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/hydro,
 /area/submap/Manor1)
 "cy" = (
@@ -652,12 +710,8 @@
 /area/submap/Manor1)
 "cA" = (
 /obj/item/weapon/paper/crumpled,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
-/area/submap/Manor1)
-"cB" = (
-/turf/simulated/floor/holofloor/wood{
-	icon_state = "wood_broken3"
-	},
 /area/submap/Manor1)
 "cC" = (
 /obj/effect/decal/cleanable/spiderling_remains,
@@ -666,11 +720,12 @@
 /area/submap/Manor1)
 "cD" = (
 /obj/structure/closet/crate,
-/obj/item/clothing/suit/armor/vest,
+/obj/item/weapon/gun/energy/locked/frontier/handbow,
+/obj/item/weapon/gun/energy/locked/frontier/handbow,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "cE" = (
-/obj/structure/closet/crate,
+/obj/random/humanoidremains,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "cF" = (
@@ -694,6 +749,7 @@
 /area/submap/Manor1)
 "cI" = (
 /obj/item/stack/material/wood,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "cJ" = (
@@ -719,6 +775,7 @@
 "cM" = (
 /obj/structure/table/woodentable,
 /obj/item/modular_computer/laptop/preset/custom_loadout/cheap,
+/obj/effect/spider/stickyweb,
 /turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 "cN" = (
@@ -727,6 +784,770 @@
 "cO" = (
 /obj/structure/flora/tree/sif,
 /turf/template_noop,
+/area/submap/Manor1)
+"cP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"dt" = (
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"eq" = (
+/obj/effect/spider/stickyweb,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ew" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/animal/giant_spider/lurker,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"eA" = (
+/turf/simulated/wall/wood{
+	can_open = 1
+	},
+/area/submap/Manor1)
+"eI" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/sandwich,
+/obj/item/weapon/gun/projectile/revolver/cappeacekeeper,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"eL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/Manor1)
+"eT" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"fo" = (
+/obj/structure/table/rack,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"fx" = (
+/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"fT" = (
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"gc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"gf" = (
+/obj/structure/coatrack,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"gF" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/flame/candle/everburn,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"gY" = (
+/obj/structure/table/woodentable,
+/obj/effect/spider/stickyweb,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"hu" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/slime_extract/rainbow,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"hM" = (
+/obj/structure/bed/chair/wood{
+	dir = 1;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"hN" = (
+/obj/structure/table/woodentable,
+/obj/item/device/soulstone,
+/obj/item/weapon/spellbook/oneuse/smoke,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ie" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/animal/giant_spider/carrier,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"ja" = (
+/obj/effect/spider/stickyweb,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"jc" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/meatsteak,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"jd" = (
+/obj/structure/table/woodentable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"jl" = (
+/mob/living/simple_mob/animal/giant_spider/frost,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/Manor1)
+"jr" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/sandwich,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"jD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/obj/item/weapon/material/whip,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"jG" = (
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"jK" = (
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/carpet/blucarpet,
+/area/submap/Manor1)
+"kb" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/meatsteak,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ks" = (
+/obj/structure/flora/pottedplant/dead,
+/mob/living/simple_mob/animal/giant_spider/lurker,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"kv" = (
+/obj/structure/simple_door/wood,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"le" = (
+/obj/random/humanoidremains,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/Manor1)
+"lz" = (
+/mob/living/simple_mob/animal/giant_spider/electric,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"lU" = (
+/obj/structure/flora/pottedplant/drooping,
+/obj/random/humanoidremains,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"my" = (
+/obj/structure/table,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"nq" = (
+/obj/effect/spider/stickyweb,
+/obj/random/humanoidremains,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"nr" = (
+/obj/structure/table/woodentable,
+/obj/effect/spider/stickyweb,
+/obj/item/weapon/gun/energy/medigun,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"oM" = (
+/obj/structure/table/woodentable,
+/obj/item/trash/candle,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"pf" = (
+/mob/living/simple_mob/animal/giant_spider/ion,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/Manor1)
+"pl" = (
+/mob/living/simple_mob/animal/giant_spider/broodmother,
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"pA" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper{
+	info = "I am done with all of you. Father has gone missing, and no one cares. Mother contunies to stay up all day, chanting, and staring into space. Brother keeps going out hunting with his gang of friends. The spiders are watching me and just keep getting bigger. I am done. After the feast tonight, I am leaving, and I am taking our squish butler.";
+	name = "Goodbye"
+	},
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"pI" = (
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"pR" = (
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/mob/living/simple_mob/animal/giant_spider/electric,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"rg" = (
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"rj" = (
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"ro" = (
+/obj/item/weapon/bone/skull/unknown,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"rS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/Manor1)
+"sD" = (
+/obj/structure/table/woodentable,
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"sL" = (
+/obj/effect/spider/stickyweb,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/Manor1)
+"sV" = (
+/obj/structure/sink{
+	pixel_y = 30
+	},
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/Manor1)
+"tt" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"tM" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/food/snacks/lasagna,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ua" = (
+/obj/item/weapon/material/knife,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ut" = (
+/obj/structure/bed/chair/wood,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"uA" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/shoes/boots/winter/climbing,
+/obj/item/clothing/suit/storage/hooded/wintercoat/kilanocoat,
+/obj/item/clothing/head/hood/winter,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"vd" = (
+/obj/structure/table/woodentable,
+/obj/item/toy/plushie/carp/void,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"vI" = (
+/mob/living/simple_mob/animal/giant_spider/thermic,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"wp" = (
+/mob/living/simple_mob/animal/giant_spider/electric,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/Manor1)
+"ws" = (
+/obj/item/weapon/material/kitchen/utensil/spoon,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ww" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/food/snacks/sausage,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"xH" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/sharkmeatcooked,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"xI" = (
+/obj/item/weapon/bone/ribs,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"yI" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/animal/giant_spider/carrier,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"zV" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/food/snacks/jelliedtoast,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Aq" = (
+/mob/living/simple_mob/animal/giant_spider/nurse,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"At" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/animal/giant_spider/thermic,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/Manor1)
+"AJ" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"AM" = (
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/Manor1)
+"AQ" = (
+/obj/structure/table/woodentable,
+/obj/random/explorer_shield,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Bb" = (
+/mob/living/simple_mob/construct/wraith,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Bz" = (
+/obj/item/weapon/bone/leg,
+/turf/simulated/floor/carpet/turcarpet,
+/area/submap/Manor1)
+"BC" = (
+/obj/random/humanoidremains,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"BE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"CL" = (
+/obj/effect/rune,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"CO" = (
+/obj/structure/bed/chair/wood{
+	dir = 1;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"DL" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/meatsteak,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"DW" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/gun/energy/locked/frontier/rifle,
+/obj/item/clothing/suit/storage/hooded/techpriest{
+	armor = list("melee"=20,"bullet"=10,"laser"=50,"energy"=60,"bomb"=25,"bio"=50,"rad"=25)
+	},
+/obj/item/weapon/shield/energy/imperial,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Fc" = (
+/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/spider/stickyweb,
+/obj/random/humanoidremains,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"FA" = (
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"FH" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"FU" = (
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/animal/giant_spider/carrier,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Gg" = (
+/obj/structure/loot_pile/surface/bones,
+/obj/effect/spider/stickyweb,
+/obj/item/weapon/gun/projectile/gyropistol,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"GM" = (
+/mob/living/simple_mob/animal/giant_spider/ion,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"GU" = (
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/spider/stickyweb/dark,
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Hd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Hl" = (
+/mob/living/simple_mob/animal/giant_spider/nurse,
+/turf/simulated/floor/carpet/turcarpet,
+/area/submap/Manor1)
+"Hu" = (
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"HJ" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/material/kitchen/utensil/fork,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Ig" = (
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb/dark,
+/mob/living/simple_mob/animal/giant_spider/electric,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Iz" = (
+/obj/effect/spider/stickyweb,
+/mob/living/simple_mob/animal/giant_spider/webslinger,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/Manor1)
+"Jh" = (
+/obj/structure/toilet{
+	dir = 8;
+	icon_state = "toilet00"
+	},
+/mob/living/simple_mob/animal/giant_spider/lurker,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/Manor1)
+"Jn" = (
+/obj/structure/table/woodentable,
+/obj/random/drinksoft,
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Js" = (
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/obj/random/humanoidremains,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"KN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"LR" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/snacks/sharkmeatcooked,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Md" = (
+/mob/living/simple_mob/animal/giant_spider/carrier,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Ms" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/obj/effect/spider/stickyweb,
+/obj/item/weapon/gun/projectile/automatic/advanced_smg,
+/obj/random/humanoidremains,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ML" = (
+/obj/structure/bed/chair/comfy/purp{
+	dir = 4;
+	icon_state = "comfychair_preview"
+	},
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"MZ" = (
+/obj/effect/spider/stickyweb/dark,
+/mob/living/simple_mob/animal/giant_spider/nurse,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"Nc" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/animal/giant_spider/nurse,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ND" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/material/knife/ritual,
+/obj/item/weapon/material/sharpeningkit,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Oo" = (
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/random/humanoidremains,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ON" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"OZ" = (
+/obj/structure/table/rack,
+/obj/random/grenade/lethal,
+/obj/random/grenade/lethal,
+/obj/random/grenade/lethal,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Pg" = (
+/obj/item/weapon/bone/arm,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/carpet/turcarpet,
+/area/submap/Manor1)
+"Pi" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/gun/projectile/deagle/gold,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Pw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/humanoidremains,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"PY" = (
+/obj/structure/table/standard,
+/obj/effect/spider/stickyweb,
+/obj/item/weapon/reagent_containers/food/snacks/slice/meatbread/filled,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Qh" = (
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_mob/animal/giant_spider/carrier,
+/obj/effect/spider/stickyweb/dark,
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"QW" = (
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"RI" = (
+/obj/structure/table/woodentable,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"RX" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/gun/energy/hooklauncher/ring,
+/obj/random/medical/pillbottle,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Sl" = (
+/obj/item/weapon/material/kitchen/utensil/fork,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Sx" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper,
+/obj/effect/spider/stickyweb,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Sy" = (
+/obj/structure/table/woodentable,
+/obj/random/drinksoft,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"SC" = (
+/obj/structure/table/woodentable,
+/obj/random/drinksoft,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Tv" = (
+/obj/structure/flora/pottedplant/drooping,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Uh" = (
+/mob/living/simple_mob/animal/giant_spider/pepper,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"UD" = (
+/mob/living/simple_mob/animal/giant_spider/webslinger,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/Manor1)
+"UF" = (
+/mob/living/simple_mob/animal/giant_spider/webslinger,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"VX" = (
+/mob/living/simple_mob/animal/giant_spider/carrier,
+/turf/simulated/floor/carpet/bcarpet,
+/area/submap/Manor1)
+"VY" = (
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/tiled/hydro,
+/area/submap/Manor1)
+"WS" = (
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/carpet/turcarpet,
+/area/submap/Manor1)
+"Xc" = (
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"XE" = (
+/obj/item/weapon/bone/leg,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"YL" = (
+/obj/effect/spider/stickyweb/dark,
+/obj/item/weapon/bone,
+/obj/item/weapon/bone,
+/obj/item/weapon/bone/arm,
+/obj/item/weapon/bone/arm,
+/obj/item/weapon/bone/leg,
+/obj/item/weapon/bone/leg,
+/obj/item/weapon/bone/ribs,
+/obj/item/weapon/bone/ribs,
+/obj/item/weapon/bone/skull,
+/obj/item/weapon/gun/energy/pummeler,
+/turf/simulated/floor/carpet/purcarpet,
+/area/submap/Manor1)
+"YY" = (
+/obj/item/weapon/bone,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"Za" = (
+/obj/structure/bed/chair/wood{
+	dir = 4;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb,
+/obj/random/humanoidremains,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ZG" = (
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ZK" = (
+/obj/structure/bed/chair/wood{
+	dir = 8;
+	icon_state = "wooden_chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spider/stickyweb/dark,
+/turf/simulated/floor/holofloor/wood,
+/area/submap/Manor1)
+"ZV" = (
+/obj/effect/decal/cleanable/blood/drip,
+/mob/living/simple_mob/animal/giant_spider/nurse,
+/obj/effect/spider/stickyweb,
+/turf/simulated/floor/holofloor/wood,
 /area/submap/Manor1)
 
 (1,1,1) = {"
@@ -959,7 +1780,7 @@ aa
 ab
 ab
 ag
-ag
+xI
 ab
 ab
 aa
@@ -1009,9 +1830,9 @@ ab
 ab
 ab
 ab
+aN
 ag
-ag
-ag
+XE
 ag
 ab
 ab
@@ -1035,23 +1856,23 @@ ax
 ab
 ag
 as
-ag
-ag
-aD
+an
+an
+Hu
 ab
-aD
+QW
+aK
+YY
 ag
 ag
-ag
-ag
-ag
-ag
-ag
-ag
-az
+aN
+aK
+aK
+aK
+oM
 ab
 bR
-ag
+cE
 ag
 ag
 bQ
@@ -1073,32 +1894,32 @@ aa
 ab
 ab
 at
-ag
+an
 as
 ag
 ab
 ag
-ag
-al
+Pw
+bz
 ab
-al
-bh
+RI
+CO
 ag
 ag
 ag
 ag
 ag
-ag
-ag
-al
+ro
+aK
+RI
 ab
 az
 ag
-ag
+xI
 bq
 bQ
 ag
-ag
+aN
 al
 ab
 ab
@@ -1121,10 +1942,10 @@ ag
 ab
 aT
 aM
-aO
+AJ
 ab
 bg
-ag
+cE
 bk
 aO
 al
@@ -1132,7 +1953,7 @@ by
 ag
 ag
 ag
-ag
+aK
 ab
 bS
 ag
@@ -1197,21 +2018,21 @@ aa
 aa
 ab
 ak
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-al
-az
-al
-ag
-ag
+an
+an
+an
+KN
+an
+KN
+aK
+aK
+aK
+aK
+RI
+oM
+RI
+aK
+aK
 an
 an
 ag
@@ -1222,10 +2043,10 @@ bq
 ag
 bq
 ag
-ah
+aI
 ab
-cv
-cw
+sV
+VY
 cw
 cw
 cw
@@ -1238,21 +2059,21 @@ cN
 aa
 aa
 ab
-ag
+KN
+ar
+ar
+ar
 aq
 aq
 aq
 aq
+le
+AM
+AM
+AM
+AM
 aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
+VX
 ar
 ar
 ar
@@ -1262,11 +2083,11 @@ aq
 aq
 aq
 aq
+wp
 aq
-aq
-aq
-as
-cw
+AM
+kv
+Iz
 ab
 cF
 ab
@@ -1280,18 +2101,18 @@ cN
 aa
 aa
 ab
-ag
+an
+rS
 aq
-aq
 ag
 ag
 ag
 ag
 ag
+UF
 ag
-ag
-ag
-ag
+aK
+aK
 ag
 ag
 an
@@ -1305,12 +2126,12 @@ ag
 ag
 ag
 ag
-ag
-ag
+aK
+aK
 ab
 cx
 ab
-cG
+Jh
 ab
 cG
 ab
@@ -1322,7 +2143,7 @@ cN
 aa
 aa
 ab
-ag
+aK
 aq
 aq
 ag
@@ -1364,16 +2185,16 @@ cN
 aa
 aa
 ab
-al
+RI
 aq
-aq
+UD
 az
 ab
 aF
 ag
 ag
-ag
-ag
+gF
+ab
 ag
 ag
 ag
@@ -1394,7 +2215,7 @@ bW
 ab
 cy
 cw
-cw
+jl
 cw
 cw
 ab
@@ -1411,10 +2232,10 @@ ar
 aq
 al
 ab
-aG
+aH
+FH
+CL
 ag
-aU
-aU
 aU
 ag
 aU
@@ -1448,21 +2269,21 @@ cN
 aa
 aa
 ab
-al
-ar
+RI
+eL
 aq
 al
 ab
+hN
+bh
+Bb
+DW
+ab
 ag
 ag
-ag
-ag
-ag
-ag
-ag
-ag
+cE
 an
-an
+yI
 an
 an
 an
@@ -1490,15 +2311,15 @@ cN
 aa
 aa
 ab
-ag
-ar
+aK
+eL
 aq
 ag
 ab
-al
+gF
 ag
-aU
-aU
+CL
+FH
 aU
 ag
 aU
@@ -1532,16 +2353,16 @@ cN
 aa
 aa
 ab
-an
+aA
 ar
 ar
 an
 ab
-aH
+ND
 ag
-ag
-ag
-ag
+FH
+gF
+ab
 an
 an
 an
@@ -1553,7 +2374,7 @@ ag
 ag
 ai
 ab
-an
+aA
 an
 ab
 ab
@@ -1574,7 +2395,7 @@ cN
 aa
 ab
 ab
-an
+aA
 ar
 ar
 an
@@ -1595,15 +2416,15 @@ ab
 ab
 ab
 ab
-an
-an
+aA
+aA
 ab
 bY
 ag
 ag
 ag
-bY
-bY
+fo
+OZ
 ab
 ab
 ab
@@ -1616,7 +2437,7 @@ cN
 ab
 ab
 ag
-ag
+cE
 ar
 ar
 an
@@ -1626,25 +2447,25 @@ aK
 ag
 ag
 ag
+cE
 ag
-ag
-ag
-ag
-an
-an
-an
-an
+fT
+aK
+aA
+aA
+aA
+Ms
 bH
 ab
 ab
-an
-an
+aA
+aA
 ab
+lz
 ag
+cE
 ag
-ag
-ag
-ag
+aN
 cC
 ab
 ab
@@ -1670,16 +2491,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
+bP
+bP
+bP
 bt
 bt
-an
-an
+Nc
+aA
 ab
 ab
-an
+aA
 an
 ab
 bZ
@@ -1700,7 +2521,7 @@ cN
 ac
 ae
 ag
-ag
+vI
 aq
 ar
 aB
@@ -1708,17 +2529,17 @@ ab
 aK
 aP
 al
+Pi
+SC
 al
-al
-al
-al
-aG
-al
-al
-al
+DL
+Sx
+Sy
+RI
+jr
 al
 bh
-an
+aA
 ab
 ab
 as
@@ -1751,27 +2572,27 @@ ag
 aP
 aV
 al
+kb
+sD
+Jn
+jd
+xH
 al
-al
-al
-al
-al
-al
-al
+SC
 al
 bh
-ag
+aK
 ab
 al
 ag
 ag
-al
-al
-cj
+RI
+RI
+uA
 ab
 ab
-cz
-cE
+Fc
+cD
 ab
 aa
 aa
@@ -1782,7 +2603,7 @@ cN
 (26,1,1) = {"
 cN
 ac
-ag
+Md
 ag
 an
 ar
@@ -1790,16 +2611,16 @@ ar
 ag
 ab
 ag
-ag
+fT
 af
 af
 af
-af
-af
-af
-af
-af
-af
+ZG
+Qh
+ZK
+ZK
+Oo
+pR
 af
 ag
 ag
@@ -1808,9 +2629,9 @@ al
 ag
 ag
 ag
-ag
-ck
-co
+Md
+cC
+gf
 ab
 ab
 ab
@@ -1824,25 +2645,25 @@ cN
 (27,1,1) = {"
 cN
 ab
-ah
-ag
+aI
+nq
 an
 ar
 ar
 an
 ab
 aL
+BC
 aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
+bU
+BE
+ie
+cP
+cP
+MZ
+cP
+bU
+rj
 aQ
 aQ
 bN
@@ -1852,7 +2673,7 @@ aQ
 bU
 bU
 bU
-bU
+BE
 cr
 bU
 bU
@@ -1866,8 +2687,8 @@ cN
 (28,1,1) = {"
 cN
 ab
-ai
-ag
+Tv
+aK
 an
 ar
 ar
@@ -1875,18 +2696,18 @@ an
 ab
 aL
 aQ
+ja
+Gg
+jD
+BE
+BE
+pl
+ON
+YL
+ON
 aQ
 aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
+rg
 bN
 aQ
 aQ
@@ -1908,30 +2729,30 @@ cN
 (29,1,1) = {"
 cN
 ac
-ag
-ag
+Md
+aK
 an
 ar
 ar
 ag
 ab
 ag
+eq
+bP
+bt
+Za
+bt
+FU
+pI
+Xc
+FA
+Ig
+GU
 ag
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ag
-ag
+aK
 ab
 al
-ag
+aN
 ag
 ag
 ag
@@ -1950,29 +2771,29 @@ cN
 (30,1,1) = {"
 cN
 ac
-ad
-ag
-ag
+bP
+aK
+aK
 ar
-ar
+At
 ag
 ab
-ag
-aP
-aV
-al
-al
-al
-al
-al
-al
-al
-al
-al
-bh
-an
+aK
+ut
+HJ
+gY
+LR
+RI
+Sy
+fx
+jc
+sD
+Jn
+sD
+hM
+aA
 ab
-al
+RI
 ag
 ag
 al
@@ -1980,8 +2801,8 @@ ca
 cj
 ab
 ab
-az
-al
+oM
+RI
 ab
 aa
 aa
@@ -1993,26 +2814,26 @@ cN
 cN
 ac
 aj
-ag
+aK
 ag
 ar
 ar
 ag
 ab
-ag
-aP
+aK
+ut
+nr
+RI
+Sy
 al
+kb
 al
+SC
 al
-al
-al
-al
-al
-al
-al
-bz
+eI
+jd
 bD
-an
+aA
 ab
 ab
 as
@@ -2021,9 +2842,9 @@ ab
 ab
 ab
 ab
-ag
-af
-ag
+aK
+jG
+nq
 ab
 aa
 aa
@@ -2034,27 +2855,27 @@ cN
 (32,1,1) = {"
 cN
 ac
-af
-ag
+jG
+aK
 ag
 aq
 ar
 ag
 ab
-ag
-ag
+aK
+Aq
+jG
+jG
 af
 af
 af
 af
-af
-af
-af
+Js
 af
 bu
-bu
-an
-an
+dt
+ew
+aA
 ab
 ab
 ag
@@ -2064,8 +2885,8 @@ cb
 ag
 ag
 ag
-ag
-ag
+aK
+aK
 ab
 aa
 aa
@@ -2083,19 +2904,19 @@ aq
 aq
 ag
 ab
-ah
+aI
+aK
+aK
+ag
+ag
+fT
 ag
 ag
 ag
 ag
-ag
-ag
-ag
-ag
-ag
-an
-an
-an
+aA
+aA
+Hd
 bI
 ab
 ab
@@ -2105,9 +2926,9 @@ ab
 cc
 cl
 cl
+Bz
 cl
-cl
-ag
+aK
 ab
 ab
 aa
@@ -2146,11 +2967,11 @@ ag
 ab
 ag
 cl
+Hl
 cl
 cl
-cl
-ag
-ah
+aK
+aI
 ab
 ab
 ab
@@ -2169,18 +2990,18 @@ ag
 ab
 ag
 aR
-aR
-aR
+tM
+zV
 bb
 ag
 ag
 ag
 ag
 ag
+Sl
 ag
 ag
-ag
-ag
+UF
 bO
 ab
 ag
@@ -2192,8 +3013,8 @@ cl
 cl
 cl
 ag
-ag
-al
+aK
+RI
 cM
 ab
 aa
@@ -2204,10 +3025,10 @@ cN
 aa
 aa
 ab
-ag
+aK
+UD
 aq
-aq
-ag
+aK
 ab
 aM
 ag
@@ -2215,14 +3036,14 @@ ag
 ag
 ag
 ag
+aN
 ag
 ag
 ag
 ag
 ag
 ag
-ag
-ag
+aK
 aK
 ab
 ag
@@ -2236,7 +3057,7 @@ cl
 cl
 cl
 cl
-al
+RI
 ab
 aa
 cN
@@ -2246,12 +3067,12 @@ cN
 aa
 aa
 ab
-ag
+aK
 aq
-aq
-ag
+AM
+aK
 ab
-ag
+aK
 aR
 aW
 aZ
@@ -2261,7 +3082,7 @@ ag
 ag
 ag
 ag
-aR
+bF
 bA
 bE
 bF
@@ -2275,10 +3096,10 @@ cl
 cl
 cl
 cl
+ck
 cl
 cl
-cl
-al
+RI
 ab
 aa
 cN
@@ -2288,32 +3109,32 @@ cN
 aa
 aa
 ab
-al
-aq
-aq
-al
+RI
+AM
+AM
+RI
 ab
-ag
+aK
 aR
 aX
-aR
+ww
 bc
 ag
-ag
+ua
 ag
 ag
 ag
 bv
-aR
 bF
+PY
 bJ
 aK
 ab
-ag
+aK
 ag
 ab
-ag
-cl
+aK
+WS
 cl
 cl
 cl
@@ -2330,33 +3151,33 @@ cN
 aa
 aa
 ab
-al
-aq
-aq
-al
+RI
+AM
+AM
+RI
 ab
+aK
 ag
 ag
 ag
 ag
+cE
 ag
 ag
+aN
 ag
 ag
-ag
-ag
-ag
-ag
-ag
-ag
+aK
+aK
+aK
+aK
+ab
+aK
 ag
 ab
-ag
-ag
-ab
-ag
-cl
-cl
+aK
+Pg
+WS
 cl
 cl
 cl
@@ -2372,34 +3193,34 @@ cN
 aa
 aa
 ab
-al
-aq
+RI
+AM
 aq
 aC
 ab
-aN
+cz
 aS
 aY
 ba
 bd
 ag
 ag
-ag
+ws
 ag
 ag
 ag
 bB
 bG
 bK
-ag
+aK
 ab
-ag
-ag
+aK
+aK
 ab
 cg
-aD
-al
-al
+QW
+RI
+RI
 ag
 cl
 cl
@@ -2414,10 +3235,10 @@ cN
 aa
 aa
 ab
-ag
+aK
+AM
 aq
-aq
-ag
+aK
 ab
 ab
 ab
@@ -2435,16 +3256,16 @@ ab
 ab
 ab
 ab
-ag
-ag
+aK
+aK
 ab
 ab
 ab
 ab
 ab
 ag
-cl
-cl
+Bz
+Hl
 cl
 ag
 ab
@@ -2456,39 +3277,39 @@ cN
 aa
 aa
 ab
-ag
+aK
 aq
 aq
-ag
-ag
-ag
+aK
+aK
+lz
 ag
 al
+aK
+aK
+aK
+aK
+aK
 ag
 ag
 ag
 ag
 ag
 ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
+aK
+aK
+aK
+Md
+aK
+aK
+aK
 ah
 ab
 ag
 cl
 cl
 cl
-ag
+aK
 ab
 aa
 cN
@@ -2507,6 +3328,8 @@ aq
 aq
 aq
 aq
+AM
+sL
 aq
 aq
 aq
@@ -2516,21 +3339,19 @@ aq
 aq
 aq
 aq
-aq
-aq
-aq
-aq
-aq
-aq
-aq
+AM
+AM
+AM
+AM
+pf
 aq
 aq
 as
 ag
 cl
 cl
-cl
-ag
+WS
+aK
 ab
 aa
 cN
@@ -2540,39 +3361,39 @@ cN
 aa
 aa
 ab
-ai
+lU
+GM
+ag
+ag
+ag
+Uh
+ag
+aK
+aK
+aK
+aK
+aK
 ag
 ag
 ag
 ag
 ag
 ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
+aK
+aK
+aK
+aK
+aK
+aK
 ag
 ag
 ah
 ab
 ah
 ag
-ag
-ag
-ah
+aK
+aK
+ks
 ab
 aa
 cN
@@ -2641,20 +3462,20 @@ ag
 ag
 ag
 ag
-al
 aD
-al
-al
+ab
 az
+pA
+ab
 al
 ag
 ag
-bq
-ag
+tt
+aK
 cs
-ag
+aK
 cA
-ag
+aK
 cI
 ab
 ab
@@ -2667,8 +3488,8 @@ aa
 aa
 ab
 ap
-ag
-ag
+aN
+hu
 ab
 ag
 ag
@@ -2683,19 +3504,19 @@ bl
 bo
 bl
 bl
-bl
-bl
-bl
-bw
-bl
-bl
+RI
+ab
+RX
+eT
+ab
+al
 bl
 bp
 bw
 bw
-bl
+jK
 cA
-bq
+ZV
 cI
 ab
 ab
@@ -2712,32 +3533,32 @@ ab
 ab
 aw
 ab
-ag
-ag
-as
+aN
 ag
 as
 ag
+as
 ag
+aN
 ab
 ag
 bm
 bp
 bw
-bl
-bl
-bl
-bl
-bP
-bP
+jK
+RI
+ab
+vd
+an
+ab
+al
 bT
-bl
 ch
 bl
 bl
 bw
-cB
 ag
+aK
 ab
 ab
 aa
@@ -2755,7 +3576,7 @@ ab
 ab
 ab
 aE
-al
+AQ
 ab
 ag
 ab
@@ -2765,18 +3586,18 @@ ab
 ag
 ag
 bq
-ag
-ag
-ag
+Aq
+aA
+gc
+eA
+KN
+an
+ab
 al
-al
-al
-al
-ag
-bV
 ag
 ag
 ag
+cE
 ag
 ag
 ab
@@ -2807,7 +3628,7 @@ ab
 ab
 ag
 br
-bx
+ML
 bC
 ab
 ab
@@ -2815,7 +3636,7 @@ ab
 ab
 ab
 ab
-ag
+lz
 bx
 cm
 cp
@@ -2849,7 +3670,7 @@ aa
 ab
 ab
 bs
-bs
+my
 ab
 ab
 aa


### PR DESCRIPTION
Major Changes to
-Manor (Aka spider manor)
--Tldr: Slightly adjusted some room layouts, added more loot, and spiders.

---The main hall is now the center of the nest, giant spiders everywhere. With egg and spiderling creating spiders being rather common.
---Added two secrets rooms, one has a goofy item, pill bottle, and a lore note. The other has some culty stuff, a frontier marksmen rifle, and a Tech Priest robes var edited to have higher resistance to lasers and energy but their low melee and bullet values remain the same.
---There is now gold and black winter coats elsewhere, and in the storage room, more gold, and fancy minerals, to try and give the sense of fancy rich folk home infested with spiders.
---Main/obvious loot: Several Revolvers, two goofy guns, some weird frontier weapons, and a sword.

--The intention with the spiders is to create an overwhelming swarm that needs to be rushed, otherwise the spiderlings or eggs created would just replenish their numbers.

-Also fixed the untextured wood tiles by using the normal wood tiles. 

Then minor adjustments
-Changed Cult Bar windows to Plastiatnium to reduce the times and scenarios where the cultists break out.
-Changed the armory of Doom Peninsula merc base to include armor, to hopefully entice some folks to come to it. 
-Changed the armory of the Ambush/Sniper Base, because one of, if not the only criticism I can recall I got about it was the loot being lacking.