### PR TITLE
Makes npc humanmobs low priority for ai processing

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/human_defines.dm
@@ -13,4 +13,6 @@
 	var/hide_glasses = FALSE
 	var/speech_sound_enabled = TRUE
 	var/nutrition_hidden = FALSE
+
+/mob/living/carbon/human/ai_controlled
 	low_priority = TRUE

--- a/modular_chomp/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/human_defines.dm
@@ -13,3 +13,4 @@
 	var/hide_glasses = FALSE
 	var/speech_sound_enabled = TRUE
 	var/nutrition_hidden = FALSE
+	low_priority = TRUE


### PR DESCRIPTION
Makes ai controlled carbonmobs stop processing their ai when there are no players on the level like all the simplemobs already do. No more roundstart combat runtimes and things are now a bit more fair for the helpless paused mobs at the mercy of these rampaging carbons in the wilderness