### PR TITLE
Advanced Roller Beds now have bonus surgery chance

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -216,6 +216,7 @@
 /obj/structure/bed/roller/adv
 	name = "advanced roller bed"
 	icon_state = "rollerbedadv"
+	surgery_odds = 80 //CHOMPedit
 	bedtype = /obj/structure/bed/roller/adv
 	rollertype = /obj/item/roller/adv
 


### PR DESCRIPTION
Apparently they never have had any, was the same as the basic rollerbed which was nerfed by upstream from 75% to 50% at one point. Honestly something that was expected to come with it in the first place tbh

Advanced beds now have 80% chance surgery odds, a number I pulled out of my ass to make field surgery more risky, less suicide, open to suggestions for chance. Kinda tempted to increase it but nothing should be better then a sterile operating room.