### PR TITLE
Fixes point-blank throws

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1125,6 +1125,7 @@
 	if(!item)
 		return FALSE //Grab processing has a chance of returning null
 
+/* CHOMPEdit. If I want to do a nice little give I use the actual verb for it.
 	if(a_intent == I_HELP && Adjacent(target) && isitem(item) && ishuman(target))
 		var/obj/item/I = item
 		var/mob/living/carbon/human/H = target
@@ -1135,6 +1136,7 @@
 			to_chat(src, SPAN_NOTICE("You offer \the [I] to \the [target]."))
 			do_give(H)
 		return TRUE
+*/
 
 	drop_from_inventory(item)
 


### PR DESCRIPTION
Disables the funny feature someone had felt the urge to code in that overrides intentional throws with a give action. We have an actual verb for that in IC tab.