### PR TITLE
Buff Outsider positions, remove station autosleever ghost spawns

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -80062,9 +80062,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/medical/medical_restroom)
 "xpf" = (
-/obj/machinery/transhuman/autoresleever{
-	ghost_spawns = 1
-	},
+/obj/machinery/transhuman/autoresleever,
 /turf/simulated/floor/tiled/white,
 /area/medical/cryo/autoresleeve)
 "xpv" = (

--- a/modular_chomp/code/game/jobs/job/noncrew.dm
+++ b/modular_chomp/code/game/jobs/job/noncrew.dm
@@ -1,7 +1,7 @@
 /datum/job/noncrew
     title = JOB_OUTSIDER
     disallow_jobhop = TRUE
-    total_positions = 3
+    total_positions = 6
     spawn_positions = 6
     supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property"
 


### PR DESCRIPTION
For the purposes of playing off manifest, there was originally a 'secret' that the autoresleever acted as a ghost pod for off manifest play. I am removing this secret now that Outsider positions are a thing, and buffing the number of Outsider positions at the same time.