### PR TITLE
Let dead folk see/hear stuff like ghosts

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -111,7 +111,7 @@
 		if(is_preference_enabled(/datum/client_preference/ghost_ears) && (speaker in view(src)))
 			message = "<b>[message]</b>"
 
-	if(is_deaf())
+	if(is_deaf() && stat != DEAD) //CHOMPEdit - Dead people should be able to hear stuff like ghosts can
 		if(speaker == src)
 			to_chat(src, "<span class='filter_say'><span class='warning'>You cannot hear yourself speak!</span></span>")
 		else


### PR DESCRIPTION
This could perhaps be behind a preference. This fixes a slight oversight with gradual corpse digestion though, in that once in that state you won't hear messages from the pred without becoming a ghost and leaving the vore belly.