### PR TITLE
A couple toilet tweaks and fixes

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -95,8 +95,8 @@
 	name = "prison toilet"
 	icon_state = "toilet2"
 
-/obj/structure/toilet/prison/attack_hand(mob/living/user)
-	return
+//obj/structure/toilet/prison/attack_hand(mob/living/user) //CHOMPEdit
+//	return
 
 /obj/structure/toilet/prison/attackby(obj/item/I, mob/living/user)
 	if(istype(I, /obj/item/weapon/grab))
@@ -123,7 +123,7 @@
 					GM.adjustBruteLoss(5)
 			else
 				to_chat(user, "<span class='notice'>You need a tighter grip.</span>")
-	
+
 
 /obj/structure/urinal
 	name = "urinal"

--- a/code/modules/pda/pda.dm
+++ b/code/modules/pda/pda.dm
@@ -463,7 +463,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 /obj/item/device/pda/Destroy()
 	PDAs -= src
-	if (src.id && prob(100) && !delete_id) //IDs are kept in 90% of the cases //VOREStation Edit - 100% of the cases, excpet when specified otherwise
+	if (src.id && !delete_id && src.id.loc == src) //CHOMPEdit
 		src.id.forceMove(get_turf(src.loc))
 	else
 		QDEL_NULL(src.id)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixed toilets ignoring the flushed victim's size_multiplier.
Fixed prison subtype not working at all.
Added functionality for un-bluespaced non-station toilets (less capacity but contents unrecoverable, too tight for valid size mobs without edits)
Added max total w_class flush load limits (3 w_class normal, 10 w_class bluespaced). Going over the limit will glog and interrupt the process for anything above the limit. The w_class limit also counts mob size_multipliers (x13) when applicable.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Flushing too much/big stuff can now glog toilets. Also un-bluespaced non-station ones can be flushed too (much weaker tho and not connected to station systems)
fix: Fixed flushing ignoring mob size_multiplier.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
