### PR TITLE
adds some missing overmap shuttle features and fixes charging

### DIFF
--- a/maps/southern_cross/overmap/shuttles.dm
+++ b/maps/southern_cross/overmap/shuttles.dm
@@ -4,6 +4,7 @@
 	name = "Stargazer"
 	warmup_time = 1
 	current_location = "stargazer_dock"
+	docking_controller_tag = "stargazer"
 	shuttle_area = /area/shuttle/stargazer
 	fuel_consumption = 2
 	move_direction = NORTH
@@ -25,8 +26,9 @@
 	name = "Baby_mammoth"
 	warmup_time = 5
 	current_location = "baby_mammoth_dock"
+	docking_controller_tag = "shuttle4_shuttle"
 	shuttle_area = /area/shuttle/baby_mammoth
-	fuel_consumption = 5
+	fuel_consumption = 2
 	move_direction = NORTH
 
 /obj/effect/overmap/visitable/ship/landable/baby_mammoth
@@ -46,8 +48,9 @@
 	name = "Ursula"
 	warmup_time = 2
 	current_location = "ursula_dock"
+	docking_controller_tag = "ursula"
 	shuttle_area = /area/shuttle/ursula
-	fuel_consumption = 3
+	fuel_consumption = 2
 	move_direction = NORTH
 
 /obj/effect/overmap/visitable/ship/landable/ursula
@@ -67,6 +70,7 @@
 	name = "Needle"
 	warmup_time = 0
 	current_location = "needle_dock"
+	docking_controller_tag = "needle"
 	shuttle_area = /area/shuttle/needle
 	fuel_consumption = 1
 	move_direction = NORTH
@@ -88,6 +92,7 @@
 	name = "Echidna"
 	warmup_time = 4
 	current_location = "echidna_dock"
+	docking_controller_tag = "echidna"
 	shuttle_area = /area/shuttle/echidna
 	fuel_consumption = 2
 	move_direction = NORTH

--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -2058,6 +2058,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/green,
+/obj/structure/cable/green,
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
 "fb" = (
@@ -5489,9 +5490,9 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/ursula)
@@ -5504,8 +5505,18 @@
 	opacity = 1
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
@@ -5517,11 +5528,11 @@
 	dir = 1;
 	opacity = 1
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
 "qC" = (
@@ -5598,6 +5609,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/ursula)
 "qR" = (
@@ -5606,10 +5622,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/ursula)
@@ -5619,28 +5635,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/ursula)
@@ -5652,11 +5658,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/outerportmaint)
 "qU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/closet/walllocker/emerglocker{
 	dir = 1;
 	pixel_x = 25;
@@ -5668,7 +5669,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5694,6 +5695,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/ursula)
 "qW" = (
@@ -5710,7 +5716,7 @@
 	tag_interior_door = "ursula_inner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/green{
+/obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5734,7 +5740,7 @@
 	landmark_tag = "ursula_dock";
 	name = "Ursula Dock"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -5755,7 +5761,7 @@
 	locked = 1;
 	name = "External Access"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8408,14 +8414,20 @@
 /obj/structure/sign/poster/nanotrasen{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/baby_mammoth)
 "wI" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/baby_mammoth)
 "wJ" = (
@@ -8424,6 +8436,11 @@
 	dir = 1
 	},
 /obj/machinery/mech_recharger,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/baby_mammoth)
 "wK" = (
@@ -8618,14 +8635,24 @@
 	pixel_x = -25;
 	pixel_y = 32
 	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/baby_mammoth)
 "wY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/baby_mammoth)
@@ -8633,18 +8660,13 @@
 /obj/structure/fuel_port{
 	pixel_y = -28
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
+/obj/structure/cable/blue{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/shuttle/baby_mammoth)
@@ -8661,28 +8683,33 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/baby_mammoth)
 "xb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/cable/blue{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/baby_mammoth)
 "xc" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/green{
+/obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8706,7 +8733,7 @@
 	locked = 1;
 	name = "Internal Access"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8719,7 +8746,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8739,7 +8766,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -8766,7 +8793,7 @@
 	layer = 2.5;
 	name = "window blast shield"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -13165,6 +13192,14 @@
 /obj/item/device/cataloguer,
 /turf/simulated/floor/tiled,
 /area/expoutpost/prep)
+"Nv" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/shuttle/floor/black,
+/area/shuttle/baby_mammoth)
 "Nx" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/structure/cable/blue{
@@ -45885,7 +45920,7 @@ vr
 vr
 vr
 ws
-vr
+Nv
 xb
 xz
 xU


### PR DESCRIPTION
Shuttles now dock properly on the station, airlocks automatically open on dock.

Jump cost for all ships halved (500 delta v for a small ship really?)

Re wired the Ursula, Baby Mammoth, and Needle to take power from both sides, so it can charge if its on station, I tested it and it worked but I am not too sure with the other shuttles. Shuttles with no SMES are untouched

I was gonna make the voidcraft tiles deconstructable/destroyable but that's beyond my skill level.

https://user-images.githubusercontent.com/10555869/216247980-41b3dde4-377f-4eab-9a51-c1e287ea2249.mp4

![Rf0Pdx68Gv](https://user-images.githubusercontent.com/10555869/216248726-0c91f221-ec4b-4556-9857-212248d0e6af.png)

![xupN7TWFw6](https://user-images.githubusercontent.com/10555869/216248699-6d034203-702a-4c7f-966d-1805b93cf118.png)
