### PR TITLE
Fixes error with Species Sounds

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -406,10 +406,14 @@ var/list/species_sound_map = list(
 
 /*
  * The following helper proc will select a species' default sounds - useful for if we're set to "Unset"
- * Yes it's a one-line proc, but I wanted to reduce duplicated lines as much as possible.
+ * This is ONLY called by Unset, meaning we haven't chosen a species sound.
 */
 /proc/select_default_species_sound(var/datum/preferences/pref) // Called in character setup. This is similar to check_gendered_sounds, except here we pull from the prefs.
-	var/datum/species/valid = coalesce(GLOB.all_species[pref.custom_base], GLOB.all_species[pref.species])
+	// First, we determine if we're custom-choosing a body or if we're a base game species.
+	var/datum/species/valid = GLOB.all_species[pref.species]
+	if(valid.selects_bodytype == (SELECTS_BODYTYPE_CUSTOM || SELECTS_BODYTYPE_SHAPESHIFTER)) // Custom species or xenochimera handling here
+		valid = coalesce(GLOB.all_species[pref.custom_base], GLOB.all_species[pref.species])
+	// Now we start getting our sounds.
 	if(valid.gender_specific_species_sounds) // Do we have gender-specific sounds?
 		if(pref.identifying_gender == FEMALE && valid.species_sounds_female)
 			return valid.species_sounds_female

--- a/code/modules/client/preference_setup/vore/02_size.dm
+++ b/code/modules/client/preference_setup/vore/02_size.dm
@@ -296,7 +296,7 @@
 		var/oursound = get_species_sound(ourpref)["cough"]
 		S = sound(pick(oursound))
 		if(pref.species_sound == "Unset")
-			oursound = get_species_sound(select_default_species_sound(user))["cough"]
+			oursound = get_species_sound(select_default_species_sound(pref))["cough"]
 			S = sound(pick(oursound))
 		if(pref.species_sound == "None" || oursound == null)
 			to_chat(user, "<span class='warning'>This set does not have cough sounds!</span>")
@@ -311,7 +311,7 @@
 		var/oursound = get_species_sound(ourpref)["sneeze"]
 		S = sound(pick(oursound))
 		if(pref.species_sound == "Unset")
-			oursound = get_species_sound(select_default_species_sound(user))["sneeze"]
+			oursound = get_species_sound(select_default_species_sound(pref))["sneeze"]
 			S = sound(pick(oursound))
 		if(pref.species_sound == "None" || oursound == null)
 			to_chat(user, "<span class='warning'>This set does not have sneeze sounds!</span>")
@@ -326,7 +326,7 @@
 		var/oursound = get_species_sound(ourpref)["scream"]
 		S = sound(pick(oursound))
 		if(pref.species_sound == "Unset")
-			oursound = get_species_sound(select_default_species_sound(user))["scream"]
+			oursound = get_species_sound(select_default_species_sound(pref))["scream"]
 			S = sound(pick(oursound))
 		if(pref.species_sound == "None" || oursound == null)
 			to_chat(user, "<span class='warning'>This set does not have scream sounds!</span>")
@@ -341,7 +341,7 @@
 		var/oursound = get_species_sound(ourpref)["pain"]
 		S = sound(pick(oursound))
 		if(pref.species_sound == "Unset")
-			oursound = get_species_sound(select_default_species_sound(user))["pain"]
+			oursound = get_species_sound(select_default_species_sound(pref))["pain"]
 			S = sound(pick(oursound))
 		if(pref.species_sound == "None" || oursound == null)
 			to_chat(user, "<span class='warning'>This set does not have pain sounds!</span>")
@@ -356,7 +356,7 @@
 		var/oursound = get_species_sound(ourpref)["gasp"]
 		S = sound(pick(oursound))
 		if(pref.species_sound == "Unset")
-			oursound = get_species_sound(select_default_species_sound(user))["gasp"]
+			oursound = get_species_sound(select_default_species_sound(pref))["gasp"]
 			S = sound(pick(oursound))
 		if(pref.species_sound == "None" || oursound == null)
 			to_chat(user, "<span class='warning'>This set does not have gasp sounds!</span>")
@@ -371,7 +371,7 @@
 		var/oursound = get_species_sound(ourpref)["death"]
 		S = sound(pick(oursound))
 		if(pref.species_sound == "Unset")
-			oursound = get_species_sound(select_default_species_sound(user))["death"]
+			oursound = get_species_sound(select_default_species_sound(pref))["death"]
 			S = sound(pick(oursound))
 		if(pref.species_sound == "None" || oursound == null)
 			to_chat(user, "<span class='warning'>This set does not have death sounds!</span>")

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -88,6 +88,7 @@
 	// CHOMPEdit: Reverted these back to Polaris, but commented them out. We're using species-specific sounds instead.
 	// male_scream_sound = list ('sound/effects/mob_effects/una_scream1.ogg','sound/effects/mob_effects/una_scream2.ogg')
 	// female_scream_sound = list ('sound/effects/mob_effects/una_scream1.ogg','sound/effects/mob_effects/una_scream2.ogg')
+	species_sounds = "Lizard" // Species sounds
 
 	pain_verb_1p = list("hiss", "growl") // CHOMPEdit: Unathi pain emotes
 	pain_verb_3p = list("hisses", "growls") // CHOMPEdit: Pain emotes


### PR DESCRIPTION
Unset ran into an error that did not occur during testing - select_default_species_sound was changed to use pref instead of user, and the testing calls were not updated.

Unathi had no species sounds, this was fixed.