### PR TITLE
Fixes a bug reforming introduced to the autoresleever

### DIFF
--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -63,7 +63,7 @@
 		return
 	if(!istype(ghost,/mob/observer/dead))
 		return
-	if(ghost.mind && ghost.mind.current && ghost.mind.current.stat != DEAD)
+	if(ghost.mind && ghost.mind.current && ghost.mind.current.stat != DEAD && ghost.mind.current.enabled == TRUE) //CHOMPEdit - Disabled body shouldn't block this.
 		if(istype(ghost.mind.current.loc, /obj/item/device/mmi))
 			if(tgui_alert(ghost, "Your brain is still alive, using the auto-resleever will delete that brain. Are you sure?", "Delete Brain", list("No","Yes")) != "Yes")
 				return
@@ -78,17 +78,17 @@
 	if(!is_alien_whitelisted(ghost, GLOB.all_species[ghost_client?.prefs?.species]) && !check_rights(R_ADMIN, 0)) // Prevents a ghost ghosting in on a slot and spawning via a resleever with race they're not whitelisted for, getting around normal join restrictions.
 		to_chat(ghost, "<span class='warning'>You are not whitelisted to spawn as this species!</span>")
 		return
-	
+
 	// CHOMPedit start
 	var/datum/species/chosen_species
 	if(ghost.client.prefs.species) // In case we somehow don't have a species set here.
 		chosen_species = GLOB.all_species[ghost_client.prefs.species]
-		
+
 	if(chosen_species.flags && NO_SCAN)
 		to_chat(ghost, "<span class='warning'>This species cannot be resleeved!</span>")
 		return
 	// CHOMPEdit End: Add checks for Whitelist + Resleeving
-	
+
 	//Name matching is ugly but mind doesn't persist to look at.
 	var/charjob
 	var/datum/data/record/record_found
@@ -187,12 +187,12 @@
 
 	log_admin("[new_character.ckey]'s character [new_character.real_name] has been auto-resleeved.")
 	message_admins("[new_character.ckey]'s character [new_character.real_name] has been auto-resleeved.")
-	
+
 	var/obj/item/weapon/implant/backup/imp = new(src)
 
 	if(imp.handle_implant(new_character,new_character.zone_sel.selecting))
 		imp.post_implant(new_character)
-	
+
 	var/datum/transcore_db/db = SStranscore.db_by_mind_name(new_character.mind.name)
 	if(db)
 		var/datum/transhuman/mind_record/record = db.backed_up[new_character.mind.name]


### PR DESCRIPTION
Instant digestion left your body alive, which didn't used to be an issue, except for reforming to work I move the body into ghost's contents instead of qdel'ing the body. The autosleever would thus detect that the body was still alive and block resleeving.
This fixes that by additionally checking to see if the body is enabled, which for both current and future uses of having a mob disabled should probably allow autoresleeving to occur. (The future case where transformed mobs have their original form disabled will have the mind's current be the actual mob they got turned into, and the future case where z-levels that get paused disable mobs on the z-level until the z-level is woken up again will not happen if a ckey'd mob is alive on the z-level.)