### PR TITLE
A bunch of little tweaks and fixes for juicy gurgles

### DIFF
--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -420,11 +420,11 @@
 			return
 		if(B.owner)
 			if(B.reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && B.reagents.total_volume < B.custom_max_volume)
-				B.owner.adjust_nutrition((B.nutrition_percent / 100) * (power * 0.6) * removed)
-				B.digest_nutri_gain = B.nutrition_percent / 100 * (power * 0.4) * removed
+				B.owner.adjust_nutrition(removed * (B.nutrition_percent / 100) * power)
+				B.digest_nutri_gain += removed * (B.nutrition_percent / 100) + 0.5
 				B.GenerateBellyReagents_digesting()
 			else
-				B.owner.adjust_nutrition((B.nutrition_percent / 100) * power * removed) //CHOMPEdit End
+				B.owner.adjust_nutrition(removed * (B.nutrition_percent / 100) * power) //CHOMPEdit End
 
 	if(volume < meltdose) // Not enough to melt anything
 		M.take_organ_damage(0, removed * power * 0.2) //burn damage, since it causes chemical burns. Acid doesn't make bones shatter, like brute trauma would.

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -473,11 +473,11 @@
 			return
 		if(B.owner)
 			if(B.reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && B.reagents.total_volume < B.custom_max_volume)
-				B.owner.adjust_nutrition((B.nutrition_percent / 100) * (power * 0.6) * volume)
-				B.digest_nutri_gain = B.nutrition_percent / 100 * (power * 0.4) * volume
+				B.owner.adjust_nutrition(volume * (B.nutrition_percent / 100) * power)
+				B.digest_nutri_gain += volume * (B.nutrition_percent / 100) + 0.5
 				B.GenerateBellyReagents_digesting()
 			else
-				B.owner.adjust_nutrition((B.nutrition_percent / 100) * power * volume)
+				B.owner.adjust_nutrition(volume * (B.nutrition_percent / 100) * power)
 	L.adjustFireLoss(volume * power * 0.2)
 	remove_self(volume) //CHOMPAdd End
 

--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -179,16 +179,20 @@
 				gen_interval = 0
 			else
 				gen_interval++
-	if(reagents.total_volume && LAZYLEN(contents))
+	if(reagents.total_volume >= 5 && LAZYLEN(contents))
 		SEND_SIGNAL(src, COMSIG_BELLY_UPDATE_VORE_FX, FALSE, reagents.total_volume) // Signals vore_fx() reagents updates.
-		for(var/mob/living/L in contents)
-			if(L.digestable && digest_mode == DM_DIGEST)
+		var/affecting_amt = reagents.total_volume / max(LAZYLEN(contents), 1)
+		if(affecting_amt > 5)
+			affecting_amt = 5
+		if(affecting_amt >= 1)
+			for(var/mob/living/L in contents)
+				if(L.digestable && digest_mode == DM_DIGEST)
+					if(reagents.total_volume)
+						reagents.trans_to(L, affecting_amt, 1, FALSE)
+				vore_fx(L, FALSE, reagents.total_volume)
+			for(var/obj/item/I in contents)
 				if(reagents.total_volume)
-					reagents.trans_to(L, reagents.total_volume * 0.1, 1 / max(LAZYLEN(contents), 1), FALSE)
-			vore_fx(L, FALSE, reagents.total_volume)
-		for(var/obj/item/I in contents)
-			if(reagents.total_volume)
-				reagents.trans_to(I, reagents.total_volume * 0.1, 1 / max(LAZYLEN(contents), 1), FALSE)
+					reagents.trans_to(I, affecting_amt, 1, FALSE)
 
 /obj/belly/proc/GenerateBellyReagents()
 	if(isrobot(owner))
@@ -209,7 +213,7 @@
 			reagents.add_reagent(reagent, generated_reagents[reagent] * digest_nutri_gain / gen_cost)
 	else
 		owner.adjust_nutrition((4.5 * digest_nutri_gain) * owner.get_digestion_efficiency_modifier())
-		digest_nutri_gain = 0
+	digest_nutri_gain = 0
 
 /obj/belly/proc/GenerateBellyReagents_digested()
 	if(reagents.total_volume <= custom_max_volume - 25 * gen_amount)
@@ -218,6 +222,7 @@
 	else
 		for(var/reagent in generated_reagents)
 			reagents.add_reagent(reagent, generated_reagents[reagent] / gen_amount * (custom_max_volume - reagents.total_volume))
+	digest_nutri_gain = 0
 
 //////////////////////////// REAGENT_ABSORB ////////////////////////
 

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -398,7 +398,7 @@
 			playsound(src, soundfile, vol = sound_volume, vary = 1, falloff = VORE_SOUND_FALLOFF, preference = /datum/client_preference/eating_noises, volume_channel = VOLUME_CHANNEL_VORE) //CHOMPEdit
 			recent_sound = TRUE
 
-	if(reagents.total_volume > 0 && !isliving(thing)) //CHOMPAdd
+	if(reagents.total_volume >= 5 && !isliving(thing)) //CHOMPAdd
 		reagents.trans_to(thing, reagents.total_volume * 0.1, 1 / max(LAZYLEN(contents), 1), FALSE) //CHOMPAdd
 	//Messages if it's a mob
 	if(isliving(thing))
@@ -427,7 +427,7 @@
 		//Stop AI processing in bellies
 		if(M.ai_holder)
 			M.ai_holder.go_sleep()
-		if(reagents.total_volume > 0 && M.digestable) //CHOMPEdit Start
+		if(reagents.total_volume >= 5 && M.digestable) //CHOMPEdit Start
 			if(digest_mode == DM_DIGEST)
 				reagents.trans_to(M, reagents.total_volume * 0.1, 1 / max(LAZYLEN(contents), 1), FALSE)
 			to_chat(M, "<span class='warning'><B>You splash into a pool of [reagent_name]!</B></span>")

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -90,6 +90,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 		if(B.reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && B.reagents.total_volume < B.reagents.maximum_volume) //digestion producing reagents
 			var/mob/living/silicon/robot/R = B.owner
 			R.cell.charge += 20*damage_gain
+			B.digest_nutri_gain += offset * (1.5 * damage_gain / difference)
 			B.GenerateBellyReagents_digesting()
 		else
 			var/mob/living/silicon/robot/R = B.owner
@@ -97,7 +98,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	if(offset && damage_gain > 0) // If any different than default weight, multiply the % of offset.
 		if(B.reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && B.reagents.total_volume < B.reagents.maximum_volume) //digestion producing reagents
 			B.owner.adjust_nutrition(offset * (3 * damage_gain / difference) * L.get_digestion_nutrition_modifier() * B.owner.get_digestion_efficiency_modifier()) //Uncertain if balanced fairly, can adjust by multiplier for the cost of reagent, dont go below 1 or else it will result in more nutrition than normal - Jack
-			B.digest_nutri_gain = offset * (1.5 * damage_gain / difference) * L.get_digestion_nutrition_modifier() * B.owner.get_digestion_efficiency_modifier() //for transfering nutrition value over to GenerateBellyReagents_digesting()
+			B.digest_nutri_gain += offset * (1.5 * damage_gain / difference) * L.get_digestion_nutrition_modifier() * B.owner.get_digestion_efficiency_modifier() //for transfering nutrition value over to GenerateBellyReagents_digesting()
 			B.GenerateBellyReagents_digesting()
 		else
 			B.owner.adjust_nutrition(offset * (4.5 * damage_gain / difference) * L.get_digestion_nutrition_modifier() * B.owner.get_digestion_efficiency_modifier()) //4.5 nutrition points per health point. Normal same size 100+100 health prey with average weight would give 900 points if the digestion was instant. With all the size/weight offset taxes plus over time oxyloss+hunger taxes deducted with non-instant digestion, this should be enough to not leave the pred starved.
@@ -223,7 +224,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	B.put_in_egg(H, 1)*/
 
 /datum/digest_mode/egg/handle_atoms(obj/belly/B, list/touchable_atoms)
-	if(B.owner.nutrition < 25) //CHOMPEdit Start
+	if(B.owner.nutrition < 5) //CHOMPEdit Start
 		return
 	var/list/egg_contents = list()
 	for(var/E in touchable_atoms)
@@ -249,7 +250,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 			if(B.egg_type in tf_vore_egg_types)
 				B.egg_path = tf_vore_egg_types[B.egg_type]
 			B.ownegg = new B.egg_path(B)
-			B.owner.adjust_nutrition(-25)
+			B.owner.adjust_nutrition(-5)
 			if(B.ownegg && B.egg_name)
 				B.ownegg.egg_name = B.egg_name
 				B.ownegg.name = B.egg_name //CHOMPEdit End


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
-Fixed a few math jank hijinks revealed underneath recent fixes.
-Tweaked a whole bunch of liquid generation/application mechanisms.
-Made liquidbellies need a minimum of 5u to splash/stew contents, and minimum of 1u per target, preventing values getting divided too thin for metabolism code to care (no effect while still getting deleted).
-Made liquid stewing digestion not use more than 5u at a time per victim. This way a single prey won't just sponge up everything at once.
-Fixed liquid generating digestion with acids generating reagents at a huge loss.
-Digestion generated acids now keep up with the consumption while maintaining a slight net profit.
-Made reagent digestion gain vars stack with each other so that regular digestion and liquid digestion can both proc the liquid generation during one cycle without erasing one or another.
-And made the nutrition gains from liquid digestion a little more consistent.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: fixed a bunch of janky mechanics around liquidbelly acid mechanics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
