### PR TITLE
Monkeys can now leave remains

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -510,7 +510,8 @@ var/global/list/remainless_species = list(SPECIES_PROMETHEAN,
 				SPECIES_DIONA,
 				SPECIES_ALRAUNE,
 				SPECIES_PROTEAN,
-				SPECIES_MONKEY,					//Exclude all monkey subtypes, to prevent abuse of it. They aren't,
+				/*
+				SPECIES_MONKEY,					//Exclude all monkey subtypes, to prevent abuse of it. They aren't, //CHOMPEDIT How about let preds have skeletons, people can do so much worse than this
 				SPECIES_MONKEY_TAJ,				//set to have remains anyway, but making double sure,
 				SPECIES_MONKEY_SKRELL,
 				SPECIES_MONKEY_UNATHI,
@@ -518,6 +519,7 @@ var/global/list/remainless_species = list(SPECIES_PROMETHEAN,
 				SPECIES_MONKEY_NEVREAN,
 				SPECIES_MONKEY_SERGAL,
 				SPECIES_MONKEY_VULPKANIN,
+				*/
 				SPECIES_XENO,					//Same for xenos,
 				SPECIES_XENO_DRONE,
 				SPECIES_XENO_HUNTER,

--- a/code/modules/mob/living/carbon/human/species/station/monkey.dm
+++ b/code/modules/mob/living/carbon/human/species/station/monkey.dm
@@ -70,6 +70,12 @@
 /datum/species/monkey/get_random_name()
 	return "[lowertext(name)] ([rand(100,999)])"
 
+/datum/species/monkey/handle_post_spawn(var/mob/living/carbon/human/H)//CHOMPadd begin
+	if(!H.ckey)
+		H.can_be_drop_prey = TRUE
+		H.digest_leave_remains = 1
+	return ..()//CHOMPadd end
+
 /datum/species/monkey/tajaran
 	name = SPECIES_MONKEY_TAJ
 	name_plural = "Farwa"

--- a/code/modules/vore/eating/leave_remains_vr.dm
+++ b/code/modules/vore/eating/leave_remains_vr.dm
@@ -24,6 +24,24 @@
 	skull_type = /obj/item/weapon/digestion_remains/skull/teshari
 /datum/species/vox
 	skull_type = /obj/item/weapon/digestion_remains/skull/vox
+//CHOMPadd start
+/datum/species/monkey
+	skull_type = /obj/item/weapon/digestion_remains/skull
+/datum/species/monkey/tajaran
+	skull_type = /obj/item/weapon/digestion_remains/skull/tajaran
+/datum/species/monkey/unathi
+	skull_type = /obj/item/weapon/digestion_remains/skull/unathi
+/datum/species/monkey/skrell
+	skull_type = /obj/item/weapon/digestion_remains/skull/skrell
+/datum/species/monkey/shark
+	skull_type = /obj/item/weapon/digestion_remains/skull/akula
+/datum/species/monkey/sparra
+	skull_type = /obj/item/weapon/digestion_remains/skull/rapala
+/datum/species/monkey/vulpkanin
+	skull_type = /obj/item/weapon/digestion_remains/skull/vulpkanin
+/datum/species/monkey/sergal
+	skull_type = /obj/item/weapon/digestion_remains/skull/sergal
+//CHOMPadd end.
 
 /obj/belly/proc/handle_remains_leaving(var/mob/living/M)
 	if(!ishuman(M))	//Are we even humanoid?
@@ -46,7 +64,7 @@
 	if(H.species.skull_type)
 		new H.species.skull_type(src, owner, H) //CHOMPEdit
 		skull_amount--
-	
+
 	if(skull_amount && H.species.selects_bodytype)
 		// We still haven't found correct skull...
 		if(H.species.base_species == SPECIES_HUMAN)


### PR DESCRIPTION
This was intentionally disabled for 'abuse' from years ago.
It's a pref that only affects the pred if they have leave-remains on in their vorgan anyway, let people have bones inside of them if they really want it.

Also enables monkeys to have drop nom prey enabled by default

![ShareX_pLluyOUUeP](https://user-images.githubusercontent.com/10555869/215394325-eac2603a-9685-4dc0-ae31-12e7580da6de.png)
![vY6LjIbzjB](https://user-images.githubusercontent.com/10555869/215394333-5170871d-5944-47d1-827a-35fa5e916942.png)
