### PR TITLE
Reworks how egg mode functions

### DIFF
--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -121,6 +121,7 @@
 	var/sound_volume = 100					// Volume knob.
 	var/speedy_mob_processing = FALSE		// Independent belly processing to utilize SSobj instead of SSbellies 3x speed.
 	var/cycle_sloshed = FALSE				// Has vorgan entrance made a wet slosh this cycle? Soundspam prevention for multiple items entered.
+	var/egg_cycles = 0						// Process egg mode after 10 cycles.
 
 /obj/belly/proc/GetFullnessFromBelly()
 	if(!affects_vore_sprites)

--- a/code/modules/vore/eating/bellymodes_datum_vr.dm
+++ b/code/modules/vore/eating/bellymodes_datum_vr.dm
@@ -224,8 +224,10 @@ GLOBAL_LIST_INIT(digest_modes, list())
 	B.put_in_egg(H, 1)*/
 
 /datum/digest_mode/egg/handle_atoms(obj/belly/B, list/touchable_atoms)
-	if(B.owner.nutrition < 5) //CHOMPEdit Start
+	if(B.egg_cycles < 10) //CHOMPEdit Start
+		B.egg_cycles ++
 		return
+	B.egg_cycles = 0
 	var/list/egg_contents = list()
 	for(var/E in touchable_atoms)
 		if(istype(E, /obj/item/weapon/storage/vore_egg)) // Don't egg other eggs.
@@ -250,10 +252,10 @@ GLOBAL_LIST_INIT(digest_modes, list())
 			if(B.egg_type in tf_vore_egg_types)
 				B.egg_path = tf_vore_egg_types[B.egg_type]
 			B.ownegg = new B.egg_path(B)
-			B.owner.adjust_nutrition(-5)
 			if(B.ownegg && B.egg_name)
 				B.ownegg.egg_name = B.egg_name
-				B.ownegg.name = B.egg_name //CHOMPEdit End
+				B.ownegg.name = B.egg_name
+		var/scale_clamp = 1
 		for(var/atom/movable/C in egg_contents)
 			if(isitem(C) && egg_contents.len == 1) //Only egging one item
 				var/obj/item/I = C
@@ -266,32 +268,34 @@ GLOBAL_LIST_INIT(digest_modes, list())
 				egg_contents -= I
 				B.ownegg = null
 				return list("to_update" = TRUE)
-			if(isliving(C))
-				var/mob/living/M = C
-				var/mob_holder_type = M.holder_type || /obj/item/weapon/holder
-				B.ownegg.w_class = M.size_multiplier * 4 //Egg size and weight scaled to match occupant.
-				var/obj/item/weapon/holder/H = new mob_holder_type(B.ownegg, M)
-				B.ownegg.max_storage_space = H.w_class
-				B.ownegg.icon_scale_x = 0.25 * B.ownegg.w_class
-				B.ownegg.icon_scale_y = 0.25 * B.ownegg.w_class
-				B.ownegg.update_transform()
-				egg_contents -= M
-				if(B.ownegg.w_class > 4)
-					B.ownegg.slowdown = B.ownegg.w_class - 4
-				B.ownegg = null
-				return list("to_update" = TRUE)
-			C.forceMove(B.ownegg)
 			if(isitem(C))
 				var/obj/item/I = C
 				B.ownegg.w_class += I.w_class //Let's assume a regular outfit can reach total w_class of 16.
+				I.forceMove(B.ownegg)
+			if(isliving(C))
+				var/mob/living/M = C
+				var/mob_holder_type = M.holder_type || /obj/item/weapon/holder
+				B.ownegg.w_class += M.size_multiplier * 4 //Egg size and weight scaled to match occupant.
+				if(M.size_multiplier > scale_clamp)
+					scale_clamp = M.size_multiplier
+				var/obj/item/weapon/holder/H = new mob_holder_type(B.ownegg, M)
+				B.ownegg.max_storage_space = H.w_class
+				//B.ownegg.icon_scale_x = 0.25 * B.ownegg.w_class
+				//B.ownegg.icon_scale_y = 0.25 * B.ownegg.w_class
+				//B.ownegg.update_transform()
+				egg_contents -= M
+				//if(B.ownegg.w_class > 4)
+				//	B.ownegg.slowdown = B.ownegg.w_class - 4
+				//B.ownegg = null
+				//return list("to_update" = TRUE)
 		B.ownegg.calibrate_size()
 		B.ownegg.orient2hud()
 		B.ownegg.w_class = clamp(B.ownegg.w_class * 0.25, 1, 8) //A total w_class of 16 will result in a backpack sized egg.
-		B.ownegg.icon_scale_x = clamp(0.25 * B.ownegg.w_class, 0.25, 1)
-		B.ownegg.icon_scale_y = clamp(0.25 * B.ownegg.w_class, 0.25, 1)
+		B.ownegg.icon_scale_x = clamp(0.25 * B.ownegg.w_class, 0.25, scale_clamp)
+		B.ownegg.icon_scale_y = clamp(0.25 * B.ownegg.w_class, 0.25, scale_clamp)
 		B.ownegg.update_transform()
 		if(B.ownegg.w_class > 4)
-			B.ownegg.slowdown = B.ownegg.w_class - 4
+			B.ownegg.slowdown = 4 //CHOMPEdit End
 		B.ownegg = null
 		return list("to_update" = TRUE)
 	return

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -38,9 +38,17 @@
 	SEND_SIGNAL(src, COMSIG_BELLY_UPDATE_PREY_LOOP) // CHOMPedit: signals listening atoms to update prey_loop. May be cancelled by early exit otherwise.
 
 /////////////////////////// Exit Early ////////////////////////////
-	var/list/touchable_atoms = contents - items_preserved
+	var/list/touchable_atoms = contents.Copy() //CHOMPEdit Start
 	for(var/mob/observer/G in touchable_atoms) //CHOMPEdit: don't bother trying to process ghosts.
 		touchable_atoms -= G
+	if(!length(touchable_atoms))
+		return
+	var/datum/digest_mode/DM = GLOB.digest_modes["[digest_mode]"]
+	if(DM == DM_EGG)
+		if(DM.handle_atoms(src, touchable_atoms))
+			updateVRPanels()
+		return
+	touchable_atoms -= items_preserved
 	if(!length(touchable_atoms))
 		return
 
@@ -57,11 +65,10 @@
 
 ///////////////////// Early Non-Mode Handling /////////////////////
 
-	var/datum/digest_mode/DM = GLOB.digest_modes["[digest_mode]"]
 	if(!DM)
 		log_debug("Digest mode [digest_mode] didn't exist in the digest_modes list!!")
 		return FALSE
-	if(DM.handle_atoms(src, touchable_atoms))
+	if(DM.handle_atoms(src, touchable_atoms)) //CHOMPEdit End
 		updateVRPanels()
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Egg mode is now time based rather than nutrition based, and will egg anything eggable in the vorgan contents after 10 cycles (1 minute normal, 20sec on turbo mode)
Eggs can contain both, mobs and items. Even multiple mobs for some cramped egg-sharing funtimes.
Eggs w_class is now capped at 4 so a heavy egg will just be heavy rather than immobilizing.
Egg mode no longer ignores hold mode's items_preserved list.
Egg mode also now skips what other modes would do to contents while waiting, so items and mobs can safely wait for their egg cycle. (although item digest mode with acid reagents can still affect them, but who's gonna be using those in their egg hole anyway)
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
refactor: Reworked how egg belly mode functions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
