### PR TITLE
Religion Defaults list changes

### DIFF
--- a/code/modules/client/preferences_factions.dm
+++ b/code/modules/client/preferences_factions.dm
@@ -95,13 +95,13 @@ var/global/list/antag_visiblity_choices = list(
 	)
 
 var/global/list/religion_choices = list(
-	"Unitarianism",
-	"Neopaganism",
-	"Islam",
-	"Christianity",
-	"Judaism",
-	"Hinduism",
-	"Buddhism",
+	//"Unitarianism", //CHOMPEDIT: Commenting out some IRL religions to encourage fictional ones and worldbuilding.
+	//"Neopaganism", //CHOMPEDIT: Commenting out some IRL religions
+	//"Islam",//CHOMPEDIT: Commenting out some IRL religions
+	//"Christianity", //CHOMPEDIT: Commenting out some IRL religions
+	//"Judaism", //CHOMPEDIT: Commenting out some IRL religions
+	//"Hinduism", //CHOMPEDIT: Commenting out some IRL religions
+	//"Buddhism", //CHOMPEDIT: Commenting out some IRL religions. Can still use them via Free text entry
 	"Pleromanism",
 	"Spectralism",
 	"Phact Shintoism",


### PR DESCRIPTION
Removes some IRL religions from the Default list of religions, primarily to encourage the custom ones present and for peeps to just define worldbuild their own religions.

These can still be used if wanted via free text entry but personally don't see much point in having them in there much less at the top of the choices

Keeping in the vague ones that are technically based on IRL stuff but aren't actually religious movements ex Pleromanism etc

This change is just a suggestion with the above reasoning.