### PR TITLE
Fixes grid check announcement

### DIFF
--- a/code/modules/power/grid_checker.dm
+++ b/code/modules/power/grid_checker.dm
@@ -64,8 +64,8 @@
 /obj/machinery/power/grid_checker/proc/power_failure(var/announce = TRUE)
 	if(announce)
 		command_announcement.Announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, \
-		the colony's power will be shut off for an indeterminate duration while the powernet monitor restarts automatically, or \
-		when Engineering can manually resolve the issue.",
+		the station's power will be shut off for an indeterminate duration while the powernet monitor restarts automatically, or \
+		when Engineering can manually resolve the issue.", //CHOMPEdit
 		"Critical Power Failure",
 		new_sound = 'sound/AI/poweroff.ogg')
 	power_failing = TRUE


### PR DESCRIPTION
I'm quite sure that neither centcom nor sif infrastructure are affected by the event occuring on the station.