### PR TITLE
A couple dirt fixes

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -38,11 +38,12 @@
 	icon_state = "dirt"
 	mouse_opacity = 0
 
-/obj/effect/decal/cleanable/Initialize(var/mapload, var/_age)
+/obj/effect/decal/cleanable/dirt/Initialize(var/mapload, var/_age) //CHOMPEdit
 	.=..()
 	var/turf/simulated/our_turf = src.loc
 	if(our_turf && istype(our_turf) && our_turf.can_dirty && _age)
 		our_turf.dirt = 101
+		qdel(src) //CHOMPEdit
 
 /obj/effect/decal/cleanable/flour
 	name = "flour"


### PR DESCRIPTION
Fixes all cleanable decals (such as graffiti and such) creatign a huge pile of dirt onto the turf when spawned. Also fixes decal dirt staying as a persistable decal after spawning despite its coded behavior being supposed to just dirty the turf into a regular dirt overlay.