### PR TITLE
Borgs can now use nutrition to recharge.

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -1315,9 +1315,9 @@
 		items_preserved |= item
 	else
 		owner.adjust_nutrition((nutrition_percent / 100) * 5 * digested)
-		if(isrobot(owner))
-			var/mob/living/silicon/robot/R = owner
-			R.cell.charge += ((nutrition_percent / 100) * 50 * digested)
+		// if(isrobot(owner)) //CHOMPEdit: Borgos can now use nutrition too.
+		//	var/mob/living/silicon/robot/R = owner
+		//	R.cell.charge += ((nutrition_percent / 100) * 50 * digested)
 		digested = TRUE //CHOMPEdit
 	return digested
 

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	var/difference = B.owner.size_multiplier / L.size_multiplier
 	if(B.health_impacts_size) //CHOMPEdit - Health probably changed so...
 		B.owner.update_fullness() //CHOMPEdit - This is run whenever a belly's contents are changed.
-	if(isrobot(B.owner))
+	/*if(isrobot(B.owner)) //CHOMPEdit: Borgos can now use nutrition too
 		if(B.reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && B.reagents.total_volume < B.reagents.maximum_volume) //digestion producing reagents
 			var/mob/living/silicon/robot/R = B.owner
 			R.cell.charge += 20*damage_gain
@@ -94,7 +94,7 @@ GLOBAL_LIST_INIT(digest_modes, list())
 			B.GenerateBellyReagents_digesting()
 		else
 			var/mob/living/silicon/robot/R = B.owner
-			R.cell.charge += 25*damage_gain
+			R.cell.charge += 25*damage_gain */
 	if(offset && damage_gain > 0) // If any different than default weight, multiply the % of offset.
 		if(B.reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && B.reagents.total_volume < B.reagents.maximum_volume) //digestion producing reagents
 			B.owner.adjust_nutrition(offset * (3 * damage_gain / difference) * L.get_digestion_nutrition_modifier() * B.owner.get_digestion_efficiency_modifier()) //Uncertain if balanced fairly, can adjust by multiplier for the cost of reagent, dont go below 1 or else it will result in more nutrition than normal - Jack

--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -1,3 +1,5 @@
+/mob/living/silicon/robot
+	nutrition = 0 //No starter nutrition to overcharge the cell with.
 
 /mob/living/silicon/robot/updateicon() //TODO - Make the belly stuff resting sprite stuff into feature flags and replace dogborg var - 7/19/23
 	vr_sprite_check()
@@ -79,3 +81,10 @@
 	else if (vis_height != module_sprites[icontype][SKIN_HEIGHT])
 		vis_height = module_sprites[icontype][SKIN_HEIGHT]
 		update_transform()
+
+/mob/living/silicon/robot/use_power()
+	if(cell && cell.charge < cell.maxcharge)
+		if(nutrition >= 20)
+			nutrition -= 20
+			cell.charge += 200
+	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
The previously completely useless mob/living/ nutrition var that most of the vore features use to shove the gains into is no longer useless for borgs.
Borgs also now start with 0 nutrition cause otherwise that would just be free overcharge right at the spawn.
Figured this was easier and more efficient than trying to jam borg-specific code into every feature that utilizes the nutrition var.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Vore nutrition is no longer useless for borgs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
