### PR TITLE
Makes ticket stuff less overprotective

### DIFF
--- a/modular_chomp/code/modules/tickets/tickets.dm
+++ b/modular_chomp/code/modules/tickets/tickets.dm
@@ -141,10 +141,6 @@ GLOBAL_DATUM_INIT(tickets, /datum/tickets, new)
 
 //Get a ticket given a ckey
 /datum/tickets/proc/CKey2ActiveTicket(ckey)
-	if(!usr?.client.holder || !has_mentor_powers(usr?.client))
-		message_admins("[usr] has attempted to look up a ticket with CKEY [ckey] without sufficent privileges.")
-		return
-
 	for(var/datum/ticket/T as anything in active_tickets)
 		if(T.initiator_ckey == ckey)
 			return T


### PR DESCRIPTION
I have checked this proc and its fine to remove these lines. I have added these as an additional precaution but they seemed to be a little too "verbose" in the logs which I haven't caught before.

But this at least looks like it would fix another tiny rather unnoticeable bug so two wins in one?
This would basically revert this proc to its older version.