### PR TITLE
Alien critter rebranding

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
@@ -8,6 +8,7 @@
 /datum/species/hi_zoxxen //zorrens get wierd chemistry because of their past of expirementing on themselves. Check the cataloguer for deathclaws
 	chem_strength_heal =    1.3
 	chemOD_threshold =		0.5
+	chemOD_mod =		1.3
 	brute_mod = 1.1
 	burn_mod = 0.9
 

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
@@ -1,0 +1,50 @@
+//There is already a station file, but feels wrong to put zaddat balancing changes with the restriction file, and feels wrong to lump them in with a modular station_vr so hello station_ch file
+
+/datum/species/zaddat
+	toxins_mod =    0.5 //toxins rarely come into play, and zaddat just has negatives. Along with their parasite letting them survive in their polluted planet, this seems reasonable.
+
+//So both of this are based off Fennec foxes I belivive. Those are desert critters, giving them more warm focused levels. And for variety giving them minor brute weakness and minor burn resistant
+//I also want to make a dig because fennec foxes actually make burrows and such, but I can't figure out how to do it in a way that is both flavorful but not abuseable
+/datum/species/hi_zoxxen //zorrens get wierd chemistry because of their past of expirementing on themselves. Check the cataloguer for deathclaws
+	chem_strength_heal =    1.5
+	chemOD_threshold =		0.5
+	brute_mod = 1.1
+	burn_mod = 0.9
+
+	cold_level_1 = 270 //Default 260 - Lower is better
+	cold_level_2 = 210 //Default 200
+	cold_level_3 = 120 //Default 120
+
+	breath_cold_level_1 = 250	//Default 240 - Lower is better
+	breath_cold_level_2 = 190	//Default 180
+	breath_cold_level_3 = 100	//Default 100
+
+	heat_level_1 = 400 //Default 360 - Higher is better
+	heat_level_2 = 460 //Default 400
+	heat_level_3 = 1080 //Default 1000
+
+	breath_heat_level_1 = 430	//Default 380 - Higher is better
+	breath_heat_level_2 = 510	//Default 450
+	breath_heat_level_3 = 1200	//Default 1250
+
+/datum/species/fl_zorren
+	item_slowdown_mod = 1.2
+	slowdown = 1.2
+	brute_mod = 1.1
+	burn_mod = 0.9
+
+	cold_level_1 = 270 //Default 260 - Lower is better
+	cold_level_2 = 210 //Default 200
+	cold_level_3 = 120 //Default 120
+
+	breath_cold_level_1 = 250	//Default 240 - Lower is better
+	breath_cold_level_2 = 190	//Default 180
+	breath_cold_level_3 = 100	//Default 100
+
+	heat_level_1 = 400 //Default 360 - Higher is better
+	heat_level_2 = 460 //Default 400
+	heat_level_3 = 1080 //Default 1000
+
+	breath_heat_level_1 = 430	//Default 380 - Higher is better
+	breath_heat_level_2 = 510	//Default 450
+	breath_heat_level_3 = 1200	//Default 1250

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
@@ -6,9 +6,8 @@
 //So both of this are based off Fennec foxes I belivive. Those are desert critters, giving them more warm focused levels. And for variety giving them minor brute weakness and minor burn resistant
 //I also want to make a dig because fennec foxes actually make burrows and such, but I can't figure out how to do it in a way that is both flavorful but not abuseable
 /datum/species/hi_zoxxen //zorrens get wierd chemistry because of their past of expirementing on themselves. Check the cataloguer for deathclaws
-	chem_strength_heal =    1.3
-	chemOD_threshold =		0.5
-	chemOD_mod =		2
+	chemOD_threshold =		0.75
+	radiation_mod = 0.5
 	brute_mod = 1.1
 	burn_mod = 0.9
 

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
@@ -8,7 +8,7 @@
 /datum/species/hi_zoxxen //zorrens get wierd chemistry because of their past of expirementing on themselves. Check the cataloguer for deathclaws
 	chem_strength_heal =    1.3
 	chemOD_threshold =		0.5
-	chemOD_mod =		1.3
+	chemOD_mod =		2
 	brute_mod = 1.1
 	burn_mod = 0.9
 
@@ -30,7 +30,7 @@
 
 /datum/species/fl_zorren
 	item_slowdown_mod = 1.2
-	slowdown = 1.2
+	slowdown = -0.2
 	brute_mod = 1.1
 	burn_mod = 0.9
 

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
@@ -6,7 +6,7 @@
 //So both of this are based off Fennec foxes I belivive. Those are desert critters, giving them more warm focused levels. And for variety giving them minor brute weakness and minor burn resistant
 //I also want to make a dig because fennec foxes actually make burrows and such, but I can't figure out how to do it in a way that is both flavorful but not abuseable
 /datum/species/hi_zoxxen //zorrens get wierd chemistry because of their past of expirementing on themselves. Check the cataloguer for deathclaws
-	chem_strength_heal =    1.5
+	chem_strength_heal =    1.3
 	chemOD_threshold =		0.5
 	brute_mod = 1.1
 	burn_mod = 0.9

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4624,6 +4624,7 @@
 #include "modular_chomp\code\modules\mob\living\carbon\human\species\outsider\vox.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\human\species\station\prommie_blob.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\human\species\station\station.dm"
+#include "modular_chomp\code\modules\mob\living\carbon\human\species\station\station_ch.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\human\species\station\station_special_ch.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\human\species\station\teshari.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\human\species\station\protean\_protean_defines.dm"


### PR DESCRIPTION
Alright, so I felt like zaddats are pain and suffering. Zorren and Fennecs had no diffrence from the base.
Here is zaddat's old stats
/datum/species/zaddat
Zaddat
brute_mod = 1.15
burn_mod =  1.15
toxins_mod = 1.5
flash_mod = 2
flash_burn = 15
metabolic_rate = 0.7
gluttonous = 1
minimum_breath_pressure = 20
hazard_high_pressure = HAZARD_HIGH_PRESSURE + 500  // Dangerously high pressure.
warning_high_pressure = WARNING_HIGH_PRESSURE + 500 // High pressure warning.
warning_low_pressure = 300   // Low pressure warning.
hazard_low_pressure = 220     // Dangerously low pressure.
safe_pressure = 400
poison_type = "nitrogen"s

The buff?
toxins_mod =    0.5

That's it. Simple but makes the rare damage less effective. Along with it playing in with the symbiotie keeping their species alive on their polluted planet.

Now onto zorren/fennec. Both share some universal changes, but others aren't.
Universal
-Has a 90% burn mod, at the cost of a 110% brute mod.
-They are now worst off at dealing with cold, but a bit better with warmth. Not as much as lizards. The fennec foxes are desert critters.

Fennec
-120% item slowdown
-120% speed

Zorren
-50% OD rate (ODs at half the normal amount.)
-130% chem heal
-130% OD damage

And the zorren one is very strange. Going to put some math here, and if folks think that is to strong, I'll gladlly change it.
Bicard Heals = 4 * chem modifer * removed amount
Zorren Heal = 4 * 1.3 * 15 = 78
Normal Heal (Zorren amount) = 4 * 1 * 15 = 60
Normal heal (Normal amount) = 4 * 1 * 30 = 120
Zorren Heal (Mini-maxing) = 156

Tricord = 1.5 * chem mod * removed amount
ZH = 1.5 * 1.3 * 60 = 117
NH(ZA) = 1.5 * 1 * 60 = 90
NH(NA) = 1.5 * 1 * 120 = 180
ZH(MM)=234

Side note, how is tricord not more used?
Also as a reminder, not all chems are actually affected by the chem heal thing, or some things are affected negativly.
Example here is dylvo
M.adjustToxLoss(-4 * removed * chem_effective)
and here is a downside for a chem
M.adjustToxLoss(10 * removed * chem_effective)
And another downside although this one may be benfitical?
M.eye_blurry = min(M.eye_blurry + 10, 250 * chem_effective)

osteodaxon (Bone meds) don't seem to mess with it, same with myelamine (blood clot) but I may be missing things. I am sleepy, but here is all the information that is relevatiant.