### PR TITLE
Fixes infinite stack exploit

### DIFF
--- a/code/modules/recycling/recycling.dm
+++ b/code/modules/recycling/recycling.dm
@@ -149,8 +149,8 @@
 
 /obj/machinery/recycling/sorter/proc/dispense_if_possible()
 	for(var/mat in materials)
-		while(materials[mat] >= (SHEET_MATERIAL_AMOUNT/10)) //CHOMPEDIT: Lowers the amount needed to make dust
-			materials[mat] -= (SHEET_MATERIAL_AMOUNT/10) //CHOMPEDIT: Lowers the amount needed to make dust
+		while(materials[mat] >= SHEET_MATERIAL_AMOUNT)
+			materials[mat] -= SHEET_MATERIAL_AMOUNT
 			new /obj/item/material_dust(get_step(src, dir), mat)
 			sleep(2 SECONDS)
 


### PR DESCRIPTION
People have been exploiting this to generate infinite diamonds and phoron by getting 5-10 sheets from recycling one sheet. Should just buff the crusher efficiency instead.

Also might be an indirect cause for the recent 18k/h "invalid stack amount" runtime spam incident possibly caused by excess stack exploit and byond being jank with big numbers and such.