### PR TITLE
Technomancer hand teleporters no longer work in VR

### DIFF
--- a/maps/southern_cross/southern_cross_overrides.dm
+++ b/maps/southern_cross/southern_cross_overrides.dm
@@ -8,3 +8,9 @@
 	. = ..()
 	access |= access_explorer
 	access |= access_pilot
+
+/obj/item/weapon/disposable_teleporter/attack_self(mob/user as mob)//Prevents people from using technomancer gear to escape to station from the VR pods.
+	if(istype(get_area(user), /area/vr))
+		to_chat(user, "<span class='danger'>\The [src] does not appear to work in VR! This is useless to you!</span>")
+		return
+	. = ..()


### PR DESCRIPTION
People playing with antag equipment in VR: Good
Using it to escape VR: Cringe
This disables the hand teleporter from working in the VR Z-level
Map specific check so no runtimes if any other map is loaded.