### PR TITLE
Add inshoe steppies

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -108,7 +108,7 @@
 			if(H.shoes)
 				var/obj/item/clothing/shoes/S = H.shoes
 				if(istype(S))
-					S.handle_movement(src,(H.m_intent == "run" ? 1 : 0))
+					S.handle_movement(src,(H.m_intent == "run" ? 1 : 0), H) // CHOMPEdit handle_movement now needs to know who is moving, for inshoe steppies
 					if(S.track_blood && S.blood_DNA)
 						bloodDNA = S.blood_DNA
 						bloodcolor=S.blood_color

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -704,15 +704,19 @@
 	update_icon()
 	return ..()
 
-/obj/item/clothing/shoes/proc/handle_movement(var/turf/walking, var/running)
-	if(prob(1) && !recent_squish) //VOREStation edit begin
+// CHOMPEdit Begin - tweaking handle_movement for inshoes steppies
+/obj/item/clothing/shoes/proc/handle_movement(var/turf/walking, var/running, var/mob/living/carbon/human/pred)
+	if(!recent_squish && istype(pred))
 		recent_squish = 1
-		spawn(100)
+		spawn(40) // Cooldown reduced from 100 to 40. Faster, but not that spammy
 			recent_squish = 0
 		for(var/mob/living/M in contents)
-			var/emote = pick(inside_emotes)
-			to_chat(M,emote) //VOREStation edit end
-	return
+			if(pred.step_mechanics_pref && M.step_mechanics_pref)
+				src.handle_inshoe_stepping(pred, M)
+			else if (prob(1)) // Same old inshoe mechanics
+				var/emote = pick(inside_emotes)
+				to_chat(M,emote)
+	return //CHOMPEDIT End
 
 /obj/item/clothing/shoes/update_clothing_icon()
 	if (ismob(src.loc))

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -574,6 +574,11 @@
 		G.can_revert = TRUE
 		qdel(G)
 		log_and_message_admins("[key_name(src)] used the OOC escape button to revert back from being petrified.")
+	//CHOMPEdit - In-shoe OOC escape. Checking voices as precaution if something akin to obj TF or possession happens
+	else if(!istype(src, /mob/living/voice) && istype(src.loc, /obj/item/clothing/shoes))
+		var/obj/item/clothing/shoes/S = src.loc
+		forceMove(get_turf(src))
+		log_and_message_admins("[key_name(src)] used the OOC escape button to escape from of a pair of shoes. [ADMIN_FLW(src)] - Shoes [ADMIN_VV(S)]")
 	//Don't appear to be in a vore situation
 	else
 		to_chat(src,"<span class='alert'>You aren't inside anyone, though, is the thing.</span>")

--- a/modular_chomp/code/modules/clothing/clothing.dm
+++ b/modular_chomp/code/modules/clothing/clothing.dm
@@ -82,3 +82,76 @@
 /obj/item/clothing/under/equipped(var/mob/user, var/slot)
 	. = ..()
 	handle_digitigrade(user)
+
+//In shoe steppies!
+/obj/item/clothing/shoes/proc/handle_inshoe_stepping(var/mob/living/carbon/human/pred, var/mob/living/carbon/human/prey)
+	if(!istype(pred)) return //Sorry, inshoe steppies only for carbon/human/ for now. Based on the regular stepping mechanics
+	if(!istype(prey)) return
+	if(!pred.canmove || pred.buckled) return //We can't be stepping on anyone if buckled or incapable of moving
+	if(pred in buckled_mobs) return
+	if(pred.flying) return //If we're flying, can't really step.
+
+	// I kept interactions very similar to normal steppies, and removed some attack logs unless harm intent:
+	// I_HELP: No painful description, messages only sent to prey. Similar to inshoe steppies from before.
+	// I_DISARM: Painful yet harmless descriptions, weaken on walk. Attack logs on weaken.
+	// I_GRAB: Grabby/Squishing descriptions, weaken on walk. Attack logs on weaken.
+	// I_HARM: Rand .5-1.5 multiplied by .25 min or 1.75 max, multiplied by 3.5 on walk. Ranges from .125 min to 9.1875 max damage to each limb
+	var/message_pred = null
+	var/message_prey = null
+
+	switch(pred.a_intent)
+		if(I_HELP)
+			if(pred.m_intent == "run")
+				message_prey = "[pred] moves, pressing down on you within their [name] with each step."
+			else
+				message_prey = "As [pred] walks, their foot presses you tightly against the sole of their [name]!"
+
+		if(I_DISARM)
+			if(pred.m_intent == "run")
+				message_pred = "You step on [prey], squishing and pinning them within your [name]!"
+				message_prey = "[pred] steps on you, squishing and pinning you within their [name]!"
+			else
+				message_pred = "You firmly push your foot down on [prey], painfully but harmlessly pinning them to the sole of your [name]!"
+				message_prey = "[pred] firmly pushes their foot down on you, painfully but harmlessly pinning you to the sole of their [name]!"
+				prey.Weaken(5) // For flavour, only noticed prey if tossed out of shoe
+				add_attack_logs(pred, prey, "Pinned inshoe (walk, weaken(5))")
+
+		if(I_GRAB)
+			if(pred.m_intent == "run")
+				message_pred = "You step down onto [prey], squishing and trapping them inbetween your toes!"
+				message_prey = "[pred] steps down on you, squishing and trapping you inbetween their toes!"
+			else
+				message_pred = "You pin [prey] down against the sole of your [name] with your foot, your toes curling up around their body, tightly trapping them inbetween them!"
+				message_prey = "[pred] pins you down against the sole of their [name] with their foot, their toes curling up around your body, tighly trapping you inbetween them!"
+				prey.Weaken(5) // For flavour, only noticed prey if tossed out of shoe
+				add_attack_logs(pred, prey, "Grabbed inshoe (walk, weaken(5))")
+
+		if(I_HURT)
+			var/size_damage_multiplier = pred.size_multiplier - prey.size_multiplier
+
+			if(size_damage_multiplier < 0) // In case of odd situations such as wearing a shoe containing someone bigger than you.
+				size_damage_multiplier = 0
+
+			//Assuming regular micro pickup sizes outside dorms, size_damage multiplier should range from .25 to 1.75... right?
+			var/damage = (rand(5, 15) * size_damage_multiplier) / 10 // This will sting, but not kill unless pred walks. Will range from .125 to 2.625 damage, randomly, to each limb
+
+			if(pred.m_intent == "run")
+				message_pred = "You carelessly step down onto [prey], crushing them within your [name]!"
+				message_prey = "[pred] steps carelessly on your body, crushing you within their [name]!"
+				add_attack_logs(pred, prey, "Crushed underfoot (run, about [damage] damage per limb)")
+			else
+				message_pred = "You methodically place your foot down upon [prey]'s body, applying pressure, crushing them against the sole of your [name]!"
+				message_prey = "[pred] methodically places their foot upon your body, applying pressure, crushing you against the sole of their [name]!"
+				damage *= 3.5 //Walking damage multiplier
+				add_attack_logs(pred, prey, "Crushed underfoot (walk, about [damage] damage per limb)")
+
+			for(var/obj/item/organ/external/I in prey.organs)
+				// Running Total: 1.50 damage min, 28.875 damage max, depending on size & RNG.
+				// Walking Total: 5.25 damage min, 101.0625 damage max, depending on size & RNG. Ouch.
+				I.take_damage(damage, 0)
+
+	if(message_pred != null)
+		to_chat(pred, "<span class='warning'>[message_pred]</span>")
+	to_chat(prey, "<span class='warning'>[message_prey]</span>")
+
+	return

--- a/modular_chomp/code/modules/player_tips/player_tips_list.dm
+++ b/modular_chomp/code/modules/player_tips/player_tips_list.dm
@@ -49,7 +49,9 @@ When editing the list, please try and keep similar probabilities near each other
 				prob(10); "[info] Not every hostile NPC you encounter while mining or exploring need to be defeated. Sometimes, it's better to avoid or run away from them.",
 				prob(1); "[info] Stay robust, my friends.",
 				prob(35); "[info] You can insert your I.D into your PDA. This frees up your belt from having to carry your PDA. Furthermore, by clicking and dragging the PDA to game screen, you can use it without holding it!",
-				prob(35); "[info] Your vore-bellies have multiple add-ons! Muffling is excellent to ensure your prey does not accidentally inform everyone about their predicament, and jam suit sensors is a great courtesy to avoid medical being worried about your prey!"
+				prob(35); "[info] Your vore-bellies have multiple add-ons! Muffling is excellent to ensure your prey does not accidentally inform everyone about their predicament, and jam suit sensors is a great courtesy to avoid medical being worried about your prey!",
+				prob(35); "[info] Remember to check your vore panel preferences! There you can find toggles for things other than just vore(tm), such as stepping mechanics and spontaneous transformation.",
+				prob(25); "[info] If you would like to toggle stepping mechanics, head to the vore panel and click on personal preferences! Disabling stepping mechanics will disable stepping descriptions and will prevent your character from taking damage if a bigger character walks over yours with harm intent. Your character will still be stunned, however."
 				)
 
 		if("roleplay")


### PR DESCRIPTION
Based on one of the `ss13-suggestions-and-feedback-forum` posts, I attempted to bring the _steppies_ mechanics to in-shoe interactions. These will also only be enabled if both prey and pred have stepping mechanics enabled in the vore panel, else it will revert to old in-shoe messages, with its awful `prob(1)`.

All damage and effects are based on https://github.com/CHOMPStation2/CHOMPStation2/blob/master/code/modules/vore/resizing/resize_vr.dm#L260, but with an increased weaken timer to account for the time needed to take your boots off and shake the prey from shoes.

Additionally, I added a few tips to remind people that the vore panel has preferences for the steppies too!

Finally, this is my first PR with additional features! Let me know if I missed anything.

Here is how it looks: 
- **Recording**: [OneDrive cloud link](https://1drv.ms/v/s!AkF92os5E5O3kKEZ3xRrf-GX4Xy8bg?e=1y1tal)
- **Pred Side**: 
![image](https://github.com/CHOMPStation2/CHOMPStation2/assets/38367315/128c3d13-70c4-4b3f-b254-5c94538eb683)
![image](https://github.com/CHOMPStation2/CHOMPStation2/assets/38367315/3aa7cdca-d0fa-4714-849b-e98f66811c3d)

- **Prey Side**: 
![image](https://github.com/CHOMPStation2/CHOMPStation2/assets/38367315/6a1c3453-b722-47ac-933f-23e192e4f360)






