### PR TITLE
FIXES #4930 Circuit Examine Text

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -213,7 +213,9 @@
 	. = ..()
 	if(Adjacent(user))
 		for(var/obj/item/integrated_circuit/IC in contents)
-			. += IC.external_examine(user)
+			var/external_examine = IC.external_examine(user)
+			if (external_examine != null)
+				. += external_examine
 		if(opened)
 			tgui_interact(user)
 


### PR DESCRIPTION
![image](https://github.com/CHOMPStation2/CHOMPStation2/assets/91218429/4304d0fb-4648-4ca1-a33d-93a8d641e77b)

Fixes issue with new lines showing for circuits inside an assembly with null examine text.

Also fixes an issue with screens not displaying their circuit names.