### PR TITLE
Removes CKEYS from the pregame lobby

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -117,7 +117,7 @@
 			var/datum/job/refJob = null
 			for(var/mob/new_player/player in player_list)
 				refJob = player.client.prefs.get_highest_job()
-				stat("[player.key]", (player.ready)?("(Playing as: [(refJob)?(refJob.title):("Unknown")])"):(null))
+				stat("Player", (player.ready)?("(Playing as: [(refJob)?(refJob.title):("Unknown")])"):(null)) //CHOMPEDIT: Anonymizing [player.key]
 				totalPlayers++
 				if(player.ready)totalPlayersReady++
 


### PR DESCRIPTION
Anonymizes all waiting players as "Player" instead of identifying them by their Byond key in line with our general anonymization efforts. Ideally, someone who knows how should change this to use the selected character name instead if possible

This means you can queue up as EX CMO without everyone knowing who is playing the CMO on round start.