### PR TITLE
Makes our digest_act compatible with non-belly digestion

### DIFF
--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -68,7 +68,7 @@
 				decontaminate()
 				if(istype(B))
 					gurgled_color = B.contamination_color //Apply the correct color setting so uncontaminable things can still have the right overlay.
-					gurgle_contaminate(B, B.contamination_flavor, B.contamination_color) //CHOMPEdit End
+					gurgle_contaminate(B, B.contamination_flavor, B.contamination_color)
 	if(digest_stage <= 0)
 		if(istype(src, /obj/item/device/pda))
 			var/obj/item/device/pda/P = src
@@ -101,7 +101,7 @@
 		else
 			GLOB.items_digested_roundstat++
 			var/g_sound_volume = 100
-			if(istype(B)) //CHOMPEdit Start
+			if(istype(B))
 				g_sound_volume = B.sound_volume
 			var/soundfile
 			if(w_class >= 4)

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -30,41 +30,43 @@
 	if(digest_stage == null)
 		digest_stage = w_class
 
+	var/obj/belly/B //CHOMPEdit Start
 	if(isbelly(item_storage))
-		var/obj/belly/B = item_storage
-		if(!touchable_amount) //CHOMPEdit Start
-			touchable_amount = 1
-		if(splashing > 0)
-			g_damage = 0.25 * splashing
-		else
-			g_damage = 0.25 * (B.digest_brute + B.digest_burn) / touchable_amount
-		if(g_damage <= 0)
-			return FALSE
+		B = item_storage
+	if(!touchable_amount)
+		touchable_amount = 1
+	if(splashing > 0)
+		g_damage = 0.25 * splashing
+	else if(istype(B))
+		g_damage = 0.25 * (B.digest_brute + B.digest_burn) / touchable_amount
+	if(g_damage <= 0)
+		return FALSE
+	if(g_damage > digest_stage)
+		g_damage = digest_stage
+		digest_stage = 0 //Don't bother with further math for 1 hit kills.
+	if(digest_stage > 0)
 		if(g_damage > digest_stage)
 			g_damage = digest_stage
-			digest_stage = 0 //Don't bother with further math for 1 hit kills.
-		if(digest_stage > 0)
-			if(g_damage > digest_stage)
-				g_damage = digest_stage
-			digest_stage -= g_damage
-			d_mult = round(1 / w_class * digest_stage, 0.25)
-			if(d_mult < d_mult_old)
-				d_mult_old = d_mult
-				var/d_stage_name
-				switch(d_mult)
-					if(0.75)
-						d_stage_name = "blemished"
-					if(0.5)
-						d_stage_name = "disfigured"
-					if(0.25)
-						d_stage_name = "deteriorating"
-					if(0)
-						d_stage_name = "ruined"
-				if(d_stage_name)
-					if(!oldname)
-						oldname = cleanname ? cleanname : name
-					cleanname = "[d_stage_name] [oldname]"
-					decontaminate()
+		digest_stage -= g_damage
+		d_mult = round(1 / w_class * digest_stage, 0.25)
+		if(d_mult < d_mult_old)
+			d_mult_old = d_mult
+			var/d_stage_name
+			switch(d_mult)
+				if(0.75)
+					d_stage_name = "blemished"
+				if(0.5)
+					d_stage_name = "disfigured"
+				if(0.25)
+					d_stage_name = "deteriorating"
+				if(0)
+					d_stage_name = "ruined"
+			if(d_stage_name)
+				if(!oldname)
+					oldname = cleanname ? cleanname : name
+				cleanname = "[d_stage_name] [oldname]"
+				decontaminate()
+				if(istype(B))
 					gurgled_color = B.contamination_color //Apply the correct color setting so uncontaminable things can still have the right overlay.
 					gurgle_contaminate(B, B.contamination_flavor, B.contamination_color) //CHOMPEdit End
 	if(digest_stage <= 0)
@@ -75,7 +77,10 @@
 		for(var/mob/living/voice/V in possessed_voice) // Delete voices.
 			V.Destroy() //Destroy the voice.
 		for(var/mob/living/M in contents)//Drop mobs from objects(shoes) before deletion
-			M.forceMove(item_storage)
+			if(item_storage)
+				M.forceMove(item_storage)
+			else
+				M.forceMove(src.loc)
 		for(var/obj/item/O in contents)
 			if(istype(O,/obj/item/weapon/storage/internal)) //Dump contents from dummy pockets.
 				for(var/obj/item/SO in O)
@@ -84,6 +89,8 @@
 					qdel(O)
 			else if(item_storage)
 				O.forceMove(item_storage)
+			else
+				O.forceMove(src.loc)
 		if(istype(src,/obj/item/stack))
 			var/obj/item/stack/S = src
 			if(S.get_amount() <= 1)
@@ -93,16 +100,17 @@
 				digest_stage = w_class
 		else
 			GLOB.items_digested_roundstat++
-			if(isbelly(item_storage)) //CHOMPEdit Start
-				var/obj/belly/B = item_storage
-				var/soundfile
-				if(w_class >= 4)
-					soundfile = pick('sound/vore/shortgurgles/gurgle_L1.ogg', 'sound/vore/shortgurgles/gurgle_L2.ogg', 'sound/vore/shortgurgles/gurgle_L3.ogg')
-				else if(w_class >= 3)
-					soundfile = pick('sound/vore/shortgurgles/gurgle_M1.ogg', 'sound/vore/shortgurgles/gurgle_M2.ogg', 'sound/vore/shortgurgles/gurgle_M3.ogg')
-				else
-					soundfile = pick('sound/vore/shortgurgles/gurgle_S1.ogg', 'sound/vore/shortgurgles/gurgle_S2.ogg', 'sound/vore/shortgurgles/gurgle_S3.ogg')
-				playsound(src, soundfile, vol = B.sound_volume, vary = 1, falloff = VORE_SOUND_FALLOFF, preference = /datum/client_preference/eating_noises, volume_channel = VOLUME_CHANNEL_VORE) //CHOMPEdit End
+			var/g_sound_volume = 100
+			if(istype(B)) //CHOMPEdit Start
+				g_sound_volume = B.sound_volume
+			var/soundfile
+			if(w_class >= 4)
+				soundfile = pick('sound/vore/shortgurgles/gurgle_L1.ogg', 'sound/vore/shortgurgles/gurgle_L2.ogg', 'sound/vore/shortgurgles/gurgle_L3.ogg')
+			else if(w_class >= 3)
+				soundfile = pick('sound/vore/shortgurgles/gurgle_M1.ogg', 'sound/vore/shortgurgles/gurgle_M2.ogg', 'sound/vore/shortgurgles/gurgle_M3.ogg')
+			else
+				soundfile = pick('sound/vore/shortgurgles/gurgle_S1.ogg', 'sound/vore/shortgurgles/gurgle_S2.ogg', 'sound/vore/shortgurgles/gurgle_S3.ogg')
+			playsound(src, soundfile, vol = g_sound_volume, vary = 1, falloff = VORE_SOUND_FALLOFF, preference = /datum/client_preference/eating_noises, volume_channel = VOLUME_CHANNEL_VORE) //CHOMPEdit End
 			qdel(src)
 	if(g_damage > w_class)
 		return w_class


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Played around with the stardog map and code yesterday and noticed the way the new acid turfs work needed a little adjustment to our item digestion code to function properly.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed digest_act proc not working properly for non-belly use (acid turfs etc.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
