### PR TITLE
A few more shapeshifter tweaks

### DIFF
--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -93,6 +93,7 @@
 		if(!M.allow_spontaneous_tf && !tf_admin_pref_override)
 			return
 	if(M.tf_mob_holder)
+		new /obj/effect/effect/teleport_greyscale(M.loc) //CHOMPAdd
 		var/mob/living/ourmob = M.tf_mob_holder
 		if(ourmob.ai_holder)
 			var/datum/ai_holder/our_AI = ourmob.ai_holder
@@ -113,6 +114,7 @@
 				B.owner = ourmob
 				M.vore_organs -= B
 				ourmob.vore_organs += B
+			ourmob.nutrition = M.nutrition
 		ourmob.ckey = M.ckey
 
 		ourmob.Life(1)
@@ -134,9 +136,15 @@
 		if(M.stat == DEAD)	//We can let it undo the TF, because the person will be dead, but otherwise things get weird.
 			return
 		var/mob/living/new_mob = spawn_mob(M)
-		new_mob.faction = M.faction
 
 		if(new_mob && isliving(new_mob))
+			new_mob.faction = M.faction //CHOMPEdit Start
+			if(istype(new_mob, /mob/living/simple_mob))
+				var/mob/living/simple_mob/S = new_mob
+				if(!S.voremob_loaded)
+					S.voremob_loaded = TRUE
+					S.init_vore()
+			new /obj/effect/effect/teleport_greyscale(M.loc) //CHOMPEdit End
 			for(var/obj/belly/B as anything in new_mob.vore_organs)
 				new_mob.vore_organs -= B
 				qdel(B)
@@ -167,6 +175,7 @@
 				B.owner = new_mob
 				M.vore_organs -= B
 				new_mob.vore_organs += B
+			new_mob.nutrition = M.nutrition //CHOMPAdd
 
 			new_mob.ckey = M.ckey
 			if(M.ai_holder && new_mob.ai_holder)
@@ -191,6 +200,7 @@
 /mob/living/proc/revert_mob_tf()
 	if(!tf_mob_holder)
 		return
+	new /obj/effect/effect/teleport_greyscale(src.loc) //CHOMPAdd
 	var/mob/living/ourmob = tf_mob_holder
 	if(ourmob.ai_holder)
 		var/datum/ai_holder/our_AI = ourmob.ai_holder
@@ -211,6 +221,7 @@
 			B.owner = ourmob
 			vore_organs -= B
 			ourmob.vore_organs += B
+		ourmob.nutrition = nutrition
 	ourmob.ckey = ckey
 	ourmob.Life(1)
 
@@ -343,6 +354,7 @@
 				B.owner = ourmob
 				M.vore_organs -= B
 				ourmob.vore_organs += B
+			ourmob.nutrition = M.nutrition
 		ourmob.ckey = M.ckey
 
 		ourmob.Life(1)

--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -93,19 +93,16 @@
 		if(!M.allow_spontaneous_tf && !tf_admin_pref_override)
 			return
 	if(M.tf_mob_holder)
-		new /obj/effect/effect/teleport_greyscale(M.loc) //CHOMPAdd
+		new /obj/effect/effect/teleport_greyscale(M.loc) //CHOMPEdit Start
 		var/mob/living/ourmob = M.tf_mob_holder
 		if(ourmob.ai_holder)
 			var/datum/ai_holder/our_AI = ourmob.ai_holder
 			our_AI.set_stance(STANCE_IDLE)
 		M.tf_mob_holder = null
-		var/ourmob_ckey  //CHOMPEdit Start
-		if(ourmob.ckey)
-			ourmob_ckey = ourmob.ckey
 		var/turf/get_dat_turf = get_turf(target)
 		ourmob.loc = get_dat_turf
 		ourmob.forceMove(get_dat_turf)
-		if(!ourmob.ckey)
+		if(!M.tf_form_ckey)
 			ourmob.vore_selected = M.vore_selected
 			M.vore_selected = null
 			for(var/obj/belly/B as anything in M.vore_organs)
@@ -125,10 +122,10 @@
 				M.drop_from_inventory(W)
 
 		if(M.tf_form == ourmob)
-			if(ourmob_ckey)
-				M.ckey = ourmob_ckey
+			if(M.tf_form_ckey)
+				M.ckey = M.tf_form_ckey
 			else
-				ourmob.mind = null
+				M.mind = null
 			ourmob.tf_form = M
 			M.forceMove(ourmob)
 		else
@@ -202,19 +199,16 @@
 /mob/living/proc/revert_mob_tf()
 	if(!tf_mob_holder)
 		return
-	new /obj/effect/effect/teleport_greyscale(src.loc) //CHOMPAdd
+	new /obj/effect/effect/teleport_greyscale(src.loc) //CHOMPEdit Start
 	var/mob/living/ourmob = tf_mob_holder
 	if(ourmob.ai_holder)
 		var/datum/ai_holder/our_AI = ourmob.ai_holder
 		our_AI.set_stance(STANCE_IDLE)
 	tf_mob_holder = null
-	var/ourmob_ckey  //CHOMPEdit Start
-	if(ourmob.ckey)
-		ourmob_ckey = ourmob.ckey
 	var/turf/get_dat_turf = get_turf(src)
 	ourmob.loc = get_dat_turf
 	ourmob.forceMove(get_dat_turf)
-	if(!ourmob.ckey)
+	if(!tf_form_ckey)
 		ourmob.vore_selected = vore_selected
 		vore_selected = null
 		for(var/obj/belly/B as anything in vore_organs)
@@ -234,10 +228,10 @@
 			src.drop_from_inventory(W)
 
 	if(tf_form == ourmob)
-		if(ourmob_ckey)
-			src.ckey = ourmob_ckey
+		if(tf_form_ckey)
+			src.ckey = tf_form_ckey
 		else
-			ourmob.mind = null
+			src.mind = null
 		ourmob.tf_form = src
 		src.forceMove(ourmob)
 	else
@@ -343,13 +337,10 @@
 			var/datum/ai_holder/our_AI = ourmob.ai_holder
 			our_AI.set_stance(STANCE_IDLE)
 		M.tf_mob_holder = null
-		var/ourmob_ckey  //CHOMPEdit Start
-		if(ourmob.ckey)
-			ourmob_ckey = ourmob.ckey
 		var/turf/get_dat_turf = get_turf(target)
 		ourmob.loc = get_dat_turf
 		ourmob.forceMove(get_dat_turf)
-		if(!ourmob.ckey)
+		if(!M.tf_form_ckey) //CHOMPEdit Start
 			ourmob.vore_selected = M.vore_selected
 			M.vore_selected = null
 			for(var/obj/belly/B as anything in M.vore_organs)
@@ -370,10 +361,10 @@
 				M.drop_from_inventory(W)
 
 		if(M.tf_form == ourmob)
-			if(ourmob_ckey)
-				M.ckey = ourmob_ckey
+			if(M.tf_form_ckey)
+				M.ckey = M.tf_form_ckey
 			else
-				ourmob.mind = null
+				M.mind = null
 			ourmob.tf_form = M
 			M.forceMove(ourmob)
 		else

--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -127,6 +127,8 @@
 		if(M.tf_form == ourmob)
 			if(ourmob_ckey)
 				M.ckey = ourmob_ckey
+			else
+				ourmob.mind = null
 			ourmob.tf_form = M
 			M.forceMove(ourmob)
 		else
@@ -234,6 +236,8 @@
 	if(tf_form == ourmob)
 		if(ourmob_ckey)
 			src.ckey = ourmob_ckey
+		else
+			ourmob.mind = null
 		ourmob.tf_form = src
 		src.forceMove(ourmob)
 	else
@@ -368,6 +372,8 @@
 		if(M.tf_form == ourmob)
 			if(ourmob_ckey)
 				M.ckey = ourmob_ckey
+			else
+				ourmob.mind = null
 			ourmob.tf_form = M
 			M.forceMove(ourmob)
 		else

--- a/modular_chomp/code/modules/mob/living/living.dm
+++ b/modular_chomp/code/modules/mob/living/living.dm
@@ -121,9 +121,15 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 				new_mob_ckey = new_mob.ckey
 		else
 			new_mob = new new_form(get_turf(src))
-		new_mob.faction = src.faction
 
 		if(new_mob && isliving(new_mob))
+			new_mob.faction = src.faction
+			if(istype(new_mob, /mob/living/simple_mob))
+				var/mob/living/simple_mob/S = new_mob
+				if(!S.voremob_loaded)
+					S.voremob_loaded = TRUE
+					S.init_vore()
+			new /obj/effect/effect/teleport_greyscale(src.loc)
 			if(!new_mob.ckey)
 				for(var/obj/belly/B as anything in new_mob.vore_organs)
 					new_mob.vore_organs -= B
@@ -155,6 +161,7 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 					B.owner = new_mob
 					src.vore_organs -= B
 					new_mob.vore_organs += B
+				new_mob.nutrition = src.nutrition
 
 			new_mob.ckey = src.ckey
 			if(new_mob_ckey)

--- a/modular_chomp/code/modules/mob/living/living.dm
+++ b/modular_chomp/code/modules/mob/living/living.dm
@@ -13,6 +13,7 @@
 	var/virtual_reality_mob = FALSE // gross boolean for keeping VR mobs in VR
 	var/datum/looping_sound/mob/on_fire/firesoundloop
 	var/mob/living/tf_form // Shapeshifter shenanigans
+	var/tf_form_ckey
 	// var/datum/looping_sound/mob/stunned/stunnedloop
 	/* // Not sure if needed, screams aren't a carbon thing rn.
 	var/scream_sound = null
@@ -110,7 +111,6 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 		if(!ispath(new_form, /mob/living) && !ismob(new_form))
 			return
 		var/mob/living/new_mob
-		var/new_mob_ckey
 		if(shapeshifting && src.tf_form)
 			new_mob = src.tf_form
 			new_mob.verbs |= /mob/living/proc/shapeshift_form
@@ -118,7 +118,7 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 			new_mob.forceMove(src.loc)
 			visible_message("<span class='warning'>[src] twists and contorts, shapeshifting into a different form!</span>")
 			if(new_mob.ckey)
-				new_mob_ckey = new_mob.ckey
+				new_mob.tf_form_ckey = new_mob.ckey
 		else
 			new_mob = new new_form(get_turf(src))
 
@@ -164,8 +164,8 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 				new_mob.nutrition = src.nutrition
 
 			new_mob.ckey = src.ckey
-			if(new_mob_ckey)
-				src.ckey = new_mob_ckey
+			if(new_mob.tf_form_ckey)
+				src.ckey = new_mob.tf_form_ckey
 			if(src.ai_holder && new_mob.ai_holder)
 				var/datum/ai_holder/old_AI = src.ai_holder
 				old_AI.set_stance(STANCE_SLEEP)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Shapeshifting and other mob transformations (vr/metamouseguns/etc) now have a quick visual effect pop between the forms.
Mob TF now also carries shared nutrition pool between forms. (with the exception of multiplayer shapeshifter stuff)
Fixed new mob TF happening without init_vore proc, causing the user's main vorgan to be overwritten by the voremob's default vorgan settings.
Also removes mind from reverted non-multiplayer tf_form mobs, preventing cryo/gateway from double-announcing the user and their stored form upon leaving.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added visual effect and shared nutrition to mob TF mechanics.
fix: Fixed mob TF with uninitialized voremobs overwriting user's main vorgan with the mob's own settings.
fix: Stored reverted non-multiplayer tf_forms no longer cause double cryo announcements when user leaves round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
