### PR TITLE
Adds new mechanic for liquidbellies

### DIFF
--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -375,7 +375,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		if(H.head)
-			if(H.head.unacidable)
+			if(H.head.unacidable || is_type_in_list(H.head,item_digestion_blacklist)) //CHOMPEdit
 				to_chat(H, "<span class='danger'>Your [H.head] protects you from the acid.</span>")
 				remove_self(volume)
 				return
@@ -389,7 +389,7 @@
 			return
 
 		if(H.wear_mask)
-			if(H.wear_mask.unacidable)
+			if(H.wear_mask.unacidable || is_type_in_list(H.wear_mask,item_digestion_blacklist)) //CHOMPEdit
 				to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid.</span>")
 				remove_self(volume)
 				return
@@ -403,7 +403,7 @@
 			return
 
 		if(H.glasses)
-			if(H.glasses.unacidable)
+			if(H.glasses.unacidable || is_type_in_list(H.glasses,item_digestion_blacklist)) //CHOMPEdit
 				to_chat(H, "<span class='danger'>Your [H.glasses] partially protect you from the acid!</span>")
 				removed /= 2
 			else if(removed > meltdose)
@@ -433,7 +433,7 @@
 
 /datum/reagent/acid/touch_obj(var/obj/O)
 	..()
-	if(O.unacidable)
+	if(O.unacidable || is_type_in_list(O,item_digestion_blacklist)) //CHOMPEdit)
 		return
 	if((istype(O, /obj/item) || istype(O, /obj/effect/plant)) && (volume > meltdose))
 		var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(O.loc)

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -373,9 +373,14 @@
 	if(alien == IS_GREY) //ywedit
 		return
 	if(ishuman(M))
+		var/item_digestion = TRUE //CHOMPEdit Start
+		if(isbelly(M.loc))
+			var/obj/belly/B = M.loc
+			if(B.item_digest_mode == IM_HOLD || B.item_digest_mode == IM_DIGEST_FOOD)
+				item_digestion = FALSE
 		var/mob/living/carbon/human/H = M
 		if(H.head)
-			if(H.head.unacidable || is_type_in_list(H.head,item_digestion_blacklist)) //CHOMPEdit
+			if(H.head.unacidable || is_type_in_list(H.head,item_digestion_blacklist) || !item_digestion)
 				to_chat(H, "<span class='danger'>Your [H.head] protects you from the acid.</span>")
 				remove_self(volume)
 				return
@@ -389,7 +394,7 @@
 			return
 
 		if(H.wear_mask)
-			if(H.wear_mask.unacidable || is_type_in_list(H.wear_mask,item_digestion_blacklist)) //CHOMPEdit
+			if(H.wear_mask.unacidable || is_type_in_list(H.wear_mask,item_digestion_blacklist) || !item_digestion)
 				to_chat(H, "<span class='danger'>Your [H.wear_mask] protects you from the acid.</span>")
 				remove_self(volume)
 				return
@@ -403,7 +408,7 @@
 			return
 
 		if(H.glasses)
-			if(H.glasses.unacidable || is_type_in_list(H.glasses,item_digestion_blacklist)) //CHOMPEdit
+			if(H.glasses.unacidable || is_type_in_list(H.glasses,item_digestion_blacklist) || !item_digestion) //CHOMPEdit End
 				to_chat(H, "<span class='danger'>Your [H.glasses] partially protect you from the acid!</span>")
 				removed /= 2
 			else if(removed > meltdose)
@@ -433,7 +438,12 @@
 
 /datum/reagent/acid/touch_obj(var/obj/O)
 	..()
-	if(O.unacidable || is_type_in_list(O,item_digestion_blacklist)) //CHOMPEdit)
+	var/item_digestion = TRUE //CHOMPEdit Start
+	if(isbelly(O.loc))
+		var/obj/belly/B = O.loc
+		if(B.item_digest_mode == IM_HOLD || B.item_digest_mode == IM_DIGEST_FOOD)
+			item_digestion = FALSE
+	if(O.unacidable || is_type_in_list(O,item_digestion_blacklist)  || !item_digestion) //CHOMPEdit End
 		return
 	if((istype(O, /obj/item) || istype(O, /obj/effect/plant)) && (volume > meltdose))
 		var/obj/effect/decal/cleanable/molten_item/I = new/obj/effect/decal/cleanable/molten_item(O.loc)

--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -69,7 +69,11 @@
 	"Milk",
 	"Cream",
 	"Honey",
-	"Cherry Jelly"
+	"Cherry Jelly",
+	"Digestive acid",
+	"Lube",
+	"Biomass",
+	"Fertilizer"
 	)
 
 	//CHOMP - vore sprites
@@ -102,6 +106,7 @@
 	var/slow_brutal = FALSE					// Gradual corpse digestion: Stumpy's Special
 	var/sound_volume = 100					// Volume knob.
 	var/speedy_mob_processing = FALSE		// Independent belly processing to utilize mob Life() instead of subsystem for 3x speed.
+	var/cycle_sloshed = FALSE				// Has vorgan entrance made a wet slosh this cycle? Soundspam prevention for multiple items entered.
 
 
 /obj/belly/Initialize()
@@ -259,6 +264,41 @@
 			gen_cost = 10
 			reagentid = "cherryjelly"
 			reagentcolor = "#801E28"
+		if("Digestive acid")
+			generated_reagents = list("stomacid" = 1)
+			reagent_name = "digestive acid"
+			gen_amount = 1
+			gen_cost = 5
+			reagentid = "stomacid"
+			reagentcolor = "#664330"
+		if("Space cleaner")
+			generated_reagents = list("cleaner" = 1)
+			reagent_name = "space cleaner"
+			gen_amount = 1
+			gen_cost = 10
+			reagentid = "cleaner"
+			reagentcolor = "#A5F0EE"
+		if("Lube")
+			generated_reagents = list("lube" = 1)
+			reagent_name = "lube"
+			gen_amount = 1
+			gen_cost = 10
+			reagentid = "lube"
+			reagentcolor = "#009CA8"
+		if("Biomass")
+			generated_reagents = list("biomass" = 1)
+			reagent_name = "biomass"
+			gen_amount = 1
+			gen_cost = 10
+			reagentid = "biomass"
+			reagentcolor = "#DF9FBF"
+		if("Fertilizer")
+			generated_reagents = list("fertilizer" = 1)
+			reagent_name = "fertilizer"
+			gen_amount = 1
+			gen_cost = 10
+			reagentid = "fertilizer"
+			reagentcolor = "#664330"
 
 /////////////////////// FULLNESS MESSAGES //////////////////////
 

--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -72,8 +72,7 @@
 	"Cherry Jelly",
 	"Digestive acid",
 	"Lube",
-	"Biomass",
-	"Fertilizer"
+	"Biomass"
 	)
 
 	//CHOMP - vore sprites
@@ -292,13 +291,6 @@
 			gen_cost = 10
 			reagentid = "biomass"
 			reagentcolor = "#DF9FBF"
-		if("Fertilizer")
-			generated_reagents = list("fertilizer" = 1)
-			reagent_name = "fertilizer"
-			gen_amount = 1
-			gen_cost = 10
-			reagentid = "fertilizer"
-			reagentcolor = "#664330"
 
 /////////////////////// FULLNESS MESSAGES //////////////////////
 

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -357,7 +357,7 @@
 			playsound(src, soundfile, vol = sound_volume, vary = 1, falloff = VORE_SOUND_FALLOFF, preference = /datum/client_preference/eating_noises, volume_channel = VOLUME_CHANNEL_VORE) //CHOMPEdit
 			recent_sound = TRUE
 
-	if(reagents.total_volume > 0) //CHOMPAdd Start
+	if(reagents.total_volume > 0 && !isliving(thing)) //CHOMPAdd Start
 		if(!istype(thing,/obj/item/weapon/reagent_containers)) //Don't fill containers with free juice. Splashing only.
 			reagents.trans_to(thing, reagents.total_volume, 1 / (LAZYLEN(contents) ? LAZYLEN(contents) : 1), TRUE) //CHOMPAdd End
 	//Messages if it's a mob
@@ -387,6 +387,8 @@
 		//Stop AI processing in bellies
 		if(M.ai_holder)
 			M.ai_holder.go_sleep()
+		if(reagents.total_volume > 0 && M.digestable) //CHOMPAdd
+			reagents.trans_to(M, reagents.total_volume, 1 / (LAZYLEN(contents) ? LAZYLEN(contents) : 1), TRUE) //CHOMPAdd
 	else if(count_items_for_sprite) //CHOMPEdit - If this is enabled also update fullness for non-living things
 		owner.update_fullness() //CHOMPEdit - This is run whenever a belly's contents are changed.
 	if(istype(thing, /obj/item/capture_crystal)) //CHOMPEdit: Capture crystal occupant gets to see belly text too.

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -316,9 +316,16 @@
 
 // Called whenever an atom enters this belly
 /obj/belly/Entered(atom/movable/thing, atom/OldLoc)
-	. = ..()  //CHOMPEdit: radios
-	thing.belly_cycles = 0 //CHOMPEdit: reset cycle count
-	if(istype(thing, /mob/observer)) //CHOMPEdit. Silence, spook.
+	. = ..()  //CHOMPEdit Start
+	if(istype(owner.loc,/turf/simulated) && !cycle_sloshed && reagents.total_volume > 0)
+		var/turf/simulated/T = owner.loc
+		var/list/slosh_sounds = T.vorefootstep_sounds["human"]
+		var/S = pick(slosh_sounds)
+		if(S)
+			playsound(T, S, sound_volume * (reagents.total_volume / 100), FALSE, preference = /datum/client_preference/digestion_noises)
+			cycle_sloshed = TRUE
+	thing.belly_cycles = 0 //reset cycle count
+	if(istype(thing, /mob/observer)) //Silence, spook.
 		if(desc)
 			//Allow ghosts see where they are if they're still getting squished along inside.
 			var/formatted_desc
@@ -329,8 +336,7 @@
 		return
 	if(OldLoc in contents)
 		return //Someone dropping something (or being stripdigested)
-	//CHOMPEdit Start - Prevent reforming causing a lot of log spam/sounds
-	if(istype(OldLoc, /mob/observer) || istype(OldLoc, /obj/item/device/mmi))
+	if(istype(OldLoc, /mob/observer) || istype(OldLoc, /obj/item/device/mmi)) // Prevent reforming causing a lot of log spam/sounds
 		return //Someone getting reformed most likely (And if not, uh... shouldn't happen anyways?)
 	//CHOMPEdit end
 
@@ -351,6 +357,9 @@
 			playsound(src, soundfile, vol = sound_volume, vary = 1, falloff = VORE_SOUND_FALLOFF, preference = /datum/client_preference/eating_noises, volume_channel = VOLUME_CHANNEL_VORE) //CHOMPEdit
 			recent_sound = TRUE
 
+	if(reagents.total_volume > 0) //CHOMPAdd Start
+		if(!istype(thing,/obj/item/weapon/reagent_containers)) //Don't fill containers with free juice. Splashing only.
+			reagents.trans_to(thing, reagents.total_volume, 1 / (LAZYLEN(contents) ? LAZYLEN(contents) : 1), TRUE) //CHOMPAdd End
 	//Messages if it's a mob
 	if(isliving(thing))
 		var/mob/living/M = thing
@@ -893,8 +902,12 @@
 			Prey.bloodstr.del_reagent("numbenzyme")
 			Prey.bloodstr.trans_to_holder(Pred.bloodstr, Prey.bloodstr.total_volume, 0.5, TRUE) // Copy=TRUE because we're deleted anyway
 			Prey.ingested.trans_to_holder(Pred.bloodstr, Prey.ingested.total_volume, 0.5, TRUE) // Therefore don't bother spending cpu
+			Prey.touching.del_reagent("stomacid") //CHOMPEdit: Don't need this stuff in our bloodstream.
+			Prey.touching.del_reagent("cleaner") //CHOMPEdit: Don't need this stuff in our bloodstream.
 			Prey.touching.trans_to_holder(Pred.bloodstr, Prey.touching.total_volume, 0.5, TRUE) // On updating the prey's reagents
 		else if(M.reagents)
+			M.reagents.del_reagent("stomacid") //CHOMPEdit: Don't need this stuff in our bloodstream.
+			M.reagents.del_reagent("cleaner") //CHOMPEdit: Don't need this stuff in our bloodstream.
 			M.reagents.trans_to_holder(Pred.bloodstr, M.reagents.total_volume, 0.5, TRUE)
 
 	owner.update_fullness() //CHOMPEdit - This is run whenever a belly's contents are changed.

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -900,15 +900,15 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/Prey = M
 			Prey.bloodstr.del_reagent("numbenzyme")
-			Prey.bloodstr.trans_to_holder(Pred.bloodstr, Prey.bloodstr.total_volume, 0.5, TRUE) // Copy=TRUE because we're deleted anyway
-			Prey.ingested.trans_to_holder(Pred.bloodstr, Prey.ingested.total_volume, 0.5, TRUE) // Therefore don't bother spending cpu
-			Prey.touching.del_reagent("stomacid") //CHOMPEdit: Don't need this stuff in our bloodstream.
-			Prey.touching.del_reagent("cleaner") //CHOMPEdit: Don't need this stuff in our bloodstream.
-			Prey.touching.trans_to_holder(Pred.bloodstr, Prey.touching.total_volume, 0.5, TRUE) // On updating the prey's reagents
+			Prey.bloodstr.trans_to_holder(Pred.ingested, Prey.bloodstr.total_volume, 0.5, TRUE) // Copy=TRUE because we're deleted anyway //CHOMPEdit Start
+			Prey.ingested.trans_to_holder(Pred.ingested, Prey.ingested.total_volume, 0.5, TRUE) // Therefore don't bother spending cpu
+			Prey.touching.del_reagent("stomacid") //Don't need this stuff in our bloodstream.
+			Prey.touching.del_reagent("cleaner") //Don't need this stuff in our bloodstream.
+			Prey.touching.trans_to_holder(Pred.ingested, Prey.touching.total_volume, 0.5, TRUE) // On updating the prey's reagents
 		else if(M.reagents)
-			M.reagents.del_reagent("stomacid") //CHOMPEdit: Don't need this stuff in our bloodstream.
-			M.reagents.del_reagent("cleaner") //CHOMPEdit: Don't need this stuff in our bloodstream.
-			M.reagents.trans_to_holder(Pred.bloodstr, M.reagents.total_volume, 0.5, TRUE)
+			M.reagents.del_reagent("stomacid") //Don't need this stuff in our bloodstream.
+			M.reagents.del_reagent("cleaner") //Don't need this stuff in our bloodstream.
+			M.reagents.trans_to_holder(Pred.ingested, M.reagents.total_volume, 0.5, TRUE) //CHOMPEdit End
 
 	owner.update_fullness() //CHOMPEdit - This is run whenever a belly's contents are changed.
 	//Incase they have the loop going, let's double check to stop it.
@@ -989,6 +989,8 @@
 		//Reagent sharing for absorbed with pred - Copy so both pred and prey have these reagents.
 		Prey.bloodstr.trans_to_holder(Pred.ingested, Prey.bloodstr.total_volume, copy = TRUE)
 		Prey.ingested.trans_to_holder(Pred.ingested, Prey.ingested.total_volume, copy = TRUE)
+		Prey.touching.del_reagent("stomacid") //CHOMPEdit Don't need this stuff in our bloodstream.
+		Prey.touching.del_reagent("cleaner") //CHOMPEdit Don't need this stuff in our bloodstream.
 		Prey.touching.trans_to_holder(Pred.ingested, Prey.touching.total_volume, copy = TRUE)
 		// TODO - Find a way to make the absorbed prey share the effects with the pred.
 		// Currently this is infeasible because reagent containers are designed to have a single my_atom, and we get

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -1,6 +1,7 @@
 // Process the predator's effects upon the contents of its belly (i.e digestion/transformation etc)
 /obj/belly/process(wait) //Passed by controller
 	recent_sound = FALSE
+	cycle_sloshed = FALSE //CHOMPAdd
 
 	if(loc != owner)
 		if(istype(owner))


### PR DESCRIPTION
Liquidbellies now splash prey/items with their reagents upon entering the belly, strength scaled to reagent amount and divided by amount of belly contents. Reagent amount affects slosh sound volume played when things enter the wet vorgan.
Also added a few new belly reagent options suitable for splashing or other effects, these being stomach acid, lube, biomass, and fertilizer. Felt pretty balanced on test runs what comes to usefulness or abusefulness concerns.
Also made reagent unacidable checks respect the item digestion blacklist.
And fixed digestion death moving prey's reagents directly into bloodstream instead of ingested metabolism.