### PR TITLE
Fixes access to belly sprite settings on 1-belly mobs

### DIFF
--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -222,7 +222,7 @@
 			"undergarment_chosen" = selected.undergarment_chosen,
 			"undergarment_if_none" = selected.undergarment_if_none || "None",
 			"undergarment_color" = selected.undergarment_color,
-			"belly_sprite_option_shown" = LAZYLEN(host.vore_icon_bellies) > 1 ? TRUE : FALSE,
+			"belly_sprite_option_shown" = LAZYLEN(host.vore_icon_bellies) >= 1 ? TRUE : FALSE,
 			"tail_option_shown" = istype(host, /mob/living/carbon/human),
 			"tail_to_change_to" = selected.tail_to_change_to,
 			"tail_colouration" = selected.tail_colouration,


### PR DESCRIPTION
While I do understand the original intention to remove unnecessary clutter from vorepanel, there was one little oversight that kinda broke some things.

Trying to change the setting on an existing vorgan setup while playing a 1-belly simplemob was made completely impossible, which kind of became a problem when that vorgan setup was loaded from a character slot using the taur belly option (nonfunctional for the mob) and being completely unable to change that to regular stomach setting that would work for the mob.