### PR TITLE
Fixed slicing moldy pizza. (Why're you slicing it anyway?)

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -3701,7 +3701,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/slice/oldpizza
 	name = "moldy pizza slice"
 	desc = "This used to be pizza..."
-	icon_state = "old_pizza"
+	icon_state = "oldpizzaslice"								// CHOMP EDIT For some reason this was set to old_pizza, which isn't a thing in the dmi (I guess nobody ever tried slicing it so nobody ever knew?)
 	filling_color = "#BAA14C"
 	bitesize = 2
 	center_of_mass = list("x"=16, "y"=13)


### PR DESCRIPTION
[Fixed](https://streamable.com/g2u2j4) the moldy pizza sprites. 
For some reason the moldy pizza (box) > (whole) > 
Broke before reaching (slice). 
The sprite it was trying to call was old_pizza, which doesn't exist.  oldpizzaslice does though. ancient_pizza exists, which may have been the pattern they trying to follow. But whoever sprited the pizza slices didn't make them all use the same naming convention. (Weird).

Fixed now though. The link is a streamable link to view the changes, though- it's literally just me cutting up two moldy pizzas. lol