### PR TITLE
Adds update_transform to simplemob digestion

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -936,6 +936,8 @@
 			M.forceMove(G)
 		else
 			qdel(M)
+	if(isanimal(owner))
+		owner.update_transform()
 	//CHOMPEdit End
 
 // Handle a mob being absorbed


### PR DESCRIPTION
This should make it so that gurgling something as a simplemob with custom x/y scales won't mess up those and their offsets anymore.