### PR TITLE
Makes robust guts pickable by non-customs

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -3,3 +3,6 @@
 
 /datum/trait/positive/linguist
 	custom_only = FALSE
+
+/datum/trait/positive/toxin_gut
+	custom_only = FALSE


### PR DESCRIPTION
What it says on the title. Eating the forbidden pizza is now no longer a custom species exclusive power.