### PR TITLE
Gives staff remote LOOC logs distinct color from regular LOOC

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -180,7 +180,7 @@
 	for(var/client/target in r_receivers)
 		var/admin_stuff = "/([key])([admin_jump_link(mob, target.holder)])"
 
-		to_chat(target, "<span class='ooc looc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>(R)</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span>")
+		to_chat(target, "<span class='ooc rlooc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>(R)</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span>") //CHOMPEdit
 
 /mob/proc/get_looc_source()
 	return src

--- a/code/modules/vchat/css/ss13styles.css
+++ b/code/modules/vchat/css/ss13styles.css
@@ -76,6 +76,7 @@ body.inverted {
 .ooc .everyone			{color: #002eb8;}
 .inverted .ooc .everyone {color: #004ed8;} /* Dark mode */
 .looc				    {color: #3A9696;}
+.rlooc					{color: #3ABB96;} /* CHOMPEdit */
 .ooc .elevated			{color: #2e78d9;}
 .ooc .moderator			{color: #184880;}
 .ooc .developer			{color: #1b521f;}

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -17,6 +17,7 @@ em						{font-style: normal;font-weight: bold;}
 /* OOC */
 .ooc					{font-weight: bold;}
 .looc					{color: #3A9696;}
+.rlooc					{color: #3ABB96;} //CHOMPEdit
 .ooc img.text_tag		{width: 32px; height: 10px;}
 
 .ooc .everyone			{color: #002eb8;}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
Gives staff remote LOOC logs distinct color from regular LOOC

I've had enough of missing actual targeted LOOC messages just because they happened to pop in during a completely unrelated heated Remote LOOC conversation at the other side of the map between other uninvolved players, and thus drowned among that ocean of identical shade of blue scrolling off the the view at mach speeds.
## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
admin: Changed Remote LOOC logs to use a different color from normal LOOC logs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
