### PR TITLE
Early ports fixes to MMI's leaving you blind.

### DIFF
--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -66,6 +66,7 @@
 		brainmob.loc = src
 		brainmob.container = src
 		brainmob.set_stat(CONSCIOUS)
+		brainmob.blinded = 0 //CHOMPedit earlyport, gives MMIs proper vision again
 		dead_mob_list -= brainmob//Update dem lists
 		living_mob_list += brainmob
 


### PR DESCRIPTION
Your brain is blind and deaf, MMIs restore hearing but not vision making ~~Medicaid Stations~~ Mech MMIs impossible. This restores that so you can see and hear in an MMI again.


https://user-images.githubusercontent.com/10555869/205411353-b6b57014-5197-4e03-ad8d-772dfa9cf044.mp4


https://user-images.githubusercontent.com/10555869/205411359-d4286b7e-ea58-4fd7-9c62-4ffc3c0e9660.mp4

Works by putting on or off, audible and visible emotes included. 