### PR TITLE
makes proteans store their bodytype like custom species/prometheans, also fixing their eyes in the process

### DIFF
--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -244,8 +244,8 @@
 		var/list/choices
 		var/datum/species/spec = GLOB.all_species[pref.species]
 		if (spec.selects_bodytype == SELECTS_BODYTYPE_SHAPESHIFTER && istype(spec, /datum/species/shapeshifter))
-			var/datum/species/shapeshifter/spec_shifter = spec
-			choices = spec_shifter.valid_transform_species
+			var/datum/species/spec_shifter = spec
+			choices = spec_shifter.get_valid_shapeshifter_forms()
 		else
 			choices = GLOB.custom_species_bases
 			if(pref.species != SPECIES_CUSTOM)

--- a/code/modules/client/preference_setup/vore/07_traits.dm
+++ b/code/modules/client/preference_setup/vore/07_traits.dm
@@ -244,8 +244,8 @@
 		var/list/choices
 		var/datum/species/spec = GLOB.all_species[pref.species]
 		if (spec.selects_bodytype == SELECTS_BODYTYPE_SHAPESHIFTER && istype(spec, /datum/species/shapeshifter))
-			var/datum/species/spec_shifter = spec
-			choices = spec_shifter.get_valid_shapeshifter_forms()
+			var/datum/species/spec_shifter = spec //CHOMPEdit
+			choices = spec_shifter.get_valid_shapeshifter_forms() //CHOMPEdit
 		else
 			choices = GLOB.custom_species_bases
 			if(pref.species != SPECIES_CUSTOM)

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/protean/protean_powers.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/protean/protean_powers.dm
@@ -66,7 +66,7 @@
 		var/datum/robolimb/M = chargen_robolimbs[company]
 		if(!(choice in M.parts))
 			continue
-		if(impersonate_bodytype in M.species_cannot_use)
+		if(species?.base_species in M.species_cannot_use)
 			continue
 		if(M.whitelisted_to && !(ckey in M.whitelisted_to))
 			continue
@@ -283,7 +283,6 @@
 
 	var/new_species = tgui_input_list(usr, "Please select a species to emulate.", "Shapeshifter Body", GLOB.playable_species)
 	if(new_species)
-		impersonate_bodytype = new_species
 		species?.base_species = new_species // Really though you better have a species
 		regenerate_icons() //Expensive, but we need to recrunch all the icons we're wearing
 

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -14,6 +14,9 @@
 	flesh_color = "#505050"
 	base_color = "#FFFFFF" //Color mult, start out with this
 
+	selects_bodytype = SELECTS_BODYTYPE_SHAPESHIFTER
+	base_species = SPECIES_HUMAN
+
 	flags =            NO_SCAN | NO_SLIP | NO_MINOR_CUT | NO_HALLUCINATION | NO_INFECT
 	appearance_flags = HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_HAIR_COLOR | HAS_UNDERWEAR | HAS_LIPS
 	spawn_flags		 = SPECIES_CAN_JOIN | SPECIES_IS_WHITELISTED | SPECIES_WHITELIST_SELECTABLE
@@ -126,9 +129,12 @@
 		saved_nif.quick_implant(H)
 
 /datum/species/protean/get_bodytype(var/mob/living/carbon/human/H)
-	if(H)
-		return H.impersonate_bodytype || ..()
-	return ..()
+	if(!H || base_species == name) return ..()
+	var/datum/species/S = GLOB.all_species[base_species]
+	return S.get_bodytype(H)
+
+/datum/species/protean/get_valid_shapeshifter_forms(var/mob/living/carbon/human/H)
+	return GLOB.playable_species
 
 /datum/species/protean/handle_post_spawn(var/mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
title

it also means they can pick their bodytype in the preferences menu like the custom species and prometheans
actually planned on doing this with that PR, but it was done upstream and so didn't have the modular protean files

unfortunately, I'm not willing to go through and code up a proc to verify all their prosthetics to make sure they fit the bodytype / change prosthetics to match it, but it didn't do that before this PR either, so...