### PR TITLE
Fixes a 32k/h carbon pain runtime spam

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -451,6 +451,8 @@
 	return 0
 
 /mob/living/carbon/can_feel_pain(var/check_organ)
+	if(!species) //CHOMPEdit
+		return 0
 	if(isSynthetic())
 		return 0
 	return !(species.flags & NO_PAIN)


### PR DESCRIPTION
dear god...

Figured out the ingame cause that triggered this runtime spam too, and that turned out to be the brainmobs inside the heads of 9 decapitated monkeymobs in VR, which each were apparently throwing this runtime every second.