### PR TITLE
Adds event/shenanigans vareditable shapeshifter mechanic

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -302,6 +302,10 @@
 	if((direct & (direct - 1)) && mob.loc == n)
 		my_mob.setMoveCooldown(total_delay * SQRT_2) //CHOMPEDIT
 
+	if(!isliving(my_mob)) //CHOMPAdd
+		moving = 0
+		return
+
 	// If we have a grab
 	var/list/grablist = my_mob.ret_grab()
 	if(LAZYLEN(grablist))

--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -351,7 +351,7 @@
 					continue
 				M.drop_from_inventory(W)
 
-		if(M.tf_form == ourmob) //CHOMPEdit Start
+		if(M.tf_form == ourmob)
 			if(ourmob_ckey)
 				M.ckey = ourmob_ckey
 			ourmob.tf_form = M

--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -98,6 +98,9 @@
 			var/datum/ai_holder/our_AI = ourmob.ai_holder
 			our_AI.set_stance(STANCE_IDLE)
 		M.tf_mob_holder = null
+		var/ourmob_ckey  //CHOMPEdit Start
+		if(ourmob.ckey)
+			ourmob_ckey = ourmob.ckey
 		ourmob.ckey = M.ckey
 		var/turf/get_dat_turf = get_turf(target)
 		ourmob.loc = get_dat_turf
@@ -118,7 +121,9 @@
 					continue
 				M.drop_from_inventory(W)
 
-		if(M.tf_form == ourmob) //CHOMPEdit Start
+		if(M.tf_form == ourmob)
+			if(ourmob_ckey)
+				M.ckey = ourmob_ckey
 			ourmob.tf_form = M
 			M.forceMove(ourmob)
 		else
@@ -190,6 +195,9 @@
 		var/datum/ai_holder/our_AI = ourmob.ai_holder
 		our_AI.set_stance(STANCE_IDLE)
 	tf_mob_holder = null
+	var/ourmob_ckey  //CHOMPEdit Start
+	if(ourmob.ckey)
+		ourmob_ckey = ourmob.ckey
 	ourmob.ckey = ckey
 	var/turf/get_dat_turf = get_turf(src)
 	ourmob.loc = get_dat_turf
@@ -211,7 +219,9 @@
 				continue
 			src.drop_from_inventory(W)
 
-	if(tf_form == ourmob) //CHOMPEdit Start
+	if(tf_form == ourmob)
+		if(ourmob_ckey)
+			src.ckey = ourmob_ckey
 		ourmob.tf_form = src
 		src.forceMove(ourmob)
 	else
@@ -317,6 +327,9 @@
 			var/datum/ai_holder/our_AI = ourmob.ai_holder
 			our_AI.set_stance(STANCE_IDLE)
 		M.tf_mob_holder = null
+		var/ourmob_ckey  //CHOMPEdit Start
+		if(ourmob.ckey)
+			ourmob_ckey = ourmob.ckey
 		ourmob.ckey = M.ckey
 		var/turf/get_dat_turf = get_turf(target)
 		ourmob.loc = get_dat_turf
@@ -339,6 +352,8 @@
 				M.drop_from_inventory(W)
 
 		if(M.tf_form == ourmob) //CHOMPEdit Start
+			if(ourmob_ckey)
+				M.ckey = ourmob_ckey
 			ourmob.tf_form = M
 			M.forceMove(ourmob)
 		else

--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -118,7 +118,11 @@
 					continue
 				M.drop_from_inventory(W)
 
-		qdel(target)
+		if(M.tf_form == ourmob) //CHOMPEdit Start
+			ourmob.tf_form = M
+			M.forceMove(ourmob)
+		else
+			qdel(target) //CHOMPEdit End
 		return
 	else
 		if(M.stat == DEAD)	//We can let it undo the TF, because the person will be dead, but otherwise things get weird.
@@ -207,7 +211,11 @@
 				continue
 			src.drop_from_inventory(W)
 
-	qdel(src)
+	if(tf_form == ourmob) //CHOMPEdit Start
+		ourmob.tf_form = src
+		src.forceMove(ourmob)
+	else
+		qdel(src) //CHOMPEdit End
 
 
 /mob/living/proc/handle_tf_holder()
@@ -330,7 +338,11 @@
 					continue
 				M.drop_from_inventory(W)
 
-		qdel(target)
+		if(M.tf_form == ourmob) //CHOMPEdit Start
+			ourmob.tf_form = M
+			M.forceMove(ourmob)
+		else
+			qdel(target) //CHOMPEdit End
 		firer.visible_message("<span class='notice'>\The [shot_from] boops pleasantly.</span>")
 		return
 	else

--- a/modular_chomp/code/modules/mob/living/living.dm
+++ b/modular_chomp/code/modules/mob/living/living.dm
@@ -166,7 +166,7 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 /mob/living/proc/shapeshift_form()
 	set name = "Shapeshift Form"
 	set category = "Abilities"
-	set desc = "Shape shift between set mob forms."
+	set desc = "Shape shift between set mob forms. (Requires a spawned mob to be varedited into the user's tf_form var as mob reference.)"
 	if(!istype(tf_form))
 		to_chat(src, "<span class='notice'>No shapeshift form set. (Requires a spawned mob to be varedited into the user's tf_form var as mob reference.)</span>")
 		return

--- a/modular_chomp/code/modules/mob/living/living.dm
+++ b/modular_chomp/code/modules/mob/living/living.dm
@@ -110,11 +110,14 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 		if(!ispath(new_form, /mob/living) && !ismob(new_form))
 			return
 		var/mob/living/new_mob
+		var/new_mob_ckey
 		if(shapeshifting && src.tf_form)
 			new_mob = src.tf_form
 			new_mob.verbs |= /mob/living/proc/shapeshift_form
 			new_mob.tf_form = src
 			new_mob.forceMove(src.loc)
+			if(new_mob.ckey)
+				new_mob_ckey = new_mob.ckey
 		else
 			new_mob = new new_form(get_turf(src))
 		new_mob.faction = src.faction
@@ -152,6 +155,8 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 				new_mob.vore_organs += B
 
 			new_mob.ckey = src.ckey
+			if(new_mob_ckey)
+				src.ckey = new_mob_ckey
 			if(src.ai_holder && new_mob.ai_holder)
 				var/datum/ai_holder/old_AI = src.ai_holder
 				old_AI.set_stance(STANCE_SLEEP)

--- a/modular_chomp/code/modules/mob/living/living.dm
+++ b/modular_chomp/code/modules/mob/living/living.dm
@@ -168,7 +168,7 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 	set category = "Abilities"
 	set desc = "Shape shift between set mob forms."
 	if(!istype(tf_form))
-		to_chat(src, "<span class='notice'>No shapeshift form set.</span>")
+		to_chat(src, "<span class='notice'>No shapeshift form set. (Requires a spawned mob to be varedited into the user's tf_form var as mob reference.)</span>")
 		return
 	else
 		transform_into_mob(tf_form, TRUE, TRUE, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Basic HowTo: Staff can spawn a mob to be the shapeshift form, and then varedit the target user to add verb "shapeshift_form" (shows up in abilities tab) and then edit the target user's "tf_form" var into a mob reference of the spawned mob. Once done, the user can swap between forms kind of blobform style. TF rays will revert the shapeshift, but won't delete the shapeshifted form so the user can still shapeshift back.
Tested to work with regular TF mechanics on top of this stuff with no conflicts or issues so far.
Now also supports ckey swapping with an occupied tf_form mob when applicable.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added event/shenanigans vareditable shapeshifter mechanic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
