### PR TITLE
Fixes #5667 VR Crash

### DIFF
--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -84,6 +84,10 @@
 	var/mob/living/M = target
 	if(!istype(M))
 		return
+	//CHOMPADDITION: prevent trding bodies that have no mind and are carbon, mianly fixes VR crash
+	if(istype(M,/mob/living/carbon) && !M.mind)
+		return
+	//CHOMPADDITION: prevent trding bodies that have no mind and are carbon, mianly fixes VR crash
 	if(target != firer)	//If you shot yourself, you probably want to be TFed so don't bother with prefs.
 		if(!M.allow_spontaneous_tf && !tf_admin_pref_override)
 			return


### PR DESCRIPTION
Make it so that a carbon body without a mind can not be TFed, the only time this is really the case is when you dsconnect in VR. Possibly sleevemated bodies too.