### PR TITLE
Small synth buff, as a treat

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -47,7 +47,7 @@
 #define DROPLIMB_BURN 2
 
 // Damage above this value must be repaired with surgery.
-#define ROBOLIMB_REPAIR_CAP 30
+#define ROBOLIMB_REPAIR_CAP 50 //chompedit from 30 to 50
 
 #define ORGAN_FLESH    0 // Normal organic organs.
 #define ORGAN_ASSISTED 1 // Like pacemakers, not robotic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Increases the repair cap from 30 to 50, id do 15 but '45' is a weird number.
Synthetics needed a small little help-me-up especially in a codebase that's mechanically intensive if you choose to be intensive. Giving them an extra hit to play with so far seems fair, especially since you already have the disadvantage of no chems.

Edit: I also realized we already had our "broken limb" threshold set to 60, but a 7 year old upstream PR made a variable that overrode it for synths only. If requested, I can remove that var and make it 60, but that might be too much buff now IMO

## Changelog

:cl:
balance: Repair threshold for synthetic repairs bumped up by 20
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
