### PR TITLE
Adds \improper tag to the corrupted size gun.

### DIFF
--- a/code/game/objects/items/sahoc_ch.dm
+++ b/code/game/objects/items/sahoc_ch.dm
@@ -107,7 +107,7 @@
 //BADvanced size gun
 //
 /obj/item/weapon/gun/energy/sizegun/not_advanced
-	name = "Corrupted size gun"
+	name = "\improper corrupted size gun"	// CHOMPedit Adds \improper
 	desc = "A highly advanced ray gun with a knob on the side to adjust the size you desire. Or at least that's what it used to be."
 	projectile_type = /obj/item/projectile/beam/sizelaser/chaos
 	charge_cost = 60 //1/3 of the base price for a normal one.


### PR DESCRIPTION
Makes the text
> That's Corrupted size gun.
Show up instead as
> That's a corrupted size gun.