### PR TITLE
Enables Testing Character Voices in Setup

### DIFF
--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -103,7 +103,7 @@
 	. += "<b>Scaling Center:</b> <a [pref.offset_override ? "" : ""] href='?src=\ref[src];toggle_offset_override=1'><b>[pref.offset_override ? "Odd" : "Even"]</b></a><br>" //CHOMPEdit
 	. += "<b>Voice Frequency:</b> <a href='?src=\ref[src];voice_freq=1'>[pref.voice_freq]</a><br>"
 	. += "<b>Voice Sounds:</b> <a href='?src=\ref[src];voice_sounds_list=1'>[pref.voice_sound]</a><br>"
-//	. += "<a href='?src=\ref[src];voice_test=1'><b>Test Voice:</b></a><br>"	Maybe later
+	. += "<a href='?src=\ref[src];voice_test=1'><b>Test Selected Voice</b></a><br>" // CHOMPEdit: Enables testing voices
 	. += "<br>"
 	. += "<b>Relative Weight:</b>  <a href='?src=\ref[src];weight=1'>[pref.weight_vr]</a><br>"
 	. += "<b>Weight Gain Rate:</b> <a href='?src=\ref[src];weight_gain=1'>[pref.weight_gain]</a><br>"
@@ -200,8 +200,40 @@
 			pref.voice_sound = "goon speak 1"	//CHOMPEdit - Defaults voice to a less jarring sound
 		else
 			pref.voice_sound = choice
-	/*	Maybe later
+	// CHOMPEdit: Enable testing voice sounds
 	else if(href_list["voice_test"])
-		SEND_SOUND(user, sound(pick(voice_sounds_list), 50, frequency = pref.voice_freq))
-	*/
+		var/sound/S = pick(pref.voice_sound)
+		switch(pref.voice_sound)
+			if("beep-boop")
+				S = sound(pick(talk_sound))
+			if("goon speak 1")
+				S = sound(pick(goon_speak_one_sound))
+			if("goon speak 2")
+				S = sound(pick(goon_speak_two_sound))
+			if("goon speak 3")
+				S = sound(pick(goon_speak_three_sound))
+			if("goon speak 4")
+				S = sound(pick(goon_speak_four_sound))
+			if("goon speak blub")
+				S = sound(pick(goon_speak_blub_sound))
+			if("goon speak bottalk")
+				S = sound(pick(goon_speak_bottalk_sound))
+			if("goon speak buwoo")
+				S = sound(pick(goon_speak_buwoo_sound))
+			if("goon speak cow")
+				S = sound(pick(goon_speak_cow_sound))
+			if("goon speak lizard")
+				S = sound(pick(goon_speak_lizard_sound))
+			if("goon speak pug")
+				S = sound(pick(goon_speak_pug_sound))
+			if("goon speak pugg")
+				S = sound(pick(goon_speak_pugg_sound))
+			if("goon speak roach")
+				S = sound(pick(goon_speak_roach_sound))
+			if("goon speak skelly")
+				S = sound(pick(goon_speak_skelly_sound))
+		S.frequency = pick(pref.voice_freq)
+		S.volume = 50
+		SEND_SOUND(user, S)
+	// CHOMPEdit End
 	return ..();


### PR DESCRIPTION
As title;
This function was WIP, @blackmajor didn't have time to finish it.
I went ahead and finished this up, and realized it was worth PR'ing separately for speedmerge, because this is MASSIVELY convenient.

TL;DR:
You can hit "Test Character Voice" in setup, to play a preview of what your voice will sound like with the selected type and frequency.

See demonstration [here](https://streamable.com/m6u9vc).
