### PR TITLE
change start menu, make buttons static when start menu changes

### DIFF
--- a/code/__defines/admin_ch.dm
+++ b/code/__defines/admin_ch.dm
@@ -1,2 +1,4 @@
 #define SMITE_PIE				"Pie Splat"
 #define SMITE_SPICE				"Spicy Air"
+
+#define NEWSFILE 				"data/news.sav"

--- a/code/game/objects/items/weapons/inducer_vr.dm
+++ b/code/game/objects/items/weapons/inducer_vr.dm
@@ -259,9 +259,10 @@
 
 /obj/item/weapon/cell/standin/New(newloc, var/mob/living/carbon/human/H)
 	..()
-	hume = H
-	charge = H.nutrition
-	maxcharge = initial(H.nutrition)
+	if(istype(H, /mob/living/carbon/human))//ChompEDIT - fix a runtime
+		hume = H
+		charge = H.nutrition
+		maxcharge = initial(H.nutrition)
 
 	QDEL_IN(src, 20 SECONDS)
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -1,5 +1,4 @@
 #define RECOMMENDED_VERSION 513
-#define NEWSFILE "data/news.sav" //ChompEDIT - news dir
 // CHOMPedit Start - Tracy
 /proc/prof_init()
 	var/lib
@@ -34,7 +33,12 @@
 	//Newsfile
 	var/savefile/F = new(NEWSFILE)
 	if(F)
-		servernews_hash = md5("[F["title"]]" + "[F["body"]]")
+		var/title
+		F["title"] >> title
+		F["title"] >> title //This is done twice on purpose. For some reason BYOND misses the first read, if performed before the world starts
+		var/body
+		F["body"] >> body
+		servernews_hash = md5("[title]" + "[body]")
 	//ChompADD End
 
 	if(byond_version < RECOMMENDED_VERSION)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -1,5 +1,5 @@
 #define RECOMMENDED_VERSION 513
-
+#define NEWSFILE "data/news.sav" //ChompEDIT - news dir
 // CHOMPedit Start - Tracy
 /proc/prof_init()
 	var/lib
@@ -31,6 +31,10 @@
 	//ChompADD Start - Better Changelogs
 	var/latest_changelog = file("html/changelogs_ch/archive/" + time2text(world.timeofday, "YYYY-MM") + ".yml")
 	changelog_hash = fexists(latest_changelog) ? md5(latest_changelog) : 0 //for telling if the changelog has changed recently
+	//Newsfile
+	var/savefile/F = new(NEWSFILE)
+	if(F)
+		servernews_hash = md5("[F["title"]]" + "[F["body"]]")
 	//ChompADD End
 
 	if(byond_version < RECOMMENDED_VERSION)

--- a/code/global.dm
+++ b/code/global.dm
@@ -41,6 +41,7 @@ var/const/starsys_name	= "Virgo-Erigone"
 //CHOMPStation Removal End
 var/const/game_version	= "CHOMPStation"	//CHOMPStation Edit TFF 24/12/19 - Chompers
 var/changelog_hash		= ""
+var/servernews_hash		= "" //ChompADD - news hash gen
 var/game_year			= (text2num(time2text(world.realtime, "YYYY")) + 544) //YW EDIT
 var/round_progressing = 1
 

--- a/code/modules/admin/news.dm
+++ b/code/modules/admin/news.dm
@@ -1,4 +1,4 @@
-#define NEWSFILE "data/news.sav"	//where the memos are saved
+//#define NEWSFILE "data/news.sav"	//where the memos are saved //ChompEDIT - moved to __defines/admin_ch
 
 /client/
 	//var/last_news_hash = null // Stores a hash of the last news window it saw, which gets compared to the current one to see if it is different.
@@ -18,8 +18,15 @@
 
 	var/savefile/F = new(NEWSFILE)
 	if(F)
-		var/title = F["title"]
-		var/body = html2paper_markup(F["body"])
+		//ChompEDIT start - handle reads correctly
+		var/title
+		F["title"] >> title //This is done twice on purpose. For some reason BYOND misses the first read, if performed before the world starts
+		F["title"] >> title
+		var/body
+		F["body"] >> body
+		body = html2paper_markup(body)
+		//ChompEDIT end
+
 		var/new_title = sanitize(tgui_input_text(src,"Write a good title for the news update.  Note: HTML is NOT supported.","Write News", title), extra = 0)
 		if(!new_title)
 			return
@@ -32,11 +39,11 @@
 
 		if(findtext(new_body,"<script",1,0) ) // Is this needed with santize()?
 			return
+		servernews_hash = md5("[new_title]" + "[new_body]") //ChompADD - update the servernews hash global
 		F["title"] << new_title
 		F["body"] << new_body
 		F["author"] << key
 		F["timestamp"] << time2text(world.realtime, "DDD, MMM DD YYYY")
-		servernews_hash = md5("[F["title"]]" + "[F["body"]]") //ChompADD - update the servernews hash global
 		message_admins("[key] modified the news to read:<br>[new_title]<br>[new_body]")
 
 /client/proc/get_server_news() //ChompEDIT - child of /client/

--- a/code/modules/admin/news.dm
+++ b/code/modules/admin/news.dm
@@ -45,8 +45,8 @@
 	var/savefile/F = new(NEWSFILE)
 	if(F)
 		var/fbody = "[F["body"]]" //ChompADD
-		client.prefs.lastnews = md5(fbody) //ChompADD
-		SScharacter_setup.queue_preferences_save(client.prefs) //ChompADD
+		prefs.lastnews = md5(fbody) //ChompADD
+		SScharacter_setup.queue_preferences_save(prefs) //ChompADD
 		return F
 // This is used when submitting the news input, so the safe markup can get past sanitize.
 /proc/paper_markup2html(var/text)

--- a/code/modules/admin/news.dm
+++ b/code/modules/admin/news.dm
@@ -5,11 +5,8 @@
 
 // Returns true if news was updated since last seen.
 /client/proc/check_for_new_server_news()
-	var/savefile/F = get_server_news()
-	if(F)
-		var/dat = "[F["body"]]" //ChompEDIT
-		if(md5(dat) != prefs.lastnews) //ChompEDIT
-			return TRUE
+	if(servernews_hash != prefs.lastnews) //ChompEDIT
+		return TRUE
 	return FALSE
 
 /client/proc/modify_server_news()
@@ -39,15 +36,17 @@
 		F["body"] << new_body
 		F["author"] << key
 		F["timestamp"] << time2text(world.realtime, "DDD, MMM DD YYYY")
+		servernews_hash = md5("[F["title"]]" + "[F["body"]]") //ChompADD - update the servernews hash global
 		message_admins("[key] modified the news to read:<br>[new_title]<br>[new_body]")
 
 /client/proc/get_server_news() //ChompEDIT - child of /client/
 	var/savefile/F = new(NEWSFILE)
 	if(F)
-		var/fbody = "[F["body"]]" //ChompADD
-		prefs.lastnews = md5(fbody) //ChompADD
-		SScharacter_setup.queue_preferences_save(prefs) //ChompADD
+		if(servernews_hash != prefs.lastnews) //ChompADD
+			prefs.lastnews = servernews_hash //ChompADD
+			SScharacter_setup.queue_preferences_save(prefs) //ChompADD
 		return F
+
 // This is used when submitting the news input, so the safe markup can get past sanitize.
 /proc/paper_markup2html(var/text)
 	text = replacetext(text, "\n", "<br>")

--- a/code/modules/admin/news.dm
+++ b/code/modules/admin/news.dm
@@ -7,7 +7,8 @@
 /client/proc/check_for_new_server_news()
 	var/savefile/F = get_server_news()
 	if(F)
-		if(md5(F["body"]) != prefs.lastnews)
+		var/dat = "[F["body"]]" //ChompEDIT
+		if(md5(dat) != prefs.lastnews) //ChompEDIT
 			return TRUE
 	return FALSE
 
@@ -40,9 +41,12 @@
 		F["timestamp"] << time2text(world.realtime, "DDD, MMM DD YYYY")
 		message_admins("[key] modified the news to read:<br>[new_title]<br>[new_body]")
 
-/proc/get_server_news()
+/client/proc/get_server_news() //ChompEDIT - child of /client/
 	var/savefile/F = new(NEWSFILE)
 	if(F)
+		var/fbody = "[F["body"]]" //ChompADD
+		client.prefs.lastnews = md5(fbody) //ChompADD
+		SScharacter_setup.queue_preferences_save(client.prefs) //ChompADD
 		return F
 // This is used when submitting the news input, so the safe markup can get past sanitize.
 /proc/paper_markup2html(var/text)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -371,7 +371,7 @@
 /mob/new_player/proc/handle_server_news()
 	if(!client)
 		return
-	var/savefile/F = get_server_news()
+	var/savefile/F = client.get_server_news()
 	if(F)
 		//client.prefs.lastnews = md5(F["body"]) //Chomp REMOVE
 		//SScharacter_setup.queue_preferences_save(client.prefs) //Chomp REMOVE

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -38,15 +38,18 @@
 
 	if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
 		if(ready)
-			output += "<p>\[ <span class='linkOn'><b>Ready</b></span> | <a href='byond://?src=\ref[src];ready=0'>Not Ready</a> \]<br></p>" //ChompEDIT - fixed height
+			output += "<p>\[ <span class='linkOn'><b>Ready</b></span> | <a href='byond://?src=\ref[src];ready=0'>Not Ready</a> \]</p>" //ChompEDIT - fixed height
 		else
-			output += "<p>\[ <a href='byond://?src=\ref[src];ready=1'>Ready</a> | <span class='linkOn'><b>Not Ready</b></span> \]<br></p>" //ChompEDIT - fixed height
+			output += "<p>\[ <a href='byond://?src=\ref[src];ready=1'>Ready</a> | <span class='linkOn'><b>Not Ready</b></span> \]</p>" //ChompEDIT - fixed height
+		output += "<p><s>Join Game!</s></p>" //ChompEDIT - fixed height
 
 	else
 		output += "<p><a href='byond://?src=\ref[src];manifest=1'>View the Crew Manifest</A></p>" //ChompEDIT - fixed height
 		output += "<p><a href='byond://?src=\ref[src];late_join=1'>Join Game!</A></p>"
 
 	output += "<p><a href='byond://?src=\ref[src];observe=1'>Observe</A></p>"
+
+	output += "<hr>" //ChompADD - a line divider between functional and info buttons
 
 	if(!IsGuestKey(src.key))
 		establish_db_connection()
@@ -65,25 +68,25 @@
 			if(newpoll)
 				output += "<p><b><a href='byond://?src=\ref[src];showpoll=1'>Show Player Polls</A><br>(NEW!)</b></p>" //ChompEDIT - fixed height
 			else
-				output += "<p><a href='byond://?src=\ref[src];showpoll=1'>Show Player Polls</A><br></p>" //ChompEDIT - fixed height
+				output += "<p><a href='byond://?src=\ref[src];showpoll=1'>Show Player Polls</A><br><i>No Changes</i></p>" //ChompEDIT - fixed height
 
 	if(client.check_for_new_server_news())
 		output += "<p><b><a href='byond://?src=\ref[src];shownews=1'>Show Server News</A><br>(NEW!)</b></p>" //ChompEDIT 'Game updates' --> 'Server news'
 	else
-		output += "<p><a href='byond://?src=\ref[src];shownews=1'>Show Server News</A><br></p>" //ChompEDIT 'Game updates' --> 'Server news'
+		output += "<p><a href='byond://?src=\ref[src];shownews=1'>Show Server News</A><br><i>No Changes</i></p>" //ChompEDIT 'Game updates' --> 'Server news'
 
 	if(SSsqlite.can_submit_feedback(client))
 		output += "<p>[href(src, list("give_feedback" = 1), "Give Feedback")]</p>"
 
 	if(GLOB.news_data.station_newspaper)
 		if(client.prefs.lastlorenews == GLOB.news_data.newsindex)
-			output += "<p><a href='byond://?src=\ref[src];open_station_news=1'>Show [using_map.station_name] News</A></p>"
+			output += "<p><a href='byond://?src=\ref[src];open_station_news=1'>Show [using_map.station_name] News<br><i>No Changes</i></A></p>" //ChompEDIT - fixed height
 		else
-			output += "<p><b><a href='byond://?src=\ref[src];open_station_news=1'>Show [using_map.station_name] News (NEW!)</A></b></p>"
+			output += "<p><b><a href='byond://?src=\ref[src];open_station_news=1'>Show [using_map.station_name] News<br>(NEW!)</A></b></p>" //ChompEDIT - fixed height
 
 	//ChompEDIT start: Show Changelog
 	if(client.prefs.lastchangelog == changelog_hash)
-		output += "<p><a href='byond://?src=\ref[src];open_changelog=1'>Show Changelog</A></p>"
+		output += "<p><a href='byond://?src=\ref[src];open_changelog=1'>Show Changelog</A><br><i>No Changes</i></p>"
 	else
 		output += "<p><b><a href='byond://?src=\ref[src];open_changelog=1'>Show Changelog</A><br>(NEW!)</b></p>"
 	//ChompEDIT End
@@ -98,7 +101,7 @@
 		client.prefs.lastlorenews = GLOB.news_data.newsindex
 		SScharacter_setup.queue_preferences_save(client.prefs)
 
-	panel = new(src, "Welcome","Welcome", 210, 350, src) // VOREStation Edit //ChompEDIT, height 300 -> 350
+	panel = new(src, "Welcome","Welcome", 210, 360, src) // VOREStation Edit //ChompEDIT, height 300 -> 360
 	panel.set_window_options("can_close=0")
 	panel.set_content(output)
 	panel.open()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -375,11 +375,18 @@
 	if(F)
 		//client.prefs.lastnews = md5(F["body"]) //Chomp REMOVE
 		//SScharacter_setup.queue_preferences_save(client.prefs) //Chomp REMOVE
+		//ChompEDIT start - handle reads correctly
+		var/title
+		F["title"] >> title
+		F["title"] >> title //This is done twice on purpose. For some reason BYOND misses the first read, if performed before the world starts
+		var/body
+		F["body"] >> body
+		//ChompEDIT end
 
 		var/dat = "<html><body><center>"
-		dat += "<h1>[F["title"]]</h1>"
+		dat += "<h1>[title]</h1>"
 		dat += "<br>"
-		dat += "[F["body"]]"
+		dat += "[body]"
 		dat += "<br>"
 		dat += "<font size='2'><i>Last written by [F["author"]], on [F["timestamp"]].</i></font>"
 		dat += "</center></body></html>"

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -38,12 +38,12 @@
 
 	if(!ticker || ticker.current_state <= GAME_STATE_PREGAME)
 		if(ready)
-			output += "<p>\[ <span class='linkOn'><b>Ready</b></span> | <a href='byond://?src=\ref[src];ready=0'>Not Ready</a> \]</p>"
+			output += "<p>\[ <span class='linkOn'><b>Ready</b></span> | <a href='byond://?src=\ref[src];ready=0'>Not Ready</a> \]<br></p>" //ChompEDIT - fixed height
 		else
-			output += "<p>\[ <a href='byond://?src=\ref[src];ready=1'>Ready</a> | <span class='linkOn'><b>Not Ready</b></span> \]</p>"
+			output += "<p>\[ <a href='byond://?src=\ref[src];ready=1'>Ready</a> | <span class='linkOn'><b>Not Ready</b></span> \]<br></p>" //ChompEDIT - fixed height
 
 	else
-		output += "<a href='byond://?src=\ref[src];manifest=1'>View the Crew Manifest</A><br><br>"
+		output += "<p><a href='byond://?src=\ref[src];manifest=1'>View the Crew Manifest</A></p>" //ChompEDIT - fixed height
 		output += "<p><a href='byond://?src=\ref[src];late_join=1'>Join Game!</A></p>"
 
 	output += "<p><a href='byond://?src=\ref[src];observe=1'>Observe</A></p>"
@@ -63,14 +63,14 @@
 				break
 			qdel(query) //CHOMPEdit TGSQL
 			if(newpoll)
-				output += "<p><b><a href='byond://?src=\ref[src];showpoll=1'>Show Player Polls</A> (NEW!)</b></p>"
+				output += "<p><b><a href='byond://?src=\ref[src];showpoll=1'>Show Player Polls</A><br>(NEW!)</b></p>" //ChompEDIT - fixed height
 			else
-				output += "<p><a href='byond://?src=\ref[src];showpoll=1'>Show Player Polls</A></p>"
+				output += "<p><a href='byond://?src=\ref[src];showpoll=1'>Show Player Polls</A><br></p>" //ChompEDIT - fixed height
 
 	if(client.check_for_new_server_news())
 		output += "<p><b><a href='byond://?src=\ref[src];shownews=1'>Show Server News</A><br>(NEW!)</b></p>" //ChompEDIT 'Game updates' --> 'Server news'
 	else
-		output += "<p><a href='byond://?src=\ref[src];shownews=1'>Show Server News</A></p>" //ChompEDIT 'Game updates' --> 'Server news'
+		output += "<p><a href='byond://?src=\ref[src];shownews=1'>Show Server News</A><br></p>" //ChompEDIT 'Game updates' --> 'Server news'
 
 	if(SSsqlite.can_submit_feedback(client))
 		output += "<p>[href(src, list("give_feedback" = 1), "Give Feedback")]</p>"
@@ -98,7 +98,7 @@
 		client.prefs.lastlorenews = GLOB.news_data.newsindex
 		SScharacter_setup.queue_preferences_save(client.prefs)
 
-	panel = new(src, "Welcome","Welcome", 210, 320, src) // VOREStation Edit //ChompEDIT, height 300 -> 320
+	panel = new(src, "Welcome","Welcome", 210, 350, src) // VOREStation Edit //ChompEDIT, height 300 -> 350
 	panel.set_window_options("can_close=0")
 	panel.set_content(output)
 	panel.open()

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -373,8 +373,8 @@
 		return
 	var/savefile/F = get_server_news()
 	if(F)
-		client.prefs.lastnews = md5(F["body"])
-		SScharacter_setup.queue_preferences_save(client.prefs)
+		//client.prefs.lastnews = md5(F["body"]) //Chomp REMOVE
+		//SScharacter_setup.queue_preferences_save(client.prefs) //Chomp REMOVE
 
 		var/dat = "<html><body><center>"
 		dat += "<h1>[F["title"]]</h1>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Makes the new_player splash menu fixed-height on some of the buttons.
This is in attempt to make it more consistent, and kill the scrollbar without the huge gap variance in the menu size.
Also fixes 'Show server news!' (NEW) not being cleared when viewed.

images:
![image](https://github.com/CHOMPStation2/CHOMPStation2/assets/30182250/099c8cd9-9a3a-41f1-8541-d9fb201bdffd)
![image](https://github.com/CHOMPStation2/CHOMPStation2/assets/30182250/fde96c01-5b71-4382-94a8-c139659376a4)

(Live will have an extra button, show player polls)

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: start menu consistency/redesign
fix: Show server news (NEW) now resets on read
fix: fix a runtime in inducer.vr
fix: fixed weird savefile behavior when done before roundstart
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
