### PR TITLE
turns ocean into actually ocean on southern cross 5 & 10

### DIFF
--- a/maps/southern_cross/southern_cross-10.dmm
+++ b/maps/southern_cross/southern_cross-10.dmm
@@ -144,7 +144,7 @@
 /turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/surface/outside/wilderness/normal)
 "aN" = (
-/turf/simulated/floor/water/deep,
+/turf/simulated/floor/water/deep/ocean,
 /area/surface/outside/ocean)
 "aO" = (
 /obj/effect/zone_divider,
@@ -788,7 +788,7 @@
 /area/surface/outpost/shelter/utilityroom)
 "No" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/water/deep,
+/turf/simulated/floor/water/deep/ocean,
 /area/surface/outside/ocean)
 "Nq" = (
 /obj/effect/map_effect/portal/master/side_b/wilderness_to_caves{

--- a/maps/southern_cross/southern_cross-5.dmm
+++ b/maps/southern_cross/southern_cross-5.dmm
@@ -1314,7 +1314,7 @@
 /area/surface/outpost/main/corridor/right_lower)
 "cF" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/water/deep,
+/turf/simulated/floor/water/deep/ocean,
 /area/surface/outside/ocean)
 "cG" = (
 /obj/machinery/door/firedoor/border_only,
@@ -18336,7 +18336,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/outpost/main/dorms/dorm_1)
 "Ig" = (
-/turf/simulated/floor/water/deep,
+/turf/simulated/floor/water/deep/ocean,
 /area/surface/outside/ocean)
 "Ih" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,


### PR DESCRIPTION
does what it says on the tin

the area is called "sea" but it isn't actually a sea.
the only place you can find ocean tiles is in the cult bar, frost oasis and leopardmander den, I want ocean fsh