### PR TITLE
fix reset module breaking and broken med sprites

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -538,6 +538,7 @@
 	var/choice = tgui_input_list(M, "Choose your drink!", "Drink Choice", options)
 	if(src && choice && !M.stat && in_range(M,src))
 		icontype = options[choice]
+		selected_icon = module_sprites[icontype][SKIN_ICON_STATE] //CHOMPEdit - sprite selection refactor
 		var/active_sound = 'sound/effects/bubbles.ogg'
 		playsound(src.loc, "[active_sound]", 100, 0, 4)
 		to_chat(M, "<span class='filter_notice'>Your Tank now displays [choice]. Drink up and enjoy!</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -266,8 +266,16 @@
 			icontype = "Custom"
 		else
 			icontype = module_sprites[1]
-			selected_icon = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit - Spriteselector
-			icon_state = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit - Spriteselector
+			selected_icon = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit Start- Spriteselector
+			icon_state = module_sprites[icontype][SKIN_ICON_STATE]
+			if (isnull(module_sprites[icontype][SKIN_OFFSET]))
+				pixel_x = 0
+				old_x = 0
+				default_pixel_x = 0
+			else
+				pixel_x = module_sprites[icontype][SKIN_OFFSET]
+				old_x = module_sprites[icontype][SKIN_OFFSET]
+				default_pixel_x = module_sprites[icontype][SKIN_OFFSET]//CHOMPEdit End
 	updateicon()
 	return module_sprites
 
@@ -1078,8 +1086,16 @@
 		else
 			transform_with_anim()	//VOREStation edit end: sprite animation
 
-	selected_icon = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit - Spriteselector
-	icon_state = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit - Spriteselector
+	selected_icon = module_sprites[icontype][SKIN_ICON_STATE]//CHOMPEdit Start - Spriteselector
+	icon_state = module_sprites[icontype][SKIN_ICON_STATE]
+	if (isnull(module_sprites[icontype][SKIN_OFFSET]))
+		pixel_x = 0
+		old_x = 0
+		default_pixel_x = 0
+	else
+		pixel_x = module_sprites[icontype][SKIN_OFFSET]
+		old_x = module_sprites[icontype][SKIN_OFFSET]
+		default_pixel_x = module_sprites[icontype][SKIN_OFFSET]//CHOMPEdit End
 	updateicon()
 
 	if (module_sprites.len > 1 && triesleft >= 1 && client)

--- a/code/modules/mob/living/silicon/robot/robot_modules/Widerobot_Exploration_ch.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/Widerobot_Exploration_ch.dm
@@ -29,8 +29,8 @@
 
 /obj/item/weapon/robot_module/robot/exploration
 	sprites = list(
-				"ExploreHound" = "exploration",
-				"ExploreHound V2" = "exploration-v2",
+				"ExploreHound" = 	list(SKIN_ICON_STATE = "exploration", SKIN_ICON = 'modular_chomp/icons/mob/widerobot_exp_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
+				"ExploreHound V2" = list(SKIN_ICON_STATE = "exploration-v2", SKIN_ICON = 'modular_chomp/icons/mob/widerobot_exp_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
 				)
 	can_be_pushed = 0
 /obj/item/weapon/robot_module/robot/exploration/New(var/mob/living/silicon/robot/R)

--- a/code/modules/mob/living/silicon/robot/robot_modules/station.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/station.dm
@@ -79,7 +79,7 @@ var/global/list/robot_modules = list(
 
 	if(R.radio)
 		R.radio.recalculateChannels()
-	R.choose_icon(0, R.set_module_sprites(list("Default" = "robot")))
+	R.choose_icon(0, R.set_module_sprites(list("Default" = list(SKIN_ICON_STATE = "robot", SKIN_ICON = 'icons/mob/robots.dmi'))))//CHOMPEdit - Sprite selector
 
 /obj/item/weapon/robot_module/Destroy()
 	for(var/module in modules)

--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -260,10 +260,10 @@
 
 /obj/item/weapon/robot_module/robot/miner/kmine
 	sprites = list(
-					"KMine" = 			list(SKIN_ICON_STATE = "kmine",SKIN_ICON = 'icons/mob/widerobot_car_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
-					"CargoHound" = 		list(SKIN_ICON_STATE = "cargohound",SKIN_ICON = 'icons/mob/widerobot_car_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
-					"CargoHoundDark" = 	list(SKIN_ICON_STATE = "cargohounddark",SKIN_ICON = 'icons/mob/widerobot_car_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
-					"Borgi" = 			list(SKIN_ICON_STATE = "borgi-mine",SKIN_ICON = 'icons/mob/widerobot_car_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32), //CHOMPEdit
+					"KMine" = 			list(SKIN_ICON_STATE = "kmine",SKIN_ICON = 'icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
+					"CargoHound" = 		list(SKIN_ICON_STATE = "cargohound",SKIN_ICON = 'icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
+					"CargoHoundDark" = 	list(SKIN_ICON_STATE = "cargohounddark",SKIN_ICON = 'icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
+					"Borgi" = 			list(SKIN_ICON_STATE = "borgi-mine",SKIN_ICON = 'icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32), //CHOMPEdit
 					"Cat Mining" = 		list(SKIN_ICON_STATE = "vixmine",SKIN_ICON = 'modular_chomp/icons/mob/catborg/catborg.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32), //CHOMPEdit
 					"Cat Cargo" = 		list(SKIN_ICON_STATE = "vixcargo",SKIN_ICON = 'modular_chomp/icons/mob/catborg/catborg.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32), //CHOMPEdit
 					"Drake" = 			list(SKIN_ICON_STATE = "drakemine",SKIN_ICON = 'icons/mob/drakeborg/drakeborg_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),

--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -159,20 +159,20 @@
 					"Medical Hound" = 				list(SKIN_ICON_STATE = "medihound", SKIN_ICON = 'icons/mob/widerobot_med_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
 					"Dark Medical Hound (Static)" = list(SKIN_ICON_STATE = "medihounddark", SKIN_ICON = 'icons/mob/widerobot_med_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
 					"Mediborg model V-2" = 			list(SKIN_ICON_STATE = "vale", SKIN_ICON = 'icons/mob/widerobot_med_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
-					"Borgi" = 						list(SKIN_ICON_STATE = "borgi-medi", SKIN_ICON = 'icons/mob/widerobot_med_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
+					"Borgi-Med" =					list(SKIN_ICON_STATE = "borgi-medi", SKIN_ICON = 'icons/mob/widerobot_med_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
 					"Mediborg model V-3" = 			list(SKIN_ICON_STATE = "vale2", SKIN_ICON = 'modular_chomp/icons/mob/widerobot_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32), //CHOMPEdit
-					"Cat" = 						list(SKIN_ICON_STATE = "vixmed", SKIN_ICON = 'modular_chomp/icons/mob/catborg/catborg.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32,SKIN_REST_BELLY = 1,SKIN_REST_BELLY = 1), //CHOMPEdit
-					"Drake" = 						list(SKIN_ICON_STATE = "drakemed", SKIN_ICON = 'icons/mob/drakeborg/drakeborg_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
-					"Raptor V-4" = 					list(SKIN_ICON_STATE = "medraptor", SKIN_ICON = 'modular_chomp/icons/mob/raptorborg/raptor.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 45),
+					"Cat-Med" = 					list(SKIN_ICON_STATE = "vixmed", SKIN_ICON = 'modular_chomp/icons/mob/catborg/catborg.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32,SKIN_REST_BELLY = 1,SKIN_REST_BELLY = 1), //CHOMPEdit
+					"Drake-Med" =					list(SKIN_ICON_STATE = "drakemed", SKIN_ICON = 'icons/mob/drakeborg/drakeborg_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
+					"Raptor V-4-Med" = 				list(SKIN_ICON_STATE = "medraptor", SKIN_ICON = 'modular_chomp/icons/mob/raptorborg/raptor.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 45),
 					"MEKA" = 						list(SKIN_ICON_STATE = "mekamed", SKIN_ICON = 'modular_chomp/icons/mob/tallborg/tallrobots.dmi', SKIN_OFFSET = 0, SKIN_HEIGHT = 64), //CHOMPEdit Start - Tallborgs
 					"NIKO" = 						list(SKIN_ICON_STATE = "mmekamed", SKIN_ICON = 'modular_chomp/icons/mob/tallborg/tallrobots.dmi', SKIN_OFFSET = 0, SKIN_HEIGHT = 64),
 					"NIKA" = 						list(SKIN_ICON_STATE = "fmekamed", SKIN_ICON = 'modular_chomp/icons/mob/tallborg/tallrobots.dmi', SKIN_OFFSET = 0, SKIN_HEIGHT = 64),
 					"K4T" = 						list(SKIN_ICON_STATE = "k4tmed", SKIN_ICON = 'modular_chomp/icons/mob/tallborg/tallrobots.dmi', SKIN_OFFSET = 0, SKIN_HEIGHT = 64),
 					"K4Talt" = 						list(SKIN_ICON_STATE = "k4tmed_alt1", SKIN_ICON = 'modular_chomp/icons/mob/tallborg/tallrobots.dmi', SKIN_OFFSET = 0, SKIN_HEIGHT = 64), //CHOMPEdit End - Tallborgs
 					"Traumahound" = 				list(SKIN_ICON_STATE = "traumavale",SKIN_ICON = 'icons/mob/widerobot_trauma_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
-					"Drake" = 						list(SKIN_ICON_STATE = "draketrauma",SKIN_ICON = 'icons/mob/widerobot_trauma_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
-					"Borgi" = 						list(SKIN_ICON_STATE = "borgi-trauma",SKIN_ICON = 'icons/mob/widerobot_trauma_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
-					"Raptor V-4" = 					list(SKIN_ICON_STATE = "traumaraptor",SKIN_ICON = 'modular_chomp/icons/mob/raptorborg/raptor.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 45)
+					"Drake-Tramua" =				list(SKIN_ICON_STATE = "draketrauma",SKIN_ICON = 'icons/mob/drakeborg/drakeborg_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
+					"Borgi-Tramua" =				list(SKIN_ICON_STATE = "borgi-trauma",SKIN_ICON = 'icons/mob/widerobot_trauma_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
+					"Raptor V-4-Tramua" = 			list(SKIN_ICON_STATE = "traumaraptor",SKIN_ICON = 'modular_chomp/icons/mob/raptorborg/raptor.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 45)
 					)
 
 /* merged into medihound list

--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot_modules/station_vr.dm
@@ -260,10 +260,10 @@
 
 /obj/item/weapon/robot_module/robot/miner/kmine
 	sprites = list(
-					"KMine" = 			list(SKIN_ICON_STATE = "kmine",SKIN_ICON = 'icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
-					"CargoHound" = 		list(SKIN_ICON_STATE = "cargohound",SKIN_ICON = 'icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
-					"CargoHoundDark" = 	list(SKIN_ICON_STATE = "cargohounddark",SKIN_ICON = 'icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
-					"Borgi" = 			list(SKIN_ICON_STATE = "borgi-mine",SKIN_ICON = 'icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32), //CHOMPEdit
+					"KMine" = 			list(SKIN_ICON_STATE = "kmine",SKIN_ICON = 'modular_chomp/icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
+					"CargoHound" = 		list(SKIN_ICON_STATE = "cargohound",SKIN_ICON = 'modular_chomp/icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
+					"CargoHoundDark" = 	list(SKIN_ICON_STATE = "cargohounddark",SKIN_ICON = 'modular_chomp/icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),
+					"Borgi" = 			list(SKIN_ICON_STATE = "borgi-mine",SKIN_ICON = 'modular_chomp/icons/mob/widerobot_car_ch.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32), //CHOMPEdit
 					"Cat Mining" = 		list(SKIN_ICON_STATE = "vixmine",SKIN_ICON = 'modular_chomp/icons/mob/catborg/catborg.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32), //CHOMPEdit
 					"Cat Cargo" = 		list(SKIN_ICON_STATE = "vixcargo",SKIN_ICON = 'modular_chomp/icons/mob/catborg/catborg.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32), //CHOMPEdit
 					"Drake" = 			list(SKIN_ICON_STATE = "drakemine",SKIN_ICON = 'icons/mob/drakeborg/drakeborg_vr.dmi', SKIN_OFFSET = -16, SKIN_HEIGHT = 32),

--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -73,14 +73,6 @@
 
 /mob/living/silicon/robot/proc/vr_sprite_check()
 	icon = module_sprites[icontype][SKIN_ICON]
-	if (isnull(module_sprites[icontype][SKIN_OFFSET]))
-		pixel_x = 0
-		old_x = 0
-		default_pixel_x = 0
-	else
-		pixel_x = module_sprites[icontype][SKIN_OFFSET]
-		old_x = module_sprites[icontype][SKIN_OFFSET]
-		default_pixel_x = module_sprites[icontype][SKIN_OFFSET]
 
 	if (isnull(module_sprites[icontype][SKIN_HEIGHT]))
 		vis_height = 32


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
somehow i missed testing the reset upgrade module, also fixing overlapping sprite entries from the trauma med merge
fixes explo hound too
and kmine

(not sure why the robot_vr change is in here...)
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: reset module being borg
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
