### PR TITLE
Makes arm mounted implants craftable via R&D

### DIFF
--- a/code/modules/organs/internal/augment.dm
+++ b/code/modules/organs/internal/augment.dm
@@ -27,7 +27,7 @@
 	var/radial_name = null	// The augment's name in the Radial Menu.
 	var/radial_state = null	// Icon state for the augment's radial icon.
 
-	var/aug_cooldown = 30 SECONDS
+	var/aug_cooldown = 1 SECONDS //CHOMPedit, no reason for it to be 30 seconds, the powerful implants already have their own values
 	var/cooldown = null
 
 /obj/item/organ/internal/augment/Initialize()

--- a/modular_chomp/code/modules/research/designs/implants.dm
+++ b/modular_chomp/code/modules/research/designs/implants.dm
@@ -1,0 +1,91 @@
+/datum/design/item/organ/internal/augment/AssembleDesignName()
+	..()
+	name = "Biotech implant device prototype ([item_name])"
+
+/datum/design/item/organ/internal/augment/armmounted/laserarm
+	desc = "A large implant that fits into a subject's arm. It deploys a laser-emitting array by some painful means."
+	id = "laserarm_implant"
+	req_tech = list(TECH_COMBAT = 5, TECH_BIO = 5, TECH_ENGINEERING = 2)
+	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3000, MAT_URANIUM = 2000)
+	build_path = /obj/item/organ/internal/augment/armmounted
+	sort_string = "JVACC"
+
+/datum/design/item/organ/internal/augment/armmounted/dartbow
+	desc = "A small implant that fits into a subject's arm. It deploys a dart launching mechanism through the flesh through unknown means."
+	id = "dart_implant"
+	req_tech = list(TECH_COMBAT = 5, TECH_BIO = 5, TECH_ILLEGAL = 2)
+	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3000, MAT_URANIUM = 2000, MAT_PHORON = 1000)
+	build_path = /obj/item/organ/internal/augment/armmounted/dartbow
+	sort_string = "JVACD"
+
+/datum/design/item/organ/internal/augment/armmounted/hand
+	desc = "An augment that fits neatly into the hand, useful for determining the usefulness of an object for research."
+	id = "research_implant"
+	req_tech = list(TECH_BIO = 5, TECH_MATERIAL = 2)
+	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3000)
+	build_path = /obj/item/organ/internal/augment/armmounted/hand
+	sort_string = "JVACE"
+
+/datum/design/item/organ/internal/augment/armmounted/hand/blade
+	desc = "A small implant that fits neatly into the hand. It deploys a small, but dangerous blade."
+	id = "claw_implant"
+	req_tech = list(TECH_COMBAT = 5, TECH_BIO = 5, TECH_MATERIAL = 2)
+	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3000, MAT_PLASTEEL = 4000)
+	build_path = /obj/item/organ/internal/augment/armmounted/hand/blade
+	sort_string = "JVACF"
+
+/datum/design/item/organ/internal/augment/armmounted/hand/sword
+	desc = "An augment that fits neatly into the hand, It deploys a powerful energy blade."
+	id = "esword_implant"
+	req_tech = list(TECH_COMBAT = 5, TECH_BIO = 5, TECH_ILLEGAL = 5)
+	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3000, MAT_PLASTEEL = 4000, MAT_METALHYDROGEN = 500)
+	build_path = /obj/item/organ/internal/augment/armmounted/hand/sword
+	sort_string = "JVACG"
+
+/datum/design/item/organ/internal/augment/armmounted/shoulder/blade
+	desc = "A large implant that fits into a subject's arm. It deploys a large metal blade by some painful means."
+	id = "sword_implant"
+	req_tech = list(TECH_COMBAT = 5, TECH_BIO = 5, TECH_MATERIAL = 3)
+	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3000, MAT_PLASTEEL = 6000)
+	build_path = /obj/item/organ/internal/augment/armmounted/shoulder/blade
+	sort_string = "JVACH"
+
+/datum/design/item/organ/internal/augment/armmounted/shoulder/multiple
+	desc = "A large implant that fits into a subject's arm. It deploys an array of tools by some painful means."
+	id = "tool_implant"
+	req_tech = list(TECH_BIO = 5, TECH_MATERIAL = 2, TECH_ENGINEERING = 3)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000)
+	build_path = /obj/item/organ/internal/augment/armmounted/shoulder/multiple
+	sort_string = "JVACI"
+
+/datum/design/item/organ/internal/augment/armmounted/shoulder/multiple/medical
+	desc = "A large implant that fits into a subject's arm. It deploys an array of tools by some painful means."
+	id = "surgical_implant"
+	req_tech = list(TECH_BIO = 6, TECH_MATERIAL = 4)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_SILVER = 1000)
+	build_path = /obj/item/organ/internal/augment/armmounted/shoulder/multiple/medical
+	sort_string = "JVACJ"
+
+/datum/design/item/organ/internal/augment/armmounted/shoulder/surge
+	desc = "A large implant that fits into a subject's arm. It looks kind of like a skeleton."
+	id = "stim_implant"
+	req_tech = list(TECH_COMBAT = 3, TECH_BIO = 7, TECH_MATERIAL = 2)
+	materials = list(MAT_STEEL = 6000, MAT_GLASS = 6000, MAT_URANIUM = 1000)
+	build_path = /obj/item/organ/internal/augment/armmounted/shoulder/surge
+	sort_string = "JVACK"
+
+/datum/design/item/organ/internal/augment/armmounted/taser
+	desc = "A large implant that fits into a subject's arm. It deploys a taser-emitting array by some painful means."
+	id = "taser_implant"
+	req_tech = list(TECH_COMBAT = 5, TECH_BIO = 5, TECH_ENGINEERING = 2)
+	materials = list(MAT_STEEL = 3000, MAT_GLASS = 3000)
+	build_path = /obj/item/organ/internal/augment/armmounted/taser
+	sort_string = "JVACL"
+
+/datum/design/item/organ/internal/augment/bioaugment/thermalshades
+	desc = "A miniscule implant that houses a pair of thermolensed sunglasses. Don't ask how they deploy, you don't want to know."
+	id = "thermal_implant"
+	req_tech = list(TECH_COMBAT = 5, TECH_BIO = 7, TECH_MATERIAL = 2, TECH_ILLEGAL = 4)
+	materials = list(MAT_STEEL = 2000, MAT_GLASS = 2000, MAT_URANIUM = 2000, MAT_PLASTEEL = 1000)
+	build_path = /obj/item/organ/internal/augment/bioaugment/thermalshades
+	sort_string = "JVACM"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4673,6 +4673,7 @@
 #include "modular_chomp\code\modules\reagents\reagents\medicine.dm"
 #include "modular_chomp\code\modules\recycling\v_garbosystem.dm"
 #include "modular_chomp\code\modules\research\mechfab_designs.dm"
+#include "modular_chomp\code\modules\research\designs\implants.dm"
 #include "modular_chomp\code\modules\research\designs\power_cells.dm"
 #include "modular_chomp\code\modules\research\designs\weapons.dm"
 #include "modular_chomp\code\modules\resleeving\machines.dm"


### PR DESCRIPTION
The only way to get those items currently was to hope a RNG away mission loot pile gave it to you, in which you needed someone to implant it into you like a organ, This PR will make them craftable, all of them needing biotech 5 from the protolathe to unlock aside from a few other bits of research for the specific ones.
Also buffs the base implant cooldown to 1 second instead of 30 so stuff like the tool implant works, 
Hopefully the research and material costs are balanced, and it gives medical something to do other than 'Wait for exploration to die'
The flesh is weak. 
![LQTcCGO0yn](https://user-images.githubusercontent.com/10555869/231537543-66045ef9-7de3-47b2-9e39-efee398820f8.png)

And an example of the toolkit and laser arm implant.
https://user-images.githubusercontent.com/10555869/231537796-bfec685a-5652-433e-8932-52995663ce19.mp4

**Current Bug I cant be assed to fix: Using a screwdriver doesn't swap the implant from left arm to right.**