### PR TITLE
Fixes Discomfort Messages not showing up at all

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species_getters.dm
+++ b/code/modules/mob/living/carbon/human/species/species_getters.dm
@@ -93,12 +93,12 @@
 	var/list/custom_cold = H.custom_cold
 	var/list/custom_heat = H.custom_heat
 	if(msg_type == ENVIRONMENT_COMFORT_MARKER_COLD && length(cold_discomfort_strings) /*&& !covered*/)
-		if(custom_cold.len > 0)
+		if(custom_cold && (custom_cold.len > 0)) // CHOMPEDIT: Fixes Discomfort messages not showing up at all.
 			discomfort_message = pick(custom_cold)
 		else
 			discomfort_message = pick(cold_discomfort_strings)
 	else if(msg_type == ENVIRONMENT_COMFORT_MARKER_HOT && length(heat_discomfort_strings) /*&& covered*/)
-		if(custom_heat.len > 0)
+		if(custom_heat && (custom_heat.len > 0)) // CHOMPEDIT: Fixes Discomfort messages not showing up at all.
 			discomfort_message = pick(custom_heat)
 		else
 			discomfort_message = pick(heat_discomfort_strings)


### PR DESCRIPTION
If Custom Cold + Custom Heat are not set on a mob, the list is empty and for w/e reason doesn't initialize properly, resulting in a null value. This is only resolved when you reset the list first, but even then, it still remains null in-game. This is a fix in case the custom_ var is ever null, it will fallback to the default, so as to not break thrown alerts.

Fix for the ACTUAL cause (variable being null and list not initializing, resulting in users hitting "edit" on the custom strings in menu and it not working until it's reset first at least one TBD).