### PR TITLE
fix a runtime in siffet.dm

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/sif/siffet.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/sif/siffet.dm
@@ -58,10 +58,10 @@
 
 /mob/living/simple_mob/animal/sif/siffet/IIsAlly(mob/living/L)
 	. = ..()
-	//CHOMPADDIITON: Compatibility with structures
-	if(!. && isnull(L.mob_size))
+	//CHOMPAdd START: Compatibility with structures
+	if(!. && !istype(L, /mob/living))
 		return TRUE
-	//CHOMPADDIITON: Compatibility with structures
 	else
 		if(!. && L.mob_size > 10) //Attacks things it considers small enough to take on, otherwise only attacks if attacked.
 			return TRUE
+	//CHOMPAdd END


### PR DESCRIPTION
badly formed var check, but in this case we can use istype instead of if("var" in thing.vars)