### PR TITLE
Make ticket printer smaller

### DIFF
--- a/code/game/objects/items/devices/ticket_printer.dm
+++ b/code/game/objects/items/devices/ticket_printer.dm
@@ -6,6 +6,7 @@
 	slot_flags = SLOT_BELT | SLOT_HOLSTER
 	var/print_cooldown = 1 MINUTE
 	var/last_print
+	w_class = ITEMSIZE_SMALL //CHOMP Add because something so small, trivial, and used for silly RP should not be practically gigantic.
 
 /obj/item/device/ticket_printer/attack_self(mob/user)
 	. = ..()


### PR DESCRIPTION
Because something so small, trivial, and used for silly RP should not be practically gigantic.