### PR TITLE
Add ticket printer to security lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -198,7 +198,8 @@
 		/obj/item/device/flashlight/maglight,
 		/obj/item/device/holowarrant,				//CHOMPStation addition
 		/obj/item/device/retail_scanner/security,	//CHOMPStation addition
-		/obj/item/clothing/glasses/hud/security		//CHOMPStation addition
+		/obj/item/clothing/glasses/hud/security,	//CHOMPStation addition
+		/obj/item/device/ticket_printer			//CHOMPStation addition
 		)
 
 /obj/structure/closet/secure_closet/security/Initialize()

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -155,6 +155,7 @@
 		/obj/item/weapon/gun/projectile/revolvershotgun,
 		/obj/item/ammo_magazine/m12gdrumjack/beanbag,
 		/obj/item/ammo_magazine/m12gdrumjack/beanbag,
+		/obj/item/device/ticket_printer,		//CHOMPStation addition
 		/obj/item/device/retail_scanner/security	//CHOMPStation addition
 		)
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security_vr.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security_vr.dm
@@ -51,6 +51,7 @@
 //		/obj/item/clothing/head/beret/sec/corporate/hos, //CHOMP Remove
 //		/obj/item/clothing/suit/storage/hooded/wintercoat/security, //CHOMP Remove
 //		/obj/item/clothing/shoes/boots/winter/security, //CHOMP Remove
+		/obj/item/device/ticket_printer, //CHOMP Add
 		/obj/item/device/flashlight/maglight)
 
 //Custom NT Security Lockers, Only found at central command


### PR DESCRIPTION
Security officer, Warden, and HoS now get the ticket printer from https://github.com/CHOMPStation2/CHOMPStation2/pull/5293

These are silly monopoly tickets, they are not a substitute for actual warrants and the real job and corporate regulation enforcement duties.