### PR TITLE
Adds Tracy integration

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -1,4 +1,6 @@
 #define RECOMMENDED_VERSION 513
+
+// CHOMPedit Start - Tracy
 /proc/prof_init()
 	var/lib
 
@@ -9,6 +11,7 @@
 
 	var/init = call(lib, "init")()
 	if("0" != init) CRASH("[lib] init error: [init]")
+// CHOMPedit End
 
 /world/New()
 	//prof_init() // CHOMPedit - Uncomment to enable Tracy. Requires https://github.com/mafemergency/byond-tracy/

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -1,5 +1,17 @@
 #define RECOMMENDED_VERSION 513
+/proc/prof_init()
+	var/lib
+
+	switch(world.system_type)
+		if(MS_WINDOWS) lib = "prof.dll"
+		if(UNIX) lib = "libprof.so"
+		else CRASH("unsupported platform")
+
+	var/init = call(lib, "init")()
+	if("0" != init) CRASH("[lib] init error: [init]")
+
 /world/New()
+	//prof_init() // CHOMPedit - Uncomment to enable Tracy. Requires https://github.com/mafemergency/byond-tracy/
 	world_startup_time = world.timeofday
 	rollover_safety_date = world.realtime - world.timeofday // 00:00 today (ish, since floating point error with world.realtime) of today
 	to_world_log("Map Loading Complete")


### PR DESCRIPTION
This adds the integration of a pretty neat profiler to nicely measure the procs.

To enable it, the marked line has to be uncommented and the prof.dll/libprof.so file to be compiled and placed next to the vorestation.dme

How to compile the dll/so and where to get Tracy can be found in the instructions here:
https://github.com/mafemergency/byond-tracy/

Example Output:
![image](https://github.com/CHOMPStation2/CHOMPStation2/assets/12716288/1f58c8ab-05f7-4397-8b53-d79793b3ccfb)
![image](https://github.com/CHOMPStation2/CHOMPStation2/assets/12716288/30766536-da2c-42f1-b92e-51f47e50b2a3)