### PR TITLE
[Integrated Circuits] Adds new assembly

### DIFF
--- a/code/controllers/subsystems/circuits.dm
+++ b/code/controllers/subsystems/circuits.dm
@@ -57,7 +57,7 @@ SUBSYSTEM_DEF(circuit)
 		/obj/item/device/electronic_assembly/tiny/box,
 		/obj/item/device/electronic_assembly/medium/default,
 		/obj/item/device/electronic_assembly/medium/box,
-		/obj/item/device/electronic_assembly/medium/tank,
+		/obj/item/device/electronic_assembly/medium/tank, //ChompAdd needed to make assembly appear in list
 		/obj/item/device/electronic_assembly/medium/clam,
 		/obj/item/device/electronic_assembly/medium/medical,
 		/obj/item/device/electronic_assembly/medium/gun,

--- a/code/controllers/subsystems/circuits.dm
+++ b/code/controllers/subsystems/circuits.dm
@@ -57,6 +57,7 @@ SUBSYSTEM_DEF(circuit)
 		/obj/item/device/electronic_assembly/tiny/box,
 		/obj/item/device/electronic_assembly/medium/default,
 		/obj/item/device/electronic_assembly/medium/box,
+		/obj/item/device/electronic_assembly/medium/tank,
 		/obj/item/device/electronic_assembly/medium/clam,
 		/obj/item/device/electronic_assembly/medium/medical,
 		/obj/item/device/electronic_assembly/medium/gun,

--- a/code/modules/integrated_electronics/core/assemblies/generic.dm
+++ b/code/modules/integrated_electronics/core/assemblies/generic.dm
@@ -81,6 +81,16 @@
 	icon_state = "setup_medium_box"
 	desc = "It's a case, for building medium-sized electronics with. This one has a boxy design."
 
+/obj/item/device/electronic_assembly/medium/tank
+	name = "type-g electronic mechanism"
+	icon_state = "setup_stationary"
+	desc = "It's a case, for building medium-sized electronics with. This one has a boxy design and comes with an integrated tank."
+	can_anchor = TRUE
+
+/obj/item/device/electronic_assembly/medium/tank/Initialize()
+	src.force_add_circuit(new /obj/item/integrated_circuit/built_in/tank)
+	return ..()
+
 /obj/item/device/electronic_assembly/medium/clam
 	name = "type-c electronic mechanism"
 	icon_state = "setup_medium_clam"

--- a/code/modules/integrated_electronics/core/assemblies/generic.dm
+++ b/code/modules/integrated_electronics/core/assemblies/generic.dm
@@ -81,16 +81,6 @@
 	icon_state = "setup_medium_box"
 	desc = "It's a case, for building medium-sized electronics with. This one has a boxy design."
 
-/obj/item/device/electronic_assembly/medium/tank
-	name = "type-g electronic mechanism"
-	icon_state = "setup_stationary"
-	desc = "It's a case, for building medium-sized electronics with. This one has a boxy design and comes with an integrated tank."
-	can_anchor = TRUE
-
-/obj/item/device/electronic_assembly/medium/tank/Initialize()
-	src.force_add_circuit(new /obj/item/integrated_circuit/built_in/tank)
-	return ..()
-
 /obj/item/device/electronic_assembly/medium/clam
 	name = "type-c electronic mechanism"
 	icon_state = "setup_medium_clam"

--- a/code/modules/integrated_electronics/subtypes/built_in.dm
+++ b/code/modules/integrated_electronics/subtypes/built_in.dm
@@ -6,13 +6,6 @@
 	size = -1
 	w_class = ITEMSIZE_TINY
 	removable = FALSE 			// Determines if a circuit is removable from the assembly.
-	var/volume = 0
-	unacidable = TRUE
-
-/obj/item/integrated_circuit/built_in/New()
-	..()
-	if(volume)
-		create_reagents(volume)
 
 /obj/item/integrated_circuit/built_in/device_input
 	name = "assembly input"
@@ -44,24 +37,3 @@
 
 /obj/item/integrated_circuit/built_in/action_button/do_work()
 	activate_pin(1)
-
-/obj/item/integrated_circuit/built_in/tank
-	name = "integrated fluid tank"
-	desc = "A built in tank for storing huge quantities of liquids. Can store up to 600u"
-	icon = 'icons/obj/integrated_electronics/electronic_components.dmi'
-	icon_state = "reagent_storage_big"
-	volume = 600
-	flags = OPENCONTAINER
-	inputs = list()
-	outputs = list("volume used" = IC_PINTYPE_NUMBER,"self reference" = IC_PINTYPE_REF)
-	activators = list()
-
-
-/obj/item/integrated_circuit/built_in/tank/interact(mob/user)
-	set_pin_data(IC_OUTPUT, 2, WEAKREF(src))
-	push_data()
-	..()
-
-/obj/item/integrated_circuit/built_in/tank/on_reagent_change()
-	set_pin_data(IC_OUTPUT, 1, reagents.total_volume)
-	push_data()

--- a/code/modules/integrated_electronics/subtypes/built_in.dm
+++ b/code/modules/integrated_electronics/subtypes/built_in.dm
@@ -6,6 +6,13 @@
 	size = -1
 	w_class = ITEMSIZE_TINY
 	removable = FALSE 			// Determines if a circuit is removable from the assembly.
+	var/volume = 0
+	unacidable = TRUE
+
+/obj/item/integrated_circuit/built_in/New()
+	..()
+	if(volume)
+		create_reagents(volume)
 
 /obj/item/integrated_circuit/built_in/device_input
 	name = "assembly input"
@@ -37,3 +44,24 @@
 
 /obj/item/integrated_circuit/built_in/action_button/do_work()
 	activate_pin(1)
+
+/obj/item/integrated_circuit/built_in/tank
+	name = "integrated fluid tank"
+	desc = "A built in tank for storing huge quantities of liquids. Can store up to 600u"
+	icon = 'icons/obj/integrated_electronics/electronic_components.dmi'
+	icon_state = "reagent_storage_big"
+	volume = 600
+	flags = OPENCONTAINER
+	inputs = list()
+	outputs = list("volume used" = IC_PINTYPE_NUMBER,"self reference" = IC_PINTYPE_REF)
+	activators = list()
+
+
+/obj/item/integrated_circuit/built_in/tank/interact(mob/user)
+	set_pin_data(IC_OUTPUT, 2, WEAKREF(src))
+	push_data()
+	..()
+
+/obj/item/integrated_circuit/built_in/tank/on_reagent_change()
+	set_pin_data(IC_OUTPUT, 1, reagents.total_volume)
+	push_data()

--- a/modular_chomp/code/modules/integrated_electronics/core/assemblies/generic.dm
+++ b/modular_chomp/code/modules/integrated_electronics/core/assemblies/generic.dm
@@ -1,0 +1,9 @@
+/obj/item/device/electronic_assembly/medium/tank
+	name = "type-g electronic mechanism"
+	icon_state = "setup_stationary"
+	desc = "It's a case, for building medium-sized electronics with. This one has a boxy design and comes with an integrated tank."
+	can_anchor = TRUE
+
+/obj/item/device/electronic_assembly/medium/tank/Initialize()
+	src.force_add_circuit(new /obj/item/integrated_circuit/built_in/tank)
+	return ..()

--- a/modular_chomp/code/modules/integrated_electronics/subtypes/built_in.dm
+++ b/modular_chomp/code/modules/integrated_electronics/subtypes/built_in.dm
@@ -1,0 +1,31 @@
+/obj/item/integrated_circuit/built_in
+	name = "integrated circuit"
+	desc = "It's a tiny chip!  This one doesn't seem to do much, however."
+	icon = 'icons/obj/integrated_electronics/electronic_setups.dmi'
+	icon_state = "template"
+	size = -1
+	w_class = ITEMSIZE_TINY
+	removable = FALSE 			// Determines if a circuit is removable from the assembly.
+	var/volume = 0
+	unacidable = TRUE
+
+/obj/item/integrated_circuit/built_in/tank
+	name = "integrated fluid tank"
+	desc = "A built in tank for storing huge quantities of liquids. Can store up to 600u"
+	icon = 'icons/obj/integrated_electronics/electronic_components.dmi'
+	icon_state = "reagent_storage_big"
+	volume = 600
+	flags = OPENCONTAINER
+	inputs = list()
+	outputs = list("volume used" = IC_PINTYPE_NUMBER,"self reference" = IC_PINTYPE_REF)
+	activators = list()
+
+
+/obj/item/integrated_circuit/built_in/tank/interact(mob/user)
+	set_pin_data(IC_OUTPUT, 2, WEAKREF(src))
+	push_data()
+	..()
+
+/obj/item/integrated_circuit/built_in/tank/on_reagent_change()
+	set_pin_data(IC_OUTPUT, 1, reagents.total_volume)
+	push_data()

--- a/modular_chomp/code/modules/integrated_electronics/subtypes/built_in.dm
+++ b/modular_chomp/code/modules/integrated_electronics/subtypes/built_in.dm
@@ -1,13 +1,11 @@
 /obj/item/integrated_circuit/built_in
-	name = "integrated circuit"
-	desc = "It's a tiny chip!  This one doesn't seem to do much, however."
-	icon = 'icons/obj/integrated_electronics/electronic_setups.dmi'
-	icon_state = "template"
-	size = -1
-	w_class = ITEMSIZE_TINY
-	removable = FALSE 			// Determines if a circuit is removable from the assembly.
 	var/volume = 0
 	unacidable = TRUE
+
+/obj/item/integrated_circuit/built_in/New()
+	..()
+	if(volume)
+		create_reagents(volume)
 
 /obj/item/integrated_circuit/built_in/tank
 	name = "integrated fluid tank"


### PR DESCRIPTION
Adds a new assembly to the printer that comes with a built-in reagent storage tank. It's capacity is 600u. It's medium sized so can't hold a ton of other components to make up for the large built-in container. Should help with some projects.

Uses a more generic icon for the assembly. It'd be nice to get a custom one to show off the tank.