### PR TITLE
oversights with borg sprite refactor

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -538,6 +538,7 @@
 	var/choice = tgui_input_list(M, "Choose your drink!", "Drink Choice", options)
 	if(src && choice && !M.stat && in_range(M,src))
 		icontype = options[choice]
+		selected_icon = module_sprites[icontype][SKIN_ICON_STATE] //CHOMPEdit - sprite selection refactor
 		var/active_sound = 'sound/effects/bubbles.ogg'
 		playsound(src.loc, "[active_sound]", 100, 0, 4)
 		to_chat(M, "<span class='filter_notice'>Your Tank now displays [choice]. Drink up and enjoy!</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -266,8 +266,16 @@
 			icontype = "Custom"
 		else
 			icontype = module_sprites[1]
-			selected_icon = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit - Spriteselector
-			icon_state = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit - Spriteselector
+			selected_icon = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit Start- Spriteselector
+			icon_state = module_sprites[icontype][SKIN_ICON_STATE]
+			if (isnull(module_sprites[icontype][SKIN_OFFSET]))
+				pixel_x = 0
+				old_x = 0
+				default_pixel_x = 0
+			else
+				pixel_x = module_sprites[icontype][SKIN_OFFSET]
+				old_x = module_sprites[icontype][SKIN_OFFSET]
+				default_pixel_x = module_sprites[icontype][SKIN_OFFSET]//CHOMPEdit End
 	updateicon()
 	return module_sprites
 
@@ -1078,8 +1086,16 @@
 		else
 			transform_with_anim()	//VOREStation edit end: sprite animation
 
-	selected_icon = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit - Spriteselector
-	icon_state = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit - Spriteselector
+	selected_icon = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit Start - Spriteselector
+	icon_state = module_sprites[icontype][SKIN_ICON_STATE]
+	if (isnull(module_sprites[icontype][SKIN_OFFSET]))
+		pixel_x = 0
+		old_x = 0
+		default_pixel_x = 0
+	else
+		pixel_x = module_sprites[icontype][SKIN_OFFSET]
+		old_x = module_sprites[icontype][SKIN_OFFSET]
+		default_pixel_x = module_sprites[icontype][SKIN_OFFSET]//CHOMPEdit End
 	updateicon()
 
 	if (module_sprites.len > 1 && triesleft >= 1 && client)

--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -73,14 +73,6 @@
 
 /mob/living/silicon/robot/proc/vr_sprite_check()
 	icon = module_sprites[icontype][SKIN_ICON]
-	if (isnull(module_sprites[icontype][SKIN_OFFSET]))
-		pixel_x = 0
-		old_x = 0
-		default_pixel_x = 0
-	else
-		pixel_x = module_sprites[icontype][SKIN_OFFSET]
-		old_x = module_sprites[icontype][SKIN_OFFSET]
-		default_pixel_x = module_sprites[icontype][SKIN_OFFSET]
 
 	if (isnull(module_sprites[icontype][SKIN_HEIGHT]))
 		vis_height = 32


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

there was an oversight with the borg sprites pixel shifting being reset, that is now fixed
i forgot to modify the boozehounds color selection verb, that is now fixed

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: pixelshifting not working right on wideborgs
fix: boozehound sprite changing not working
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
