### PR TITLE
Enables fruit_spawner.dm

### DIFF
--- a/modular_chomp/maps/submaps/shelters/PizzaParlor-18x19.dmm
+++ b/modular_chomp/maps/submaps/shelters/PizzaParlor-18x19.dmm
@@ -379,6 +379,12 @@
 /area/survivalpod/superpose/PizzaParlor)
 "qk" = (
 /obj/structure/closet/secure_closet/freezer/meat,
+/obj/random/meat,
+/obj/random/meat,
+/obj/random/meat,
+/obj/random/meat,
+/obj/random/meat,
+/obj/random/meat,
 /turf/simulated/floor/tiled/freezer/cold,
 /area/survivalpod/superpose/PizzaParlor)
 "qz" = (
@@ -812,13 +818,21 @@
 /area/survivalpod/superpose/PizzaParlor)
 "KR" = (
 /obj/structure/closet/crate/freezer,
-/obj/random/meat,
-/obj/random/meat,
-/obj/random/meat,
-/obj/random/meat,
-/obj/random/meat,
-/obj/random/meat,
-/obj/random/meat,
+/obj/fruitspawner/mushrooms,
+/obj/fruitspawner/mushrooms,
+/obj/fruitspawner/mushrooms,
+/obj/fruitspawner/mushrooms,
+/obj/fruitspawner/mushrooms,
+/obj/fruitspawner/mushrooms,
+/obj/fruitspawner/mushrooms,
+/obj/fruitspawner/mushrooms,
+/obj/fruitspawner/mushrooms,
+/obj/fruitspawner/mushrooms,
+/obj/fruitspawner/eggplant,
+/obj/fruitspawner/eggplant,
+/obj/fruitspawner/eggplant,
+/obj/fruitspawner/eggplant,
+/obj/fruitspawner/eggplant,
 /turf/simulated/floor/tiled/freezer/cold,
 /area/survivalpod/superpose/PizzaParlor)
 "Lk" = (
@@ -976,6 +990,27 @@
 	dir = 4;
 	light_color = "#DDFFD3"
 	},
+/obj/structure/closet/crate/freezer,
+/obj/fruitspawner/tomato,
+/obj/fruitspawner/tomato,
+/obj/fruitspawner/tomato,
+/obj/fruitspawner/tomato,
+/obj/fruitspawner/tomato,
+/obj/fruitspawner/tomato,
+/obj/fruitspawner/tomato,
+/obj/fruitspawner/tomato,
+/obj/fruitspawner/tomato,
+/obj/fruitspawner/tomato,
+/obj/fruitspawner/corn,
+/obj/fruitspawner/corn,
+/obj/fruitspawner/corn,
+/obj/fruitspawner/corn,
+/obj/fruitspawner/corn,
+/obj/fruitspawner/carpet,
+/obj/fruitspawner/carpet,
+/obj/fruitspawner/carpet,
+/obj/fruitspawner/carpet,
+/obj/fruitspawner/carpet,
 /turf/simulated/floor/tiled/freezer/cold,
 /area/survivalpod/superpose/PizzaParlor)
 "Te" = (

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2593,6 +2593,7 @@
 #include "code\modules\holomap\holomap_datum.dm"
 #include "code\modules\holomap\mapper.dm"
 #include "code\modules\holomap\station_holomap.dm"
+#include "code\modules\hydroponics\fruit_spawner.dm"
 #include "code\modules\hydroponics\grown.dm"
 #include "code\modules\hydroponics\grown_inedible.dm"
 #include "code\modules\hydroponics\grown_predefined.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
The file for #6972 didn't enable in the mirror, this enables it. Also places fruit spawners in the pizza parlor outsider pod.
