### PR TITLE
Fixing non-functioning emergency shutters

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -28107,6 +28107,19 @@
 /turf/simulated/floor,
 /area/maintenance/cargo)
 "bHP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/cargo)
+"bHQ" = (
 /obj/structure/table/rack{
 	dir = 1
 	},
@@ -28117,12 +28130,8 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /obj/effect/floor_decal/industrial/warning{
-	dir = 4
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/cargo)
-"bHQ" = (
-/obj/random/obstruction,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "bHR" = (
@@ -71835,6 +71844,9 @@
 /obj/random/maintenance,
 /obj/random/maintenance,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "ssP" = (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/109300046/232347330-25bcdb32-fb2e-4a5d-9839-8cc784909dab.png)
This row of emergency shutters didn't use to work. Since one was missing, and would have possibly been blocked by the rack anyway. 

Now if this was intended, that confuses me a tad. But ultimately, don't think this changes much, just makes one section of maintenance consistently safer in breach events, since where the rack is currently, was a random obstacle which had a chance of already sealing it off.