### PR TITLE
Fixes a small oversight with digestion reagent generation

### DIFF
--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -213,7 +213,7 @@
 		for(var/reagent in generated_reagents)
 			reagents.add_reagent(reagent, generated_reagents[reagent] * digest_nutri_gain / gen_cost)
 	else
-		owner.adjust_nutrition((4.5 * digest_nutri_gain) * owner.get_digestion_efficiency_modifier())
+		owner.adjust_nutrition(digest_nutri_gain * owner.get_digestion_efficiency_modifier())
 	digest_nutri_gain = 0
 
 /obj/belly/proc/GenerateBellyReagents_digested()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes full capacity liquidbelly multiplying the "overflow" nutrition gain by 4.5x
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: fixed belly reagent digestion generation overflow giving 4.5x more nutrition than supposed to.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
