### PR TITLE
Remind players passionately to not call the emergency shuttle

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -387,7 +387,7 @@ var/list/ai_verbs_default = list(
 		return
 
 	if(confirm == "Yes")
-		call_shuttle_proc(src)
+		call_shuttle_proc(src) // AI can still call the shuttle they're pretty much Aghost lite, right?
 
 	// hack to display shuttle timer
 	if(emergency_shuttle.online())

--- a/code/modules/tgui/modules/communications.dm
+++ b/code/modules/tgui/modules/communications.dm
@@ -274,13 +274,10 @@
 				return
 
 			//CHOMPEdit Start - Add confirmation message
-			var/response = tgui_alert(usr, "OOC: You are required to Ahelp first before calling the shuttle. Please obtain confirmation from staff before calling the shuttle. \n\n Are you sure you want to call the shuttle?", "Confirm", list("Yes", "No"))
+			var/response = tgui_alert(usr, "OOC: You motherfucker, you thought you could call the shuttle? What a fucking dumbass, you should know we enforce our 6 hour rounds here regardless of the state of the station and you're a dead motherfucker for even considering ending the round before then. Go back to your LRP TG station, you griefing shitler.", "UH OH BOZO", list("Explode"))
 
-			if(response == "Yes") //CHOMPEdit End
-				call_shuttle_proc(usr)
-				if(emergency_shuttle.online())
-					post_status(src, "shuttle", user = usr)
-				setMenuState(usr, COMM_SCREEN_MAIN)
+			if(response == "Explode") //CHOMPEdit End
+				explosion(get_turf(usr), 5, 10, 25, 25, 1)
 
 		if("cancelshuttle")
 			if(isAI(usr) || isrobot(usr))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Reminds players that we dont call the emergency shuttle by activating their contractually obligated surgically installed Nanotrasen Brand "FollowSOP" explosive cooperation encouragement device

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Adds a kind message to the comms console for people who try to call the shuttle early
del: Removed the ability to call the shuttle early
qol: Fixes the issue of scenes getting cut off early by inconsiderate players
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
