### PR TITLE
Fixing a Unit test runtime on siffet

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/siffet.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/siffet.dm
@@ -58,5 +58,10 @@
 
 /mob/living/simple_mob/animal/sif/siffet/IIsAlly(mob/living/L)
 	. = ..()
-	if(!. && L.mob_size > 10) //Attacks things it considers small enough to take on, otherwise only attacks if attacked.
+	//CHOMPADDIITON: Compatibility with structures
+	if(!. && isnull(L.mob_size))
 		return TRUE
+	//CHOMPADDIITON: Compatibility with structures
+	else
+		if(!. && L.mob_size > 10) //Attacks things it considers small enough to take on, otherwise only attacks if attacked.
+			return TRUE


### PR DESCRIPTION
IIsAlly according to unit test logs can be called on on living creatures such as structures. therefore if siffet is close to structures we runtime as structure have no mob_size

This should solve this runtime

Relevant Runtime info:
[2023-03-08T10:19:27] Runtime in siffet.dm,61: undefined variable /obj/machinery/porta_turret/poi/var/mob_size
  proc name: IIsAlly (/mob/living/simple_mob/animal/sif/siffet/IIsAlly)
  src: the siffet (/mob/living/simple_mob/animal/sif/siffet)
  src.loc: the dirt (189,191,9) (/turf/simulated/floor/outdoors/dirt)
  call stack:
  the siffet (/mob/living/simple_mob/animal/sif/siffet): IIsAlly(the turret (/obj/machinery/porta_turret/poi))