### PR TITLE
gun sprite chomp check

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -29,7 +29,7 @@
 /obj/item/weapon/gun/energy/New()
 	..()
 	var/static/list/gun_icons = icon_states('icons/obj/gun_ch.dmi')
-	if (!(icon_state in gun_icons))
+	if (icon == 'icons/obj/gun_ch.dmi' && !(icon_state in gun_icons))
 		icon = 'icons/obj/gun.dmi'
 	if(self_recharge)
 		power_supply = new /obj/item/weapon/cell/device/weapon(src)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -28,6 +28,9 @@
 
 /obj/item/weapon/gun/energy/New()
 	..()
+	var/static/list/gun_icons = icon_states('icons/obj/gun_ch.dmi')
+	if (!(icon_state in gun_icons))
+		icon = 'icons/obj/gun.dmi'
 	if(self_recharge)
 		power_supply = new /obj/item/weapon/cell/device/weapon(src)
 		START_PROCESSING(SSobj, src)


### PR DESCRIPTION
checks energy gun sprites for if we have them or not since they were changed