### PR TITLE
[DNM] Tweaks whitelist code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ temp.dmi
 
 node_modules/
 package-lock.json
+
+config/jobwhitelist.txt

--- a/code/controllers/configuration_ch.dm
+++ b/code/controllers/configuration_ch.dm
@@ -3,9 +3,9 @@
 
 
 /datum/configuration
-	var/discord_restriction = 0
-	var/use_jobwhitelist = 1
-	var/emojis = 1
+	var/discord_restriction = FALSE
+	var/use_jobwhitelist = TRUE
+	var/emojis = FALSE
 
 	var/vorefootstep_volume = 75	//In future see about making a function to adjust volume serverside in config.txt, easy to do with reenable values. - Jack
 

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -66,6 +66,7 @@ var/const/TALMIN			=(1<<5)
 //VOREStation Add End
 */
 
+//CHOMPedit start: next chunk doesn't exist upstream, not sure what it's actually used for.
 var/list/assistant_occupations = list(
 )
 
@@ -157,12 +158,12 @@ var/list/whitelisted_positions = list(
 	"Chief Engineer",
 	"Research Director",
 	"Chief Medical Officer",
-	"Warden",
+	"Internal Affairs Agent",
 	"AI"
-) //CHOMPEdit: Removed Command Secretary from whitelisted jobs.
+) //CHOMPEdit: end
 
 /proc/guest_jobbans(var/job)
-	return ((job in whitelisted_positions))
+	return // ((job in whitelisted_positions)) // CHOMPedit: spaghetti that is our whitelist system means this prevents use of config/jobswhitelist.txt
 
 /proc/get_job_datums()
 	var/list/occupations = list()

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -12,8 +12,8 @@ var/list/whitelist = list()
 	if(!whitelist.len)	whitelist = null
 
 /proc/check_whitelist(mob/M /*, var/rank*/)
-	if(!config.usewhitelist)
-		return 1
+	if(!config.usewhitelist) //CHOMPedit: I guess this is an override for the blanket whitelist system.
+		return 1 //CHOMPedit
 	if(!whitelist)
 		return 0
 	return ("[M.ckey]" in whitelist)

--- a/code/game/jobs/whitelist_vr.dm
+++ b/code/game/jobs/whitelist_vr.dm
@@ -1,8 +1,8 @@
 var/list/job_whitelist = list()
 
 /hook/startup/proc/loadJobWhitelist()
-	if(config.use_jobwhitelist)
-		load_jobwhitelist()
+	if(config.use_jobwhitelist) // CHOMPedit
+		load_jobwhitelist() // CHOMPedit
 	return 1
 
 /proc/load_jobwhitelist()
@@ -13,8 +13,8 @@ var/list/job_whitelist = list()
 		job_whitelist = splittext(text, "\n")
 
 /proc/is_job_whitelisted(mob/M, var/rank)
-	if(!config.use_jobwhitelist)
-		return 1
+	if(!config.use_jobwhitelist) // CHOMPedit
+		return 1 // CHOMPedit
 	var/datum/job/job = job_master.GetJob(rank)
 	if(!job.whitelist_only)
 		return 1

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -148,12 +148,12 @@
 		lastJob = job
 		. += "<a href='?src=\ref[src];job_info=[rank]'>"
 		if(jobban_isbanned(user, rank))
-			if(config.usewhitelist && !check_whitelist(user))
+			if(config.usewhitelist && !check_whitelist(user)) // CHOMPedit start
 				. += "<del>[rank]</del></td><td><b> \[WHITELISTED]</b></td></tr>"
 				continue
 			else
 				. += "<del>[rank]</del></td><td><b> \[BANNED]</b></td></tr>"
-				continue
+				continue // CHOMPedit end
 		if(!job.player_old_enough(user.client))
 			var/available_in_days = job.available_in_days(user.client)
 			. += "<del>[rank]</del></td></a><td> \[IN [(available_in_days)] DAYS]</td></tr>"

--- a/modular_chomp/code/game/jobs/job/job_whitelist_overrides.dm
+++ b/modular_chomp/code/game/jobs/job/job_whitelist_overrides.dm
@@ -1,0 +1,32 @@
+// Probably could code this to use a config file to set whitelist_only but I don't get paid for this.
+// Captain
+/datum/job/captain
+	whitelist_only = TRUE
+
+// Head of Personnel
+/datum/job/hop
+	whitelist_only = TRUE
+
+// Head of Security
+/datum/job/hos
+	whitelist_only = TRUE
+
+// Chief Engineer
+/datum/job/chief_engineer
+	whitelist_only = TRUE
+
+// Research Director
+/datum/job/rd
+	whitelist_only = TRUE
+
+// Chief Medical Officer
+/datum/job/cmo
+	whitelist_only = TRUE
+
+// AI
+/datum/job/ai
+	whitelist_only = TRUE
+
+// Internal Affairs Agent
+/datum/job/lawyer
+	whitelist_only = TRUE

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4560,6 +4560,7 @@
 #include "modular_chomp\code\game\dna\dna2.dm"
 #include "modular_chomp\code\game\jobs\job\captain.dm"
 #include "modular_chomp\code\game\jobs\job\department.dm"
+#include "modular_chomp\code\game\jobs\job\job_whitelist_overrides.dm"
 #include "modular_chomp\code\game\jobs\job\noncrew.dm"
 #include "modular_chomp\code\game\jobs\job\silicon.dm"
 #include "modular_chomp\code\game\machinery\airconditioner_ch.dm"


### PR DESCRIPTION
DO NOT MERGE, other non-code staff work must be completed first.

Re-adds functionality to jobwhitelist.txt by commenting out a return value which forced whitelist checks to always fail. Creates job_whitelist_overrides.dm to control whitelisting rather than the whitelisted_positions check (nice one Jon, you fixed hardcoded whitelists by hardcoding the whitelist). Said return value is used for guest jobbans... which isn't needed here as guest accounts are banned. If you want to re-enable that and also have the whitelist work, have fun untangling the spaghetti. 

@Raeschen Many modified files here are missing // CHOMPedit comments, seemingly carried over from CHOMP1. I added the ones I spotted but very well could be more.

Documentation thing
Whitelist works by checking the whitelisted job "title" var (datum/job/jobposition) against the job title in jobwhitelist.txt. Changing the title var without updating the whitelist WILL break the whitelist. Futureproof fix would be replacing the title var with defines + however many hardcoded uses of the title var with said defines, then converting the whitelist to use a list of ckeys for each whitelisted position. This would make a mess of whitelist files, but no more whitelist breaking if/when somebody decides to change the title var. Until then, I guess just remember to update the whitelist if the var changes.

## Changelog
:cl:
-Replaces booleans in configuration_ch.dm with TRUE/FALSE defines
-Tweaks whitelisted positions
-Adds whitelist_only vars in new job_whitelist_overrides.dm file
-Comments out return value of guest_jobbans proc which broke the jobwhitelist system.
-Adds numerous missing CHOMPedit comments
-Adds jobwhitelist.txt to gitignore
/:cl:

