### PR TITLE
Adds verb to toggle trasheater restriction level

### DIFF
--- a/code/modules/vore/eating/living_ch.dm
+++ b/code/modules/vore/eating/living_ch.dm
@@ -313,6 +313,13 @@
 	trash_catching = !trash_catching
 	to_chat(src, "<span class='warning'>Trash catching [trash_catching ? "enabled" : "disabled"].</span>")
 
+/mob/living/proc/restrict_trasheater()
+	set name = "Restrict Trash Eater"
+	set category = "Abilities"
+	set desc = "Toggle Trash Eater restriction level."
+	adminbus_trash = !adminbus_trash
+	to_chat(src, "<span class='warning'>Trash Eater restriction level set to [adminbus_trash ? "everything not blacklisted" : "only whitelisted items"].</span>")
+
 /mob/living/proc/liquidbelly_visuals()
 	set name = "Toggle Liquidbelly Visuals"
 	set category = "Preferences"

--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
@@ -33,6 +33,8 @@
 	if(!voremob_loaded)
 		return
 	verbs |= /mob/living/proc/eat_trash
+	verbs |= /mob/living/proc/toggle_trash_catching
+	verbs |= /mob/living/proc/restrict_trasheater
 	var/obj/belly/B = new /obj/belly/(src)
 	B.affects_vore_sprites = TRUE
 	B.belly_sprite_to_affect = "stomach"


### PR DESCRIPTION
Adds an abilities tab verb to toggle trash eater restriction level between regular (whitelisted items only) and unlocked (all non-blacklisted items)
Currently only implemented on Swoopie (the only mob so far that starts with unlocked trasheater), but can be easily added to any responsible user via ingame varedit.
Also gives swoopie the trash catching toggle verb.