### PR TITLE
Makes liquidbelly acid splash use digest_act

### DIFF
--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -271,7 +271,7 @@
 			generated_reagents = list("stomacid" = 1)
 			reagent_name = "digestive acid"
 			gen_amount = 1
-			gen_cost = 5
+			gen_cost = 2
 			reagentid = "stomacid"
 			reagentcolor = "#664330"
 		if("Space cleaner")

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -3,7 +3,7 @@
 //return non-negative integer: Amount of nutrition/charge gained (scaled to nutrition, other end can multiply for charge scale).
 
 // Ye default implementation.
-/obj/item/proc/digest_act(atom/movable/item_storage = null, touchable_amount) //CHOMPEdit
+/obj/item/proc/digest_act(atom/movable/item_storage = null, touchable_amount, splashing = 0) //CHOMPEdit
 	if(istype(item_storage, /obj/item/device/dogborg/sleeper))
 		if(istype(src, /obj/item/device/pda))
 			var/obj/item/device/pda/P = src
@@ -34,7 +34,10 @@
 		var/obj/belly/B = item_storage
 		if(!touchable_amount) //CHOMPEdit Start
 			touchable_amount = 1
-		g_damage = 0.25 * (B.digest_brute + B.digest_burn) / touchable_amount
+		if(splashing > 0)
+			g_damage = 0.25 * splashing
+		else
+			g_damage = 0.25 * (B.digest_brute + B.digest_burn) / touchable_amount
 		if(g_damage <= 0)
 			return FALSE
 		if(g_damage > digest_stage)


### PR DESCRIPTION
Liquidbelly acids now utilize digest_act proc for in-belly item splashing/melting, and now also support partial digestion when acid amount is under meltdose threshold.
Instead of being a solid 30u meltdose, it's now 10u per w_class (30u for normal size item).
And since it now uses digest_act, storage items and such get to dump their contents instead of just taking it all with the old melt qdel.
This also means the in-belly melted items get to make their final gurglenoises as well.
Also lowered nutrition cost for generating stomacid, making it a little more in line with the prey damage potential and item meltdose reagent consumption.