### PR TITLE
Fixes proteans being immune to duffle chonk

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -135,6 +135,9 @@
 	// Loop through some slots, and add up their slowdowns.
 	// Includes slots which can provide armor, the back slot, and suit storage.
 	for(var/obj/item/I in list(wear_suit, w_uniform, back, gloves, head, s_store))
+		if(istype(I,/obj/item/weapon/rig)) //CHOMPAdd
+			for(var/obj/item/II in I.contents)
+				. += II.slowdown
 		. += I.slowdown
 
 	// Hands are also included, to make the 'take off your armor instantly and carry it with you to go faster' trick no longer viable.


### PR DESCRIPTION
Probably wouldn't have even noticed if it wasn't for some gamer deciding to flex this exploit with the double-duffle-slowdown taur saddlebags as non-taur of all things instead of just going with a regular duffle of same capacity.

Also why the f do the saddlebags even have 2x duffle slowdown in the first place? that's messed up.