### PR TITLE
Protean health nerfing

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/protean/protean_organs.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/protean/protean_organs.dm
@@ -2,77 +2,77 @@
 /obj/item/organ/external/chest/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 100 // <-- This is different from the rest
+	max_damage = 70 // <-- This is different from the rest
 	min_broken_damage = 1000
 	vital = 1
 	model = "protean"
 /obj/item/organ/external/groin/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 100
+	max_damage = 70
 	min_broken_damage = 1000 //Multiple
 	vital = 0
 	model = "protean"
 /obj/item/organ/external/head/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 100
+	max_damage = 70
 	min_broken_damage = 1000 //Inheritance
 	vital = 0
 	model = "protean"
 /obj/item/organ/external/arm/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 65
+	max_damage = 40
 	min_broken_damage = 1000 //Please
 	vital = 0
 	model = "protean"
 /obj/item/organ/external/arm/right/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 65
+	max_damage = 40
 	min_broken_damage = 1000
 	vital = 0
 	model = "protean"
 /obj/item/organ/external/leg/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 65
+	max_damage = 40
 	min_broken_damage = 1000
 	vital = 0
 	model = "protean"
 /obj/item/organ/external/leg/right/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 65
+	max_damage = 40
 	min_broken_damage = 1000
 	vital = 0
 	model = "protean"
 /obj/item/organ/external/hand/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 65
+	max_damage = 40
 	min_broken_damage = 1000
 	vital = 0
 	model = "protean"
 /obj/item/organ/external/hand/right/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 65
+	max_damage = 40
 	min_broken_damage = 1000
 	vital = 0
 	model = "protean"
 /obj/item/organ/external/foot/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 65
+	max_damage = 40
 	min_broken_damage = 1000
 	vital = 0
 	model = "protean"
 /obj/item/organ/external/foot/right/unbreakable/nano
 	robotic = ORGAN_NANOFORM
 	encased = FALSE
-	max_damage = 65
+	max_damage = 40
 	min_broken_damage = 1000
 	vital = 0
 	model = "protean"

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/protean/protean_species.dm
@@ -41,6 +41,8 @@
 	//radiation_mod = 0	//Can't be assed with fandangling rad protections while blob formed/suited
 	darksight = 10
 	siemens_coefficient = 2
+	brute_mod =        0.8
+	burn_mod =        1.5
 	emp_dmg_mod = 0.8
 	emp_sensitivity = EMP_BLIND | EMP_DEAFEN | EMP_BRUTE_DMG | EMP_BURN_DMG
 	item_slowdown_mod = 1.5	//Gentle encouragement to let others wear you


### PR DESCRIPTION
Re-added default protean brute and burn mods:
-Brute mod from 1 to 0.8
-Burn mod from 1 to 1.5

Nerfed protean limb health. 100 max health was way more than literally everything. Trying a balance from prometheans, making them slightly stronger than baseline promethean.
https://github.com/CHOMPStation2/CHOMPStation2/blob/master/code/modules/organs/subtypes/slime.dm
-Head, groin, chest from 100 down to 70
-Arms, legs, hands, feet down from 65 to 40.


EDIT: Changes to the groin and chest doesn't actually affect anything since they are indestructible. 