### PR TITLE
People can self-operate on robotic limbs

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1141,12 +1141,19 @@ var/global/list/common_tools = list(
 
 // check if mob is lying down on something we can operate him on.
 // The RNG with table/rollerbeds comes into play in do_surgery() so that fail_step() can be used instead.
-/proc/can_operate(mob/living/carbon/M)
-	return M.lying
+//CHOMPEDIT START self surgery
+/proc/can_operate(mob/living/carbon/M, mob/living/user)
+	. = M.lying
+	if(user && M == user && user.allow_self_surgery && user.a_intent == I_HELP)	// You can, technically, always operate on yourself after standing still. Inadvised, but you can.
+
+		if(M.isSynthetic())
+			. = TRUE
+
+	return .
 
 // Returns an instance of a valid surgery surface.
-/mob/living/proc/get_surgery_surface()
-	if(!lying)
+/mob/living/proc/get_surgery_surface(mob/living/user)
+	if(!lying && user != src)
 		return null // Not lying down means no surface.
 	var/obj/surface = null
 	for(var/obj/O in loc) // Looks for the best surface.

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1146,11 +1146,13 @@ var/global/list/common_tools = list(
 	. = M.lying
 	if(user && M == user && user.allow_self_surgery && user.a_intent == I_HELP)	// You can, technically, always operate on yourself after standing still. Inadvised, but you can.
 
-		if(M.isSynthetic())//Beep Boops only.
-			. = TRUE
-			if(M.zone_sel.selecting == BP_HEAD)//Cant see your own head to operate on it
-				to_chat(M, "<span class='warning'>You cannot see your own head to operate on it.</span>")
-				. = FALSE
+		if(M.organs_by_name[user.zone_sel.selecting])//Living people with their prosthetics can tinker with them
+			var/obj/item/organ/external/S = M.organs_by_name[user.zone_sel.selecting]
+			if(S.robotic >= ORGAN_ROBOT)
+				. = TRUE
+				if(M.zone_sel.selecting == BP_HEAD)//Cant see your own head to operate on it, mostly applies to FBPs
+					to_chat(M, "<span class='warning'>You cannot see your own head to operate on it.</span>")
+					. = FALSE
 
 	return .
 //CHOMPedit end

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1141,16 +1141,16 @@ var/global/list/common_tools = list(
 
 // check if mob is lying down on something we can operate him on.
 // The RNG with table/rollerbeds comes into play in do_surgery() so that fail_step() can be used instead.
-//CHOMPEDIT START self surgery
+//CHOMPEDIT START synth self surgery
 /proc/can_operate(mob/living/carbon/M, mob/living/user)
 	. = M.lying
 	if(user && M == user && user.allow_self_surgery && user.a_intent == I_HELP)	// You can, technically, always operate on yourself after standing still. Inadvised, but you can.
 
-		if(M.isSynthetic())
+		if(M.isSynthetic())//Beep Boops only.
 			. = TRUE
 
 	return .
-
+//CHOMPedit end
 // Returns an instance of a valid surgery surface.
 /mob/living/proc/get_surgery_surface(mob/living/user)
 	if(!lying && user != src)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1148,6 +1148,9 @@ var/global/list/common_tools = list(
 
 		if(M.isSynthetic())//Beep Boops only.
 			. = TRUE
+			if(M.zone_sel.selecting == BP_HEAD)//Cant see your own head to operate on it
+				to_chat(M, "<span class='warning'>You cannot see your own head to operate on it.</span>")
+				. = FALSE
 
 	return .
 //CHOMPedit end

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -53,7 +53,7 @@
 		dna.real_name = real_name
 		sync_organ_dna()
 
-	verbs |= /mob/living/proc/toggle_selfsurgery //CHOMPstation Re-Add for synths only, does nothing for organics. If there's a way for this verb to only appear for synths do tell me
+	verbs |= /mob/living/proc/toggle_selfsurgery //CHOMPstation Re-Add for synths/prosthetics only, does nothing for organics. If there's a way for this verb to only appear for synths do tell me
 	AddComponent(/datum/component/personal_crafting)
 
 /mob/living/carbon/human/Destroy()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -53,7 +53,7 @@
 		dna.real_name = real_name
 		sync_organ_dna()
 
-	//verbs |= /mob/living/proc/toggle_selfsurgery //VOREStation Removal
+	verbs |= /mob/living/proc/toggle_selfsurgery //CHOMPstation Re-Add for synths only, does nothing for organics. If there's a way for this verb to only appear for synths do tell me
 	AddComponent(/datum/component/personal_crafting)
 
 /mob/living/carbon/human/Destroy()

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -126,8 +126,8 @@
 
 
 /obj/item/proc/can_do_surgery(mob/living/carbon/M, mob/living/user)
-	if(M == user)
-		return 0
+	//if(M == user) CHOMPedit start, allows self surgery
+	//	return 0 CHOMPedit end
 	if(!ishuman(M))
 		return 1
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -179,7 +179,7 @@
 																										// All of this just to make it so you are forced to do bloodless surgery with a laser scalpel.
 
 	if(M == user)	// Once we determine if we can actually do a step at all, give a slight delay to self-surgery to confirm attempts.
-		to_chat(user, "<span class='critical'>You focus on attempting to perform surgery upon yourself.</span>")
+		to_chat(user, "<span class='critical'>You focus on attempting to operate on yourself.</span>")
 		if(!do_after(user, 3 SECONDS, M))
 			return 0
 

--- a/modular_chomp/code/modules/mob/living/living_defines.dm
+++ b/modular_chomp/code/modules/mob/living/living_defines.dm
@@ -1,1 +1,0 @@
-var/allow_self_surgery = FALSE

--- a/modular_chomp/code/modules/mob/living/living_defines.dm
+++ b/modular_chomp/code/modules/mob/living/living_defines.dm
@@ -1,0 +1,1 @@
+var/allow_self_surgery = FALSE

--- a/modular_chomp/code/modules/mob/living/living_powers.dm
+++ b/modular_chomp/code/modules/mob/living/living_powers.dm
@@ -1,6 +1,6 @@
 /mob/living/proc/toggle_selfsurgery()
-	set name = "Allow Synth Self Surgery"
-	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so. This only works if your character is a synthetic."
+	set name = "Allow Robotic Self Surgery"
+	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so. This only works on robotic limbs."
 	set category = "Object"
 
 	allow_self_surgery = !allow_self_surgery

--- a/modular_chomp/code/modules/mob/living/living_powers.dm
+++ b/modular_chomp/code/modules/mob/living/living_powers.dm
@@ -1,0 +1,9 @@
+/mob/living/proc/toggle_selfsurgery()
+	set name = "Allow Self Surgery"
+	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so."
+	set category = "Object"
+
+	allow_self_surgery = !allow_self_surgery
+
+	to_chat(usr, "<span class='notice'>You will [allow_self_surgery ? "now" : "no longer"] attempt to operate upon yourself.</span>")
+	log_admin("DEBUG \[[world.timeofday]\]: [src.ckey ? "[src.name]:([src.ckey])" : "[src.name]"] has [allow_self_surgery ? "Enabled" : "Disabled"] self surgery.")

--- a/modular_chomp/code/modules/mob/living/living_powers.dm
+++ b/modular_chomp/code/modules/mob/living/living_powers.dm
@@ -1,9 +1,9 @@
 /mob/living/proc/toggle_selfsurgery()
-	set name = "Allow Self Surgery"
-	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so."
+	set name = "Allow Synth Self Surgery"
+	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so. This only works if your character is a synthetic."
 	set category = "Object"
 
 	allow_self_surgery = !allow_self_surgery
 
 	to_chat(usr, "<span class='notice'>You will [allow_self_surgery ? "now" : "no longer"] attempt to operate upon yourself.</span>")
-	log_admin("DEBUG \[[world.timeofday]\]: [src.ckey ? "[src.name]:([src.ckey])" : "[src.name]"] has [allow_self_surgery ? "Enabled" : "Disabled"] self surgery.")
+	log_admin("DEBUG \[[world.timeofday]\]: [src.ckey ? "[src.name]:([src.ckey])" : "[src.name]"] has [allow_self_surgery ? "Enabled" : "Disabled"] synthetic self surgery.")

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4595,6 +4595,7 @@
 #include "modular_chomp\code\modules\mob\dead\observer\observer.dm"
 #include "modular_chomp\code\modules\mob\living\emote.dm"
 #include "modular_chomp\code\modules\mob\living\living.dm"
+#include "modular_chomp\code\modules\mob\living\living_powers.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\carbon.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\brain\MMI.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\human\emote.dm"


### PR DESCRIPTION
**EDIT: This applies to all robotic limbs now instead of just synths**

From what was me initially tinkering around out of sheer curiosity, giving synths the ability to self-operate on themselves added some interesting mechanics to the game while making synths that _tiny_ bit less of a pain to play. It is still way better to get a friend to do it for you and here's why. Also it felt more fun playing with prosthetic mechanics without the game aggressively punishing you for simply having them.

**How do I use it?**
Enable the verb in the object menu to allow yourself to attempt synth surgery. You still need to stand on a valid operating surface like a table to attempt it. There is a 3 second delay before you start the surgery. This respects table chances, (So being on a table will only allow it to work 50% of the time.

**Might be OP?**
I was doing a bit of testing and I find myself spending a good amount of time trying to mend damage even with nanopaste, because once you hit a certain amount of damage your limbs will begin to spark and you will cancel the surgery by dropping the tool or collapsing. You are basically **soft-capped** and at the mercy of RNG to not have a surgery interrupted, combined with the lower odds of doing it outside of a operating table **and** the fact it takes **longer** to even do it compared to if someone else did it, giving more time for a random malfunction to interrupt it. **No, sitting on a chair does not prevent you from collapsing**.
And if you're at the point where you're critically damaged and constantly getting sparks its a lost cause to even try.
 My testing was only 30 minutes of attempting solo exploration and it felt like I spent allot of time repairing myself but I might have missed a edge case or two.

**EDIT: Synths cant operate on their own head, they cant see it and will need outside help**

**Why?**
IMO I feel like it adds a bit of depth to synthetic players, giving them a small but not insignificant buff that isn't something boring like un-nerfing nanopaste (Which was nerfed for a very good reason) and also as a safety net of not being completely crippled cause the roboticist is in the shadow realm. Also it makes sense for synths to be able to tinker with themselves.

**What about organic self surgery?**
No.... Just no... I tested it and its way too powerful and low roleplay cause organics don't suffer the same way synths do at high limb damage due to chems/painkillers/splints. Also it tip toes the line of the 'no suicide rule' 

Extra notes: Might be way too op with #5978, may close that PR and think of another way.

![dreamseeker_UMSGVQiwdz](https://user-images.githubusercontent.com/10555869/229399616-c84c3d24-d4b2-4f08-bba8-4b28feabd2d3.png)
*note final PR does not say surgery but operating on oneself instead.
