### PR TITLE
Horde Infestation event and changes to spider spawning

### DIFF
--- a/code/modules/events/event_container_vr.dm
+++ b/code/modules/events/event_container_vr.dm
@@ -120,16 +120,20 @@
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Atmos Leak",		/datum/event/atmos_leak, 		5,		list(ASSIGNMENT_ENGINEER = 35), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Blob",		/datum/event/blob, 				-100,	list(ASSIGNMENT_SECURITY = 40, ASSIGNMENT_HOS = 10, ASSIGNMENT_WARDEN = 10, ASSIGNMENT_ENGINEER = 5), 1, min_jobs = list(ASSIGNMENT_SECURITY = 1)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Carp Migration",	/datum/event/carp_migration,	-110,	list(ASSIGNMENT_SECURITY = 50, ASSIGNMENT_HOS = 10, ASSIGNMENT_WARDEN = 10), 1, min_jobs = list(ASSIGNMENT_SECURITY = 3)),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Horde Infestation",		/datum/event/horde_infestation, 		-60,	list(ASSIGNMENT_SECURITY = 20, ASSIGNMENT_HOS = 10, ASSIGNMENT_WARDEN = 10, ASSIGNMENT_ANY = 3), 0),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Jellyfish Migration",	/datum/event/jellyfish_migration,	5,	list(ASSIGNMENT_ANY = 1, ASSIGNMENT_SECURITY = 5, ASSIGNMENT_MEDICAL = 3), 1),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Wave",		/datum/event/meteor_wave,		-90,		list(ASSIGNMENT_ENGINEER = 50, ASSIGNMENT_MEDICAL = 10, ASSIGNMENT_ANY = 1),	1, min_jobs = list(ASSIGNMENT_ENGINEER = 1)),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Metroid Infestation",			/datum/event/metroid_infestation,			-100,	list(ASSIGNMENT_SECURITY = 30, ASSIGNMENT_SCIENCE = 20, ASSIGNMENT_HOS = 15, ASSIGNMENT_WARDEN = 15, ASSIGNMENT_ANY = 2), 1 , min_jobs = list(ASSIGNMENT_SECURITY = 2, ASSIGNMENT_SCIENCE = 1)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Space Vines",		/datum/event/spacevine, 		20,		list(ASSIGNMENT_ENGINEER = 15), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Spider Infestation",		/datum/event/spider_infestation, 		-60,	list(ASSIGNMENT_SECURITY = 20, ASSIGNMENT_HOS = 10, ASSIGNMENT_WARDEN = 10, ASSIGNMENT_ANY = 3), 0),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Supply Demand",		/datum/event/supply_demand,		0,		list(ASSIGNMENT_ANY = 5, ASSIGNMENT_SCIENCE = 15, ASSIGNMENT_GARDENER = 10, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 15), 1, min_jobs = list(ASSIGNMENT_CARGO = 1)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Viral Infection",	/datum/event/viral_infection,	-50,	list(ASSIGNMENT_MEDICAL = 25), 	1, min_jobs = list(ASSIGNMENT_MEDICAL = 2)),
 	)
 	add_disabled_events(list(
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Containment Breach",	/datum/event/prison_break/station,0,	list(ASSIGNMENT_ANY = 5),		0),
+		//Spiders moved into horde infestation
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Spider Infestation",		/datum/event/spider_infestation, 		-60,	list(ASSIGNMENT_SECURITY = 20, ASSIGNMENT_HOS = 10, ASSIGNMENT_WARDEN = 10, ASSIGNMENT_ANY = 3), 0),
+		//Metroids moved into horde infestation
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Metroid Infestation",			/datum/event/metroid_infestation,			-100,	list(ASSIGNMENT_SECURITY = 30, ASSIGNMENT_SCIENCE = 20, ASSIGNMENT_HOS = 15, ASSIGNMENT_WARDEN = 15, ASSIGNMENT_ANY = 2), 1 , min_jobs = list(ASSIGNMENT_SECURITY = 2, ASSIGNMENT_SCIENCE = 1)),
+
 		//Needs Xenobio containment breach fixed
 		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Xenobiology Breach",	/datum/event/prison_break/xenobiology,	-10,	list(ASSIGNMENT_SCIENCE = 30, ASSIGNMENT_ENGINEER = 20), 1),
 		//new /datum/event_meta(EVENT_LEVEL_MAJOR, "Meteor Strike",	/datum/event/meteor_strike,		10,		list(ASSIGNMENT_ENGINEER = 15), 1),

--- a/code/modules/events/horde_infestation.dm
+++ b/code/modules/events/horde_infestation.dm
@@ -1,0 +1,101 @@
+/datum/event/horde_infestation
+	announceWhen	= 90
+	var/spawncount = 1
+	var/list/vents = list()
+	var/spiders = FALSE
+	var/metroids = FALSE
+
+/datum/event/horde_infestation/setup()
+	if(prob(25)) //CHOMP Add 25% chance for the event to fail if chosen
+		log_debug("Horde infestation failed successfully.")
+		kill()
+		return //The event dies here.
+
+	announceWhen = rand(announceWhen, announceWhen + 60)
+
+	for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines) //Gathering together all possible areas to spawn mobs.
+		//CHOMPEdit: Added a couple areas to the exclusion.
+		var/in_area = get_area(temp_vent)
+		if(istype(in_area, /area/crew_quarters/sleep) || istype(in_area, /area/hallway/secondary/entry))
+			continue
+		if(!temp_vent.welded && temp_vent.network && (temp_vent.loc.z in using_map.station_levels)) //No spawns on welded vents
+			if(temp_vent.network.normal_members.len > 10) //CHOMP Edit: Most our networks are 40. SM is 4 and toxins is 2. This needed to change in order to spawn.
+				vents += temp_vent
+
+	if(prob(50)) //50/50 chance on spiders or metroids.
+		log_debug("Hord event, spiders selected.")
+		spawncount = rand(4 * severity, 10 * severity)	
+		sent_spiders_to_station = 0
+		spiders = TRUE
+		
+	else
+		log_debug("Horde event, metroids selected.")
+		spawncount = rand(2 * severity, 4 * severity)
+		metroids = TRUE
+		
+	
+/datum/event/horde_infestation/announce()
+	if(spiders) //Horrible way of doing this
+		command_announcement.Announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", new_sound = 'sound/AI/aliens.ogg')
+	if(metroids) //Horrible way of doing this
+		command_announcement.Announce("High-energy lifeforms detected coming aboard [station_name()]. All crew members, stay alert, and listen to security instructions.", "Lifesign Alert", new_sound = 'sound/misc/alarm1.ogg')
+		
+/datum/event/horde_infestation/start()
+	if(spiders)
+		for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
+			//CHOMPEdit: Added a couple areas to the exclusion. Also made this actually work.
+			var/in_area = get_area(temp_vent)
+			if(istype(in_area, /area/crew_quarters/sleep) || istype(in_area, /area/hallway/secondary/entry))
+				continue
+			if(!temp_vent.welded && temp_vent.network && (temp_vent.loc.z in using_map.station_levels))
+				if(temp_vent.network.normal_members.len > 10) //CHOMP Edit: Most our networks are 40. SM is 4 and toxins is 2. This needed to change to 10 from 50 in order for spawns to work.
+					var/area/A = get_area(temp_vent)
+					if(!(A.forbid_events))
+						vents += temp_vent
+
+		while((spawncount >= 1) && vents.len)
+			var/obj/vent = pick(vents)
+		//CHOMPEDIT START adding spider EGGS to the possible spawns instead of singular spiderling spawns.
+			var/spawn_spiderlings = pickweight(list(
+				/obj/effect/spider/spiderling/broodling = 95,
+				/obj/effect/spider/eggcluster/broodling = 4,
+				/obj/effect/spider/eggcluster/royal/broodling = 1
+				))
+			new spawn_spiderlings(vent.loc) //VOREStation Edit - No nurses //Oh my JESUS CHRIST, this slipped past me. Literally no nurses. Well guess what, nurses are back.
+		//CHOMPEDIT END
+			vents -= vent
+			spawncount--
+	if(metroids)
+		while((spawncount >= 1) && vents.len)
+			var/obj/vent = pick(vents)
+			var/spawn_metroids = pickweight(list(
+				/mob/living/simple_mob/metroid/juvenile/baby = 60,
+				/mob/living/simple_mob/metroid/juvenile/super = 30,
+				/mob/living/simple_mob/metroid/juvenile/alpha = 10,
+				/mob/living/simple_mob/metroid/juvenile/gamma = 3,
+				/mob/living/simple_mob/metroid/juvenile/zeta = 2,
+				/mob/living/simple_mob/metroid/juvenile/omega = 1,
+				))
+			new spawn_metroids(get_turf(vent))
+			vents -= vent
+			spawncount--
+		vents.Cut()
+
+/datum/event/horde_infestation/end()
+	if(spiders)
+		return
+	if(metroids)
+		var/list/area_names = list()
+		for(var/metroids in existing_metroids)
+			var/mob/living/M = metroids
+			if(!M || M.stat == DEAD)
+				continue
+			var/area/metroid_area = get_area(M)
+			if(!metroid_area) //Huh, really?
+				if(!get_turf(M)) //No turf either?
+					qdel(M) //Must have been nullspaced
+					continue
+			area_names |= metroid_area.name
+		if(area_names.len)
+			var/english_list = english_list(area_names)
+			command_announcement.Announce("Sensors have narrowed down remaining lifeforms to the followng areas: [english_list]", "Lifesign Alert")

--- a/code/modules/events/horde_infestation.dm
+++ b/code/modules/events/horde_infestation.dm
@@ -1,5 +1,6 @@
 /datum/event/horde_infestation
-	announceWhen	= 90
+	announceWhen	= 30
+	endWhen		= 200
 	var/spawncount = 1
 	var/list/vents = list()
 	var/spiders = FALSE

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -6,10 +6,11 @@
 
 
 /datum/event/spider_infestation/setup()
-	if(prob(25) && severity == 3) //CHOMP Add 25% chance for the event to fail if chosen and is major severity
-		log_debug("Major spider infestation failed successfully.")
+	if(prob(25)) //CHOMP Add 25% chance for the event to fail if chosen
+		log_debug("Spider infestation failed successfully.")
 		kill()
 		return
+
 	announceWhen = rand(announceWhen, announceWhen + 60)
 	spawncount = rand(4 * severity, 10 * severity)	//spiderlings only have a 50% chance to grow big and strong //CHOMP Edit: old: 2/4 new: 6/14 new: 4/10
 	sent_spiders_to_station = 0
@@ -33,13 +34,18 @@
 
 	while((spawncount >= 1) && vents.len)
 		var/obj/vent = pick(vents)
+	
 	//CHOMPEDIT START adding spider EGGS to the possible spawns instead of singular spiderling spawns.
-		var/spawn_spiderlings = pickweight(list(
-			/obj/effect/spider/spiderling = 85,
-			/obj/effect/spider/eggcluster = 10,
-			/obj/effect/spider/eggcluster/royal = 5
-			))
-		new spawn_spiderlings(vent.loc) //VOREStation Edit - No nurses //Oh my JESUS CHRIST, this slipped past me. Literally no nurses. Well guess what, nurses are back.
+		if(severity == 3)
+			var/spawn_spiderlings = pickweight(list(
+				/obj/effect/spider/spiderling/broodling = 95,
+				/obj/effect/spider/eggcluster/broodling = 4,
+				/obj/effect/spider/eggcluster/royal/broodling = 1
+				))
+			new spawn_spiderlings(vent.loc)
+		if(severity < 3) //If the severity is less than 3, only spawn regular spiderlings
+			new /obj/effect/spider/spiderling/broodling(vent.loc) //VOREStation Edit - No nurses //CHOMP Edit Oh my JESUS CHRIST, this slipped past me. Literally no nurses. Well guess what, nurses are back.
+
 	//CHOMPEDIT END
 		vents -= vent
 		spawncount--

--- a/modular_chomp/game/objects/effects/spiders.dm
+++ b/modular_chomp/game/objects/effects/spiders.dm
@@ -1,0 +1,19 @@
+//Eggs
+/obj/effect/spider/eggcluster/broodling
+	spider_type = /obj/effect/spider/spiderling/broodling
+
+/obj/effect/spider/eggcluster/royal/broodling
+	spider_type = /obj/effect/spider/spiderling/varied/broodling
+
+
+
+//Spiderling types
+/obj/effect/spider/spiderling/broodling
+	name = "brood spiderling"
+	grow_as = list(/mob/living/simple_mob/animal/giant_spider/broodling, /mob/living/simple_mob/animal/giant_spider/nurse/broodling, /mob/living/simple_mob/animal/giant_spider/hunter/broodling)
+
+/obj/effect/spider/spiderling/varied/broodling
+	grow_as = list(/mob/living/simple_mob/animal/giant_spider/broodling, /mob/living/simple_mob/animal/giant_spider/nurse/broodling, /mob/living/simple_mob/animal/giant_spider/hunter/broodling,
+			/mob/living/simple_mob/animal/giant_spider/frost/broodling, /mob/living/simple_mob/animal/giant_spider/electric/broodling, /mob/living/simple_mob/animal/giant_spider/lurker/broodling,
+			/mob/living/simple_mob/animal/giant_spider/pepper/broodling, /mob/living/simple_mob/animal/giant_spider/thermic/broodling, /mob/living/simple_mob/animal/giant_spider/tunneler/broodling,
+			/mob/living/simple_mob/animal/giant_spider/webslinger/broodling)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2391,6 +2391,7 @@
 #include "code\modules\events\gravity.dm"
 #include "code\modules\events\grid_check.dm"
 #include "code\modules\events\grubinfestation_vr.dm"
+#include "code\modules\events\horde_infestation.dm"
 #include "code\modules\events\ian_storm_vr.dm"
 #include "code\modules\events\infestation.dm"
 #include "code\modules\events\ion_storm.dm"
@@ -4745,5 +4746,6 @@
 #include "modular_chomp\code\modules\vore\eating\exportpanel_ch.dm"
 #include "modular_chomp\code\modules\vore\resizing\resize.dm"
 #include "modular_chomp\code\modules\xenobio\machinery\monkey_processor.dm"
+#include "modular_chomp\game\objects\effects\spiders.dm"
 #include "modular_chomp\maps\overmap\space_pois\space_pois.dm"
 // END_INCLUDE


### PR DESCRIPTION
-Horde infestation event added as major event. 25% chance to fail. Merges spider and metroid infestation event.
-Moved major spider and major metroid infestations to disabled for event managers to trigger on their own.
-Modified spider infestation event to only spawn eggs on major event (note that above I said it was disabled for major anyway), otherwise this is mostly unchanged.
-Nerfed spawn rates of spider eggs in the event.
-Added new broodling brand spider eggs.
-Swaps station spider event spawns to all be broodling spider spawns which have nerfed health and damage