### PR TITLE
ip whitelists for those in the same home

### DIFF
--- a/code/controllers/configuration_ch.dm
+++ b/code/controllers/configuration_ch.dm
@@ -17,6 +17,8 @@
 	var/discord_ahelps_disabled = 0		//Turn this off if you don't want the TGS bot sending you messages whenever an ahelp ticket is created.
 	var/discord_ahelps_all = 0			//Turn this on if you want all admin-PMs to go to be sent to discord, and not only the first message of a ticket.
 
+	var/list/ip_whitelist = list()
+
 /hook/startup/proc/read_ch_config()
 	var/list/Lines = file2list("config/config.txt")
 	for(var/t in Lines)
@@ -62,4 +64,20 @@
 				config.nodebot_location = value
 			if ("ahelp_channel_tag")
 				config.ahelp_channel_tag = value
+
+	var/list/ip_whitelist_lines = file2list("config/ip_whitelist.txt")
+	var/increment = 1
+	for(var/t in ip_whitelist_lines)
+		if (!t) continue
+		t = trim(t)
+		if (length(t) == 0)
+			continue
+		else if (copytext(t, 1, 2) == "#")
+			continue
+		var/ip_address = splittext(t, ",")
+		for (var/name in ip_address)
+			config.ip_whitelist[name] = increment
+		increment += 1
+
+
 	return 1

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -9,6 +9,10 @@
 			if(M == src)	continue
 			if( M.key && (M.key != key) )
 				var/matches
+				//CHOMPEDIT - IP exemptions for those who are known to live together
+				if (config.ip_whitelist[key] && config.ip_whitelist[key] == config.ip_whitelist[M.key])
+					continue
+				//CHOMPEDIT end
 				if( (M.lastKnownIP == client.address) )
 					matches += "IP ([client.address])"
 				if( (client.connection != "web") && (M.computer_id == client.computer_id) )

--- a/config/example/ip_whitelist.txt
+++ b/config/example/ip_whitelist.txt
@@ -1,0 +1,4 @@
+# this file is for exempting certain groups of keys from recieving the "you're already in the game go away" message when they connect with the same IP (ie, living together)
+# each group should be on the same line, separated by a comma (and nothing else), and each group should be on a separate line
+# EXAMPLE (remove the # and it would be valid):
+#somekey1,somekey2,somekey3


### PR DESCRIPTION
creates a config file for those who live in the same home and don't want to have the tgui alert coming up every time one of them signs in