### PR TITLE
Fixes negative bellysprite size on multigut setups

### DIFF
--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -121,7 +121,8 @@
 				fullness_to_add *= absorbed_multiplier
 			if(health_impacts_size)
 				fullness_to_add *= M.health / M.getMaxHealth()
-			belly_fullness += fullness_to_add
+			if(fullness_to_add > 0)
+				belly_fullness += fullness_to_add
 	if(count_liquid_for_sprite)
 		belly_fullness += (reagents.total_volume / 100) * liquid_multiplier
 	if(count_items_for_sprite)

--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -120,7 +120,10 @@
 			if(M.absorbed)
 				fullness_to_add *= absorbed_multiplier
 			if(health_impacts_size)
-				fullness_to_add *= M.health / M.getMaxHealth()
+				if(ishuman(M))
+					fullness_to_add *= (M.health + 100) / (M.getMaxHealth() + 100)
+				else
+					fullness_to_add *= M.health / M.getMaxHealth()
 			if(fullness_to_add > 0)
 				belly_fullness += fullness_to_add
 	if(count_liquid_for_sprite)


### PR DESCRIPTION
An extra crispy corpse in one gut will no longer cancel out another gut's fullness when prey health is set to affect vore sprites.