### PR TITLE
More Borg Slots

### DIFF
--- a/code/game/jobs/job/silicon_vr.dm
+++ b/code/game/jobs/job/silicon_vr.dm
@@ -5,5 +5,5 @@
 /datum/job/cyborg
 	pto_type = PTO_CYBORG
 	minimal_player_age = 3		//1 day is a little too little time
-	total_positions = 4 		//Along with one able to spawn later in the round.
-	spawn_positions = 3 		//Let's have 3 able to spawn in roundstart
+	total_positions = 8 		// CHOMPedit: Doubles total spawn positions for cyborgs.
+	spawn_positions = 6 		// CHOMPedit: Doubles total spawn positions for cyborgs.


### PR DESCRIPTION
More Cyborg slots due to higher population and more interest in the role.

🆑
qol: Upped Cyborg job limit from 4 to 8.
/🆑