### PR TITLE
Fixes non-human center offset toggle

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1040,6 +1040,8 @@
 	var/desired_scale_y = size_multiplier * icon_scale_y //VOREStation edit
 
 	// Now for the regular stuff.
+	if(offset_override) //CHOMPEdit
+		center_offset = 0 //CHOMPEdit
 	var/matrix/M = matrix()
 	M.Scale(desired_scale_x, desired_scale_y)
 	M.Translate(center_offset * desired_scale_x, (vis_height/2)*(desired_scale_y-1)) //CHOMPEdit


### PR DESCRIPTION
Should fix the preferences tab "switch center offset" toggle not working for non-human mobs. Didn't test because lazy and just a simple 2-line paste oversight anyway.