### PR TITLE
Combines Surgeon and Medical Borg Modules

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -142,10 +142,10 @@ var/global/list/alphabet_uppercase = list("A","B","C","D","E","F","G","H","I","J
 
 // Used by robots and robot preferences for regular modules.
 var/list/robot_module_types = list(
-	"Standard", "Engineering", "Surgeon",  "Crisis",
+	"Standard", "Engineering",/* "Surgeon",*/  "Crisis", //CHOMPedit: Combining Surgeon and Crisis.
 	"Miner",    "Janitor",     "Service",      "Clerical", "Security",
 	"Research", "Medihound", "K9", "Janihound", "Sci-borg", "Pupdozer",
-	"Service-Hound", "BoozeHound", "KMine", "TraumaHound"
+	"Service-Hound", "BoozeHound", "KMine"//, "TraumaHound" // CHOMPedit: Combining Medihound and Traumahound.
 )
 // List of modules added during code red
 var/list/emergency_module_types = list(

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -197,7 +197,7 @@
 	name = "MediHound hypospray"
 	desc = "An advanced chemical synthesizer and injection system utilizing carrier's reserves, designed for heavy-duty medical equipment."
 	charge_cost = 10
-	reagent_ids = list("inaprovaline", "dexalin", "bicaridine", "kelotane", "anti_toxin", "spaceacillin", "paracetamol")
+	reagent_ids = list("inaprovaline", "tricordrazine", "dexalin", "bicaridine", "kelotane", "anti_toxin", "spaceacillin", "tramadol", "adranol") // CHOMPedit: More chems for Medihound
 	var/datum/matter_synth/water = null
 
 /obj/item/weapon/reagent_containers/borghypo/hound/process() //Recharges in smaller steps and uses the water reserves as well.

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -5,7 +5,7 @@ var/global/list/robot_modules = list(
 	"Research" 		= /obj/item/weapon/robot_module/robot/research/general,
 	"Miner" 		= /obj/item/weapon/robot_module/robot/miner/general,
 	"Crisis" 		= /obj/item/weapon/robot_module/robot/medical/crisis,
-	"Surgeon" 		= /obj/item/weapon/robot_module/robot/medical/surgeon,
+//	"Surgeon" 		= /obj/item/weapon/robot_module/robot/medical/surgeon, // CHOMPedit: Surgeon module removal.
 	"Security" 		= /obj/item/weapon/robot_module/robot/security/general,
 	"Combat" 		= /obj/item/weapon/robot_module/robot/security/combat,
 	"Engineering"	= /obj/item/weapon/robot_module/robot/engineering/general,
@@ -224,6 +224,8 @@ var/global/list/robot_modules = list(
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor) //Give the surgeon ability to watch Crew monitor
 	can_be_pushed = 0
 
+/* CHOMPedit start: Removal of Surgeon module. *
+
 /obj/item/weapon/robot_module/robot/medical/surgeon
 	name = "surgeon robot module"
 	sprites = list(
@@ -309,6 +311,8 @@ var/global/list/robot_modules = list(
 
 	..()
 
+* CHOMPedit end: Removal of Surgeon module. */
+
 /obj/item/weapon/robot_module/robot/medical/crisis
 	name = "crisis robot module"
 	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor) //Give the medical Crisis ability to watch Crew monitor
@@ -343,22 +347,41 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/weapon/reagent_containers/borghypo/crisis(src)
 	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)
 	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src)
+	src.modules += new /obj/item/device/sleevemate(src) // CHOMPedit: Lets them scan people.
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src)
 	src.modules += new /obj/item/weapon/gripper/no_use/organ(src)
 	src.modules += new /obj/item/weapon/gripper/medical(src)
 	src.modules += new /obj/item/weapon/shockpaddles/robot(src)
 	src.modules += new /obj/item/weapon/inflatable_dispenser/robot(src) //VOREStation Add - This is kinda important for rescuing people without making it worse for everyone
+// CHOMPedit start: Combining Surgeon and Crisis.
+	src.modules += new /obj/item/weapon/autopsy_scanner(src)
+	src.modules += new /obj/item/weapon/surgical/scalpel/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/hemostat/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/retractor/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/cautery/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bonegel/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/FixOVein/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bonesetter/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/circular_saw/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/surgicaldrill/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bioregen/cyborg(src)
+// CHOMPedit end: Combining Surgeon and Crisis.
 	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
-	src.modules += new /obj/item/device/sleevemate(src)
 	src.emag.reagents.add_reagent("pacid", 250)
 	src.emag.name = "Polyacid spray"
 
-	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)
+	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(30000) // CHOMPedit: Increased capacity.
 	synths += medicine
 
+	var/obj/item/stack/medical/advanced/clotting/C = new (src) // CHOMPedit: Clotting kit from medhound.
 	var/obj/item/stack/medical/advanced/ointment/O = new /obj/item/stack/medical/advanced/ointment(src)
 	var/obj/item/stack/medical/advanced/bruise_pack/B = new /obj/item/stack/medical/advanced/bruise_pack(src)
 	var/obj/item/stack/medical/splint/S = new /obj/item/stack/medical/splint(src)
+// CHOMPedit start: Clotting kit from medhound.
+	C.uses_charge = 1
+	C.charge_costs = list(5000)
+	C.synths = list(medicine)
+// CHOMPedit end: Clotting kit from medhound.
 	O.uses_charge = 1
 	O.charge_costs = list(1000)
 	O.synths = list(medicine)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -51,7 +51,7 @@
 	robot_modules["BoozeHound"] = /obj/item/weapon/robot_module/robot/clerical/butler/booze
 	robot_modules["KMine"] = /obj/item/weapon/robot_module/robot/miner/kmine
 	robot_modules["Stray"] = /obj/item/weapon/robot_module/robot/stray
-	robot_modules["TraumaHound"] = /obj/item/weapon/robot_module/robot/medical/traumahound
+//	robot_modules["TraumaHound"] = /obj/item/weapon/robot_module/robot/medical/traumahound // CHOMPedit: Combining Medihound and Traumahound.
 	return 1
 
 //Just add a new proc with the robot_module type if you wish to run some other vore code
@@ -285,6 +285,7 @@
 
 /obj/item/weapon/robot_module/robot/medical/medihound
 	name = "MediHound module"
+	subsystems = list(/mob/living/silicon/proc/subsystem_crew_monitor) //CHOMPedit: Give the Medihound ability to watch the crew monitor.
 	sprites = list(
 					"Medical Hound" = "medihound",
 					"Dark Medical Hound (Static)" = "medihounddark",
@@ -298,14 +299,21 @@
 					"NIKO" = "mmekamed",
 					"NIKA" = "fmekamed",
 					"K4T" = "k4tmed",
-					"K4Talt" = "k4tmed_alt1" //CHOMPEdit End - Tallborgs
+					"K4Talt" = "k4tmed_alt1", //CHOMPEdit End - Tallborgs
+// CHOMPedit start: Trauma sprites for regular medihound borgs.
+					"Traumahound" = "traumavale",
+					"Traumadrake" = "draketrauma",
+					"Traumaborgi" = "borgi-trauma",
+					"Traumaraptor V-4" = "traumaraptor"
+// CHOMPedit end: Trauma sprites for regular medihound borgs.
 					)
 
 /obj/item/weapon/robot_module/robot/medical/medihound/New(var/mob/living/silicon/robot/R)
 	src.modules += new /obj/item/weapon/dogborg/jaws/small(src) //In case a patient is being attacked by carp.
 	src.modules += new /obj/item/device/dogborg/boop_module(src) //Boop the crew.
 	src.modules += new /obj/item/device/healthanalyzer(src) // See who's hurt specificially.
-	src.modules += new /obj/item/borg/sight/hud/med(src) //See who's hurt generally.
+	src.modules += new /obj/item/roller_holder(src) // CHOMPedit: Allows medihounds to deploy roller beds in case prefs don't align.
+//	src.modules += new /obj/item/borg/sight/hud/med(src) // CHOMPedit: Already has an integrated medical scanner.
 	src.modules += new /obj/item/weapon/reagent_containers/syringe(src) //In case the chemist is nice!
 	src.modules += new /obj/item/weapon/reagent_containers/glass/beaker/large(src)//For holding the chemicals when the chemist is nice, made it the large variant in 2022
 	src.modules += new /obj/item/device/sleevemate(src) //Lets them scan people.
@@ -313,10 +321,23 @@
 	src.modules += new /obj/item/weapon/inflatable_dispenser/robot(src) //This is kinda important for rescuing people without making it worse for everyone
 	src.modules += new /obj/item/weapon/gripper/medical(src) //Let them do literally anything in medbay other than patch external damage and lick people
 	src.modules += new /obj/item/weapon/reagent_containers/dropper/industrial(src) //dropper is nice to have for so much actually
+// CHOMPedit start: Combining Medihound and Traumahound.
+	src.modules += new /obj/item/weapon/autopsy_scanner(src)
+	src.modules += new /obj/item/weapon/surgical/scalpel/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/hemostat/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/retractor/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/cautery/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bonegel/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/FixOVein/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bonesetter/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/circular_saw/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/surgicaldrill/cyborg(src)
+	src.modules += new /obj/item/weapon/surgical/bioregen/cyborg(src)
+	src.modules += new /obj/item/weapon/gripper/no_use/organ(src)
+// CHOMPedit end: Combining Medihound and Traumahound.
 	src.emag 	 = new /obj/item/weapon/dogborg/pounce(src) //Pounce
-	src.modules += new /obj/item/weapon/gripper/medical(src)//Now you can set up cyro or make peri. //CHOMPEdit
 
-	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(15000)  //CHOMPedit
+	var/datum/matter_synth/medicine = new /datum/matter_synth/medicine(30000)  //CHOMPedit: QOL, More capacity before requiring a restock.
 	synths += medicine
 
 	var/obj/item/stack/medical/advanced/clotting/C = new (src)
@@ -330,14 +351,14 @@
 	src.modules += C
 	src.modules += S
 
-	var/datum/matter_synth/water = new /datum/matter_synth(500)
+	var/datum/matter_synth/water = new /datum/matter_synth(1000) // CHOMPedit: Now starts with maximum water capacity.
 	water.name = "Water reserves"
-	water.recharge_rate = 10  //CHOMPedit water shouldn't be a giant pain to get, rechargers should provide it.
+	water.recharge_rate = 20  //CHOMPedit water shouldn't be a giant pain to get, rechargers should provide it. Doubled to account for new max capacity.
 	water.max_energy = 1000  //CHOMPedit increased water storage from 500 to 1000
 	R.water_res = water
 	synths += water
 
-	var/obj/item/weapon/reagent_containers/borghypo/hound/H = new /obj/item/weapon/reagent_containers/borghypo/hound(src)
+	var/obj/item/weapon/reagent_containers/borghypo/hound/H = new /obj/item/weapon/reagent_containers/borghypo/hound(src) // CHOMPedit: Updated with new chems.
 	H.water = water
 	src.modules += H
 
@@ -384,6 +405,8 @@
 	R.verbs |= /mob/living/proc/shred_limb
 	R.verbs |= /mob/living/silicon/robot/proc/rest_style
 	..()
+
+/* CHOMPedit start: Commenting out Traumahound, no longer used. *
 
 /obj/item/weapon/robot_module/robot/medical/traumahound
 	name = "traumahound robot module"
@@ -468,6 +491,8 @@
 	R.verbs |= /mob/living/proc/shred_limb
 	R.verbs |= /mob/living/silicon/robot/proc/rest_style
 	..()
+
+* CHOMPedit end: Commenting out Traumahound, no longer used. */
 
 /obj/item/weapon/robot_module/robot/security/ert
 	name = "Emergency Responce module"

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -22,7 +22,7 @@
 	reagent_ids = list("tricordrazine", "inaprovaline", "oxycodone", "dexalin" ,"spaceacillin")
 
 /obj/item/weapon/reagent_containers/borghypo/crisis
-	reagent_ids = list("tricordrazine", "inaprovaline", "anti_toxin", "tramadol", "dexalin" ,"spaceacillin")
+	reagent_ids = list("inaprovaline", "tricordrazine", "dexalin", "bicaridine", "kelotane", "anti_toxin", "spaceacillin", "tramadol", "adranol") // CHOMPedit: Unifying chems with dogborg equivalent.
 
 /obj/item/weapon/reagent_containers/borghypo/lost
 	reagent_ids = list("tricordrazine", "bicaridine", "dexalin", "anti_toxin", "tramadol", "spaceacillin")


### PR DESCRIPTION
Combines the Medical Borg and Surgeon Borg modules, alongside providing a light buff.

:cl:
balance: Combined the medical borg and surgeon borg modules into one.
balance: Doubled medical borg's medicine capacity from 15,000 to 30,000.
balance: medical borgs now have access to more basic chems from their hyposprays.
qol: Gave the medihound access to the remote crew monitor, which it was lacking.
/:cl: