### PR TITLE
Probably fixes simplemob nom debug logs

### DIFF
--- a/code/modules/vore/eating/simple_animal_vr.dm
+++ b/code/modules/vore/eating/simple_animal_vr.dm
@@ -39,7 +39,7 @@
 		voremob_loaded = TRUE
 		init_vore()
 		belly = vore_selected
-	..()
+	return ..()
 
 //
 // Simple proc for animals to have their digestion toggled on/off externally


### PR DESCRIPTION
The only possible cause I could find, given the circumstances and the rest of the code. The debug log trigger expects a returned TRUE from feed_grabbed_to_self proc, which in turn expects a returned TRUE from perform_the_nom proc.