### PR TITLE
Nerfs submachine gun. Cuts the damage by 1/3

### DIFF
--- a/code/modules/projectiles/projectile/bullets_ch.dm
+++ b/code/modules/projectiles/projectile/bullets_ch.dm
@@ -165,6 +165,7 @@ only use the hollow_point and armor_penetration values.*/
 	grains = 180
 	velocity = 400
 	hud_state = "pistol"
+	damage = 20
 
 /obj/item/projectile/bullet/a10mm/ap
 	grains = 200


### PR DESCRIPTION
Funny thing, this gun was supposed to be doing 25 brute, but when Cadyn ballistics happened, that got overidden to 60 brute and nobody got around to fixing it.