### PR TITLE
Fixes planetary lighting

### DIFF
--- a/code/controllers/subsystems/planets.dm
+++ b/code/controllers/subsystems/planets.dm
@@ -31,6 +31,7 @@ SUBSYSTEM_DEF(planets)
 				admin_notice("<span class='danger'>Z[Z] is shared by more than one planet!</span>", R_DEBUG)
 				continue
 			z_to_planet[Z] = NP
+			planet_lighting_zs |= Z // I guess this is problematic if planet datums get deleted later. // CHOMPedit
 
 // DO NOT CALL THIS DIRECTLY UNLESS IT'S IN INITIALIZE,
 // USE turf/simulated/proc/make_indoors() and

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -1,3 +1,5 @@
+var/static/list/planet_lighting_zs = list() // Tracks which z-levels use planetary lighting. // CHOMPedit
+
 /turf
 	///Lumcount added by sources other than lighting datum objects, such as the overlay lighting component.
 	var/dynamic_lumcount = 0
@@ -104,7 +106,7 @@
 
 ///Checks planets and fake_suns to see if our turf should be handled by either
 /turf/proc/check_for_sun()
-	if((z in SSplanets.z_to_planet) || (z in fake_sunlight_zs))
+	if((z in planet_lighting_zs) || (z in fake_sunlight_zs)) // CHOMPedit
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
Fixes planetary lighting bug from #6852 . Previous if() checked numbers against planet datums, so it always failed and thus Sif lost its sun.

:cl:
-Fixes planetary lighting.
/:cl: