### PR TITLE
Process digest triggers death hooks now - Fixes #5540

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -1095,6 +1095,7 @@
 							var/mob/living/carbon/human/h = l
 							thismuch = thismuch * h.species.digestion_nutrition_modifier
 						l.adjust_nutrition(thismuch)
+					ourtarget.death() //CHOMPEdit - Call .death() on process digest to trigger death hooks like nif_soulcatcher or digest_check (setting vore respawn timer)
 					b.handle_digestion_death(ourtarget, instant = TRUE) //CHOMPEdit
 				if("Absorb")
 					if(tgui_alert(ourtarget, "\The [usr] is attempting to instantly absorb you. Is this something you are okay with happening to you?","Instant Absorb", list("No", "Yes")) != "Yes")


### PR DESCRIPTION
Investigating #5540, I noticed process digest directly calls `b.handle_digestion_death(...)`. The prey never really dies before being `qdel()` and, therefore, never triggers death hooks, such as `nif_soulcatcher(...)`.

Process digest now calls `.death()`, allowing prey to have a respawn timer, receive the informative "You're dead!" message and, if `mob/living/carbon/human`, to be caught by soul catchers, fixing the issue. 

