### PR TITLE
Picked the lock in engineering <3

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -9830,9 +9830,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/hatch{
-	icon_state = "door_locked";
 	id_tag = "engine_electrical_maintenance";
-	locked = 1;
 	name = "SMES Access";
 	req_access = list(10)
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
A small QOL change to engineering. Literally just unbolts the engine side SMES maintenance door.
<!-- Describe The Pull Request. -->

## Changelog
The locked = 1 door was changed to a locked = 0 door :) (also sets the sprite from _locked to _closed. A small note so nobody thinks the file change was useless. If I didn't change the mapped in sprite var then it would have been unbolted, but LOOKED bolted.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Engine Side SMES Maintenance now starts unbolted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
