### PR TITLE
adds user_vars_to_edit (for events and stuff or just fun)

### DIFF
--- a/modular_chomp/code/game/objects/items.dm
+++ b/modular_chomp/code/game/objects/items.dm
@@ -1,6 +1,8 @@
 /obj/item
 	var/item_tf_spawn_allowed = FALSE
 	var/list/ckeys_allowed_itemspawn = list()
+	var/user_vars_to_edit //fun times :3 - pretty much just grabbed from tg immabehonest - list(variable_name = variable_value) eg list("name" = "Wizardly Wizard", "real_name" = "Wizardly Wizard")
+	var/user_vars_remembered //not needed for manual editing, just stores the original vars from the above list to make sure they go back to normal later
 
 /obj/item/proc/item_tf_spawnpoint_set()
 	if(!item_tf_spawn_allowed)
@@ -15,4 +17,34 @@
 /obj/item/Destroy(force, ...)
 	if(item_tf_spawn_allowed)
 		item_tf_spawnpoints -= src
+	user_vars_remembered = null
 	return ..()
+
+/obj/item/dropped(mob/living/user)
+	. = ..()
+	if (!istype(user))
+		return
+	if(LAZYLEN(user_vars_remembered))
+		for(var/variable in user_vars_remembered)
+			if(variable in user.vars)
+				if(user.vars[variable] == user_vars_to_edit[variable])
+					user.vars[variable] = user_vars_remembered[variable]
+		user_vars_remembered = initial(user_vars_remembered)
+
+/obj/item/equipped(mob/living/user, slot_equipped)
+	. = ..()
+	if (!istype(user))
+		return
+	if(("[slot_equipped]" in slot_flags_enumeration) && (slot_flags & slot_flags_enumeration["[slot_equipped]"]))
+		if (LAZYLEN(user_vars_to_edit))
+			for(var/variable in user_vars_to_edit)
+				if(variable in user.vars)
+					LAZYSET(user_vars_remembered, variable, user.vars[variable])
+					user.vv_edit_var(variable, user_vars_to_edit[variable])
+	else
+		if(LAZYLEN(user_vars_remembered))
+			for(var/variable in user_vars_remembered)
+				if(variable in user.vars)
+					if(user.vars[variable] == user_vars_to_edit[variable])
+						user.vars[variable] = user_vars_remembered[variable]
+			user_vars_remembered = initial(user_vars_remembered)


### PR DESCRIPTION
## About The Pull Request

adds a user_vars_to_edit var to items
basically, it's a list that sets the variables defined in the list to their values in the list when the user equips the item in a slot it can be equipped in. eg list("name" = "Wizardly Wizard", "real_name" = "Wizardly Wizard") will set the user's name to Wizardly Wizard when they put it on, and when they take it off it'll be back to normal

this can be used for things like invisible cloaks (or invisible hats, I dunno), shoes that let you run through walls, a headset that applies 200 brute damage when you put it on, or just generally fun things if you can think of a way to do it.

could be used to make quick and easy items for events without having to change much, and it can be done in the round too, on the spot, as needed

## Changelog

:cl:
add: adds user_vars_to_edit (for events and stuff or just fun)
/:cl: