### PR TITLE
Exploration Adjustments: Small Scale

### DIFF
--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -2912,7 +2912,6 @@
 /obj/item/weapon/gun/energy/locked/phasegun/rifle{
 	pixel_y = -4
 	},
-/obj/item/weapon/gun/energy/locked/frontier/holdout,
 /obj/item/clothing/accessory/holster/hip,
 /obj/item/device/gps,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -4720,6 +4719,14 @@
 "oA" = (
 /turf/simulated/shuttle/wall/voidcraft/green,
 /area/shuttle/stargazer)
+"oB" = (
+/obj/structure/table/sifwoodentable,
+/obj/item/weapon/paper{
+	info = "Heyo, notice from one of the few reaming clean-up crew. Somethings up with the gateway, things seem to be changing. Careful, it's destination might even change at some point.";
+	name = "Notice"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/prep)
 "oC" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod{
@@ -5936,6 +5943,8 @@
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 4
 	},
+/obj/item/weapon/gun/energy/locked/phasegun/rifle,
+/obj/item/weapon/gun/energy/locked/phasegun/rifle,
 /turf/simulated/shuttle/floor/darkred,
 /area/shuttle/stargazer)
 "rw" = (
@@ -45387,7 +45396,7 @@ KN
 NV
 Qt
 iY
-TR
+oB
 XO
 MR
 LG

--- a/maps/southern_cross/southern_cross-8.dmm
+++ b/maps/southern_cross/southern_cross-8.dmm
@@ -236,7 +236,7 @@
 	dir = 4;
 	name = "hacked cigarette machine";
 	prices = list();
-	products = list(/obj/item/weapon/storage/fancy/cigarettes = 10, /obj/item/weapon/storage/box/matches = 10, /obj/item/weapon/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
+	products = list(/obj/item/weapon/storage/fancy/cigarettes=10,/obj/item/weapon/storage/box/matches=10,/obj/item/weapon/flame/lighter/zippo=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)
 	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/merchant)
@@ -251,7 +251,7 @@
 	contraband = null;
 	dir = 1;
 	name = "Old Vending Machine";
-	products = list(/obj/item/device/assembly/prox_sensor = 5, /obj/item/device/assembly/signaler = 4, /obj/item/device/assembly/infra = 4, /obj/item/device/assembly/prox_sensor = 4, /obj/item/weapon/handcuffs = 8, /obj/item/device/flash = 4, /obj/item/weapon/cartridge/signal = 4, /obj/item/clothing/glasses/sunglasses = 4)
+	products = list(/obj/item/device/assembly/prox_sensor=5,/obj/item/device/assembly/signaler=4,/obj/item/device/assembly/infra=4,/obj/item/device/assembly/prox_sensor=4,/obj/item/weapon/handcuffs=8,/obj/item/device/flash=4,/obj/item/weapon/cartridge/signal=4,/obj/item/clothing/glasses/sunglasses=4)
 	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/merchant)
@@ -9182,7 +9182,7 @@
 	dir = 4;
 	name = "hacked cigarette machine";
 	prices = list();
-	products = list(/obj/item/weapon/storage/fancy/cigarettes = 10, /obj/item/weapon/storage/box/matches = 10, /obj/item/weapon/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
+	products = list(/obj/item/weapon/storage/fancy/cigarettes=10,/obj/item/weapon/storage/box/matches=10,/obj/item/weapon/flame/lighter/zippo=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -10315,7 +10315,7 @@
 /obj/machinery/vending/cigarette{
 	name = "hacked cigarette machine";
 	prices = list();
-	products = list(/obj/item/weapon/storage/fancy/cigarettes = 10, /obj/item/weapon/storage/box/matches = 10, /obj/item/weapon/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
+	products = list(/obj/item/weapon/storage/fancy/cigarettes=10,/obj/item/weapon/storage/box/matches=10,/obj/item/weapon/flame/lighter/zippo=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)
 	},
 /turf/unsimulated/floor{
 	icon_state = "steel"
@@ -10717,7 +10717,7 @@
 /area/shuttle/syndicate)
 "mBJ" = (
 /mob/living/simple_mob/animal/passive/cat/space{
-	armor_soak = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 100, "bio" = 100, "rad" = 100);
+	armor_soak = list("melee"=100,"bullet"=100,"laser"=100,"energy"=100,"bomb"=100,"bio"=100,"rad"=100);
 	desc = "They look well taken care of. There is a small scratch mark through the L of their collar that looks like it was made by a claw.";
 	description_antag = "That space suit looks like it can withstand just about any assault. You feel that you will regret hurting this one.";
 	description_fluff = "Back after a very long trip. Their suit smells of adventure!";
@@ -12993,7 +12993,7 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/merchant)
 "pGr" = (
-/obj/structure/table/reinforced,
+/obj/structure/table/steel_reinforced,
 /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
 /obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
 /turf/unsimulated/floor{
@@ -13779,7 +13779,7 @@
 /obj/machinery/vending/cigarette{
 	name = "hacked cigarette machine";
 	prices = list();
-	products = list(/obj/item/weapon/storage/fancy/cigarettes = 10, /obj/item/weapon/storage/box/matches = 10, /obj/item/weapon/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
+	products = list(/obj/item/weapon/storage/fancy/cigarettes=10,/obj/item/weapon/storage/box/matches=10,/obj/item/weapon/flame/lighter/zippo=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)
 	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/shuttle/syndicate)
@@ -16304,7 +16304,7 @@
 /obj/machinery/vending/assist{
 	contraband = null;
 	name = "AntagCorpVend";
-	products = list(/obj/item/device/assembly/prox_sensor = 5, /obj/item/device/assembly/signaler = 4, /obj/item/device/assembly/infra = 4, /obj/item/device/assembly/prox_sensor = 4, /obj/item/weapon/handcuffs = 8, /obj/item/device/flash = 4, /obj/item/weapon/cartridge/signal = 4, /obj/item/clothing/glasses/sunglasses = 4)
+	products = list(/obj/item/device/assembly/prox_sensor=5,/obj/item/device/assembly/signaler=4,/obj/item/device/assembly/infra=4,/obj/item/device/assembly/prox_sensor=4,/obj/item/weapon/handcuffs=8,/obj/item/device/flash=4,/obj/item/weapon/cartridge/signal=4,/obj/item/clothing/glasses/sunglasses=4)
 	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/shuttle/syndicate)
@@ -16927,7 +16927,7 @@
 /obj/machinery/vending/cigarette{
 	name = "hacked cigarette machine";
 	prices = list();
-	products = list(/obj/item/weapon/storage/fancy/cigarettes = 10, /obj/item/weapon/storage/box/matches = 10, /obj/item/weapon/flame/lighter/zippo = 4, /obj/item/clothing/mask/smokable/cigarette/cigar/havana = 2)
+	products = list(/obj/item/weapon/storage/fancy/cigarettes=10,/obj/item/weapon/storage/box/matches=10,/obj/item/weapon/flame/lighter/zippo=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)
 	},
 /turf/unsimulated/floor{
 	dir = 5;

--- a/maps/submaps/surface_submaps/plains/Diner.dmm
+++ b/maps/submaps/surface_submaps/plains/Diner.dmm
@@ -465,6 +465,11 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/white,
 /area/submap/diner)
+"Km" = (
+/obj/structure/table/standard,
+/obj/item/device/flashlight/lamp,
+/turf/simulated/floor/tiled/white,
+/area/submap/diner)
 
 (1,1,1) = {"
 aa
@@ -874,7 +879,7 @@ aa
 (16,1,1) = {"
 aa
 ad
-bj
+Km
 ap
 ap
 ap

--- a/maps/submaps/surface_submaps/wilderness/FrostflyNest.dmm
+++ b/maps/submaps/surface_submaps/wilderness/FrostflyNest.dmm
@@ -9,7 +9,7 @@
 	},
 /area/submap/FrostflyNest)
 "d" = (
-/turf/simulated/wall/solidrock,
+/turf/simulated/mineral,
 /area/submap/FrostflyNest)
 "e" = (
 /turf/simulated/floor/outdoors/dirt{
@@ -29,12 +29,7 @@
 	},
 /area/submap/FrostflyNest)
 "h" = (
-/obj/structure/prop/nest{
-	color = "#041164";
-	creature_types = list(/mob/living/simple_mob/animal/sif/frostfly);
-	name = "frostfly den";
-	spawn_delay = 300
-	},
+/mob/living/simple_mob/animal/sif/frostfly,
 /turf/simulated/floor/outdoors/dirt{
 	outdoors = 0
 	},
@@ -120,7 +115,7 @@ f
 i
 e
 e
-e
+h
 g
 d
 d
@@ -142,7 +137,7 @@ d
 d
 d
 i
-e
+h
 e
 l
 d

--- a/maps/submaps/surface_submaps/wilderness/MCamp1.dmm
+++ b/maps/submaps/surface_submaps/wilderness/MCamp1.dmm
@@ -75,9 +75,9 @@
 /area/submap/MilitaryCamp1)
 "t" = (
 /obj/structure/table/standard,
+/mob/living/simple_mob/mechanical/viscerator,
+/mob/living/simple_mob/mechanical/viscerator,
 /obj/random/energy,
-/mob/living/simple_mob/mechanical/viscerator,
-/mob/living/simple_mob/mechanical/viscerator,
 /turf/simulated/floor,
 /area/submap/MilitaryCamp1)
 "u" = (
@@ -120,6 +120,7 @@
 /area/submap/MilitaryCamp1)
 "C" = (
 /obj/structure/table,
+/obj/random/firstaid,
 /turf/simulated/floor,
 /area/submap/MilitaryCamp1)
 "D" = (

--- a/maps/submaps/surface_submaps/wilderness/Manor1.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Manor1.dmm
@@ -326,10 +326,6 @@
 /obj/item/clothing/accessory/sweater/blue,
 /turf/simulated/floor/carpet/blucarpet,
 /area/submap/Manor1)
-"bn" = (
-/obj/structure/window/reinforced/full,
-/turf/template_noop,
-/area/submap/Manor1)
 "bo" = (
 /obj/item/weapon/material/twohanded/baseballbat/metal,
 /turf/simulated/floor/carpet/blucarpet,
@@ -341,15 +337,6 @@
 "bq" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/holofloor/wood,
-/area/submap/Manor1)
-"br" = (
-/obj/structure/bed/chair/comfy/purp{
-	dir = 4;
-	icon_state = "comfychair_preview"
-	},
-/turf/simulated/floor/holofloor/wood{
-	icon_state = "wood_broken5"
-	},
 /area/submap/Manor1)
 "bs" = (
 /obj/structure/table,
@@ -1744,8 +1731,8 @@ aa
 aa
 aa
 ab
-bn
-bn
+ac
+ac
 ab
 aa
 aa
@@ -3634,7 +3621,7 @@ ab
 ab
 ab
 ag
-br
+bx
 ML
 bC
 ab

--- a/maps/submaps/surface_submaps/wilderness/Shelter.dmm
+++ b/maps/submaps/surface_submaps/wilderness/Shelter.dmm
@@ -45,7 +45,7 @@
 /obj/item/clothing/mask/gas/explorer,
 /obj/item/clothing/accessory/permit/gun/planetside,
 /obj/item/clothing/suit/armor/pcarrier/light/nt,
-/obj/random/projectile/scrapped_smg,
+/obj/random/projectile/scrapped_gun,
 /obj/random/projectile/scrapped_pistol,
 /turf/simulated/floor/outdoors/rocks/caves,
 /area/submap/Shelter1)


### PR DESCRIPTION
Rather minor changes.
-Added  phase rifles to another deep space shuttle. 
-Removed the two holdout frontier weapons that were missed. 
-Added a note warning explorers that the gateway is getting adjusted. 
-Fixes a table in an admin area.
-Fixes a table and floor tile in the Dinner POI
-Adds another medkit to the minefield POI, to try and get more folks to go to it.
 -Removed the indestructible frostfly spawner, replacing it with three of them. Also replaced the cursed solid rock with normal rock, so now that thing is actually approachable.
 -Replaced a broken SMG spawner with a random broken gun spawner.