### PR TITLE
Tweaks borg nutrition recharge and gives roaches mouse nutrition.

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/passive/cockroach.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/passive/cockroach.dm
@@ -13,6 +13,7 @@
 
 	maxHealth = 1
 	health = 1
+	nutrition = 20 //CHOMPEdit
 
 	movement_cooldown = -1
 

--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -84,7 +84,7 @@
 
 /mob/living/silicon/robot/use_power()
 	if(cell && cell.charge < cell.maxcharge)
-		if(nutrition >= 20 * CYBORG_POWER_USAGE_MULTIPLIER)
-			nutrition -= 20 * CYBORG_POWER_USAGE_MULTIPLIER
-			cell.charge += 200 * CYBORG_POWER_USAGE_MULTIPLIER
+		if(nutrition >= 1 * CYBORG_POWER_USAGE_MULTIPLIER)
+			nutrition -= 1 * CYBORG_POWER_USAGE_MULTIPLIER
+			cell.charge += 10 * CYBORG_POWER_USAGE_MULTIPLIER
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Draining cockroaches no longer gives the nutrition of a whole crew member.
Borg nutrition power recharge now works with smaller "units".
Turns out the power use proc happens way more frequently than I thought and can actually keep up with power drain just fine at smaller doses even under load.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Cockroaches now carry the same drainable nutrition value as mice do.
balance: Borg nutrition recharge now uses smaller increments with higher frequency.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
