### PR TITLE
Fixes init_vore for a load of recent upstream mobs

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/skeleton.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/skeleton.dm
@@ -88,7 +88,9 @@
 	emote_hear = list("rattles","makes a spooky sound","cackles madly","plinks","clacks")
 
 /mob/living/simple_mob/vore/alienanimals/skeleton/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "stomach"
 	B.desc = "You're not sure quite how, but you've found your way inside of the skeleton's stomach! It's cramped and cold and sounds heavily of xylophones!"

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/space_mouse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/space_mouse.dm
@@ -65,7 +65,9 @@
 	vore_default_item_mode = IM_DIGEST
 
 /mob/living/simple_mob/vore/alienanimals/dustjumper/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "stomach"
 	B.desc = "You've been packed into the impossibly tight stomach of the dust jumper!!! The broiling heat seeps into you while the walls churn in powerfully, forcing you to curl up in the darkness."

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/spacewhale.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/spacewhale.dm
@@ -53,7 +53,9 @@
 	emote_see = list("ripples and flows", "flashes rhythmically","glows faintly","investigates something")
 
 /mob/living/simple_mob/vore/overmap/spacewhale/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "stomach"
 	B.desc = "It's warm and wet, makes sense, considering it's inside of a space whale. You should take a moment to reflect upon how you got here, and how you might avoid situations like this in the future, while this whale attempts to mercilessly destroy you through various gastric processes."

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/startreader.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/startreader.dm
@@ -85,7 +85,7 @@
 
 	var/flipped = FALSE
 	var/flip_cooldown = 0
-	
+
 	can_be_drop_prey = FALSE //CHOMP Add
 
 /datum/say_list/startreader
@@ -94,7 +94,9 @@
 
 
 /mob/living/simple_mob/vore/alienanimals/startreader/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "gastric sac"
 	B.desc = "It's cramped and hot! You're forced into a small ball as your shape is squeezed into the slick, wet chamber. Despite being swallowed into the creature, you find that you actually stretch out of the top a ways, and can JUST BARELY wiggle around..."

--- a/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/succlet.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/alien animals/succlet.dm
@@ -73,7 +73,9 @@
 	say_got_target = list("...")
 
 /mob/living/simple_mob/vore/alienanimals/succlet/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "stummy"
 	B.desc = "It's a star shaped stomach. A stummy, if you will. It's warm and soft, not unlike plush, but it's tight!"

--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/carp.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/carp.dm
@@ -59,7 +59,7 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/melee
 
 	var/knockdown_chance = 15
-	
+
 	can_be_drop_prey = FALSE //CHOMP Add
 
 /mob/living/simple_mob/animal/space/carp/apply_melee_effects(var/atom/A)
@@ -147,7 +147,9 @@
 	ai_holder_type = /datum/ai_holder/simple_mob/vore
 
 /mob/living/simple_mob/animal/space/carp/large/huge/vorny/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "stomach"
 	B.desc = "You've been swallowed whole and alive by a massive white carp! The stomach around you is oppressively tight, squeezing and grinding wrinkled walls across your body, making it hard to make any movement at all. The chamber is flooded with fluids that completely overwhelm you."

--- a/code/modules/mob/living/simple_mob/subtypes/animal/squirrel.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/squirrel.dm
@@ -68,7 +68,9 @@
 	vore_default_item_mode = IM_DIGEST
 
 /mob/living/simple_mob/vore/squirrel/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "stomach"
 	B.digest_mode = DM_SELECT

--- a/code/modules/mob/living/simple_mob/subtypes/vore/fennec.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/fennec.dm
@@ -145,7 +145,9 @@
 	add_overlay(bigshadow)
 
 /mob/living/simple_mob/vore/fennec/huge/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "Stomach"
 	B.desc = "The slimy wet insides of a rather large fennec! Not quite as clean as the fen on the outside."

--- a/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander.dm
@@ -81,6 +81,8 @@
 	src.adjust_nutrition(src.max_nutrition)
 
 /mob/living/simple_mob/vore/leopardmander/init_vore()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
 	. = ..()
 	var/obj/belly/B = vore_selected
 	B.name = "stomach"

--- a/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/pakkun.dm
@@ -138,7 +138,9 @@
 		ai_holder.remove_target()
 
 /mob/living/simple_mob/vore/pakkun/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	if(isbelly(B)) //ChompEDIT - fix a runtime
 		B.name = "stomach"
@@ -263,7 +265,9 @@
 	..()
 
 /mob/living/simple_mob/vore/pakkun/snapdragon/snappy/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	if(isbelly(B)) //ChompEDIT - fix a runtime
 		B.digest_mode = DM_HOLD

--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
@@ -142,6 +142,8 @@
 	. = ..()
 
 /mob/living/simple_mob/shadekin/init_vore()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
 	if(LAZYLEN(vore_organs))
 		return
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore_hostile.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore_hostile.dm
@@ -71,7 +71,9 @@
 	unacidable = TRUE
 
 /mob/living/simple_mob/vore/vore_hostile/abyss_lurker/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "interior"
 	B.desc = "It's hot and overwhelmingly tight! The interior of the pale creature groans with the effort of squeezing you. Everything is hot and churning and eager to grind and smother you in thick fluids. The weight of the creature's body pressing in at you makes it hard to move at all, while you are squeezed to the very core of the creature! There seems almost not to even be an organ for this so much as the creature has folded around you, trying to incorporate your matter into its body with vigor!"
@@ -189,7 +191,9 @@
 	var/leap_sound = 'sound/weapons/spiderlunge.ogg'
 
 /mob/living/simple_mob/vore/vore_hostile/leaper/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "stomach"
 	B.desc = "The flesh of the tall creature's stomach folds over you in doughy waves, squeezing you into the tightest shape it can manage with idle flexes churning down on you. Your limbs often find themselves lost between folds and tugged this way or that, held in a skin tight press that is not painful, but is hard to pull away from. You can see a strange, glittering pink and purple light glimmering through the flesh of the monster all around you, like your very own sea of stars. The walls rush in to fill all the space, squeezing you from head to toe no matter how you might wiggle, the weight of the semi-transparent interior flesh keeping you neatly secured deep inside while wringing the fight out of you."
@@ -305,7 +309,9 @@
 	unacidable = TRUE
 
 /mob/living/simple_mob/vore/vore_hostile/gelatinous_cube/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "interior"
 	B.desc = "An incredibly thick oozing slime surrounds you, filling in all the space around your form! It's hard to catch a breath here as the jiggling gel that makes up the body of the creature swiftly fills in the hole you made in its surface by entering. The gel is semi-transparent, and you can see your surroundings though its surface, and similarly you can be seen floating in the gel from the outside. When the cube moves, your whole body is wobbled along with it. There are clouds of still processing material floating all around you as the corrosive substance works on breaking everything down."

--- a/code/modules/mob/living/simple_mob/subtypes/vore/wolftaur.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/wolftaur.dm
@@ -68,7 +68,9 @@
 	base_wander_delay = 8
 
 /mob/living/simple_mob/vore/wolftaur/init_vore()
-	..()
+	if(!voremob_loaded) //CHOMPAdd
+		return //CHOMPAdd
+	.=..() //CHOMPEdit
 	var/obj/belly/B = vore_selected
 	B.name = "stomach"
 	B.desc = "After a gruelling compressive traversal down through the taur's gullet, you briefly get deposited in an oppressively tight stomach at it's humanoid waist. However, the wolf has little interest in keeping you here, instead treating you as a mere snack, an orifice opens beneath you and you're soon dragged deeper into her depths. Soon you're splashing into an active, waiting caustic slurry, and the world around you drops as though you're trapped in a hammock. The taur's underbelly sags with your weight, and you feel a heavy pat from the woman outside settling in to make the most of her meal."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes init_vore runtimes on mobs missing the on-demand belly loading part.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed a bunch of voremob init runtimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
