### PR TITLE
Add a mode to muffle items.

### DIFF
--- a/code/__defines/belly_modes_vr.dm
+++ b/code/__defines/belly_modes_vr.dm
@@ -22,6 +22,7 @@
 #define DM_FLAG_JAMSENSORS		0x20
 #define DM_FLAG_FORCEPSAY		0x40
 #define DM_FLAG_SLOWBODY		0x80 //CHOMPAdd
+#define DM_FLAG_MUFFLEITEMS		0x100 //CHOMPAdd
 
 //Item related modes
 #define IM_HOLD									"Hold"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -361,12 +361,13 @@
 	if(user.client)	user.client.screen |= src
 	if(user.pulling == src) user.stop_pulling()
 	if((slot_flags & slot))
-		if(equip_sound)
+		if(equip_sound && !muffled_by_belly(user))
 			playsound(src, equip_sound, 20)
-		else
+		else if(!muffled_by_belly(user))
 			playsound(src, drop_sound, 20)
 	else if(slot == slot_l_hand || slot == slot_r_hand)
-		playsound(src, pickup_sound, 20, preference = /datum/client_preference/pickup_sounds)
+		if(!muffled_by_belly(user))
+			playsound(src, pickup_sound, 20, preference = /datum/client_preference/pickup_sounds)
 	return
 
 // As above but for items being equipped to an active module on a robot.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -360,6 +360,7 @@
 	user.position_hud_item(src,slot)
 	if(user.client)	user.client.screen |= src
 	if(user.pulling == src) user.stop_pulling()
+	// Chomp edit starts
 	if((slot_flags & slot))
 		if(equip_sound && !muffled_by_belly(user))
 			playsound(src, equip_sound, 20)
@@ -368,6 +369,7 @@
 	else if(slot == slot_l_hand || slot == slot_r_hand)
 		if(!muffled_by_belly(user))
 			playsound(src, pickup_sound, 20, preference = /datum/client_preference/pickup_sounds)
+	// Chomp edit stops
 	return
 
 // As above but for items being equipped to an active module on a robot.

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -22,7 +22,15 @@
 
 /obj/item/weapon/storage/backpack/equipped(var/mob/user, var/slot)
 	if (slot == slot_back && src.use_sound)
-		playsound(src, src.use_sound, 50, 1, -5)
+// Chomp edit
+		if(isbelly(user.loc))
+			var/obj/belly/B = user.loc
+			if(B.mode_flags & DM_FLAG_MUFFLEITEMS)
+				return
+		else
+// Chomp edit end
+			playsound(src, src.use_sound, 50, 1, -5)
+
 	..(user, slot)
 
 /*

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -240,7 +240,9 @@
 	// Chomp edit
 		if(isbelly(user.loc))
 			var/obj/belly/B = user.loc
-			if(!B.mode_flags & DM_FLAG_MUFFLEITEMS)
+			if(B.mode_flags & DM_FLAG_MUFFLEITEMS)
+				// Do nothing
+			else
 				playsound(src, src.use_sound, 50, 0, -5)
 	// Chomp edit end
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -237,7 +237,12 @@
 
 /obj/item/weapon/storage/proc/open(mob/user as mob)
 	if (use_sound)
-		playsound(src, src.use_sound, 50, 0, -5)
+	// Chomp edit
+		if(isbelly(user.loc))
+			var/obj/belly/B = user.loc
+			if(!B.mode_flags & DM_FLAG_MUFFLEITEMS)
+				playsound(src, src.use_sound, 50, 0, -5)
+	// Chomp edit end
 
 	orient2hud(user)
 	if(user.s_active)

--- a/code/game/objects/items_vr.dm
+++ b/code/game/objects/items_vr.dm
@@ -25,3 +25,14 @@
 	listening_objects |= src
 	new_voice.verbs -= /mob/living/voice/verb/change_name //No changing your name! Bad!
 	new_voice.verbs -= /mob/living/voice/verb/hang_up //Also you can't hang up. You are the item!
+
+// Chomp edit
+/obj/item/proc/muffled_by_belly(var/mob/user)
+	if(isbelly(user.loc))
+		var/obj/belly/B = user.loc
+		if(B.mode_flags & DM_FLAG_MUFFLEITEMS)
+			return TRUE
+		return FALSE
+	else
+		return FALSE
+// Chomp edit end

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -72,7 +72,7 @@
 	//Actual full digest modes
 	var/tmp/static/list/digest_modes = list(DM_HOLD,DM_DIGEST,DM_ABSORB,DM_DRAIN,DM_SELECT,DM_UNABSORB,DM_HEAL,DM_SHRINK,DM_GROW,DM_SIZE_STEAL,DM_EGG)
 	//Digest mode addon flags
-	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN, "Jams Sensors" = DM_FLAG_JAMSENSORS, "Complete Absorb" = DM_FLAG_FORCEPSAY, "Slow Body Digestion" = DM_FLAG_SLOWBODY) //CHOMPEdit
+	var/tmp/static/list/mode_flag_list = list("Numbing" = DM_FLAG_NUMBING, "Stripping" = DM_FLAG_STRIPPING, "Leave Remains" = DM_FLAG_LEAVEREMAINS, "Muffles" = DM_FLAG_THICKBELLY, "Affect Worn Items" = DM_FLAG_AFFECTWORN, "Jams Sensors" = DM_FLAG_JAMSENSORS, "Complete Absorb" = DM_FLAG_FORCEPSAY, "Slow Body Digestion" = DM_FLAG_SLOWBODY, "Muffle Items" = DM_FLAG_MUFFLEITEMS) //CHOMPEdit
 	//Item related modes
 	var/tmp/static/list/item_digest_modes = list(IM_HOLD,IM_DIGEST_FOOD,IM_DIGEST,IM_DIGEST_PARALLEL)
 


### PR DESCRIPTION
# About this pull request
This PR adds a 'muffling' mode for items, for bellies. 
In clearer terms, putting on or removing items, opening bags, no longer makes any noise. 

I did not extend this to every noise making options, as this would require a freaking ton of chances, and I'm too lazy for that. But that should still be a nice improvement.

# Why is it good for the game
It allows you to make your belly appear more muffled than before, while allowing prey people to do things inside of it. Like eating food for their NIF, or silently pulling out their tablet computer.