### PR TITLE
Fix Supermatter Warning the Entire Station on explode

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -249,6 +249,9 @@
 	var/alert_msg = " Integrity at [integrity]%"
 	var/message_sound = 'sound/ambience/matteralarm.ogg'
 
+	if(!(src.z in using_map.station_levels)) // CHOMPEdit: SM Global Warn Fix; Is our location the same as the station? If no, then we're not going to warn.
+		return // CHOMPEdit: SM Global Warn Fix; No need to announce if we're outside the station's Z, at a POI, etc.
+
 	if(final_countdown) // Chompers additon
 		return
 	if(damage > emergency_point)
@@ -406,6 +409,10 @@
 
 /obj/machinery/power/supermatter/proc/countdown()
 	set waitfor = FALSE
+
+	if(!(src.z in using_map.station_levels)) // CHOMPEdit: SM Global Warn Fix; Is our location the same as the station? If no, then we're not going to use a stabilization field.
+		explode() // CHOMPEdit: SM Global Warn Fix;  Just exploding, because we're not on the station's Z. No safety countdown.
+		return // CHOMPEdit: SM Global Warn Fix; Stops the code here.
 
 	if(final_countdown) // We're already doing it go away
 		return


### PR DESCRIPTION
SM, as it exists currently, will play the delamination warning over radio comms/globally when it is close to exploding, even if it isn't located on the station.
It would also benefit from a causality field, even outside it.
This was discovered as a result of the new space POIs, and is now being remedied.

This fixes that.

Supermatter will no longer warn the entire station if it is presently being damaged unless it exists on the same levels as the station. 

It will also skip the causality field otherwise, though this is subject to Headmin review.