### PR TITLE
Changing too_much_tox (phoron) to too_much_tox (toxin).

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -135,10 +135,10 @@ The box in your backpack has an oxygen tank and breath mask in it."
 	desc = "You're not getting enough phoron. Find some good air before you pass out!"
 	icon_state = "not_enough_tox"
 
-/obj/screen/alert/tox_in_air			// CHOMP EDIT : Oxygen is toxic to phoron breathers and nitrogen breathers. I'm tired of seeing "You're choking on phoron!" when it's not phoron.
-	name = "Choking (Toxic)"
-	desc = "There's a dangerous toxin in the air and you're breathing it in. Find some fresh air. \
-Your emergency supply kit should have an air tank and gas mask in it!"
+/obj/screen/alert/tox_in_air											// CHOMP EDIT : Oxygen is toxic to phoron breathers and nitrogen breathers. I'm tired of seeing "You're choking on phoron!" when it's not phoron.
+	name = "Choking (Toxic)"										// CHOMP EDIT
+	desc = "There's a dangerous toxin in the air and you're breathing it in. Find some fresh air. \		// CHOMP EDIT
+Your emergency supply kit should have an air tank and gas mask in it!"						// CHOMP EDIT
 	icon_state = "too_much_tox"
 
 /obj/screen/alert/not_enough_fuel

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -135,10 +135,10 @@ The box in your backpack has an oxygen tank and breath mask in it."
 	desc = "You're not getting enough phoron. Find some good air before you pass out!"
 	icon_state = "not_enough_tox"
 
-/obj/screen/alert/tox_in_air
-	name = "Choking (Phoron)"
-	desc = "There's highly flammable, toxic phoron in the air and you're breathing it in. Find some fresh air. \
-The box in your backpack has an oxygen tank and gas mask in it."
+/obj/screen/alert/tox_in_air			// CHOMP EDIT : Oxygen is toxic to phoron breathers and nitrogen breathers. I'm tired of seeing "You're choking on phoron!" when it's not phoron.
+	name = "Choking (Toxic)"
+	desc = "There's a dangerous toxin in the air and you're breathing it in. Find some fresh air. \
+Your emergency supply kit should have an air tank and gas mask in it!"
 	icon_state = "too_much_tox"
 
 /obj/screen/alert/not_enough_fuel

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -137,7 +137,7 @@ The box in your backpack has an oxygen tank and breath mask in it."
 
 /obj/screen/alert/tox_in_air											// CHOMP EDIT : Oxygen is toxic to phoron breathers and nitrogen breathers. I'm tired of seeing "You're choking on phoron!" when it's not phoron.
 	name = "Choking (Toxic)"										// CHOMP EDIT
-	desc = "There's a dangerous toxin in the air and you're breathing it in. Find some fresh air. \		// CHOMP EDIT
+	desc = "There's a dangerous toxin in the air and you're breathing it in. Find some fresh air. \
 Your emergency supply kit should have an air tank and gas mask in it!"						// CHOMP EDIT
 	icon_state = "too_much_tox"
 


### PR DESCRIPTION
Changing the too_much_tox alert to be actually "too much tox" and not "too much phoron".
> I do plan to come back to this and make it so phoron and nitrogen breathers will get a custom too_much_tox_*oxy* alert. But for now I was just tired of the general "too_much_tox" alert assuming it's phoron. With human crew that's fine since phoron is what causes tox.  But when there are phoron/nitrogen breathers and oxygen is what's causing tox, seeing a warning saying it's phoron makes no sense. (Especially if a phoron breather is choking and their alert says it's because they're breathing phoron and they need to get an oxygen tank)