### PR TITLE
Sets sensors for clothes to 0 on Pirate/Russian/Clown by default

### DIFF
--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -78,6 +78,7 @@
 	desc = "<i><font face='comic sans ms'>Honk!</i></font>"
 	icon_state = "clown"
 	rolled_sleeves = -1
+	has_sensor = 0 // CHOMPEdit: Fixes sensors issue
 
 /obj/item/clothing/under/rank/head_of_personnel
 	desc = "It's a jumpsuit worn by someone who works in the position of \"Head of Personnel\"."

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -246,12 +246,14 @@
 	icon_state = "pirate"
 	item_state_slots = list(slot_r_hand_str = "sl_suit", slot_l_hand_str = "sl_suit")
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS
+	has_sensor = 0 // CHOMPEdit: Fixes sensors issue
 
 /obj/item/clothing/under/soviet
 	name = "soviet uniform"
 	desc = "For the Motherland!"
 	icon_state = "soviet"
 	item_state_slots = list(slot_r_hand_str = "grey", slot_l_hand_str = "grey")
+	has_sensor = 0 // CHOMPEdit: Fixes sensors issue
 
 /obj/item/clothing/under/redcoat
 	name = "redcoat uniform"


### PR DESCRIPTION
This fixes mobs showing up on the sensors console despite not being station-affiliated.

