### PR TITLE
Adds double (emergency) tanks for nitrogen and phoron breathers.

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_xeno_ch.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno_ch.dm
@@ -12,3 +12,14 @@
 		cloaks[initial(cloak_type.name)] = cloak_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cloaks))
 
+/datum/gear/double_tank/nitrogen
+	display_name = "Pocket sized double nitrogen tank (Customs)"
+	path = /obj/item/weapon/tank/emergency/nitrogen/double
+	whitelisted = SPECIES_CUSTOM
+	sort_category = "Xenowear"
+
+/datum/gear/double_tank/phoron
+	display_name = "Pocket sized double phoron tank (Vox, Customs)"
+	path = /obj/item/weapon/tank/emergency/phoron/double
+	whitelisted = list(SPECIES_VOX, SPECIES_CUSTOM)
+	sort_category = "Xenowear"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Title.
<!-- Describe The Pull Request. -->

## Changelog
Adds in the xeno tab of the loadout a selection for "Pocket sized double (x) tank".
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Pocket sized double nitrogen tank (Customs)
add: Pocket sized double phoron tank (Vox, Customs)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
