### PR TITLE
Makes some exposed tiles match the outside

### DIFF
--- a/maps/submaps/surface_submaps/mountains/crashed_ufo_frigate.dmm
+++ b/maps/submaps/surface_submaps/mountains/crashed_ufo_frigate.dmm
@@ -534,13 +534,15 @@
 /obj/machinery/porta_turret/alien/destroyed,
 /turf/simulated/shuttle/floor/alienplating{
 	oxygen = 20.7263;
-	nitrogen = 93.7835
+	nitrogen = 93.7835;
+	temperature = 243.15
 	},
 /area/submap/cave/crashed_ufo_frigate)
 "xX" = (
 /turf/simulated/shuttle/floor/alienplating{
 	oxygen = 20.7263;
-	nitrogen = 93.7835
+	nitrogen = 93.7835;
+	temperature = 243.15
 	},
 /area/submap/cave/crashed_ufo_frigate)
 

--- a/maps/submaps/surface_submaps/mountains/crashed_ufo_frigate.dmm
+++ b/maps/submaps/surface_submaps/mountains/crashed_ufo_frigate.dmm
@@ -530,8 +530,18 @@
 "ch" = (
 /turf/simulated/shuttle/wall/alien/hard_corner,
 /area/submap/cave/crashed_ufo_frigate)
+"de" = (
+/obj/machinery/porta_turret/alien/destroyed,
+/turf/simulated/shuttle/floor/alienplating{
+	oxygen = 20.7263;
+	nitrogen = 93.7835
+	},
+/area/submap/cave/crashed_ufo_frigate)
 "xX" = (
-/turf/simulated/shuttle/floor/alienplating/external,
+/turf/simulated/shuttle/floor/alienplating{
+	oxygen = 20.7263;
+	nitrogen = 93.7835
+	},
 /area/submap/cave/crashed_ufo_frigate)
 
 (1,1,1) = {"
@@ -1988,9 +1998,9 @@ ad
 ad
 ad
 ad
-aZ
+de
 xX
-aZ
+de
 ad
 ad
 ad

--- a/maps/submaps/surface_submaps/valley/cliffmanor.dmm
+++ b/maps/submaps/surface_submaps/valley/cliffmanor.dmm
@@ -23,7 +23,10 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "f" = (
 /obj/structure/cliff/automatic{
@@ -55,22 +58,38 @@
 "k" = (
 /obj/structure/table/wooden_reinforced,
 /obj/random/energy/highend,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "l" = (
 /obj/structure/table/wooden_reinforced,
 /obj/random/gun/random,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "m" = (
 /obj/structure/table/wooden_reinforced,
 /obj/random/firstaid,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "n" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/clothing/head/psy_crown/wrath,
 /turf/simulated/floor/wood,
+/area/submap/cliffmanor)
+"o" = (
+/mob/living/simple_mob/humanoid/cultist/tesh,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "p" = (
 /mob/living/simple_mob/vore/alienanimals/space_jellyfish{
@@ -93,7 +112,10 @@
 /area/submap/cliffmanor)
 "r" = (
 /obj/structure/railing,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "s" = (
 /turf/simulated/wall/log,
@@ -116,13 +138,24 @@
 "x" = (
 /obj/structure/table/wooden_reinforced,
 /obj/random/projectile/random,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "y" = (
 /obj/structure/cliff/automatic{
 	dir = 4
 	},
 /turf/simulated/floor/outdoors/dirt,
+/area/submap/cliffmanor)
+"A" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/flame/candle/everburn,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "B" = (
 /obj/structure/bed,
@@ -170,6 +203,19 @@
 "J" = (
 /turf/simulated/floor/wood,
 /area/submap/cliffmanor)
+"K" = (
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
+/area/submap/cliffmanor)
+"L" = (
+/mob/living/simple_mob/humanoid/cultist/castertesh,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
+/area/submap/cliffmanor)
 "M" = (
 /obj/structure/cliff/automatic{
 	dir = 6
@@ -180,7 +226,10 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "O" = (
 /obj/structure/table/wooden_reinforced,
@@ -191,7 +240,10 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "Q" = (
 /obj/structure/cliff/automatic{
@@ -205,7 +257,10 @@
 /area/submap/cliffmanor)
 "S" = (
 /obj/structure/table/wooden_reinforced,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "T" = (
 /obj/structure/railing{
@@ -237,7 +292,10 @@
 /area/submap/cliffmanor)
 "X" = (
 /mob/living/simple_mob/humanoid/cultist/human/bloodjaunt/fireball,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "Y" = (
 /obj/structure/cliff/automatic/corner{
@@ -477,21 +535,21 @@ u
 u
 Q
 e
-J
-J
-J
-R
-J
+K
+K
+K
+L
+K
 s
 O
 i
 c
 s
-J
-R
-J
-J
-J
+K
+L
+K
+K
+K
 r
 G
 v
@@ -508,21 +566,21 @@ u
 u
 Q
 e
-J
-J
-J
-J
-J
+K
+K
+K
+K
+K
 h
 J
 I
 J
 h
-J
-J
-J
-J
-J
+K
+K
+K
+K
+K
 r
 G
 v
@@ -540,9 +598,9 @@ u
 Q
 e
 X
-J
-J
-a
+K
+K
+o
 S
 s
 J
@@ -550,9 +608,9 @@ J
 J
 s
 S
-a
-J
-J
+o
+K
+K
 X
 r
 G
@@ -570,21 +628,21 @@ u
 u
 Q
 e
-J
-J
+K
+K
 S
 l
-i
+A
 s
 J
 J
 J
 s
-i
+A
 x
 S
-J
-J
+K
+K
 r
 G
 v
@@ -1004,21 +1062,21 @@ u
 u
 Q
 e
-J
-J
+K
+K
 S
 m
-i
+A
 s
 J
 J
 J
 s
-i
+A
 k
 S
-J
-J
+K
+K
 r
 G
 v
@@ -1036,9 +1094,9 @@ u
 Q
 e
 X
-J
-J
-a
+K
+K
+o
 S
 s
 J
@@ -1046,9 +1104,9 @@ J
 J
 s
 S
-a
-J
-J
+o
+K
+K
 X
 r
 G
@@ -1066,21 +1124,21 @@ u
 u
 Q
 e
-J
-J
-J
-J
-J
+K
+K
+K
+K
+K
 h
 J
 I
 J
 h
-J
-J
-J
-J
-J
+K
+K
+K
+K
+K
 r
 G
 v
@@ -1097,21 +1155,21 @@ u
 u
 Q
 e
-J
-J
-J
-R
-J
+K
+K
+K
+L
+K
 s
 c
 i
 n
 s
-J
-R
-J
-J
-J
+K
+L
+K
+K
+K
 r
 G
 v

--- a/maps/submaps/surface_submaps/valley/cliffmanor.dmm
+++ b/maps/submaps/surface_submaps/valley/cliffmanor.dmm
@@ -19,7 +19,8 @@
 /obj/random/material/refined,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "e" = (
@@ -28,7 +29,8 @@
 	},
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "f" = (
@@ -63,7 +65,8 @@
 /obj/random/energy/highend,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "l" = (
@@ -71,7 +74,8 @@
 /obj/random/gun/random,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "m" = (
@@ -79,7 +83,8 @@
 /obj/random/firstaid,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "n" = (
@@ -91,7 +96,8 @@
 /mob/living/simple_mob/humanoid/cultist/tesh,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "p" = (
@@ -117,7 +123,8 @@
 /obj/structure/railing,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "s" = (
@@ -129,7 +136,8 @@
 /obj/random/material/precious,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "u" = (
@@ -146,7 +154,8 @@
 /obj/random/projectile/random,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "y" = (
@@ -160,7 +169,8 @@
 /obj/item/weapon/flame/candle/everburn,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "B" = (
@@ -172,7 +182,8 @@
 /mob/living/simple_mob/humanoid/cultist/noodle,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "D" = (
@@ -194,7 +205,8 @@
 /obj/random/material/refined,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "G" = (
@@ -218,14 +230,16 @@
 "K" = (
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "L" = (
 /mob/living/simple_mob/humanoid/cultist/castertesh,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "M" = (
@@ -240,7 +254,8 @@
 	},
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "O" = (
@@ -254,7 +269,8 @@
 	},
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "Q" = (
@@ -267,7 +283,8 @@
 /obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "T" = (
@@ -278,7 +295,8 @@
 /obj/random/material/precious,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "U" = (
@@ -301,14 +319,16 @@
 /obj/item/weapon/flame/candle/everburn,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "X" = (
 /mob/living/simple_mob/humanoid/cultist/human/bloodjaunt/fireball,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 "Y" = (
@@ -323,7 +343,8 @@
 /obj/item/weapon/flame/candle/everburn,
 /turf/simulated/floor/wood{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/cliffmanor)
 

--- a/maps/submaps/surface_submaps/valley/cliffmanor.dmm
+++ b/maps/submaps/surface_submaps/valley/cliffmanor.dmm
@@ -17,7 +17,10 @@
 /obj/structure/table/wooden_reinforced,
 /obj/random/medical/pillbottle,
 /obj/random/material/refined,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "e" = (
 /obj/structure/railing{
@@ -124,7 +127,10 @@
 /obj/structure/railing,
 /obj/structure/table/wooden_reinforced,
 /obj/random/material/precious,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "u" = (
 /turf/simulated/floor/water,
@@ -164,7 +170,10 @@
 /area/submap/cliffmanor)
 "C" = (
 /mob/living/simple_mob/humanoid/cultist/noodle,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "D" = (
 /obj/structure/cliff/automatic/corner{
@@ -183,7 +192,10 @@
 /obj/structure/table/wooden_reinforced,
 /obj/random/medical/pillbottle,
 /obj/random/material/refined,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "G" = (
 /obj/structure/cliff/automatic,
@@ -251,10 +263,6 @@
 	},
 /turf/simulated/floor/outdoors/dirt,
 /area/submap/cliffmanor)
-"R" = (
-/mob/living/simple_mob/humanoid/cultist/castertesh,
-/turf/simulated/floor/wood,
-/area/submap/cliffmanor)
 "S" = (
 /obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/wood{
@@ -268,7 +276,10 @@
 	},
 /obj/structure/table/wooden_reinforced,
 /obj/random/material/precious,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "U" = (
 /obj/structure/cliff/automatic/corner{
@@ -288,7 +299,10 @@
 	},
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/flame/candle/everburn,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 "X" = (
 /mob/living/simple_mob/humanoid/cultist/human/bloodjaunt/fireball,
@@ -307,7 +321,10 @@
 /obj/structure/railing,
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/flame/candle/everburn,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/wood{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/cliffmanor)
 
 (1,1,1) = {"
@@ -818,13 +835,13 @@ v
 v
 Q
 T
-J
-J
-J
-J
-J
-J
-J
+K
+K
+K
+K
+K
+K
+K
 d
 G
 v
@@ -849,13 +866,13 @@ v
 v
 Q
 W
-R
-J
-J
+L
+K
+K
 C
-J
-J
-R
+K
+K
+L
 Z
 G
 v
@@ -880,13 +897,13 @@ v
 v
 Q
 F
-J
-J
-J
-J
-J
-J
-J
+K
+K
+K
+K
+K
+K
+K
 t
 G
 v

--- a/maps/submaps/surface_submaps/valley/fallenportal.dmm
+++ b/maps/submaps/surface_submaps/valley/fallenportal.dmm
@@ -27,7 +27,8 @@
 "g" = (
 /turf/simulated/floor/gorefloor{
 	oxygen = 20.7263;
-	nitrogen = 93.7835
+	nitrogen = 93.7835;
+	temperature = 243.15
 	},
 /area/submap/fallenportal)
 "h" = (
@@ -37,7 +38,8 @@
 "i" = (
 /turf/simulated/floor/gorefloor2{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/fallenportal)
 "j" = (

--- a/maps/submaps/surface_submaps/valley/fallenportal.dmm
+++ b/maps/submaps/surface_submaps/valley/fallenportal.dmm
@@ -24,9 +24,27 @@
 /obj/structure/simple_door/cult,
 /turf/simulated/floor/cult,
 /area/submap/fallenportal)
+"g" = (
+/turf/simulated/floor/gorefloor{
+	oxygen = 20.7263;
+	nitrogen = 93.7835
+	},
+/area/submap/fallenportal)
 "h" = (
 /mob/living/simple_mob/construct/artificer/caster,
 /turf/simulated/floor/gorefloor2,
+/area/submap/fallenportal)
+"i" = (
+/turf/simulated/floor/gorefloor2{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
+/area/submap/fallenportal)
+"j" = (
+/turf/simulated/floor/cult{
+	oxygen = 20.7263;
+	nitrogen = 93.7835
+	},
 /area/submap/fallenportal)
 "k" = (
 /obj/structure/table/borosilicate,
@@ -108,7 +126,10 @@
 /mob/living/simple_mob/vore/demonAI/wendigo{
 	faction = "cult"
 	},
-/turf/simulated/floor/cult,
+/turf/simulated/floor/cult{
+	oxygen = 20.7263;
+	nitrogen = 93.7835
+	},
 /area/submap/fallenportal)
 "z" = (
 /obj/structure/closet/crate,
@@ -141,7 +162,10 @@
 /mob/living/simple_mob/vore/demonAI{
 	faction = "cult"
 	},
-/turf/simulated/floor/cult,
+/turf/simulated/floor/cult{
+	oxygen = 20.7263;
+	nitrogen = 93.7835
+	},
 /area/submap/fallenportal)
 "F" = (
 /obj/structure/table/borosilicate,
@@ -189,7 +213,10 @@
 /area/template_noop)
 "P" = (
 /mob/living/simple_mob/humanoid/cultist/human/bloodjaunt/fireball,
-/turf/simulated/floor/cult,
+/turf/simulated/floor/cult{
+	oxygen = 20.7263;
+	nitrogen = 93.7835
+	},
 /area/submap/fallenportal)
 "R" = (
 /obj/effect/landmark/loot_spawn,
@@ -301,7 +328,7 @@ O
 O
 O
 O
-H
+g
 G
 G
 G
@@ -350,9 +377,9 @@ h
 X
 J
 J
-X
+j
 E
-X
+j
 l
 l
 y
@@ -377,12 +404,12 @@ X
 X
 o
 J
-D
+i
 l
-X
-X
-X
-X
+j
+j
+j
+j
 G
 K
 t
@@ -404,7 +431,7 @@ H
 X
 X
 f
-H
+g
 l
 l
 l
@@ -434,9 +461,9 @@ J
 J
 l
 l
-X
-X
-X
+j
+j
+j
 G
 G
 A
@@ -459,11 +486,11 @@ X
 X
 x
 J
-X
-X
+j
+j
 P
 l
-D
+i
 G
 v
 v
@@ -516,7 +543,7 @@ J
 R
 l
 l
-H
+g
 l
 A
 t
@@ -540,7 +567,7 @@ X
 m
 r
 J
-H
+g
 l
 l
 l
@@ -567,8 +594,8 @@ D
 X
 x
 J
-X
-X
+j
+j
 P
 l
 l
@@ -596,9 +623,9 @@ J
 J
 l
 l
-X
-X
-X
+j
+j
+j
 G
 G
 A
@@ -625,7 +652,7 @@ l
 l
 l
 l
-D
+i
 G
 k
 t
@@ -648,11 +675,11 @@ X
 o
 J
 l
-H
-X
-X
-X
-X
+g
+j
+j
+j
+j
 G
 K
 t
@@ -674,9 +701,9 @@ x
 H
 J
 J
-X
+j
 y
-X
+j
 l
 l
 E

--- a/maps/submaps/surface_submaps/valley/leechpond.dmm
+++ b/maps/submaps/surface_submaps/valley/leechpond.dmm
@@ -9,7 +9,10 @@
 /turf/simulated/floor/outdoors/mud,
 /area/submap/leechpond)
 "y" = (
-/turf/simulated/floor/wood/sif,
+/turf/simulated/floor/wood/sif{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/leechpond)
 "C" = (
 /turf/simulated/floor/water,
@@ -23,7 +26,10 @@
 /area/submap/leechpond)
 "U" = (
 /obj/effect/landmark/loot_spawn,
-/turf/simulated/floor/wood/sif,
+/turf/simulated/floor/wood/sif{
+	nitrogen = 93.7835;
+	oxygen = 20.7263
+	},
 /area/submap/leechpond)
 
 (1,1,1) = {"

--- a/maps/submaps/surface_submaps/valley/leechpond.dmm
+++ b/maps/submaps/surface_submaps/valley/leechpond.dmm
@@ -11,7 +11,8 @@
 "y" = (
 /turf/simulated/floor/wood/sif{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/leechpond)
 "C" = (
@@ -28,7 +29,8 @@
 /obj/effect/landmark/loot_spawn,
 /turf/simulated/floor/wood/sif{
 	nitrogen = 93.7835;
-	oxygen = 20.7263
+	oxygen = 20.7263;
+	temperature = 243.15
 	},
 /area/submap/leechpond)
 

--- a/maps/submaps/surface_submaps/valley/puzzledungeon.dmm
+++ b/maps/submaps/surface_submaps/valley/puzzledungeon.dmm
@@ -2,7 +2,8 @@
 "a" = (
 /turf/simulated/floor/outdoors/ice{
 	oxygen = 21.8366;
-	nitrogen = 82.1472
+	nitrogen = 82.1472;
+	temperature = 293.15
 	},
 /area/submap/puzzledungeon)
 "d" = (
@@ -27,7 +28,8 @@
 /obj/machinery/crystal/ice,
 /turf/simulated/floor/outdoors/ice{
 	oxygen = 21.8366;
-	nitrogen = 82.1472
+	nitrogen = 82.1472;
+	temperature = 293.15
 	},
 /area/submap/puzzledungeon)
 "l" = (

--- a/maps/submaps/surface_submaps/valley/puzzledungeon.dmm
+++ b/maps/submaps/surface_submaps/valley/puzzledungeon.dmm
@@ -1,6 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/simulated/floor/outdoors/ice,
+/turf/simulated/floor/outdoors/ice{
+	oxygen = 21.8366;
+	nitrogen = 82.1472
+	},
 /area/submap/puzzledungeon)
 "d" = (
 /obj/structure/table/darkglass,
@@ -22,7 +25,10 @@
 /area/submap/puzzledungeon)
 "k" = (
 /obj/machinery/crystal/ice,
-/turf/simulated/floor/outdoors/ice,
+/turf/simulated/floor/outdoors/ice{
+	oxygen = 21.8366;
+	nitrogen = 82.1472
+	},
 /area/submap/puzzledungeon)
 "l" = (
 /obj/structure/table/darkglass,

--- a/maps/submaps/surface_submaps/valley/puzzledungeon.dmm
+++ b/maps/submaps/surface_submaps/valley/puzzledungeon.dmm
@@ -10,6 +10,10 @@
 /obj/item/weapon/archaeological_find,
 /turf/simulated/floor/dungeon,
 /area/submap/puzzledungeon)
+"g" = (
+/obj/structure/simple_door/cult,
+/turf/simulated/floor/dungeon,
+/area/submap/puzzledungeon)
 "h" = (
 /turf/simulated/floor/lava,
 /area/submap/puzzledungeon)
@@ -268,7 +272,7 @@ j
 S
 S
 S
-S
+g
 s
 s
 t
@@ -300,7 +304,7 @@ j
 S
 S
 S
-S
+g
 s
 s
 t
@@ -767,7 +771,7 @@ t
 t
 s
 s
-S
+g
 v
 v
 v
@@ -799,7 +803,7 @@ t
 t
 s
 s
-S
+g
 S
 S
 S


### PR DESCRIPTION
For the following POI, cliffmanor, fallenportal, leechpond, puzzledungeon, matches the outside tiles to the oxygen and nitrogen levels of sif tiles. Side note, active edge errors, I hate all of you.