### PR TITLE
Converts other borg vore gains to use nutrition var

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -610,7 +610,7 @@
 				var/actual_brute = T.getBruteLoss() - old_brute
 				var/actual_burn = T.getFireLoss() - old_burn
 				var/damage_gain = actual_brute + actual_burn
-				drain(-25 * damage_gain) //25*total loss as with voreorgan stats.
+				hound.nutrition += 2.5 * damage_gain //drain(-25 * damage_gain) //25*total loss as with voreorgan stats.//CHOMPEdit
 				if(water)
 					water.add_charge(damage_gain)
 				if(T.stat == DEAD)
@@ -698,10 +698,10 @@
 									plastic.add_charge(total_material)
 								if(material == "wood" && wood)
 									wood.add_charge(total_material)
-					drain(-50 * digested)
+					hound.nutrition += 5 * digested //drain(-50 * digested) //CHOMPEdit
 			else if(istype(target,/obj/effect/decal/remains))
 				qdel(target)
-				drain(-100)
+				hound.nutrition += 10 //drain(-100) //CHOMPEdit
 			else
 				items_preserved |= target
 		update_patient()

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -362,21 +362,20 @@
 	if((mode_flags & DM_FLAG_LEAVEREMAINS) && M.digest_leave_remains)
 		handle_remains_leaving(M)
 	digestion_death(M)
-	//if(!ishuman(owner)) CHOMPremoval. Bad.
+	//if(!ishuman(owner)) CHOMPEdit Start
 	//	owner.update_icons()
-	if(isrobot(owner))
+	/*if(isrobot(owner))
 		var/mob/living/silicon/robot/R = owner
 		if(reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && reagents.total_volume < reagents.maximum_volume) //CHOMPedit: digestion producing reagents
 			R.cell.charge += (nutrition_percent / 100) * compensation * 15 * personal_nutrition_modifier
 			GenerateBellyReagents_digested()
 		else
-			R.cell.charge += (nutrition_percent / 100) * compensation * 25 * personal_nutrition_modifier
+			R.cell.charge += (nutrition_percent / 100) * compensation * 25 * personal_nutrition_modifier*/
+	if(reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && reagents.total_volume < reagents.maximum_volume) //CHOMP digestion producing reagents
+		owner.adjust_nutrition((nutrition_percent / 100) * compensation * 3 * personal_nutrition_modifier)
+		GenerateBellyReagents_digested()
 	else
-		if(reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && reagents.total_volume < reagents.maximum_volume) //CHOMP digestion producing reagents
-			owner.adjust_nutrition((nutrition_percent / 100) * compensation * 3 * personal_nutrition_modifier)
-			GenerateBellyReagents_digested()
-		else
-			owner.adjust_nutrition((nutrition_percent / 100) * compensation * 4.5 * personal_nutrition_modifier * pred_digestion_efficiency) //CHOMPedit end
+		owner.adjust_nutrition((nutrition_percent / 100) * compensation * 4.5 * personal_nutrition_modifier * pred_digestion_efficiency) //CHOMPedit end
 
 /obj/belly/proc/steal_nutrition(mob/living/L)
 	if(L.nutrition >= 100)

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -148,12 +148,11 @@
 /obj/item/weapon/reagent_containers/food/digest_act(atom/movable/item_storage = null)
 	if(isbelly(item_storage))
 		var/obj/belly/B = item_storage
-		if(ishuman(B.owner) && reagents) //CHOMPEdit
+		if(ishuman(B.owner) && reagents) //CHOMPEdit Start
 			var/mob/living/carbon/human/H = B.owner
 			reagents.trans_to_holder(H.ingested, (reagents.total_volume * 0.5), 1, 0)
-		else if(isrobot(B.owner))
-			var/mob/living/silicon/robot/R = B.owner
-			R.cell.charge += 150
+		else if(isliving(B.owner))
+			B.owner.nutrition += 15 * w_class //CHOMPEdit End
 		qdel(src)
 		return w_class
 	. = ..()

--- a/code/modules/vore/eating/living_ch.dm
+++ b/code/modules/vore/eating/living_ch.dm
@@ -341,3 +341,9 @@
 		clear_fullscreen("belly")
 		clear_fullscreen(ATOM_BELLY_FULLSCREEN)
 		stop_sound_channel(CHANNEL_PREYLOOP)
+
+/mob/living/verb/vore_check_nutrition()
+	set name = "Check Nutrition"
+	set category = "Abilities"
+	set desc = "Check your current nutrition level."
+	to_chat(src, "<span class='notice'>Current nutrition level: [nutrition].</span>")

--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -84,7 +84,7 @@
 
 /mob/living/silicon/robot/use_power()
 	if(cell && cell.charge < cell.maxcharge)
-		if(nutrition >= 20)
-			nutrition -= 20
-			cell.charge += 200
+		if(nutrition >= 20 * CYBORG_POWER_USAGE_MULTIPLIER)
+			nutrition -= 20 * CYBORG_POWER_USAGE_MULTIPLIER
+			cell.charge += 200 * CYBORG_POWER_USAGE_MULTIPLIER
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
-Vorgan digestion finisher gain converted to nutrition.
-Sleeperbelly gains converted to nutrition.
-Digest_act food items converted to nutrition. Now also works for simplemobs.
-Made borg nutrition recharge scale with config borg power use multiplier.
-Added a mob/living ability verb to check nutrition level.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: More borg vore charge gains converted for nutrition. Also new ability verb to check nutrition level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
