### PR TITLE
Stunbatons Disrupt Solargrub Larvae

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -546,7 +546,8 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/reagent_containers/spray/pepper(src)
 	src.modules += new /obj/item/weapon/gripper/security(src)
 	src.modules += new /obj/item/device/ticket_printer(src)	//VOREStation Add
-	src.modules += new /obj/item/weapon/gun/energy/locked/phasegun/unlocked/mounted/cyborg(src) //CHOMPedit: Phasegun for regular sec cyborg.
+	src.modules += new /obj/item/weapon/gun/energy/locked/phasegun/unlocked/mounted/cyborg(src) // CHOMPedit: Phasegun for regular sec cyborg.
+	src.modules += new /obj/item/device/multitool(src) // CHOMPedit: Multitools for secborgs, lets them deal with solargrubs.
 	src.emag = new /obj/item/weapon/gun/energy/laser/mounted(src)
 
 /obj/item/weapon/robot_module/robot/security/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -547,7 +547,6 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/gripper/security(src)
 	src.modules += new /obj/item/device/ticket_printer(src)	//VOREStation Add
 	src.modules += new /obj/item/weapon/gun/energy/locked/phasegun/unlocked/mounted/cyborg(src) // CHOMPedit: Phasegun for regular sec cyborg.
-	src.modules += new /obj/item/device/multitool(src) // CHOMPedit: Multitools for secborgs, lets them deal with solargrubs.
 	src.emag = new /obj/item/weapon/gun/energy/laser/mounted(src)
 
 /obj/item/weapon/robot_module/robot/security/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -228,7 +228,6 @@
 	src.modules += new /obj/item/device/ticket_printer(src)
 	src.modules += new /obj/item/weapon/gripper/security(src) //CHOMPADD why doesnt the sec hound have the sec gripper?
 	src.modules += new /obj/item/weapon/gun/energy/locked/phasegun/unlocked/mounted/cyborg(src) // CHOMPedit: Phasegun for security hound.
-	src.modules += new /obj/item/device/multitool(src) // CHOMPedit: Multitools for secborgs, lets them deal with solargrubs.
 	src.emag 	 = new /obj/item/weapon/gun/energy/laser/mounted(src) //Emag. Not a big problem.
 
 	var/datum/matter_synth/water = new /datum/matter_synth(500) //Starts full and has a max of 500

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -227,7 +227,8 @@
 	src.modules += new /obj/item/weapon/dogborg/pounce(src) //Pounce
 	src.modules += new /obj/item/device/ticket_printer(src)
 	src.modules += new /obj/item/weapon/gripper/security(src) //CHOMPADD why doesnt the sec hound have the sec gripper?
-	src.modules += new /obj/item/weapon/gun/energy/locked/phasegun/unlocked/mounted/cyborg(src) //CHOMPedit: Phasegun for security hound.
+	src.modules += new /obj/item/weapon/gun/energy/locked/phasegun/unlocked/mounted/cyborg(src) // CHOMPedit: Phasegun for security hound.
+	src.modules += new /obj/item/device/multitool(src) // CHOMPedit: Multitools for secborgs, lets them deal with solargrubs.
 	src.emag 	 = new /obj/item/weapon/gun/energy/laser/mounted(src) //Emag. Not a big problem.
 
 	var/datum/matter_synth/water = new /datum/matter_synth(500) //Starts full and has a max of 500

--- a/code/modules/mob/living/simple_mob/subtypes/vore/solargrub_larva.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/solargrub_larva.dm
@@ -295,3 +295,13 @@ var/global/list/grub_machine_overlays = list()
 				to_chat(user, "<span class='warning'>You disturb a grub nesting in \the [O]!</span>")
 				return
 	return ..()
+
+/obj/item/weapon/melee/baton/afterattack(obj/O, mob/user, proximity)
+	if(proximity)
+		if(istype(O, /obj/machinery))
+			var/mob/living/simple_mob/animal/solargrub_larva/grub = locate() in O
+			if(grub)
+				grub.eject_from_machine(O)
+				to_chat(user, "<span class='warning'>You disturb a grub nesting in \the [O]!</span>")
+				return
+	return ..()


### PR DESCRIPTION
🆑
 balance: Stun Batons can now disrupt solargrubs infesting machinery, similar to a multitool.
/🆑