### PR TITLE
Fixes a grinder bug with "anchored" trash contents

### DIFF
--- a/modular_chomp/code/modules/recycling/v_garbosystem.dm
+++ b/modular_chomp/code/modules/recycling/v_garbosystem.dm
@@ -77,6 +77,8 @@
 							items_taken++
 							break
 					for(var/atom/movable/C in A.contents)
+						if(C.anchored)
+							C.anchored = FALSE
 						C.forceMove(loc)
 					if(isitem(A))
 						A.SpinAnimation(5,3)


### PR DESCRIPTION
Not sure how many other random items might have "anchored" items inside them, but bullet casings are definitely one of those, containing anchored projectiles that would linger on the tile, ready to magdump themselves into the next unlucky person to step in.