### PR TITLE
Public Circuitry MAP CHANGE

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -17990,11 +17990,12 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "bdR" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/structure/disposalpipe/segment,
+/obj/random/tech_supply,
+/obj/item/weapon/storage/bag/circuits/basic,
+/obj/random/technology_scanner,
+/obj/random/tech_supply,
+/obj/structure/table/steel,
 /turf/simulated/floor,
 /area/maintenance/cargo)
 "bdS" = (
@@ -22747,6 +22748,16 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/random/maintenance/medical,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/maintenance/medical,
+/obj/random/toolbox,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/random/powercell,
+/obj/structure/closet/crate,
 /turf/simulated/floor,
 /area/maintenance/cargo)
 "bsb" = (
@@ -23782,6 +23793,9 @@
 "bvn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
 /turf/simulated/floor,
 /area/maintenance/cargo)
@@ -67538,6 +67552,7 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /obj/random/cash,
+/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
 /turf/simulated/floor,
 /area/maintenance/cargo)
 "pMH" = (
@@ -77282,14 +77297,13 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/seconddeck/starboard)
 "vAY" = (
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/powercell,
-/obj/random/toolbox,
+/obj/random/contraband,
+/obj/random/contraband,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/tool,
 /obj/structure/closet/crate,
-/obj/random/maintenance/medical,
-/obj/random/maintenance/medical,
 /turf/simulated/floor,
 /area/maintenance/research_medical)
 "vBP" = (
@@ -78732,14 +78746,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/starboard)
-"wrn" = (
-/obj/structure/table/steel,
-/obj/random/tech_supply,
-/obj/random/technology_scanner,
-/obj/item/weapon/storage/bag/circuits/basic,
-/obj/random/tech_supply,
-/turf/simulated/floor/plating,
-/area/maintenance/research_medical)
 "wry" = (
 /turf/simulated/wall/r_wall,
 /area/medical/medbay2)
@@ -129264,7 +129270,7 @@ rJB
 tfv
 uqg
 vAY
-wrn
+pAQ
 qHW
 yeN
 rEl

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -22735,6 +22735,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
 /turf/simulated/wall/r_wall,
 /area/maintenance/disposal)
 "brZ" = (
@@ -67552,7 +67553,7 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /obj/random/cash,
-/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
+/obj/item/weapon/reagent_containers/glass/beaker/stopperedbottle,
 /turf/simulated/floor,
 /area/maintenance/cargo)
 "pMH" = (


### PR DESCRIPTION
Honestly, this is a QOL change.
I've gotten a tad sick n' tired of SCI staff taking the public circuitry kit in maint instead of just using the one in the Circuitry lab.
This moves it over to cargo's area, above disposals there's a new circuitry kit, a few things laying around, etc.
Also, I've deleted and replaced the electronics stuff above medbay where the kit used to lay with some stuffs to peak at for you with grubby hands. :3