### PR TITLE
PAI charging, no RNG component damage

### DIFF
--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -152,7 +152,7 @@
 		if(pcard.is_damage_critical())
 			pcard.forceMove(get_turf(src))
 			charging = null
-			pcard.damage_random_component()
+			//pcard.damage_random_component()//CHOMPEDIT: Punishing PAI for charging too soon seems kinda annoying
 			update_icon()
 		else if(pcard.pai.bruteloss)
 			pcard.pai.adjustBruteLoss(-5)


### PR DESCRIPTION
Comments out PAI receviing random component damges when attempting to charge while critical

Still ejects them when critical, just doesnt damage them further.