### PR TITLE
Fixes cloth and fiber materials missing their sheet type definitions

### DIFF
--- a/code/modules/materials/materials/organic/cloth.dm
+++ b/code/modules/materials/materials/organic/cloth.dm
@@ -11,7 +11,8 @@
 	pass_stack_colors = TRUE
 	supply_conversion_value = 2
 	hardness = 5
-	
+	stack_type = /obj/item/stack/material/cloth //CHOMPEdit
+
 
 /datum/material/cloth/generate_recipes() //Vorestation Add - adding some funny cool storage pouches to this so botany can do things other than food
 	recipes = list(
@@ -153,4 +154,5 @@
 	conductive = 0
 	pass_stack_colors = TRUE
 	hardness = 5
-	integrity = 5 
+	integrity = 5
+	stack_type = /obj/item/stack/material/fiber //CHOMPEdit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes cloth and fibers runtiming the recycling sheet machine.
Sheets existed but someone forgot to connect them to the material datums. (not me)
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed cloth and fiber materials missing sheet type definitions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
