### PR TITLE
Gives Chemistry the power of chem distillery

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -442,7 +442,7 @@
 "aaL" = (
 /obj/machinery/camera/network/research{
 	c_tag = "SCI - Toxins Test Chamber Fore";
-	network = list("Research","Toxins Test Area")
+	network = list("Research","Toxins                Test                Area")
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
@@ -3075,7 +3075,7 @@
 /obj/machinery/computer/general_air_control{
 	frequency = 1445;
 	name = "Engine Exhaust Monitoring";
-	sensors = list("engine_exhaust_sensor"="Engine Exhaust Sensor")
+	sensors = list("engine_exhaust_sensor"="Engine                Exhaust                Sensor")
 	},
 /turf/simulated/floor,
 /area/engineering/engine_waste)
@@ -5829,7 +5829,7 @@
 /obj/machinery/computer/general_air_control{
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon                Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous                Oxide","waste_sensor"="Gas                Mix                Tank")
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
@@ -5844,7 +5844,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Engine Waste")
+	sensors = list("mair_in_meter"="Mixed                Air                In","air_sensor"="Mixed                Air                Supply                Tank","mair_out_meter"="Mixed                Air                Out","dloop_atm_meter"="Distribution                Loop","wloop_atm_meter"="Engine                Waste")
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/atmos/monitoring)
@@ -8838,7 +8838,7 @@
 /obj/machinery/camera/network/research{
 	c_tag = "SCI - Toxins Test Chamber Port";
 	dir = 4;
-	network = list("Research","Toxins Test Area")
+	network = list("Research","Toxins                Test                Area")
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
@@ -9059,7 +9059,7 @@
 /obj/machinery/camera/network/research{
 	c_tag = "SCI - Toxins Test Chamber Starboard";
 	dir = 8;
-	network = list("Research","Toxins Test Area")
+	network = list("Research","Toxins                Test                Area")
 	},
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
@@ -17151,7 +17151,7 @@
 	input_tag = "cooling_in";
 	name = "Engine Cooling Control";
 	output_tag = "cooling_out";
-	sensors = list("engine_sensor"="Engine Core")
+	sensors = list("engine_sensor"="Engine                Core")
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
@@ -34123,9 +34123,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "cdk" = (
@@ -41109,7 +41106,7 @@
 	desc = "Used for watching the test chamber.";
 	layer = 4;
 	name = "Test Chamber Telescreen";
-	network = list("Toxins Test Area");
+	network = list("Toxins                Test                Area");
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -41137,7 +41134,7 @@
 	desc = "Used for watching the test chamber.";
 	layer = 4;
 	name = "Test Chamber Telescreen";
-	network = list("Toxins Test Area");
+	network = list("Toxins                Test                Area");
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -41167,7 +41164,7 @@
 	desc = "Used for watching the test chamber.";
 	layer = 4;
 	name = "Test Chamber Telescreen";
-	network = list("Toxins Test Area");
+	network = list("Toxins                Test                Area");
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -43550,7 +43547,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	name = "Research Monitor";
-	network = list("Research","Toxins Test Area","Robots","Anomaly Isolation","Research Outpost");
+	network = list("Research","Toxins                Test                Area","Robots","Anomaly                Isolation","Research                Outpost");
 	pixel_x = 32;
 	pixel_y = -4
 	},
@@ -44427,16 +44424,20 @@
 /turf/simulated/floor,
 /area/engineering/storage)
 "deQ" = (
-/obj/structure/table/steel,
-/obj/item/weapon/gun/launcher/syringe,
-/obj/item/weapon/storage/box/syringegun,
-/obj/random/medical,
-/obj/random/medical,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/item/weapon/storage/box/cdeathalarm_kit,
+/obj/item/bodybag/cryobag{
+	pixel_x = -3
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/item/bodybag/cryobag{
+	pixel_x = -3
+	},
+/obj/structure/table/steel,
+/obj/item/device/sleevemate,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/medical/surgery_storage)
 "dfc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/warning{
@@ -44792,6 +44793,24 @@
 /obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
+"dtw" = (
+/obj/item/weapon/cane{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/structure/table/steel,
+/obj/item/weapon/cane{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/box/rxglasses,
+/obj/item/weapon/cane,
+/turf/simulated/floor/tiled/freezer,
+/area/medical/surgery_storage)
 "dtI" = (
 /obj/structure/closet/emcloset,
 /obj/structure/catwalk,
@@ -45503,21 +45522,9 @@
 /turf/simulated/floor,
 /area/maintenance/bar)
 "dPW" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	name = "light switch ";
-	pixel_x = 36
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/machinery/iv_drip,
+/turf/simulated/floor/tiled/freezer,
+/area/medical/surgery_storage)
 "dQc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -47545,7 +47552,7 @@
 	req_access = list(33)
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/medical/chemistry)
+/area/medical/distillery)
 "eSF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/purple{
 	dir = 4
@@ -48013,6 +48020,11 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "fgN" = (
@@ -48448,12 +48460,18 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
 "fsC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Patient Hallway Starboard";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_wing)
 "ftm" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
@@ -49371,13 +49389,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/sc/cmo)
 "fSb" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/weapon/storage/toolbox/emergency,
-/obj/item/device/defib_kit/loaded,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_wing)
 "fSk" = (
 /obj/structure/table/standard,
 /obj/item/toy/plushie/box,
@@ -51495,6 +51511,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
+"gWj" = (
+/obj/machinery/atmospherics/unary/heater,
+/turf/simulated/floor/reinforced,
+/area/medical/distillery)
 "gWC" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 1;
@@ -52019,21 +52039,27 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "hlN" = (
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/weapon/grenade/chem_grenade,
-/obj/item/device/assembly/igniter,
-/obj/item/device/assembly/igniter,
-/obj/item/device/assembly/igniter,
-/obj/item/device/assembly/timer,
-/obj/item/device/assembly/timer,
-/obj/item/device/assembly/timer,
-/obj/structure/closet/crate{
-	name = "Grenade Crate"
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "hlX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -52451,8 +52477,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "hzO" = (
-/turf/simulated/wall,
-/area/medical/biostorage)
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/distillery)
 "hzX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52784,25 +52813,15 @@
 /turf/simulated/floor/tiled/hydro,
 /area/hallway/primary/seconddeck/ascenter)
 "hIR" = (
-/obj/structure/closet/crate,
-/obj/item/weapon/storage/box/lights/mixed,
-/obj/item/device/flashlight,
-/obj/item/device/flashlight,
-/obj/item/device/radio{
-	frequency = 1487;
-	icon_state = "med_walkietalkie";
-	name = "Medbay Emergency Radio Link"
-	},
-/obj/item/device/radio{
-	frequency = 1487;
-	icon_state = "med_walkietalkie";
-	name = "Medbay Emergency Radio Link"
-	},
-/obj/item/weapon/tool/crowbar/red,
-/obj/item/weapon/tool/crowbar/red,
-/obj/item/weapon/storage/firstaid/surgery,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/effect/floor_decal/borderfloorwhite/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/structure/table/steel,
+/obj/item/weapon/tool/wrench,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "hJg" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/shield_diffuser,
@@ -53522,6 +53541,12 @@
 "hXA" = (
 /turf/simulated/floor/grass,
 /area/hallway/primary/seconddeck/fscenter)
+"hXE" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 5
+	},
+/turf/simulated/floor/reinforced,
+/area/medical/distillery)
 "hXY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -54072,6 +54097,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"ilR" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "ini" = (
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/purple/bordercorner,
@@ -55363,15 +55395,21 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/secondary/docking_hallway2)
 "iZI" = (
-/obj/structure/closet/l3closet/medical,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/light{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "iZV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -55883,7 +55921,7 @@
 	dir = 4;
 	frequency = 1430;
 	name = "Mixing Chamber Monitor";
-	sensors = list("toxins_mixing_exterior"="Mixing Chamber - Exterior","toxins_mixing_interior"="Mixing Chamber - Interior")
+	sensors = list("toxins_mixing_exterior"="Mixing                Chamber                -                Exterior","toxins_mixing_interior"="Mixing                Chamber                -                Interior")
 	},
 /obj/machinery/light{
 	dir = 8
@@ -56876,12 +56914,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
 "jOR" = (
-/obj/structure/bedsheetbin,
+/obj/machinery/light,
 /obj/structure/table/steel,
-/obj/random/firstaid,
-/obj/random/firstaid,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/item/device/defib_kit/loaded,
+/turf/simulated/floor/tiled/freezer,
+/area/medical/surgery_storage)
 "jPg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57165,6 +57202,11 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
@@ -57883,27 +57925,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/stairwell)
 "kmi" = (
-/obj/structure/closet/crate/medical,
-/obj/item/weapon/surgical/surgicaldrill,
-/obj/item/weapon/surgical/FixOVein,
-/obj/item/weapon/surgical/circular_saw,
-/obj/item/weapon/surgical/scalpel,
-/obj/item/stack/medical/advanced/bruise_pack,
-/obj/item/weapon/surgical/retractor,
-/obj/item/weapon/surgical/hemostat,
-/obj/item/weapon/surgical/cautery,
-/obj/item/weapon/surgical/bonesetter,
-/obj/item/weapon/surgical/bonegel,
-/obj/item/stack/nanopaste,
-/obj/item/weapon/autopsy_scanner,
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 2;
-	pixel_y = 2
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
@@ -58334,10 +58361,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/medical/foyer)
 "kCx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "kDd" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -59199,7 +59227,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used to monitor the proceedings inside the test chamber.";
 	name = "Test Chamber Monitor";
-	network = list("Miscellaneous Reseach");
+	network = list("Miscellaneous                Reseach");
 	pixel_x = -32;
 	pixel_y = -4
 	},
@@ -59287,7 +59315,7 @@
 /obj/machinery/camera/network/research{
 	c_tag = "SCI - Miscellaneous Test Chamber";
 	dir = 8;
-	network = list("Research","Miscellaneous Reseach")
+	network = list("Research","Miscellaneous                Reseach")
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/misc_lab)
@@ -59837,23 +59865,10 @@
 /turf/simulated/floor/tiled,
 /area/engineering/foyer)
 "lvy" = (
-/obj/item/weapon/cane,
-/obj/item/weapon/cane{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/weapon/cane{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/gloves{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/box/rxglasses,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/powered/reagent_distillery/industrial,
+/turf/simulated/floor/reinforced,
+/area/medical/distillery)
 "lvF" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -61046,11 +61061,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -61212,14 +61222,11 @@
 /turf/simulated/floor/tiled,
 /area/security/checkpoint2)
 "mjw" = (
-/obj/structure/closet/l3closet/medical,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_wing)
 "mjR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -64432,11 +64439,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "oce" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -64446,6 +64448,15 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
@@ -64709,7 +64720,6 @@
 /turf/simulated/floor/carpet/oracarpet,
 /area/library)
 "okt" = (
-/obj/machinery/iv_drip,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -64723,6 +64733,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/structure/table/steel,
+/obj/structure/bedsheetbin,
+/obj/random/firstaid,
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
 "oku" = (
@@ -64949,6 +64962,11 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
@@ -65600,11 +65618,21 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/psych)
 "oMg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/door/airlock/glass_medical{
+	name = "Chemistry Distillery";
+	req_access = list(5)
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel_grid,
+/area/medical/distillery)
 "oNr" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	dir = 4
@@ -65637,21 +65665,27 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_foyer)
 "oPy" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/closet/crate/medical,
+/obj/item/weapon/surgical/surgicaldrill,
+/obj/item/weapon/surgical/FixOVein,
+/obj/item/weapon/surgical/circular_saw,
+/obj/item/weapon/surgical/scalpel,
+/obj/item/stack/medical/advanced/bruise_pack,
+/obj/item/weapon/surgical/retractor,
+/obj/item/weapon/surgical/hemostat,
+/obj/item/weapon/surgical/cautery,
+/obj/item/weapon/surgical/bonesetter,
+/obj/item/weapon/surgical/bonegel,
+/obj/item/stack/nanopaste,
+/obj/item/weapon/autopsy_scanner,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/turf/simulated/floor/tiled/freezer,
+/area/medical/surgery_storage)
 "oPJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -65736,8 +65770,20 @@
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
 "oSv" = (
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/patient_wing)
 "oTe" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -66042,6 +66088,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/surgeryobs)
+"oZt" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "oZL" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -68073,6 +68123,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
+"pWZ" = (
+/obj/machinery/atmospherics/unary/freezer,
+/turf/simulated/floor/reinforced,
+/area/medical/distillery)
 "pXi" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -69335,6 +69389,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
+"qKX" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "qLq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -70684,8 +70746,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
 "rEl" = (
-/turf/simulated/wall/r_wall,
-/area/medical/biostorage)
+/obj/structure/closet/l3closet/medical,
+/turf/simulated/floor/tiled/freezer,
+/area/medical/surgery_storage)
 "rEq" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -71048,15 +71111,18 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "rPr" = (
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
-/obj/structure/table/steel,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/structure/closet/l3closet/medical,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "rPK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -71205,10 +71271,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Surgery Storage";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
 "rTr" = (
@@ -71319,6 +71381,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
+"rYl" = (
+/turf/simulated/wall/r_wall,
+/area/medical/distillery)
 "rYB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -71840,15 +71905,11 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "skB" = (
@@ -71897,9 +71958,6 @@
 "snu" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "snD" = (
@@ -72624,13 +72682,30 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/port)
 "sHK" = (
-/obj/structure/bed/chair/wheelchair,
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = 21
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/timer,
+/obj/item/device/assembly/timer,
+/obj/structure/closet/crate{
+	name = "Grenade Crate"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/item/device/assembly_holder/timer_igniter,
+/obj/item/device/assembly_holder/timer_igniter,
+/obj/item/device/assembly_holder/timer_igniter,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "sIk" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -74378,19 +74453,9 @@
 /area/library)
 "tMo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Patient Hallway Starboard";
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "tMs" = (
@@ -74749,6 +74814,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cafeteria)
+"ubP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/medical/distillery)
 "ubU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76405,6 +76475,11 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
 "uYd" = (
@@ -77154,16 +77229,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bar)
 "vxB" = (
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/table/steel,
+/obj/item/weapon/gun/launcher/syringe,
+/obj/item/weapon/storage/box/syringegun,
+/obj/random/medical,
+/obj/random/medical,
+/obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "MED - Secondary Storage";
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "vxF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -77200,6 +77281,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/main)
+"vyg" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/black,
+/turf/simulated/floor/reinforced,
+/area/medical/distillery)
 "vyn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -77383,11 +77468,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
 "vDT" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -77397,6 +77477,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
@@ -77589,20 +77672,12 @@
 /turf/simulated/floor/tiled/white,
 /area/hallway/secondary/seconddeck/research_medical)
 "vIn" = (
-/obj/item/weapon/storage/box/cdeathalarm_kit,
-/obj/item/bodybag/cryobag{
-	pixel_x = -3
+/obj/machinery/camera/network/medbay{
+	c_tag = "MED - Surgery Storage";
+	dir = 8
 	},
-/obj/item/bodybag/cryobag{
-	pixel_x = -3
-	},
-/obj/structure/table/steel,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/obj/item/device/sleevemate,
-/turf/simulated/floor/tiled/dark,
-/area/medical/biostorage)
+/turf/simulated/floor/tiled/freezer,
+/area/medical/surgery_storage)
 "vIB" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -78323,20 +78398,19 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "wdd" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/medical{
-	name = "Secondary Storage";
-	req_access = list(5)
+/obj/structure/table/rack,
+/obj/item/clothing/suit/radiation,
+/obj/item/clothing/head/radiation,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel_grid,
-/area/medical/biostorage)
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "wdx" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
@@ -78555,6 +78629,26 @@
 	},
 /turf/simulated/wall,
 /area/maintenance/medbay_fore)
+"wlr" = (
+/obj/structure/closet/crate,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/item/device/radio{
+	frequency = 1487;
+	icon_state = "med_walkietalkie";
+	name = "Medbay Emergency Radio Link"
+	},
+/obj/item/device/radio{
+	frequency = 1487;
+	icon_state = "med_walkietalkie";
+	name = "Medbay Emergency Radio Link"
+	},
+/obj/item/weapon/tool/crowbar/red,
+/obj/item/weapon/tool/crowbar/red,
+/obj/item/weapon/storage/firstaid/surgery,
+/turf/simulated/floor/tiled/freezer,
+/area/medical/surgery_storage)
 "wls" = (
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc{
@@ -78709,6 +78803,13 @@
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"wqf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/distillery)
 "wqh" = (
 /turf/simulated/wall,
 /area/chapel/main)
@@ -78866,11 +78967,6 @@
 /obj/machinery/camera/network/medbay{
 	c_tag = "MED - Patient Hallway Port"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -78879,6 +78975,11 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_wing)
@@ -79097,13 +79198,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "wCl" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -80954,8 +81049,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D1)
 "xDM" = (
-/obj/structure/closet/crate/freezer,
-/obj/machinery/light,
 /turf/simulated/floor/tiled/freezer,
 /area/medical/surgery_storage)
 "xDR" = (
@@ -127751,9 +127844,9 @@ jyb
 jyb
 jyb
 jyb
+jyb
+jyb
 vNi
-lWH
-lWH
 aaa
 aaa
 aag
@@ -127984,14 +128077,14 @@ sql
 sql
 pzW
 uHn
-eCW
-mEB
-mEB
+rYl
+ubP
+ubP
 eSw
-eCW
-eCW
-eCW
-eCW
+rYl
+rYl
+rYl
+rYl
 gDC
 nby
 bOb
@@ -128009,9 +128102,9 @@ nvr
 gPc
 uTu
 kmi
+xDM
+oPy
 vNi
-aaa
-aaa
 aaa
 aaf
 wWX
@@ -128242,14 +128335,14 @@ sql
 sql
 pzW
 fAQ
-jpX
-vRU
-hPZ
-ccj
-wXx
-ogH
-uOL
-qxs
+rYl
+gWj
+hXE
+kCx
+vxB
+rPr
+sHK
+rYl
 xIp
 pXr
 bOb
@@ -128267,9 +128360,9 @@ jyb
 hWO
 whb
 xDM
+xDM
+jOR
 vNi
-aaa
-aaa
 aaa
 aaf
 aaa
@@ -128500,14 +128593,14 @@ sql
 sql
 pzW
 fAQ
-jpX
-tHW
-tAA
-eNU
-mTV
-wZh
-uhE
-ngi
+rYl
+lvy
+vyg
+qKX
+oZt
+wqf
+iZI
+oMg
 shQ
 lUr
 bOb
@@ -128524,10 +128617,10 @@ wbc
 jyb
 okt
 rSH
+xDM
+dPW
 qws
 vNi
-aaa
-aaa
 aaa
 aag
 aaa
@@ -128758,14 +128851,14 @@ sql
 sql
 pzW
 fAQ
-jpX
-ijR
-xnd
-vGd
-cEH
-rra
-hPS
-hyq
+rYl
+pWZ
+hzO
+ilR
+hIR
+wdd
+hlN
+ubP
 lQC
 hSQ
 bOb
@@ -128779,13 +128872,13 @@ lnJ
 bOb
 wVM
 snu
-nDN
-nDN
-nDN
-nDN
-gVw
-aaf
-aaf
+jyb
+deQ
+xDM
+rEl
+vNi
+vNi
+vNi
 aaf
 aag
 aaa
@@ -129016,14 +129109,14 @@ pzW
 pzW
 pzW
 ydH
-jpX
-aql
-aql
-aql
-aql
-aql
-aql
-aql
+rYl
+ubP
+ubP
+eSw
+ubP
+rYl
+rYl
+rYl
 wNw
 lUr
 bOb
@@ -129037,11 +129130,11 @@ pQo
 bOb
 fek
 nqY
-drJ
-wls
-lUA
-vda
-cda
+jyb
+dtw
+vIn
+wlr
+vNi
 aaa
 aaa
 aaa
@@ -129274,14 +129367,14 @@ vAY
 pAQ
 qHW
 yeN
-rEl
-jOR
-mjw
-iZI
-rPr
-deQ
-fSb
-hzO
+jpX
+vRU
+hPZ
+ccj
+wXx
+ogH
+uOL
+qxs
 kke
 kPH
 bOb
@@ -129295,11 +129388,11 @@ bOb
 bOb
 mff
 vDT
-evM
-lUC
-stG
-rIN
-qAJ
+nDN
+nDN
+nDN
+nDN
+gVw
 aaa
 aaa
 aaa
@@ -129532,14 +129625,14 @@ vBP
 fKc
 xiX
 htb
-rEl
-vIn
-oSv
-oMg
-fsC
-kCx
-oPy
-wdd
+jpX
+tHW
+tAA
+eNU
+mTV
+wZh
+uhE
+ngi
 elC
 lUr
 bMW
@@ -129554,9 +129647,9 @@ fZU
 gVm
 xBk
 drJ
-wUp
-ojP
-qtn
+wls
+lUA
+vda
 cda
 aaa
 aaa
@@ -129790,14 +129883,14 @@ drW
 ooT
 xkS
 ygz
-rEl
-lvy
-hlN
-hIR
-vxB
-sHK
-dPW
-hzO
+jpX
+ijR
+xnd
+vGd
+cEH
+rra
+hPS
+hyq
 wmE
 thu
 lNS
@@ -129811,11 +129904,11 @@ nYH
 tbL
 wup
 skp
-wmj
-wmj
-wmj
-wmj
-nGr
+evM
+lUC
+stG
+rIN
+qAJ
 aaa
 aaa
 aaa
@@ -130048,14 +130141,14 @@ vDl
 wry
 wry
 wry
-rEl
-hzO
-hzO
-hzO
-hzO
-hzO
-hzO
-hzO
+jpX
+aql
+aql
+aql
+aql
+aql
+aql
+aql
 qLq
 idT
 iOW
@@ -130069,11 +130162,11 @@ oKT
 uau
 vOR
 lIY
-rEb
-pOQ
-vxF
-rKn
-bup
+drJ
+wUp
+ojP
+qtn
+cda
 aaa
 aaa
 aaa
@@ -130327,11 +130420,11 @@ iXv
 tbL
 jVI
 oce
-bsC
-sib
-gEj
-avI
-vGS
+wmj
+wmj
+wmj
+wmj
+nGr
 aaa
 aaa
 aaa
@@ -130586,9 +130679,9 @@ fZU
 oqh
 xBk
 rEb
-mre
-kzs
-sUz
+pOQ
+vxF
+rKn
 bup
 aaa
 aaa
@@ -130843,11 +130936,11 @@ fZU
 fZU
 fgL
 uXT
-hBo
-hBo
-aan
-aan
-aan
+bsC
+sib
+gEj
+avI
+vGS
 aaf
 aaf
 aaf
@@ -131100,12 +131193,12 @@ eXp
 xaT
 mdj
 wCl
-vvd
-xeH
-ibY
-aaa
-aaa
-aaa
+fSb
+rEb
+mre
+kzs
+sUz
+bup
 aaa
 aaa
 aaa
@@ -131359,11 +131452,11 @@ xEj
 ueM
 tMo
 cde
-srt
-xDi
-aaa
-aaa
-aaa
+nGr
+nGr
+nGr
+nGr
+nGr
 aaa
 aaa
 aaa
@@ -131615,10 +131708,10 @@ wry
 wry
 wry
 hBo
-xDi
+oSv
+vvd
+xeH
 ibY
-xDi
-hBo
 aaf
 aaa
 aaa
@@ -131872,11 +131965,11 @@ qNE
 aaa
 aaa
 aaa
-aaf
-aaa
-aaa
-aaa
-aaa
+xDi
+fsC
+mjw
+srt
+xDi
 aaf
 aaa
 aaa
@@ -132130,11 +132223,11 @@ qNE
 aaa
 aaa
 aaa
-aaf
-aaa
-aaa
-aaa
-aaa
+xDi
+xDi
+ibY
+xDi
+hBo
 aaf
 aaa
 aaa

--- a/maps/southern_cross/southern_cross_areas.dm
+++ b/maps/southern_cross/southern_cross_areas.dm
@@ -896,6 +896,11 @@ z
 	name = "\improper First-Aid Station"
 	icon_state = "medbay2"
 
+//CHOMPedit begin 7/9/23, adds chem distillery
+/area/medical/distillery
+	name ="\improper Chemistry Distillery"
+	icon_state = "chem"
+//CHOMPedit end
 /area/medical/first_aid_station/firstdeck/
 	name = "\improper First Deck First-Aid Station"
 


### PR DESCRIPTION
Did you know there was a entire subsection of chemistry that no one knew that it existed because you need to ask science/cargo to make it for you? This maps it in.

Extends chemistry with a distillery and pushes the medkit storage a bit to the right. Split secondary storage equipment to the distillery room and the surgical storage room that no one used. I think every item should be there.

Hopefully this gives chemists some more things to do beyond the basic chems, and hopefully more people can add more high tier recipes involving this.

The current wiki doesn't have the chemicals properly documented/glogged, ill probably overhaul and organize the wiki soon enough idk, the recipes are documented though, go ham!

SCREENSHOTS:

![dreamseeker_vUUfVaSZGU](https://github.com/CHOMPStation2/CHOMPStation2/assets/10555869/07971589-d872-45f8-8d54-9778e744fab3)

![dreamseeker_dqElY4SYF8](https://github.com/CHOMPStation2/CHOMPStation2/assets/10555869/595ad24f-c7cd-45de-aeb2-b1e84218276e)

![dreamseeker_0iR6jq8Hll](https://github.com/CHOMPStation2/CHOMPStation2/assets/10555869/c49163e8-ea8d-4c9c-baca-3ee567742abf)
