### PR TITLE
Removed incorrectly placed CIV Cam

### DIFF
--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -21674,9 +21674,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/camera/network/civilian{
-	c_tag = "CIV - Library Office"
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/dorms)
 "tRd" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This PR fixes a camera placement and c_tag issue that my last fix neglected to nice.
<!-- Describe The Pull Request. -->
> On the third deck, the primary substation, there was a room with a camera with the c_tag "CIV - Library Office", my last PR fixing camera issues had addressed this, but I had not noticed a second placed camera in this substation. This PR removed that.
## Changelog
Removes the extra, incorrectly tagged, camera that was mapped into the Deck 3 Substation.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
del: Deleted second camera mapped on the Deck Three Substation.
remap: Ensures the camera system works by removing incorrectly c_tagged camera.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
