### PR TITLE
Free Neutral Hard Feet Trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
@@ -41,6 +41,12 @@
 	var_changes = list("metabolic_rate" = 2, "hunger_factor" = 1.6, "metabolism" = 0.012)	//2x metabolism speed, 32x hunger speed
 	custom_only = FALSE
 
+/datum/trait/neutral/hardfeet
+	name = "Hard Feet"	// Free protection 4 ur pawbs
+	desc = "Makes your nice clawed, scaled, hooved, armored, or otherwise just awfully calloused feet immune to glass shards."
+	cost = 0 //CHOMP Edit
+	var_changes = list("flags" = NO_MINOR_CUT) //Checked the flag is only used by shard stepping.
+
 /datum/trait/neutral/big_mouth
 	name = "Fast Eater, Minor"
 	desc = "It takes half as many bites to finish food as it does for most people."

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive.dm
@@ -7,7 +7,7 @@
 	cost = 4 //CHOMPEdit
 	var_changes = list("slowdown" = -0.5)
 	excludes = list(/datum/trait/positive/hardy,/datum/trait/positive/hardy_extreme,/datum/trait/positive/hardy_plus,/datum/trait/positive/speed_fast_minor)
-	
+
 
 /datum/trait/positive/hardy
 	name = "Hardy"
@@ -45,7 +45,7 @@
 	desc = "Decreases your susceptibility to electric shocks by 50%." //CHOMP Edit - GRAMMAR PLS.
 	cost = 3 //Let us not forget this effects tasers!
 	var_changes = list("siemens_coefficient" = 0.5) //CHOMP Edit
-	
+
 /*   //Chompedit, moving to Positive_ch.dm so it wont be messed with from upstream
 /datum/trait/positive/darksight
 	name = "Darksight"
@@ -58,7 +58,7 @@
 	desc = "Allows you to see in the dark for almost the whole screen and 20% more susceptible to flashes." //CHOMP Edit
 	cost = 2
 	var_changes = list("darksight" = 6)  //CHOMP Edit
-*/ 
+*/
 /datum/trait/positive/melee_attack
 	name = "Special Attack: Sharp Melee" // Trait Organization for easier browsing. TODO: Proper categorization of 'health/ability/resist/etc'
 	desc = "Provides sharp melee attacks that do slightly more damage."
@@ -102,7 +102,7 @@
 	cost = 2 //CHOMP Edit
 	var_changes = list("burn_mod" = 0.8) //CHOMP Edit
 	//excludes = list(/datum/trait/positive/minor_brute_resist,/datum/trait/positive/brute_resist) //CHOMP disable, this is already handled in positive_ch.dm
-	
+
 
 
 /datum/trait/positive/photoresistant
@@ -130,12 +130,13 @@
 	var_changes = list("soft_landing" = TRUE)
 	custom_only = FALSE
 
+/*
 /datum/trait/positive/hardfeet
 	name = "Hard Feet"
 	desc = "Makes your nice clawed, scaled, hooved, armored, or otherwise just awfully calloused feet immune to glass shards."
 	cost = 1 //CHOMP Edit
 	var_changes = list("flags" = NO_MINOR_CUT) //Checked the flag is only used by shard stepping.
-
+*/
 
 // CHOMPEdit: This has been removed for two years, since Jan 2020, pending "review". Uncommenting as per tankiness increase PR.
 /datum/trait/positive/antiseptic_saliva


### PR DESCRIPTION
Make your paws hard and feet harder. Or... wait... no that's not it.

It's on the tin.

- Comments out positive Hard Feet
- Adds neutral Hard Feet

> Requested by Bib, when you can legit just wear shoes, hard feet is kinda... meh. And the one species that does go shoe-less for mechanics has built-in hard feet. So all this does is force folk to wear shoes if they don't wanna put a point into the trait. I don't see anything wrong with wanting to FashionStation13 a bit and let people show off them paws. *nod