### PR TITLE
Fix Taperecorders to use m.voice not m.name

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -89,7 +89,7 @@
 /obj/item/device/taperecorder/hear_talk(mob/M, list/message_pieces, verb)
 	var/msg = multilingual_to_message(message_pieces, requires_machine_understands = TRUE, with_capitalization = TRUE)
 	if(mytape && recording)
-		mytape.record_speech("[M.name] [verb], \"[msg]\"")
+		mytape.record_speech("[M.voice] [verb], \"[msg]\"") //CHOMPEDIT: How did no one notice this before?
 
 
 /obj/item/device/taperecorder/see_emote(mob/M as mob, text, var/emote_type)


### PR DESCRIPTION
Tape recorders shouldn't identify you based on your face, but instead your voice