### PR TITLE
Implements BS recycling for the BS compostor

### DIFF
--- a/modular_chomp/code/game/objects/structures/watercloset_ch.dm
+++ b/modular_chomp/code/game/objects/structures/watercloset_ch.dm
@@ -96,12 +96,14 @@
 	density = TRUE
 	var/muffin_mode = FALSE
 	var/mob/living/simple_mob/vore/aggressive/corrupthound/muffinmonster
+	var/obj/machinery/recycling/crusher/crusher //Bluespace connection for recyclables
 
 /obj/structure/biowaste_tank/Initialize()
 	muffinmonster = new /mob/living/simple_mob/vore/aggressive/corrupthound/muffinmonster(src)
 	muffinmonster.name = "Activate Muffin Monster"
 	muffinmonster.voremob_loaded = TRUE
 	muffinmonster.init_vore()
+	crusher = locate(/obj/machinery/recycling/crusher)
 	return ..()
 
 /obj/structure/biowaste_tank/AllowDrop()
@@ -120,6 +122,9 @@
 			for(var/atom/movable/C in thing.contents)
 				C.forceMove(src)
 		qdel(thing)
+		return
+	if(istype(crusher) && istype(thing, /obj/item/debris_pack))
+		crusher.take_item(thing)
 		return
 	if(muffin_mode)
 		if(muffinmonster)
@@ -175,3 +180,4 @@
 	B.desc = "With a resounding CRUNCH, your form has gotten snagged by the Muffin Monster's rotational interlocking cutters indiscriminately crunching away at anything unlucky enough to end up in its hopper, only for the insatiable machine to grind it all down into a slurry mulch fine enough to pass through the narrow sewage lines trouble-free..."
 	B.digest_brute = 20
 	B.special_entrance_sound = 'sound/machines/blender.ogg'
+	B.recycling = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a Bluespace pipeline between BS compostor terminal and cargo recycling crusher.
Recyclable debris packs received by the machine now get BS'd directly into cargo crusher for refining.
Regular stuff still gets stored in the terminal normally.
Also Muffin Monster's "belly" now has recycling enabled. (gotta hit deactivate to BS reclaim the materials tho)
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: BS compostor can now recycle materials too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
