### PR TITLE
Buffs supermatter grinding

### DIFF
--- a/code/modules/reagents/machinery/grinder.dm
+++ b/code/modules/reagents/machinery/grinder.dm
@@ -144,6 +144,12 @@
 	user.remove_from_mob(O)
 	O.loc = src
 	holdingitems += O
+	//CHOMPedit start
+	if(istype(O,/obj/item/stack/material/supermatter))
+		var/obj/item/stack/material/supermatter/S = O
+		set_light(l_range = max(1, S.get_amount()/10), l_power = max(1, S.get_amount()/10), l_color = "#8A8A00")
+		addtimer(CALLBACK(src, .proc/puny_protons), 30 SECONDS)
+	//CHOMPedit end
 	return 0
 
 /obj/machinery/reagentgrinder/AltClick(mob/user)
@@ -223,6 +229,14 @@
 
 	// Process.
 	for (var/obj/item/O in holdingitems)
+		//CHOMPedit start
+		if(istype(O,/obj/item/stack/material/supermatter))
+			var/regrets = 0
+			for(var/obj/item/stack/material/supermatter/S in holdingitems)
+				regrets += S.get_amount()
+			puny_protons(regrets)
+			return
+		//CHOMPedit end
 
 		var/remaining_volume = beaker.reagents.maximum_volume - beaker.reagents.total_volume
 		if(remaining_volume <= 0)
@@ -266,3 +280,24 @@
 		beaker = new_beaker
 	update_icon()
 	return TRUE
+
+// CHOMPedit start: Repurposed coffee grinders and supermatter do not mix.
+/obj/machinery/reagentgrinder/proc/puny_protons(regrets = 0)
+	set_light(0)
+	if(regrets > 0) // If you thought grinding supermatter would end well. Values taken from ex_act() for the supermatter stacks.
+		SSradiation.radiate(get_turf(src), 15 + regrets * 4)
+		explosion(get_turf(src), round(regrets / 12) , round(regrets / 6), round(regrets / 3), round(regrets / 25))
+		qdel(src)
+		return
+
+	else // If you added supermatter but didn't try grinding it, or somehow this is negative.
+		for(var/obj/item/stack/material/supermatter/S in holdingitems)
+			S.loc = src.loc
+			holdingitems -= S
+			regrets += S.get_amount()
+		SSradiation.radiate(get_turf(src), 15 + regrets)
+		visible_message("<span class=\"warning\">\The [src] glows brightly, bursting into flames and flashing into ash.</span>",\
+		"<span class=\"warning\">You hear an unearthly shriek, burning heat washing over you.</span>")
+		new /obj/effect/decal/cleanable/ash(src.loc)
+		qdel(src)
+// CHOMPedit end


### PR DESCRIPTION
Supermatter shards are now capable of disintegrating coffee grinders, as might be expected of a substance capable of ashing almost anything in the game.

Placing supermatter shards in a reagent grinder will result in the grinder soon disintegrating in a puff of radiation. Grinding supermatter results in an explosion with a much more intense radiation release. Both effects scale with the number of shards in the sheet.

Here's what happens if you grind 50 shards:
![image](https://user-images.githubusercontent.com/41974248/229706249-48b2d94c-d27a-4332-9beb-6114d3fe24a5.png)
![image](https://user-images.githubusercontent.com/41974248/229706289-389d289c-57f6-4922-ae5b-f245b3e93b51.png)
![image](https://user-images.githubusercontent.com/41974248/229706305-93c651a1-854d-41d2-936b-22963c8acf15.png)
