### PR TITLE
Un-nerfs recycling digestion material gains and fixes recycling upgrades.

### DIFF
--- a/code/modules/recycling/recycling.dm
+++ b/code/modules/recycling/recycling.dm
@@ -8,6 +8,10 @@
 	var/negative_dir = null	//VOREStation Addition
 	var/hand_fed = TRUE //CHOMPAdd
 
+/obj/machinery/recycling/Initialize() //CHOMPAdd
+	. = ..()
+	default_apply_parts()
+
 /obj/machinery/recycling/process()
 	return PROCESS_KILL // these are all stateful
 

--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -521,7 +521,7 @@
 		var/obj/item/stack/S = O
 		trash = S.amount
 	for(var/mat in O.matter)
-		modified_mats[mat] = O.matter[mat] * 0.5 * trash
+		modified_mats[mat] = O.matter[mat] * trash
 	for(var/obj/item/debris_pack/digested/D in contents)
 		if(istype(D))
 			for(var/mat in modified_mats)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Removes the 0.5x "unupgraded cargo recycler" multiplier from item digestion recycle mode, considering the most likely way the material will get recycled into sheets is through the unupgraded cargo recycler, which would result in stacked 75% material loss.
Also fixed recycling machinery upgrade bug.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Removed "unupgraded" nerf from recycle mode item digestion.
fix: Fixed recycling machines not being upgradeable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
