### PR TITLE
Fixes invisible circular saws

### DIFF
--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -244,7 +244,7 @@
 	toolspeed = 0.5
 
 /obj/item/weapon/surgical/circular_saw/cyborg
-	icon_state = "cyborg_saw"
+	icon_state = "saw"//CHOMPedit, there isnt even a sprite for it so using normal sprite
 	toolspeed = 0.5
 
 /obj/item/weapon/surgical/bonegel/cyborg

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -286,6 +286,7 @@
 
 /obj/item/weapon/surgical/circular_saw/alien
 	icon = 'icons/obj/abductor.dmi'
+	icon_state = "saw3"//chompedit
 	toolspeed = 0.25
 
 /obj/item/weapon/surgical/FixOVein/alien


### PR DESCRIPTION
I didn't wanna touch the DMI so I did a dirty code edit
Closes #6377 

Oh yeah, and the cyborg saw does not even have a sprite for the saw and is a error, so I made it the default saw sprite as a placeholder.  