### PR TITLE
Looping alarm powerloss/damage bugfix

### DIFF
--- a/code/game/machinery/air_alarm.dm
+++ b/code/game/machinery/air_alarm.dm
@@ -85,6 +85,7 @@
 	var/alarms_hidden = FALSE //If the alarms from this machine are visible on consoles
 
 	var/datum/looping_sound/alarm/decompression_alarm/soundloop // CHOMPEdit: Looping Alarms
+	var/atmoswarn = FALSE // CHOMPEdit: Looping Alarms
 
 /obj/machinery/alarm/nobreach
 	breach_detection = 0
@@ -200,8 +201,10 @@
 
 	if(alarm_area?.atmosalm || danger_level > 0)  // CHOMPEdit: Looping Alarms (Trigger Decompression alarm here, on detection of any breach in the area)
 		soundloop.start()  // CHOMPEdit: Looping Alarms
+		atmoswarn = TRUE // CHOMPEdit: Looping Alarms
 	else if(danger_level == 0 && alarm_area?.atmosalm == 0)  // CHOMPEdit: Looping Alarms (Cancel Decompression alarm here)
 		soundloop.stop()  // CHOMPEdit: Looping Alarms
+		atmoswarn = FALSE // CHOMPEdit: Looping Alarms
 
 	//atmos computer remote controll stuff
 	switch(rcon_setting)
@@ -840,6 +843,12 @@
 	..()
 	spawn(rand(0,15))
 		update_icon()
+		// CHOMPEdit Start: Looping Alarms
+		if(stat & (NOPOWER | BROKEN))
+			soundloop.stop()
+		else if(atmoswarn)
+			soundloop.start()
+		// CHOMPEdit End
 
 // VOREStation Edit Start
 /obj/machinery/alarm/freezer

--- a/code/game/machinery/fire_alarm.dm
+++ b/code/game/machinery/fire_alarm.dm
@@ -31,6 +31,11 @@ FIRE ALARM
 	var/datum/looping_sound/alarm/sm_critical_alarm/critalarm // CHOMPEdit: Soundloops
 	var/datum/looping_sound/alarm/sm_causality_alarm/causality // CHOMPEdit: Soundloops
 
+	var/firewarn = FALSE // CHOMPEdit: Looping Alarms
+	var/engwarn = FALSE // CHOMPEdit: Looping Alarms
+	var/critwarn = FALSE // CHOMPEdit: Looping Alarms
+	var/causalitywarn = FALSE // CHOMPEdit: Looping Alarms
+
 /obj/machinery/firealarm/alarms_hidden
 	alarms_hidden = TRUE
 
@@ -176,6 +181,22 @@ FIRE ALARM
 	..()
 	spawn(rand(0,15))
 		update_icon()
+		// CHOMPEdit Start: Looping Red/Violet/Orange Alarms
+		if(stat & (NOPOWER | BROKEN)) // Are we broken or out of power?
+			soundloop.stop() // Stop the loop once we're out of power
+			engalarm.stop() // Stop these bc we're out of power
+			critalarm.stop() // Stop these, out of power
+			causality.stop() // etc etc
+		else
+			if(firewarn)
+				soundloop.start()
+			if(engwarn)
+				engalarm.start()
+			if(critwarn)
+				critalarm.start()
+			if(causalitywarn)
+				causality.start()
+		// CHOMPEdit End
 
 /obj/machinery/firealarm/attack_hand(mob/user as mob)
 	if(user.stat || stat & (NOPOWER | BROKEN))
@@ -195,6 +216,7 @@ FIRE ALARM
 	for(var/obj/machinery/firealarm/FA in area)
 		fire_alarm.clearAlarm(src.loc, FA)
 		FA.soundloop.stop() // CHOMPEdit: Soundloop
+		FA.firewarn = FALSE // CHOMPEdit: Soundloop Fix
 	update_icon()
 	if(user)
 		log_game("[user] reset a fire alarm at [COORD(src)]")
@@ -206,6 +228,7 @@ FIRE ALARM
 	for(var/obj/machinery/firealarm/FA in area)
 		fire_alarm.triggerAlarm(loc, FA, duration, hidden = alarms_hidden)
 		FA.soundloop.start() // CHOMPEdit: Soundloop
+		FA.firewarn = TRUE // CHOMPEdit: Soundloop Fix
 	update_icon()
 	// playsound(src, 'sound/machines/airalarm.ogg', 25, 0, 4, volume_channel = VOLUME_CHANNEL_ALARMS) // CHOMPEdit: Disable as per soundloop
 	if(user)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -276,6 +276,7 @@
 					var/area/our_area = get_area(candidate_alarm)
 					if(istype(our_area, /area/engineering))
 						candidate_alarm.critalarm.start()
+						candidate_alarm.critwarn = TRUE // Tell the fire alarm we're warning engineering
 			critwarn = 1
 		// CHOMPEdit End
 	else if(damage >= damage_archived) // The damage is still going up
@@ -288,6 +289,7 @@
 						for(var/obj/machinery/light/L in our_area)
 							L.set_alert_engineering()
 						candidate_alarm.engalarm.start()
+						candidate_alarm.engwarn = TRUE // Tell the fire alarm we're warning engineering
 			engwarn = 1 // So we don't repeatedly try and start over the soundloop/etc
 		// CHOMPEdit End
 		safe_warned = 0
@@ -451,6 +453,7 @@
 					var/area/our_area = get_area(candidate_alarm)
 					if(istype(our_area, /area/engineering))
 						candidate_alarm.causality.start()
+						candidate_alarm.causalitywarn = TRUE // Tell the fire alarm it's warning, too
 			causalitywarn = 1
 
 	if(!(src.z in using_map.station_levels)) // CHOMPEdit: SM Global Warn Fix; Is our location the same as the station? If no, then we're not going to use a stabilization field.
@@ -650,8 +653,11 @@
 			for(var/obj/machinery/light/L in our_area)
 				L.reset_alert()
 			candidate_alarm.engalarm.stop()
+			candidate_alarm.engwarn = FALSE // Tell the fire alarm we're done, too. Yes this is janky, someone will come along and fix it later:tm:
 			candidate_alarm.causality.stop() // Somehow, in case they reset the alarms and fix the SM.
+			candidate_alarm.causalitywarn = FALSE // Tell the fire alarm we're done, too. Yes this is janky, someone will come along and fix it later:tm:
 			candidate_alarm.critalarm.stop()
+			candidate_alarm.critwarn = FALSE // Tell the fire alarm we're done, too. Yes this is janky, someone will come along and fix it later:tm:
 			engwarn = 0
 			critwarn = 0
 			causalitywarn = 0


### PR DESCRIPTION
Alarms would continue to play soundloops due to mistakenly not clearing the loop on powerchange in the area.

This resolves those issues.