### PR TITLE
Soul Dew and Oasis.

### DIFF
--- a/code/modules/reagents/reactions/instant/instant_ch.dm
+++ b/code/modules/reagents/reactions/instant/instant_ch.dm
@@ -63,6 +63,19 @@
 	result = "glucose"
 	required_reagents = list("sodiumchloride" = 1, "water" = 1, "sugar" = 1)
 	result_amount = 1
+
+/decl/chemical_reaction/instant/souldew
+	name = "Soul Dew"
+	result = "souldew"
+	required_reagents = list("mutagen" = 5, "water" = 5, "cryptobiolin" = 5, "bicaridine" = 5, "kelotane" = 5, "mindbreaker" = 5)
+	result_amount = 1
+
+/decl/chemical_reaction/instant/oasis
+	name = "Oasis"
+	result = "oasis"
+	required_reagents = list("inaprovaline" = 5, "tramadol" = 5, "alkysine" = 5, "stoxin" = 5, "oxygen" = 5, "glucose" = 5)
+	result_amount = 1
+
 ///SAP RECIPES//////
 
 /decl/chemical_reaction/instant/myelamine_sap //This is the clotting agent used by clotting packs.

--- a/code/modules/reagents/reagents/medicine_ch.dm
+++ b/code/modules/reagents/reagents/medicine_ch.dm
@@ -110,7 +110,7 @@
 	var/chem_effective = 1 * M.species.chem_strength_heal
 	var/chem_effective2 = M.species.chem_strength_heal * M.species.chem_strength_heal
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(1 * removed * chem_effective, 1 * removed * chem_effective)
+		M.heal_organ_damage(0.5 * removed * chem_effective, 0.5 * removed * chem_effective)
 	if(M.stat == DEAD)
 		M.heal_organ_damage(9 * removed * chem_effective2, 9 * removed * chem_effective2)
 

--- a/code/modules/reagents/reagents/medicine_ch.dm
+++ b/code/modules/reagents/reagents/medicine_ch.dm
@@ -93,6 +93,43 @@
 	description = "A well respected drug used for treatment of schizophrenia in specific."
 	overdose = REAGENTS_OVERDOSE * 2
 
+//Complex Chems//
+/datum/reagent/souldew
+	name = "Soul Dew"
+	id = "souldew"
+	description = "A strange expirmental chemical that will try and breath life into a dead heart."
+	taste_description = "void"
+	reagent_state = LIQUID
+	color = "#BF0000"
+	overdose = REAGENTS_OVERDOSE
+	overdose_mod = 2.5
+	scannable = 1
+	affects_dead = 1
+
+/datum/reagent/souldew/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	var/chem_effective2 = M.species.chem_strength_heal * M.species.chem_strength_heal
+	if(alien != IS_DIONA)
+		M.heal_organ_damage(5 * removed * chem_effective2, 5 * removed * chem_effective2)
+
+/datum/reagent/oasis
+	name = "Oasis"
+	id = "oasis"
+	description = "A complex drug that will attempt to put the subject into a form of statis"
+	taste_description = "relief"
+	reagent_state = LIQUID
+	color = "#BF0000"
+	overdose = REAGENTS_OVERDOSE * 1.5
+	overdose_mod = 0.5
+	scannable = 1
+	affects_dead = 1
+
+/datum/reagent/souldew/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(alien != IS_DIONA)
+		M.Sleeping(1)
+		M.add_chemical_effect(CE_STABLE, 25)
+		M.add_chemical_effect(CE_PAINKILLER, 15 * M.species.chem_strength_pain)
+
+
 ///SAP REAGENTS////
 //This is all a direct port from aeiou.
 

--- a/code/modules/reagents/reagents/medicine_ch.dm
+++ b/code/modules/reagents/reagents/medicine_ch.dm
@@ -107,9 +107,12 @@
 	affects_dead = 1
 
 /datum/reagent/souldew/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	var/chem_effective = 1 * M.species.chem_strength_heal
 	var/chem_effective2 = M.species.chem_strength_heal * M.species.chem_strength_heal
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(5 * removed * chem_effective2, 5 * removed * chem_effective2)
+		M.heal_organ_damage(3 * removed * chem_effective, 3 * removed * chem_effective)
+	if(M.stat == DEAD)
+		M.heal_organ_damage(8 * removed * chem_effective2, 8 * removed * chem_effective2)
 
 /datum/reagent/oasis
 	name = "Oasis"
@@ -123,7 +126,7 @@
 	scannable = 1
 	affects_dead = 1
 
-/datum/reagent/souldew/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+/datum/reagent/oasis/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien != IS_DIONA)
 		M.Sleeping(1)
 		M.add_chemical_effect(CE_STABLE, 25)

--- a/code/modules/reagents/reagents/medicine_ch.dm
+++ b/code/modules/reagents/reagents/medicine_ch.dm
@@ -110,9 +110,9 @@
 	var/chem_effective = 1 * M.species.chem_strength_heal
 	var/chem_effective2 = M.species.chem_strength_heal * M.species.chem_strength_heal
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(3 * removed * chem_effective, 3 * removed * chem_effective)
+		M.heal_organ_damage(1 * removed * chem_effective, 1 * removed * chem_effective)
 	if(M.stat == DEAD)
-		M.heal_organ_damage(8 * removed * chem_effective2, 8 * removed * chem_effective2)
+		M.heal_organ_damage(9 * removed * chem_effective2, 9 * removed * chem_effective2)
 
 /datum/reagent/oasis
 	name = "Oasis"


### PR DESCRIPTION
New, very annoying chems to make.
One to try and be a middle ground between surgery and the medi gun. The other puts the person to sleep but tries to keep them in a stable state.

Soul Dew
--Heals brute and burn wounds, 1 point better then bicard/kelotane. It's meant for the purpose of allowing another way to fix folks past the -100% threshold that isn't surgery or medigun. Chem efficiency is also more effective upon the soul dew, aka if the person has bio-imcompability, you're waiting longer.

Oasis
--It puts you to sleep, but also has a high pain resistance and stabilize modifier.

Soul Dew
required_reagents = list("mutagen" = 5, "water" = 5, "cryptobiolin" = 5, "bicaridine" = 5, "kelotane" = 5, "mindbreaker" = 5)
Result: 1

Oasis
required_reagents = list("inaprovaline" = 5, "tramadol" = 5, "alkysine" = 5, "stoxin" = 5, "oxygen" = 5, "glucose" = 5)
result: 1