### PR TITLE
makes it so that the holder location only shows on the stat tab

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -64,8 +64,8 @@ var/list/holder_mob_icon_cache = list()
 			location = "[H.loc.loc]'s [H.loc]"
 		else
 			location = "[H.loc]"
-
-		stat("Location", location)
+		if (location != "" && statpanel("Status"))
+			stat("Location", location)
 //CHOMPEdit End
 
 /obj/item/weapon/holder/Entered(mob/held, atom/OldLoc)


### PR DESCRIPTION
because I'd like it to stop showing up on my tickets/turf tab