### PR TITLE
Adds Slippery Reflexes trait

### DIFF
--- a/code/modules/emotes/definitions/visible_animated.dm
+++ b/code/modules/emotes/definitions/visible_animated.dm
@@ -38,6 +38,11 @@
 	else if(istype(user))
 		user.SpinAnimation(7,1)
 
+/decl/emote/visible/flip/slip //CHOMPAdd
+	key = "sflip"
+	emote_message_1p = "You barely avoid falling over!"
+	emote_message_3p = "barely avoids falling over!"
+
 /decl/emote/visible/floorspin
 	key = "floorspin"
 	emote_message_1p = "You spin around on the floor!"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -424,7 +424,7 @@
 	playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
 	if(slip_reflex && !lying) //CHOMPEdit Start
 		if(world.time >= next_emote)
-			src.emote("flip")
+			src.emote("sflip")
 			return 1 //CHOMPEdit End
 	Weaken(FLOOR(stun_duration/2, 1))
 	return 1

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -422,7 +422,7 @@
 	stop_pulling()
 	to_chat(src, "<span class='warning'>You slipped on [slipped_on]!</span>")
 	playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
-	if(slip_reflex) //CHOMPEdit Start
+	if(slip_reflex && !lying) //CHOMPEdit Start
 		if(world.time >= next_emote)
 			src.emote("flip")
 			return 1 //CHOMPEdit End

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -422,6 +422,10 @@
 	stop_pulling()
 	to_chat(src, "<span class='warning'>You slipped on [slipped_on]!</span>")
 	playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
+	if(slip_reflex) //CHOMPEdit Start
+		if(world.time >= next_emote)
+			src.emote("flip")
+			return 1 //CHOMPEdit End
 	Weaken(FLOOR(stun_duration/2, 1))
 	return 1
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -177,7 +177,8 @@ var/list/_human_default_emotes = list(
 	//CHOMP Add start
 	/decl/emote/audible/prbt2,
 	/decl/emote/audible/pain,
-	/decl/emote/audible/mgeow
+	/decl/emote/audible/mgeow,
+	/decl/emote/visible/flip/slip
 	//CHOMP Add end
 )
 

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral_ch.dm
@@ -130,3 +130,12 @@
 						else
 							input += "s"
 	return input
+
+/datum/trait/neutral/slip_reflex
+	name ="Slippery Reflexes"
+	desc = "Your reflexes are quick enough to react to slippery surfaces. You are not immune though."
+	cost = 0
+
+/datum/trait/neutral/slip_reflex/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	H.slip_reflex = TRUE

--- a/modular_chomp/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/carbon.dm
@@ -1,5 +1,6 @@
 /mob/living/carbon
 	var/datum/looping_sound/mob/cozyloop/cozyloop
+	var/slip_reflex = FALSE
 
 /mob/living/carbon/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a new neutral trait that makes slips result in *flips instead. Only happens once per emote cooldown, so a second slip will still slip you if you keep going too fast.
Decided to make it neutral trait because while it can save you from one slip, the chances are you might still just smack your face into a wall anyway and end up worse off than you would've with just a slip.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added Slippery Reflexes trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
