### PR TITLE
VR Pods spawn you with loadout items now

### DIFF
--- a/modular_chomp/code/game/machinery/virtual_reality/vr_console.dm
+++ b/modular_chomp/code/game/machinery/virtual_reality/vr_console.dm
@@ -266,8 +266,7 @@
 		occupant.enter_vr(avatar)
 		avatar.regenerate_icons()
 		avatar.update_transform()
-		var/decl/hierarchy/outfit/outfit = outfit_by_type(/decl/hierarchy/outfit/job/assistant) //you spawn with assistant gear, I tried to make loadout spawn but the code sucks
-		outfit.equip(avatar, "VR Avatar", "VR Avatar")
+		job_master.EquipRank(avatar,"Visitor", 1, FALSE)
 		avatar.verbs += /mob/living/carbon/human/proc/exit_vr
 		avatar.verbs += /mob/living/carbon/human/proc/vr_transform_into_mob
 		avatar.verbs |= /mob/living/proc/set_size // Introducing NeosVR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Found the same proc from the autosleever's dressup and applied it to the VR pods, finally, no more nakey VR

Full heads up though, the proc used also generates a new email into your character's notes, and short of rewriting the entire job handling code, idk how to prevent this, and its beyond my coding skills. But its a feature that is barely used if at all, don't be afraid to give suggestion on this.
