### PR TITLE
General Map Updates & Fixes

### DIFF
--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -3011,6 +3011,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/port)
 "ano" = (
@@ -6480,6 +6483,7 @@
 /obj/structure/closet/crate/hydroponics,
 /obj/item/weapon/material/knife/machete/hatchet,
 /obj/item/weapon/material/minihoe,
+/obj/item/seeds/ambrosiagaiaseed,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "aGf" = (
@@ -9904,7 +9908,7 @@
 /obj/machinery/door/airlock/glass_research{
 	name = "Expedition Shuttle";
 	req_access = list();
-	req_one_access = list(5,43,67)
+	req_one_access = list(5,11,24,43,67)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hangar/three)
@@ -22199,7 +22203,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/auxdockaft)
 "nyV" = (
-/obj/structure/bed/chair/sofa/black{
+/obj/structure/bed/chair/sofa{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/sblucarpet,
@@ -25413,6 +25417,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/port)

--- a/maps/southern_cross/southern_cross-10.dmm
+++ b/maps/southern_cross/southern_cross-10.dmm
@@ -219,7 +219,7 @@
 	layer = 4;
 	name = "Wilderness Shelter Shutters"
 	},
-/obj/structure/fans/tiny,
+/obj/machinery/atmospheric_field_generator/perma/underdoors,
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter)
 "bd" = (
@@ -793,7 +793,7 @@
 	layer = 3;
 	name = "Wilderness Shelter Shutters"
 	},
-/obj/structure/fans/tiny,
+/obj/machinery/atmospheric_field_generator/perma/underdoors,
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
 "BF" = (
@@ -989,7 +989,8 @@
 	},
 /obj/machinery/power/rtg/fake_gen{
 	desc = "A simple power generator, used in small outposts to reliably provide power for decades.";
-	name = "Wilderness Shelter power generator"
+	name = "Wilderness Shelter power generator";
+	power_gen = 9000
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)

--- a/maps/southern_cross/southern_cross-10.dmm
+++ b/maps/southern_cross/southern_cross-10.dmm
@@ -241,6 +241,9 @@
 "be" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter)
 "bf" = (
@@ -278,7 +281,7 @@
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter)
 "bi" = (
-/obj/machinery/camera/network/exploration{
+/obj/machinery/camera/network/carrier{
 	c_tag = "WILD - Shelter First Floor";
 	dir = 8
 	},
@@ -466,6 +469,10 @@
 	},
 /turf/simulated/floor/water,
 /area/surface/outpost/wall/checkpoint)
+"el" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
 "er" = (
 /obj/effect/zone_divider,
 /obj/effect/zone_divider,
@@ -505,7 +512,7 @@
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
 "gE" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/vending/tool,
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
 "gV" = (
@@ -565,6 +572,17 @@
 /obj/effect/map_effect/perma_light/concentrated/incandescent,
 /turf/simulated/floor/water,
 /area/surface/outpost/wall/checkpoint)
+"mh" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 25
+	},
+/obj/item/device/floor_painter,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
 "mj" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -578,10 +596,7 @@
 /obj/structure/frame{
 	anchored = 1
 	},
-/obj/machinery/camera/network/substations{
-	c_tag = "WILD - Shelter Utility Room";
-	dir = 1
-	},
+/obj/item/device/geiger/wall/south,
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
 "mR" = (
@@ -626,6 +641,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/shelter)
+"qf" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/structure/closet/hydrant{
+	pixel_y = -32
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
 "qr" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
@@ -683,6 +705,10 @@
 /obj/structure/frame{
 	anchored = 1
 	},
+/obj/machinery/camera/network/carrier{
+	c_tag = "WILD - Shelter Utility Room";
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
 "uc" = (
@@ -708,7 +734,7 @@
 /turf/simulated/floor/outdoors/grass/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
 "xM" = (
-/obj/machinery/camera/network/exploration{
+/obj/machinery/camera/network/carrier{
 	c_tag = "WILD - Shelter First Floor Exterior";
 	dir = 1
 	},
@@ -718,12 +744,20 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
 "yv" = (
-/obj/machinery/camera/network/substations{
+/obj/machinery/camera/network/carrier{
 	c_tag = "WILD - Shelter Utility Exterior";
 	dir = 4
 	},
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
+"zb" = (
+/obj/structure/table/rack,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/rglass,
+/obj/fiftyspawner/rglass,
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
 "As" = (
 /turf/simulated/floor/wood,
 /area/surface/outside/river/svartan)
@@ -740,6 +774,17 @@
 	},
 /turf/simulated/floor/water/deep,
 /area/surface/outside/river/svartan)
+"AY" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/tool/crowbar/red,
+/obj/item/weapon/tool/crowbar/red,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/box/lights/mixed,
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
 "AZ" = (
 /obj/structure/simple_door/sifwood,
 /obj/machinery/door/blast/shutters{
@@ -748,6 +793,7 @@
 	layer = 3;
 	name = "Wilderness Shelter Shutters"
 	},
+/obj/structure/fans/tiny,
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
 "BF" = (
@@ -762,6 +808,25 @@
 	},
 /turf/simulated/wall/log_sif,
 /area/surface/outpost/shelter)
+"Gd" = (
+/obj/structure/table/rack,
+/obj/item/weapon/circuitboard/machine/rtg/advanced,
+/obj/item/weapon/circuitboard/machine/rtg/advanced,
+/obj/item/weapon/circuitboard/machine/rtg/advanced,
+/obj/item/stack/cable_coil,
+/obj/item/weapon/storage/belt/utility/full,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/rods,
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
+"Gw" = (
+/obj/structure/reagent_dispensers/fueltank/high,
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
 "IA" = (
 /obj/structure/curtain/medical{
 	name = "medical curtain"
@@ -778,10 +843,14 @@
 /turf/simulated/mineral/sif,
 /area/surface/outside/wilderness/normal)
 "Jk" = (
-/obj/item/device/geiger/wall/north,
-/obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/vending/engivend{
+	desc = "Spare tool vending for the Wilderness Shelter. What? Did you expect some witty description?";
+	name = "Wild Shelter-Vend";
+	products = list(/obj/item/device/geiger = 4, /obj/item/weapon/cell/high = 10, /obj/item/weapon/airlock_electronics = 10, /obj/item/weapon/module/power_control = 10, /obj/item/weapon/circuitboard/airalarm = 10, /obj/item/weapon/circuitboard/firealarm = 10, /obj/item/weapon/circuitboard/status_display = 2, /obj/item/weapon/circuitboard/ai_status_display = 2, /obj/item/weapon/circuitboard/newscaster = 2, /obj/item/weapon/circuitboard/holopad = 2, /obj/item/weapon/circuitboard/intercom = 4, /obj/item/weapon/circuitboard/security/telescreen/entertainment = 4, /obj/item/weapon/stock_parts/motor = 2, /obj/item/weapon/stock_parts/spring = 2, /obj/item/weapon/stock_parts/gear = 2, /obj/item/weapon/circuitboard/atm,/obj/item/weapon/circuitboard/guestpass,/obj/item/weapon/circuitboard/keycard_auth,/obj/item/weapon/circuitboard/geiger,/obj/item/weapon/circuitboard/photocopier,/obj/item/weapon/circuitboard/fax,/obj/item/weapon/circuitboard/request,/obj/item/weapon/circuitboard/microwave,/obj/item/weapon/circuitboard/washing,/obj/item/weapon/circuitboard/scanner_console,/obj/item/weapon/circuitboard/sleeper_console,/obj/item/weapon/circuitboard/body_scanner,/obj/item/weapon/circuitboard/medical_kiosk,/obj/item/weapon/circuitboard/sleeper,/obj/item/weapon/circuitboard/dna_analyzer);
+	req_access = null
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
@@ -806,8 +875,7 @@
 /area/surface/outside/river/svartan)
 "LI" = (
 /obj/structure/railing{
-	dir = 8;
-	icon_state = "railing0"
+	dir = 8
 	},
 /turf/simulated/floor/water,
 /area/surface/outside/river/svartan)
@@ -819,19 +887,9 @@
 /turf/simulated/floor/water/deep,
 /area/surface/outside/river/svartan)
 "Mk" = (
-/obj/structure/table/rack,
-/obj/item/weapon/circuitboard/machine/rtg/advanced,
-/obj/item/weapon/circuitboard/machine/rtg/advanced,
-/obj/item/weapon/circuitboard/machine/rtg/advanced,
-/obj/item/stack/cable_coil,
-/obj/item/weapon/storage/belt/utility/full,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/fiftyspawner/rods,
-/obj/fiftyspawner/rods,
-/turf/simulated/floor/plating,
-/area/surface/outpost/shelter/utilityroom)
+/obj/structure/simple_door/sifwood,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "No" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/water/deep/ocean,
@@ -873,6 +931,34 @@
 	},
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter)
+"Rr" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/stack/material/log/sif{
+	amount = 25;
+	icon_state = "sheet-log_3";
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/obj/item/stack/material/log/sif{
+	amount = 25;
+	icon_state = "sheet-log_3";
+	pixel_x = 5;
+	pixel_y = 2
+	},
+/obj/item/stack/tile/wood/sif{
+	amount = 60;
+	icon_state = "tile-sifwood_3"
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50;
+	icon_state = "sheet-wood_3";
+	pixel_y = 2
+	},
+/obj/item/weapon/chainsaw{
+	layer = 3.01
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
 "Sd" = (
 /obj/machinery/light{
 	dir = 8
@@ -888,6 +974,7 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/shelter)
 "SI" = (
@@ -901,9 +988,8 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/power/rtg/fake_gen{
-	desc = "A simple power generator, used in small outposts to reliably provide power for decades. This one seems to have been stripped of some parts, but is otherwise functional!... Enough...";
-	name = "Wilderness Shelter power generator";
-	power_gen = 4250
+	desc = "A simple power generator, used in small outposts to reliably provide power for decades.";
+	name = "Wilderness Shelter power generator"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
@@ -911,6 +997,22 @@
 /obj/effect/zone_divider,
 /turf/simulated/wall/wood,
 /area/surface/outside/path/wilderness)
+"Uj" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/device/radio/off{
+	pixel_y = 6
+	},
+/obj/item/device/radio/off{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off,
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
 "Wo" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -958,6 +1060,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/shelter)
+"Xn" = (
+/obj/structure/table/rack,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
 "XD" = (
 /turf/simulated/wall/solidrock,
 /area/surface/outside/wilderness/deep)
@@ -970,31 +1083,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/table/sifwooden_reinforced,
-/obj/item/stack/material/log/sif{
-	amount = 25;
-	icon_state = "sheet-log_3";
-	pixel_x = -5;
-	pixel_y = 2
-	},
-/obj/item/stack/material/log/sif{
-	amount = 25;
-	icon_state = "sheet-log_3";
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/obj/item/stack/tile/wood/sif{
-	amount = 60;
-	icon_state = "tile-sifwood_3"
-	},
-/obj/item/stack/material/wood/sif{
-	amount = 50;
-	icon_state = "sheet-wood_3";
-	pixel_y = 2
-	},
-/obj/item/weapon/chainsaw{
-	layer = 3.01
-	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
 "YL" = (
@@ -1003,6 +1091,30 @@
 "Za" = (
 /turf/simulated/mineral/sif,
 /area/surface/outside/wilderness/deep)
+"Zt" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/storage/belt/utility,
+/obj/item/weapon/storage/belt/utility,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
 "ZG" = (
 /obj/structure/showcase/sign{
 	desc = "This appears to be a sign warning people that the other side is extremely hazardous.";
@@ -43060,8 +43172,8 @@ Rc
 bi
 bv
 bv
-ba
 Mk
+ys
 ys
 ub
 aU
@@ -43319,9 +43431,9 @@ Dk
 IA
 td
 ba
-aU
-aU
-aU
+Gd
+ys
+Rr
 aU
 ab
 "}
@@ -43577,10 +43689,10 @@ ba
 OU
 SE
 ba
-ac
-ac
-ac
-ac
+Xn
+ys
+el
+aU
 ab
 "}
 (166,1,1) = {"
@@ -43835,10 +43947,10 @@ ba
 WE
 Jq
 ba
-ac
-ac
-ac
-ac
+zb
+ys
+Gw
+aU
 ab
 "}
 (167,1,1) = {"
@@ -44093,10 +44205,10 @@ ba
 es
 bs
 ba
-ac
-ac
-ac
-ac
+Uj
+ys
+qf
+aU
 ab
 "}
 (168,1,1) = {"
@@ -44351,10 +44463,10 @@ ba
 Wo
 qe
 ba
-ac
-ac
-ac
-ac
+mh
+AY
+Zt
+aU
 ab
 "}
 (169,1,1) = {"
@@ -44609,10 +44721,10 @@ ba
 ba
 ba
 ba
-ac
-ac
-ac
-ac
+aU
+aU
+aU
+aU
 ab
 "}
 (170,1,1) = {"

--- a/maps/southern_cross/southern_cross-12.dmm
+++ b/maps/southern_cross/southern_cross-12.dmm
@@ -67,7 +67,7 @@
 	layer = 4;
 	name = "Wilderness Shelter Shutters"
 	},
-/obj/structure/fans/tiny,
+/obj/machinery/atmospheric_field_generator/perma/underdoors,
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter/utilityroom)
 "cv" = (

--- a/maps/southern_cross/southern_cross-12.dmm
+++ b/maps/southern_cross/southern_cross-12.dmm
@@ -177,7 +177,7 @@
 /obj/structure/railing/grey{
 	dir = 8
 	},
-/obj/machinery/camera/network/exploration{
+/obj/machinery/camera/network/carrier{
 	c_tag = "WILD - Shelter Second Floor Exterior 3";
 	dir = 8
 	},
@@ -288,6 +288,9 @@
 /obj/structure/table/standard,
 /obj/fiftyspawner/steel,
 /obj/fiftyspawner/glass,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter/utilityroom)
 "io" = (
@@ -430,7 +433,7 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/machinery/camera/network/exploration{
+/obj/machinery/camera/network/carrier{
 	c_tag = "WILD - Shelter Second Floor Utilities"
 	},
 /turf/simulated/open/sif{
@@ -1043,7 +1046,7 @@
 "yJ" = (
 /obj/structure/table/sifwooden_reinforced,
 /obj/item/device/flashlight/lamp/green,
-/obj/machinery/camera/network/exploration{
+/obj/machinery/camera/network/carrier{
 	c_tag = "WILD - Shelter Crew Dorms";
 	dir = 4
 	},
@@ -1121,6 +1124,9 @@
 "Ai" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter)
 "Aj" = (
@@ -1182,6 +1188,12 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/wilderness/skylands)
+"Cc" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "Ci" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -1471,7 +1483,7 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/wilderness/skylands)
 "Kq" = (
-/obj/machinery/camera/network/exploration{
+/obj/machinery/camera/network/carrier{
 	c_tag = "WILD - Shelter Second Floor";
 	dir = 8
 	},
@@ -1868,8 +1880,7 @@
 /area/surface/outside/wilderness/skylands)
 "ST" = (
 /obj/effect/catwalk_plated,
-/obj/machinery/camera/network/exploration{
-	c_tag = "WILD - Shelter Second Floor Exterior 1";
+/obj/machinery/camera/network/carrier{
 	dir = 4
 	},
 /turf/simulated/floor/wood/sif,
@@ -2126,7 +2137,7 @@
 /obj/structure/railing/grey{
 	dir = 1
 	},
-/obj/machinery/camera/network/exploration{
+/obj/machinery/camera/network/carrier{
 	c_tag = "WILD - Shelter Second Floor Exterior 2";
 	dir = 1
 	},
@@ -42700,7 +42711,7 @@ qK
 lP
 Ii
 Se
-LU
+Cc
 GN
 bj
 aE

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -12599,8 +12599,8 @@
 /area/storage/emergency_storage/seconddeck/port_emergency)
 "aMP" = (
 /obj/structure/disposaloutlet{
-	pixel_y = -6;
-	launch_dist = 1
+	launch_dist = 1;
+	pixel_y = -6
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -55505,8 +55505,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/button/garbosystem{
-	pixel_y = 17;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 17
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/warehouse)
@@ -55992,7 +55992,7 @@
 	dir = 1;
 	name = "Hot Loop Waste Gas pressure regulator";
 	regulate_mode = 1;
-	target_pressure = 1500
+	target_pressure = 2500
 	},
 /turf/simulated/floor,
 /area/engineering/engine_waste)
@@ -67458,8 +67458,8 @@
 /area/hallway/secondary/entry/D3)
 "pOe" = (
 /obj/machinery/vending/loadout/uniform{
-	pixel_x = 24;
-	density = 0
+	density = 0;
+	pixel_x = 24
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/paleblue/bordercorner,

--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -9345,7 +9345,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/glass{
 	dir = 2;
-	req_one_access = list(5,17,43,67)
+	req_one_access = list(5,11,17,24,43,67)
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangerhall)
@@ -9849,7 +9849,7 @@
 /obj/machinery/door/airlock/glass_research{
 	name = "Briefing Room";
 	req_access = list();
-	req_one_access = list(5,17,43,67)
+	req_one_access = list(5,11,17,24,43,67)
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/debriefing)
@@ -9876,7 +9876,7 @@
 /obj/machinery/door/airlock/glass_research{
 	name = "Briefing Room";
 	req_access = list();
-	req_one_access = list(5,17,43,67)
+	req_one_access = list(5,11,17,24,43,67)
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/debriefing)
@@ -9967,7 +9967,7 @@
 /area/expoutpost/hangartwo)
 "zd" = (
 /obj/machinery/door/airlock/maintenance{
-	req_one_access = list(5,17,43,67)
+	req_one_access = list(5,11,17,24,43,67)
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
@@ -10180,7 +10180,7 @@
 /area/expoutpost/gateway)
 "zx" = (
 /obj/machinery/door/airlock/maintenance{
-	req_one_access = list(5,43,67)
+	req_one_access = list(5,11,17,24,43,67)
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
@@ -11699,7 +11699,7 @@
 	locked = 1;
 	name = "UNDER CONSTRUCTION";
 	req_access = list();
-	req_one_access = list(5,43,67)
+	req_one_access = list(5,11,17,24,43,67)
 	},
 /obj/item/tape/engineering,
 /turf/simulated/floor/plating,
@@ -12104,7 +12104,7 @@
 /obj/machinery/door/airlock/glass_research{
 	name = "Briefing Room";
 	req_access = list();
-	req_one_access = list(5,17,43,67)
+	req_one_access = list(5,11,17,24,43,67)
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/shuttle)
@@ -12517,7 +12517,7 @@
 	icon_state = "door_locked";
 	locked = 1;
 	name = "UNDER CONTSTRUCTION";
-	req_one_access = list(5,43,67)
+	req_one_access = list(5,11,17,24,43,67)
 	},
 /obj/item/tape/engineering,
 /obj/machinery/door/firedoor/border_only,
@@ -15498,7 +15498,7 @@
 /obj/machinery/door/airlock/glass_research{
 	name = "Expedition Shuttle";
 	req_access = list();
-	req_one_access = list(5,17,43,67)
+	req_one_access = list(5,11,17,24,43,67)
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/structure/disposalpipe/segment{
@@ -15671,7 +15671,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	req_one_access = list(5,43,67)
+	req_one_access = list(5,11,17,24,43,67)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/expoutpost/atmospherics)


### PR DESCRIPTION
Z1
Fixed lights.
Fixed a wrong color sofa.
Fixed missing access on an Airlock.
Nonan left a present in a secluded area! His FAVORITE plant!

Z2
Adjusted target pressure on Waste Loop to a more universal value. It still stays stuck closed at roundstart.

Z7
Fixed Engineering/Atmos not having access to the Explo carrier to fix breaches.

Z10 + 12
Overhauled wilderness shelter again.