### PR TITLE
Fixes brutal gurgles dropping implants on ground

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -309,6 +309,8 @@
 							if(!E.vital)
 								vitals_only = FALSE
 								if(!LAZYLEN(E.children))
+									for(var/obj/item/weapon/implant/I as anything in E.implants)
+										qdel(I)
 									E.droplimb(TRUE, DROPLIMB_EDGE)
 									qdel(E)
 									break


### PR DESCRIPTION
Even tho the option isn't currently available on vorepanel, a veredited gut with the bodypart digestion option enabled ended up awkwardly dropping the prey's backup implant right onto the floor in the middle of bar because they had implanted it in a limb rather than head :v