### PR TITLE
stops 'the space jellyfish bonks the window harmlessly. x1762'

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -215,7 +215,8 @@
 			damage = damage / 2
 		take_damage(damage)
 	else
-		visible_message("<b>\The [user]</b> bonks \the [src] harmlessly.")
+		if (user.client) //CHOMPEdit addition - The space jellyfish bonks the window harmlessly.x1762 - they aren't doing any damage to it even, so there's no point in having this here other than showing they're attacking the window - constantly, every half a second. The attack animation can take care of that.
+			visible_message("<b>\The [user]</b> bonks \the [src] harmlessly.")
 	user.do_attack_animation(src)
 	return 1
 


### PR DESCRIPTION
maybe a cooldown would be better but like... it's not even an indicator that the mob is even doing damage, it isn't even a thing like 'this will break if I hit it enough'
it's just spam.
the attack animation can take care of it