### PR TITLE
Preferred Language + Autohiss Default Options

### DIFF
--- a/code/modules/client/preference_setup/general/02_language.dm
+++ b/code/modules/client/preference_setup/general/02_language.dm
@@ -1,5 +1,6 @@
 /datum/preferences
 	var/extra_languages = 0
+	var/preferred_language = "common" // CHOMPStation Edit: Allow selecting a preferred language
 
 /datum/category_item/player_setup_item/general/language
 	name = "Language"
@@ -14,6 +15,7 @@
 	S["language_prefixes"]	>> pref.language_prefixes
 	//CHOMPEdit Begin
 	S["species"]			>> pref.species
+	S["preflang"]			>> pref.preferred_language
 	//CHOMPEdit End
 	S["language_custom_keys"]	>> pref.language_custom_keys
 
@@ -24,6 +26,7 @@
 		testing("LANGSANI: Loaded from [pref.client]'s character [pref.real_name || "-name not yet loaded-"] savefile: [english_list(pref.alternate_languages || list())]")
 	S["language_prefixes"]	<< pref.language_prefixes
 	S["language_custom_keys"]	<< pref.language_custom_keys
+	S["preflang"]			<< pref.preferred_language // CHOMPStation Edit
 
 /datum/category_item/player_setup_item/general/language/sanitize_character()
 	if(!islist(pref.alternate_languages))	pref.alternate_languages = list()
@@ -34,6 +37,11 @@
 		if(pref.alternate_languages.len > (S.num_alternate_languages + pref.extra_languages))
 			testing("LANGSANI: Truncated [pref.client]'s character [pref.real_name || "-name not yet loaded-"] language list because it was too long (len: [pref.alternate_languages.len], allowed: [S.num_alternate_languages])")
 			pref.alternate_languages.len = (S.num_alternate_languages + pref.extra_languages) // Truncate to allowed length
+
+		// CHOMPStation Edit Start
+		if(!(pref.preferred_language in pref.alternate_languages) || !pref.preferred_language) // Safety handling for if our preferred language is ever somehow removed from the character's list of langauges, or they don't have one set
+			pref.preferred_language = S.language // Reset to default, for safety
+		// CHOMPStation Edit end
 
 		// Sanitize illegal languages
 		for(var/language in pref.alternate_languages)
@@ -79,6 +87,7 @@
 
 	. += "<b>Language Keys</b><br>"
 	. += " [jointext(pref.language_prefixes, " ")] <a href='?src=\ref[src];change_prefix=1'>Change</a> <a href='?src=\ref[src];reset_prefix=1'>Reset</a><br>"
+	. += "<b>Preferred Language</b> <a href='?src=\ref[src];pref_lang=1'>[pref.preferred_language]</a><br>" // CHOMPStation Add
 
 /datum/category_item/player_setup_item/general/language/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(href_list["remove_language"])
@@ -165,5 +174,23 @@
 			tgui_alert_async(user, "Improper language key. Rejected.", "Error")
 
 		return TOPIC_REFRESH
+
+	// CHOMPStation Add: Preferred Language
+	else if(href_list["pref_lang"])
+		if(pref.species) // Safety to prevent a null runtime here
+			var/datum/species/S = GLOB.all_species[pref.species]
+			var/list/lang_opts = list(S.language) + pref.alternate_languages
+			var/selection = tgui_input_list(user, "Choose your preferred spoken language:", "Preferred Spoken Language", lang_opts, pref.preferred_language)
+			if(!selection) // Set our preferred to default, just in case.
+				tgui_alert_async(user, "Preferred Language not modified.", "Selection Canceled")
+			if(selection)
+				pref.preferred_language = selection
+				if(selection == "common" || selection == S.language)
+					tgui_alert_async(user, "You will now speak your standard default language, [S.language ? S.language : "common"], if you do not specify a language when speaking.", "Preferred Set to Default")
+				else // Did they set anything else?
+					tgui_alert_async(user, "You will now speak [pref.preferred_language] if you do not specify a language when speaking.", "Preferred Language Set")
+			return TOPIC_REFRESH
+	// CHOMPStation Add End
+
 
 	return ..()

--- a/code/modules/client/preference_setup/vore/03_egg.dm
+++ b/code/modules/client/preference_setup/vore/03_egg.dm
@@ -1,6 +1,13 @@
 // Define a place to save appearance in character setup
+// CHOMPStation Add Start: Doing this here bc AUTOHISS_FULL is more readable than #
+#define AUTOHISS_OFF 0
+#define AUTOHISS_BASIC 1
+#define AUTOHISS_FULL 2
+// CHOMPStation Add End
+
 /datum/preferences
 	var/vore_egg_type = "Egg" //The egg type they have.
+	var/autohiss = "Full"			// CHOMPStation Add: Whether we have Autohiss on. I'm hijacking the egg panel bc this one has a shitton of unused space.
 
 // Definition of the stuff for the egg type.
 /datum/category_item/player_setup_item/vore/egg
@@ -9,19 +16,35 @@
 
 /datum/category_item/player_setup_item/vore/egg/load_character(var/savefile/S)
 	S["vore_egg_type"]		>> pref.vore_egg_type
+	S["autohiss"]			>> pref.autohiss // CHOMPStation Add
 
 /datum/category_item/player_setup_item/vore/egg/save_character(var/savefile/S)
 	S["vore_egg_type"]		<< pref.vore_egg_type
+	S["autohiss"]			<< pref.autohiss // CHOMPStation Add
 
 /datum/category_item/player_setup_item/vore/egg/sanitize_character()
 	pref.vore_egg_type	 = sanitize_inlist(pref.vore_egg_type, global_vore_egg_types, initial(pref.vore_egg_type))
 
 /datum/category_item/player_setup_item/vore/egg/copy_to_mob(var/mob/living/carbon/human/character)
 	character.vore_egg_type	= pref.vore_egg_type
+	// CHOMPStation Add
+	if(pref.client) // Safety, just in case so we don't runtime.
+		if(!pref.autohiss)
+			pref.client.autohiss_mode = AUTOHISS_FULL
+		else
+			switch(pref.autohiss)
+				if("Full")
+					pref.client.autohiss_mode = AUTOHISS_FULL
+				if("Basic")
+					pref.client.autohiss_mode = AUTOHISS_BASIC
+				if("Off")
+					pref.client.autohiss_mode = AUTOHISS_OFF
+	// CHOMPStation Add
 
 /datum/category_item/player_setup_item/vore/egg/content(var/mob/user)
 	. += "<br>"
 	. += " Egg Type: <a href='?src=\ref[src];vore_egg_type=1'>[pref.vore_egg_type]</a><br>"
+	. += "<b>Autohiss Default Setting:</b> <a href='?src=\ref[src];autohiss=1'>[pref.autohiss]</a><br>" // CHOMPStation Add
 
 /datum/category_item/player_setup_item/vore/egg/OnTopic(var/href, var/list/href_list, var/mob/user)
 	if(!CanUseTopic(user))
@@ -33,5 +56,21 @@
 		if(selection)
 			pref.vore_egg_type = selection
 			return TOPIC_REFRESH
+	// CHOMPStation Add Start
+	else if(href_list["autohiss"])
+		var/list/autohiss_selection = list("Full", "Basic", "Off")
+		var/selection = tgui_input_list(user, "Choose your default autohiss setting:", "Character Preference", autohiss_selection, pref.autohiss)
+		if(selection)
+			pref.autohiss = selection
+		else if(!selection)
+			pref.autohiss = "Full"
+		return TOPIC_REFRESH
+	// CHOMPStation Add End
 	else
 		return
+
+// CHOMPStation Add Start: Doing this here bc AUTOHISS_FULL is more readable than #
+#undef AUTOHISS_OFF
+#undef AUTOHISS_BASIC
+#undef AUTOHISS_FULL
+// CHOMPStation Add End

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -647,6 +647,12 @@
 			var/datum/language/keylang = GLOB.all_languages[client.prefs.language_custom_keys[key]]
 			if(keylang)
 				new_character.language_keys[key] = keylang
+	// CHOMPStation Add: Preferred Language Setting;
+	if(client.prefs.preferred_language) // Do we have a preferred language?
+		var/datum/language/def_lang = GLOB.all_languages[client.prefs.preferred_language]
+		if(def_lang)
+			new_character.default_language = def_lang
+	// CHOMPStation Add End
 	// And uncomment this, too.
 	//new_character.dna.UpdateSE()
 

--- a/code/modules/resleeving/autoresleever.dm
+++ b/code/modules/resleeving/autoresleever.dm
@@ -172,6 +172,12 @@
 			var/datum/language/keylang = GLOB.all_languages[ghost_client.prefs.language_custom_keys[key]]
 			if(keylang)
 				new_character.language_keys[key] = keylang
+	// CHOMPStation Add: Preferred Language Setting;
+	if(ghost_client.prefs.preferred_language) // Do we have a preferred language?
+		var/datum/language/def_lang = GLOB.all_languages[ghost_client.prefs.preferred_language]
+		if(def_lang)
+			new_character.default_language = def_lang
+	// CHOMPStation Add End
 
 	//If desired, apply equipment.
 	if(equip_body)

--- a/code/modules/vore/eating/inbelly_spawn.dm
+++ b/code/modules/vore/eating/inbelly_spawn.dm
@@ -166,6 +166,12 @@ Please do not abuse this ability.
 			var/datum/language/keylang = GLOB.all_languages[prey.prefs.language_custom_keys[key]]
 			if(keylang)
 				new_character.language_keys[key] = keylang
+	// CHOMPStation Add: Preferred Language Setting;
+	if(prey.prefs.preferred_language) // Do we have a preferred language?
+		var/datum/language/def_lang = GLOB.all_languages[prey.prefs.preferred_language]
+		if(def_lang)
+			new_character.default_language = def_lang
+	// CHOMPStation Add End
 
 	new_character.regenerate_icons()
 


### PR DESCRIPTION
Autohiss can now be set to Full/Basic/None from the character menu, and by default, it is assumed Full. It will respect save/load and client connect/disconnect, meaning you no longer have to constantly toggle autohiss.

Preferred Language can now be set. This allows a default spoken language other than Common to be set from spawn, allowing characters to simply join with the language they'd prefer speaking, rather than having to fiddle with "Set Default Language" every time they spawn.
Server rules do still apply, ofc. You must be able to speak Common or at least +understand+ it capably enough to do your job.

See Preferred Language Setting here;
![](https://i.imgur.com/NnGw3hx.png)
Menu for it here:
![](https://i.imgur.com/PSS3PPf.png)

See Autohiss Settings here:
![](https://i.imgur.com/L36Hw5N.png)

Yes, Autohiss is set underneath Egg Type. I wanted to use some of the space there. I can move it up under the Size/etc panels and speech verbs if requested.
