### PR TITLE
Caps Downside of Biofuel Processor Traits

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -110,7 +110,7 @@
 
 			// Also recharge their internal battery.
 			if(H.isSynthetic() && H.nutrition < 500) //VOREStation Edit
-				H.nutrition = min(H.nutrition+(10*(1-H.species.synthetic_food_coeff)), 500) //VOREStation Edit
+				H.nutrition = min(H.nutrition+(10*(1-max(H.species.synthetic_food_coeff, 0.9))), 500) //CHOMPEdit Caps downside at 90% inefficiency
 				cell.use(7000/450*10)
 
 			// And clear up radiation


### PR DESCRIPTION
If species.synthetic_food_coeff is = 1, then charging is efficiency is zero while still draining power. Likewise values greater than 1 will result in power LOSS while charging. This fixes both issues.

Minimum charge efficiency is now 10%.