### PR TITLE
Fixes capture crystal runtime

### DIFF
--- a/code/game/objects/items/weapons/capture_crystal.dm
+++ b/code/game/objects/items/weapons/capture_crystal.dm
@@ -480,7 +480,7 @@
 
 //IF the crystal somehow ends up in a tummy and digesting with a bound mob who doesn't want to be eaten, let's move them to the ground
 /obj/item/capture_crystal/digest_act(var/atom/movable/item_storage = null)
-	if(bound_mob in contents && !bound_mob.devourable)
+	if(bound mob && bound_mob in contents && !bound_mob.devourable) //CHOMPEdit
 		bound_mob.forceMove(src.drop_location())
 	return ..()
 


### PR DESCRIPTION
Fixes empty capture crystals locking themselves in runtime loop on item gurgles.