### PR TITLE
Fixes vore belly icons not updating when content transfered from icon belly to iconless belly

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -452,6 +452,9 @@
 /obj/belly/Exited(atom/movable/thing, atom/OldLoc)
 	. = ..()
 	thing.exit_belly(src) // CHOMPedit - atom movable proc, does nothing by default. Overridden in children for special behavior.
+	if(isbelly(thing.loc)) //CHOMPEdit
+		if(count_items_for_sprite) //CHOMPEdit
+			owner.update_fullness() //CHOMPEdit
 	if(isliving(thing) && !isbelly(thing.loc))
 		owner.update_fullness() //CHOMPEdit - This is run whenever a belly's contents are changed.
 		var/mob/living/L = thing

--- a/code/modules/vore/eating/living_ch.dm
+++ b/code/modules/vore/eating/living_ch.dm
@@ -22,10 +22,17 @@
 	var/vore_sprite_color = list("stomach" = "#000", "taur belly" = "#000")
 
 	var/list/vore_icon_bellies = list("stomach")
+	var/updating_fullness = FALSE
 
 
 // Update fullness based on size & quantity of belly contents
-/mob/living/proc/update_fullness()
+/mob/living/proc/update_fullness(var/returning = FALSE)
+	if(!returning)
+		if(updating_fullness)
+			return
+		updating_fullness = TRUE
+		spawn(2)
+		updating_fullness = FALSE
 	var/list/new_fullness = list()
 	vore_fullness = 0
 	for(var/belly_class in vore_icon_bellies)

--- a/modular_chomp/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/human.dm
@@ -1,4 +1,10 @@
-/mob/living/carbon/human/update_fullness()
+/mob/living/carbon/human/update_fullness(var/returning = FALSE)
+	if(!returning)
+		if(updating_fullness)
+			return
+		updating_fullness = TRUE
+		spawn(2)
+		updating_fullness = FALSE
 	var/previous_stomach_fullness = vore_fullness_ex["stomach"]
 	var/previous_taur_fullness = vore_fullness_ex["taur belly"]
 	//update_vore_tail_sprite()

--- a/modular_chomp/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/human.dm
@@ -9,11 +9,9 @@
 	var/previous_taur_fullness = vore_fullness_ex["taur belly"]
 	//update_vore_tail_sprite()
 	//update_vore_belly_sprite()
-	var/list/new_fullness = ..()
+	var/list/new_fullness = ..(TRUE)
 	. = new_fullness
 	for(var/datum/category_group/underwear/undergarment_class in global_underwear.categories)
-		if(!undergarment_class.name)
-			continue
 		if(!new_fullness[undergarment_class.name])
 			continue
 		new_fullness[undergarment_class.name] = -1 * round(-1 * new_fullness[undergarment_class.name]) // Doing a ceiling the only way BYOND knows how I guess

--- a/modular_chomp/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/human.dm
@@ -12,6 +12,8 @@
 	var/list/new_fullness = ..()
 	. = new_fullness
 	for(var/datum/category_group/underwear/undergarment_class in global_underwear.categories)
+		if(!undergarment_class.name)
+			continue
 		if(!new_fullness[undergarment_class.name])
 			continue
 		new_fullness[undergarment_class.name] = -1 * round(-1 * new_fullness[undergarment_class.name]) // Doing a ceiling the only way BYOND knows how I guess


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes vore belly icons not updating when content transfered from icon belly to iconless belly
Also optimized the update_fullness stuff by like a lot.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed belly icons not updating when transfering contents to iconless belly and optimized fullness update call stacking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
