### PR TITLE
Replaces "advanced voidsuit" with hardsuit

### DIFF
--- a/code/game/machinery/casino_ch.dm
+++ b/code/game/machinery/casino_ch.dm
@@ -1312,7 +1312,7 @@
 		Mech: Shuttlecraft 500<br>\
 		Rig: Solgov engineering hardsuit control module 500 <br>\
 		Rig: Solgov medical hardsuit control module 500 <br>\
-		Rig: Advanced voidsuit control module 500 <br>\
+		Rig: Advanced hardsuit control module 500 <br>\
 		Rig: Pursuit hardsuit control module 750 <br>\
 		Rig: Combat hardsuit control module 750 <br>\
 		Rig: ERT-J suit control module (Elite Janitor NT approved) 250 <br>\

--- a/code/game/machinery/casino_prize_dispenser_ch.dm
+++ b/code/game/machinery/casino_prize_dispenser_ch.dm
@@ -186,7 +186,7 @@
 		CASINO_PRIZE("Mech:Shuttlecraft", /obj/item/weapon/grenade/spawnergrenade/casino/gygax/shuttlecraft, 1, 500, "mechs"),
 		CASINO_PRIZE("Rig: Solgov engineering hardsuit control module", /obj/item/weapon/rig/bayeng, 1, 500, "mechs"),
 		CASINO_PRIZE("Rig: Solgov medical hardsuit control module", /obj/item/weapon/rig/baymed, 1, 500, "mechs"),
-		CASINO_PRIZE("Rig: Advanced voidsuit control module", /obj/item/weapon/rig/ce, 1, 500, "mechs"),
+		CASINO_PRIZE("Rig: Advanced hardsuit control module", /obj/item/weapon/rig/ce, 1, 500, "mechs"),//CHOMPEDIT: Hardsuit
 		CASINO_PRIZE("Rig: Pursuit hardsuit control module", /obj/item/weapon/rig/ch/pursuit, 1, 750, "mechs"),
 		CASINO_PRIZE("Rig: Combat hardsuit control module", /obj/item/weapon/rig/combat, 1, 750, "mechs"),
 		CASINO_PRIZE("Rig: ERT-J suit control module (Elite Janitor NT approved)", /obj/item/weapon/rig/ert/janitor, 1, 250, "mechs"),

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -144,12 +144,12 @@
 		/obj/item/rig_module/vision/meson
 		)
 
-//Chief Engineer's rig. This is sort of a halfway point between the old hardsuits (voidsuits) and the rig class.
+//Chief Engineer's rig. This is sort of a halfway point between the old hardsuits (voidsuits) and the rig class. //CHOMPEDIT: if its a mechanized suit its a hardsuit
 /obj/item/weapon/rig/ce
 
-	name = "advanced voidsuit control module"
-	suit_type = "advanced voidsuit"
-	desc = "An advanced voidsuit that protects against hazardous, low pressure environments. Shines with a high polish."
+	name = "advanced hardsuit control module" //CHOMPEDIT: Hardsuit
+	suit_type = "advanced hardsuit" //CHOMPEDIT: Hardsuit
+	desc = "An advanced hardsuit that protects against hazardous, low pressure environments. Shines with a high polish."//CHOMPEDIT: Hardsuit
 	icon_state = "ce_rig"
 	armor = list(melee = 40, bullet = 10, laser = 30,energy = 25, bomb = 40, bio = 100, rad = 100)
 	slowdown = 0


### PR DESCRIPTION
The CEs rig seems to be the only leftover remnant of a RIG being incorrectly described as a voidsuit. Its mechanized, outperforms other rigs such as EVA and especially NULL and has no reason not to be called a hardsuit