### PR TITLE
Frontier phasers charge nerf, explo vendor changes, RD printer addition

### DIFF
--- a/code/datums/supplypacks/munitions_vr.dm
+++ b/code/datums/supplypacks/munitions_vr.dm
@@ -1,23 +1,25 @@
-/datum/supply_pack/munitions/expeditionguns
-	name = "Frontier phaser (station-locked) crate"
+/datum/supply_pack/munitions/expeditionguns //CHOMP Edit begin: Re-appropriating this whole block. Changing frontier phasers to phaseguns.
+	name = "Exploration phasegun (station-locked) crate"
 	contains = list(
-			/obj/item/weapon/gun/energy/locked/frontier = 2,
-			/obj/item/weapon/gun/energy/locked/frontier/holdout = 2,
+			/obj/item/weapon/gun/energy/locked/phasegun/pistol = 2,
+			/obj/item/weapon/gun/energy/locked/phasegun/rifle = 2,
+			/obj/item/weapon/gun/energy/locked/phasegun =  2
 			)
 	cost = 35
 	containertype = /obj/structure/closet/crate/secure
-	containername = "frontier phaser crate"
+	containername = "phasegun crate"
 	access = access_explorer
 
-/datum/supply_pack/munitions/expeditionbows
-	name = "Frontier bows (station-locked) crate"
+/datum/supply_pack/munitions/expeditioncannon
+	name = "Exploration phasecannon (station-locked) crate"
 	contains = list(
-			/obj/item/weapon/gun/energy/locked/frontier/handbow=2
+			/obj/item/weapon/gun/energy/locked/phasegun/cannon = 1
 			)
-	cost = 20
+	cost = 50
 	containertype = /obj/structure/closet/crate/secure
-	containername = "phaser handbow crate"
-	access = access_explorer
+	containername = "phasegun cannon crate"
+	access = access_explorer 
+//CHOMP Edit end
 
 /datum/supply_pack/munitions/ofd_charge_emp
 	name = "OFD Charge - EMP"

--- a/code/modules/mining/ore_redemption_machine/survey_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/survey_vendor.dm
@@ -54,9 +54,10 @@
 		EQUIPMENT("Defense Equipment - Plasteel Machete",		/obj/item/weapon/material/knife/machete,							50),
 		EQUIPMENT("Defense Equipment - Razor Drone Deployer",	/obj/item/weapon/grenade/spawnergrenade/manhacks/station/locked,	100),
 		EQUIPMENT("Defense Equipment - Sentry Drone Deployer",	/obj/item/weapon/grenade/spawnergrenade/ward,						150),
-		EQUIPMENT("Defense Equipment - Frontier Carbine",		/obj/item/weapon/gun/energy/locked/frontier/carbine,				400), //CHOMPEDIT
-		EQUIPMENT("Defense Equipment - Frontier Phaser",		/obj/item/weapon/gun/energy/locked/frontier,						150), //CHOMPADD
-		EQUIPMENT("Defense Equipment - Holdout Phaser", 		/obj/item/weapon/gun/energy/locked/frontier/holdout,				100), //CHOMPADD
+		EQUIPMENT("Defense Equipment - Marksman Frontier Phaser", 	/obj/item/weapon/gun/energy/locked/frontier/rifle,				1500), //CHOMPADD
+		EQUIPMENT("Defense Equipment - Frontier Carbine",		/obj/item/weapon/gun/energy/locked/frontier/carbine,				1500), //CHOMPEDIT
+		EQUIPMENT("Defense Equipment - Frontier Phaser",		/obj/item/weapon/gun/energy/locked/frontier,					1200), //CHOMPADD
+		EQUIPMENT("Defense Equipment - Holdout Frontier Phaser", 	/obj/item/weapon/gun/energy/locked/frontier/holdout,				700), //CHOMPADD
 		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Dagger",	/obj/item/weapon/kinetic_crusher/machete/dagger,					75),
 		EQUIPMENT("Hybrid Equipment - Proto-Kinetic Machete",	/obj/item/weapon/kinetic_crusher/machete,							250),
 		EQUIPMENT("Fishing Net",								/obj/item/weapon/material/fishing_net,								50),

--- a/code/modules/projectiles/guns/energy/laser_vr.dm
+++ b/code/modules/projectiles/guns/energy/laser_vr.dm
@@ -185,7 +185,7 @@
 			break
 		playsound(src,'sound/items/change_drill.ogg',25,1)
 		user.hud_used.update_ammo_hud(user, src)
-		if(power_supply.give(phase_power) < phase_power)
+		if(power_supply.give(phase_power/8) < phase_power/8) //CHOMP Edit: Nerfed charge time of all phasers by adding /8 in a couple spots to this line
 			break
 
 	recharging = 0

--- a/modular_chomp/code/modules/research/designs/weapons.dm
+++ b/modular_chomp/code/modules/research/designs/weapons.dm
@@ -3,7 +3,7 @@
 	desc = "Stuff it with paper and shoot! You'll be a hit at every party."
 	id = "confetti_cannon"
 	req_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 3000, "glass" = 3000)
+	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3000)
 	build_path = /obj/item/weapon/gun/launcher/confetti_cannon
 	sort_string = "MAAVD"
 
@@ -11,34 +11,71 @@
 /datum/design/item/weapon/phase/phase_pistol
 	id = "phasepistol"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 4000, MAT_COPPER = 30)
+	materials = list(MAT_STEEL = 4000, MAT_GLASS = 500, MAT_COPPER = 30)
 	build_path = /obj/item/weapon/gun/energy/locked/phasegun/pistol
 	sort_string = "MACAA"
 
 /datum/design/item/weapon/phase/phase_carbine
 	id = "phasecarbine"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2, TECH_POWER = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 6000, "glass" = 1500, MAT_COPPER = 40)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 500, MAT_COPPER = 500)
 	build_path = /obj/item/weapon/gun/energy/locked/phasegun
 	sort_string = "MACAB"
 
 /datum/design/item/weapon/phase/phase_rifle
 	id = "phaserifle"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_POWER = 3)
-	materials = list(DEFAULT_WALL_MATERIAL = 7000, "glass" = 2000, "silver" = 500)
+	materials = list(MAT_STEEL = 7000, MAT_GLASS = 500, MAT_SILVER = 500)
 	build_path = /obj/item/weapon/gun/energy/locked/phasegun/rifle
 	sort_string = "MACAC"
 
 /datum/design/item/weapon/phase/phase_cannon
 	id = "phasecannon"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 4, TECH_POWER = 4)
-	materials = list(DEFAULT_WALL_MATERIAL = 10000, "glass" = 2000, "silver" = 1000, "diamond" = 750)
+	materials = list(MAT_STEEL = 10000, MAT_GLASS = 2000, MAT_SILVER = 2000, MAT_DIAMOND = 750)
 	build_path = /obj/item/weapon/gun/energy/locked/phasegun/cannon
 	sort_string = "MACAD"
+
+/datum/design/item/weapon/phase/frontier_holdout
+	id = "holdout frontier phaser"
+	req_tech = list(TECH_COMBAT = 4, TECH_POWER = 7, TECH_MATERIAL = 6, TECH_PHORON = 6)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 900, MAT_COPPER = 100, MAT_DURASTEEL = 100, MAT_METALHYDROGEN = 150, MAT_VERDANTIUM = 100, MAT_PHORON = 1000)
+	build_path = /obj/item/weapon/gun/energy/locked/frontier/holdout
+	sort_string = "MACAE"
+
+/datum/design/item/weapon/phase/frontier_phaser
+	id = "frontier phaser"
+	req_tech = list(TECH_COMBAT = 4, TECH_POWER = 7, TECH_MATERIAL = 6, TECH_PHORON = 6)
+	materials = list(MAT_STEEL = 7000, MAT_GLASS = 900, MAT_COPPER = 500, MAT_DURASTEEL = 100, MAT_METALHYDROGEN = 200, MAT_VERDANTIUM = 150, MAT_PHORON = 2000)
+	build_path = /obj/item/weapon/gun/energy/locked/frontier
+	sort_string = "MACAF"
+
+/datum/design/item/weapon/phase/frontier_carbine
+	id = "carbine frontier phaser"
+	req_tech = list(TECH_COMBAT = 4, TECH_POWER = 8, TECH_MATERIAL = 6, TECH_PHORON = 6)
+	materials = list(MAT_STEEL = 6500, MAT_GLASS = 900, MAT_COPPER = 500, MAT_DURASTEEL = 150, MAT_METALHYDROGEN = 250, MAT_VERDANTIUM = 200, MAT_PHORON = 4000)
+	build_path = /obj/item/weapon/gun/energy/locked/frontier/carbine
+	sort_string = "MACAG"
+
+/datum/design/item/weapon/phase/frontier_rifle
+	id = "marksman rifle frontier phaser"
+	req_tech = list(TECH_COMBAT = 4, TECH_POWER = 7, TECH_MATERIAL = 6, TECH_PHORON = 6)
+	materials = list(MAT_STEEL = 8000, MAT_GLASS = 900, MAT_COPPER = 700, MAT_DURASTEEL = 200, MAT_METALHYDROGEN = 300, MAT_VERDANTIUM = 250, MAT_PHORON = 2000)
+	build_path = /obj/item/weapon/gun/energy/locked/frontier/rifle
+	sort_string = "MACAH"
+
+/datum/design/item/weapon/phase/frontier_handbow
+	id = "handbow frontier phaser"
+	req_tech = list(TECH_COMBAT = 4, TECH_POWER = 7, TECH_MATERIAL = 6, TECH_PHORON = 6)
+	materials = list(MAT_STEEL = 5000, MAT_GLASS = 900, MAT_COPPER = 500, MAT_DURASTEEL = 100, MAT_METALHYDROGEN = 200, MAT_VERDANTIUM = 150, MAT_PHORON = 1000)
+	build_path = /obj/item/weapon/gun/energy/locked/frontier/handbow
+	sort_string = "MACAI"
+
 //Leathals And any new CHOMP weapons.
 /datum/design/item/weapon/gun/projectile/caseless/prototype
 	id = "caselessrifle"
 	req_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 5, TECH_PHORON = 5)
-	materials = list(DEFAULT_WALL_MATERIAL = 7000, "titanium" = 4000)
+	materials = list(MAT_STEEL = 7000, MAT_TITANIUM = 4000)
 	build_path = /obj/item/weapon/gun/projectile/caseless/prototype
-	sort_string = "MACAE"
+	sort_string = "MACBA"
+

--- a/modular_chomp/code/modules/research/designs/weapons.dm
+++ b/modular_chomp/code/modules/research/designs/weapons.dm
@@ -11,14 +11,14 @@
 /datum/design/item/weapon/phase/phase_pistol
 	id = "phasepistol"
 	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 2, TECH_POWER = 2)
-	materials = list(MAT_STEEL = 4000, MAT_GLASS = 500, MAT_COPPER = 30)
+	materials = list(MAT_STEEL = 4000, MAT_GLASS = 500)
 	build_path = /obj/item/weapon/gun/energy/locked/phasegun/pistol
 	sort_string = "MACAA"
 
 /datum/design/item/weapon/phase/phase_carbine
 	id = "phasecarbine"
 	req_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 2, TECH_POWER = 2)
-	materials = list(MAT_STEEL = 6000, MAT_GLASS = 500, MAT_COPPER = 500)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 500)
 	build_path = /obj/item/weapon/gun/energy/locked/phasegun
 	sort_string = "MACAB"
 
@@ -39,35 +39,35 @@
 /datum/design/item/weapon/phase/frontier_holdout
 	id = "holdout frontier phaser"
 	req_tech = list(TECH_COMBAT = 4, TECH_POWER = 7, TECH_MATERIAL = 6, TECH_PHORON = 6)
-	materials = list(MAT_STEEL = 6000, MAT_GLASS = 900, MAT_COPPER = 100, MAT_DURASTEEL = 100, MAT_METALHYDROGEN = 150, MAT_VERDANTIUM = 100, MAT_PHORON = 1000)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 900, MAT_DURASTEEL = 100, MAT_METALHYDROGEN = 150, MAT_VERDANTIUM = 100, MAT_PHORON = 1000)
 	build_path = /obj/item/weapon/gun/energy/locked/frontier/holdout
 	sort_string = "MACAE"
 
 /datum/design/item/weapon/phase/frontier_phaser
 	id = "frontier phaser"
 	req_tech = list(TECH_COMBAT = 4, TECH_POWER = 7, TECH_MATERIAL = 6, TECH_PHORON = 6)
-	materials = list(MAT_STEEL = 7000, MAT_GLASS = 900, MAT_COPPER = 500, MAT_DURASTEEL = 100, MAT_METALHYDROGEN = 200, MAT_VERDANTIUM = 150, MAT_PHORON = 2000)
+	materials = list(MAT_STEEL = 7000, MAT_GLASS = 900, MAT_DURASTEEL = 100, MAT_METALHYDROGEN = 200, MAT_VERDANTIUM = 150, MAT_PHORON = 2000)
 	build_path = /obj/item/weapon/gun/energy/locked/frontier
 	sort_string = "MACAF"
 
 /datum/design/item/weapon/phase/frontier_carbine
 	id = "carbine frontier phaser"
 	req_tech = list(TECH_COMBAT = 4, TECH_POWER = 8, TECH_MATERIAL = 6, TECH_PHORON = 6)
-	materials = list(MAT_STEEL = 6500, MAT_GLASS = 900, MAT_COPPER = 500, MAT_DURASTEEL = 150, MAT_METALHYDROGEN = 250, MAT_VERDANTIUM = 200, MAT_PHORON = 4000)
+	materials = list(MAT_STEEL = 6500, MAT_GLASS = 900, MAT_DURASTEEL = 150, MAT_METALHYDROGEN = 250, MAT_VERDANTIUM = 200, MAT_PHORON = 4000)
 	build_path = /obj/item/weapon/gun/energy/locked/frontier/carbine
 	sort_string = "MACAG"
 
 /datum/design/item/weapon/phase/frontier_rifle
 	id = "marksman rifle frontier phaser"
 	req_tech = list(TECH_COMBAT = 4, TECH_POWER = 7, TECH_MATERIAL = 6, TECH_PHORON = 6)
-	materials = list(MAT_STEEL = 8000, MAT_GLASS = 900, MAT_COPPER = 700, MAT_DURASTEEL = 200, MAT_METALHYDROGEN = 300, MAT_VERDANTIUM = 250, MAT_PHORON = 2000)
+	materials = list(MAT_STEEL = 8000, MAT_GLASS = 900, MAT_DURASTEEL = 200, MAT_METALHYDROGEN = 300, MAT_VERDANTIUM = 250, MAT_PHORON = 2000)
 	build_path = /obj/item/weapon/gun/energy/locked/frontier/rifle
 	sort_string = "MACAH"
 
 /datum/design/item/weapon/phase/frontier_handbow
 	id = "handbow frontier phaser"
 	req_tech = list(TECH_COMBAT = 4, TECH_POWER = 7, TECH_MATERIAL = 6, TECH_PHORON = 6)
-	materials = list(MAT_STEEL = 5000, MAT_GLASS = 900, MAT_COPPER = 500, MAT_DURASTEEL = 100, MAT_METALHYDROGEN = 200, MAT_VERDANTIUM = 150, MAT_PHORON = 1000)
+	materials = list(MAT_STEEL = 5000, MAT_GLASS = 900, MAT_DURASTEEL = 100, MAT_METALHYDROGEN = 200, MAT_VERDANTIUM = 150, MAT_PHORON = 1000)
 	build_path = /obj/item/weapon/gun/energy/locked/frontier/handbow
 	sort_string = "MACAI"
 


### PR DESCRIPTION
-Added frontier phasers to research console.
--Costs and requirements reflect rechargeable battery
-Adjusted printing costs for standard phaser weapons.
-Added the frontier marksman rifle to explo vendor
-Increased frontier phaser costs
-Nerfed charge time of all phasers by dividing phase_power by 8
--It will take two minutes to charge the carbine to full power.
-Change out cargo frontier phasers crates to standard phaseguns

-----
Map changes to follow - Removal of frontier phasers from station and explo carrier gun cabinets - to be replaced by standard phasers with extra weapons battery. POIs will also be swept for frontier phasers.

Intent is to increase challenge to exploration by simply not granting people the most powerful gun in the game considering it does considerable bonus damage to mobs vs most weapons. It is also ridiculously quick to recharge (faster than recharging alien batteries even). So we want to encourage players to find and use the other powerful loot weapons available within the POIs.

The frontier phasers are still available as a reward in the explo vendor and also for Reasearch to print on request. No, frontier phasers will not available for cargo - explo's gotta put in work cataloguing or tech retrieval for these.