### PR TITLE
Fixes a funky sound bug revealed by emote PR

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -51,7 +51,7 @@
 	vol *= client.get_preference_volume_channel(VOLUME_CHANNEL_MASTER)
 	S.volume = vol
 
-	if(vary)
+	if(vary || frequency) //CHOMPEdit
 		if(frequency)
 			S.frequency = frequency
 		else


### PR DESCRIPTION
Apparently the sound system was straight up not even applying provided frequency if a sound proc didn't come with random pitch enabled.