### PR TITLE
Fixes Parry Shield, Buffs Energy Sword

### DIFF
--- a/code/game/objects/items/devices/personal_shield_generator_vr.dm
+++ b/code/game/objects/items/devices/personal_shield_generator_vr.dm
@@ -181,6 +181,9 @@
 
 	else if(W.is_screwdriver())
 		if(bcell)
+			if(istype(bcell, /obj/item/weapon/cell/device/shield_generator/parry)) //CHOMPedit: Cannot remove the cell from Parry shields.
+				to_chat(user,"<span class='notice'>You cannot remove the cell from this device.</span>") //CHOMPedit: No cell removal.
+				return //CHOMPedit: No cell removal.
 			if(istype(bcell, /obj/item/weapon/cell/device/shield_generator)) //No stealing self charging batteries!
 				var/choice = tgui_alert(user, "A popup appears on the device 'REMOVING THE INTERNAL CELL WILL DESTROY THE BATTERY. DO YOU WISH TO CONTINUE?'...Well, do you?", "Selection List", list("Cancel", "Remove"))
 				if(choice == "Remove") //Warned you...
@@ -600,6 +603,6 @@
 	charge_delay = 300
 
 /obj/item/weapon/cell/device/shield_generator/parry //The cell for the 'parry' shield gen.
-	maxcharge = 100
-	charge_amount = 100
-	charge_delay = 20 //Starts charging two seconds after it's discharged.
+	maxcharge = 200 //CHOMPedit: 100 to 200.
+	charge_amount = 200 //CHOMPedit: 100 to 200.
+	charge_delay = 30 //CHOMPedit: Starts charging three seconds after it's discharged.

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -261,7 +261,7 @@
 	desc = "May the force be within you."
 	icon_state = "esword"
 	item_state = "esword"
-	active_force = 30
+	active_force = 50 //CHOMPedit: Damage buff.
 	active_armourpen = 50
 	active_throwforce = 20
 	active_w_class = ITEMSIZE_HUGE //CHOMP Edit

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -261,7 +261,7 @@
 	desc = "May the force be within you."
 	icon_state = "esword"
 	item_state = "esword"
-	active_force = 50 //CHOMPedit: Damage buff.
+	active_force = 30
 	active_armourpen = 50
 	active_throwforce = 20
 	active_w_class = ITEMSIZE_HUGE //CHOMP Edit


### PR DESCRIPTION
:cl:
balance: Parry shield belt to last twice as long, but takes an extra second to recharge.
fix: Cell can no longer be removed from the parry shield belt.
/:cl:
:cl:Upstream
add: Zone based marking customisation
/:cl: