### PR TITLE
Changes Synth min_broken_damage threshold to be consistent with organics.

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -47,7 +47,7 @@
 #define DROPLIMB_BURN 2
 
 // Damage above this value must be repaired with surgery.
-#define ROBOLIMB_REPAIR_CAP 30
+#define ROBOLIMB_REPAIR_CAP 50 //chompedit from 30 to 50
 
 #define ORGAN_FLESH    0 // Normal organic organs.
 #define ORGAN_ASSISTED 1 // Like pacemakers, not robotic

--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -47,7 +47,7 @@
 #define DROPLIMB_BURN 2
 
 // Damage above this value must be repaired with surgery.
-#define ROBOLIMB_REPAIR_CAP 50 //chompedit from 30 to 50
+#define ROBOLIMB_REPAIR_CAP 60 //CHOMPedit, bumping it up to 60 to keep consistency with our global cap of 60
 
 #define ORGAN_FLESH    0 // Normal organic organs.
 #define ORGAN_ASSISTED 1 // Like pacemakers, not robotic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Around a year and a half ago, we had our 'broken limb' thresholds globally doubled, but a override variable (made 7 years ago) from upstream kept synthetics to 30, leaving synths with too little HP while normal crew wouldn't suffer this issue.

This simply increases the synth damage threshold from 30 to 60, effectively doubling it. If this number is too much, or would like more specific changes, please comment, open to suggestion.

Removing the specific variable makes it take the organic limb thresholds which is 40 (and 30 for feet/hands), which I personally feel is too minimal of a buff, hence the flat threshold for synths existing in the first place.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Synth limb HP is 60 instead of 30 now, just like organics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
