### PR TITLE
Fixes bellyghost organ explosion and horizontal spaceman icon update bugs

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -166,18 +166,17 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 		if(tail_style?.can_loaf && resting) // Only call these if we're resting?
 			update_tail_showing()
 			M.Scale(desired_scale_x, desired_scale_y)
+			M.Translate(cent_offset * desired_scale_x, (vis_height/2)*(desired_scale_y-1)) //CHOMPEdit
 		else
-			var/randn = rand(1, 2)
-			if(randn <= 1) // randomly choose a rotation
+			M.Scale(desired_scale_x, desired_scale_y)
+			if(isnull(resting_dir))
+				resting_dir = pick(FALSE, TRUE)
+			if(resting_dir)
+				M.Translate((1 / desired_scale_x * -6) + (desired_scale_x * cent_offset), 0.5)
 				M.Turn(-90)
 			else
+				M.Translate((1 / desired_scale_x * 6) + (desired_scale_x * cent_offset), 0.5)
 				M.Turn(90)
-			if(species.icon_height == 64)
-				M.Translate(13,-22)
-			else
-				M.Translate(1,-6)
-			M.Scale(desired_scale_y, desired_scale_x)
-		M.Translate(cent_offset * desired_scale_x, (vis_height/2)*(desired_scale_y-1)) //CHOMPEdit
 		// CHOMPEdit End
 		layer = MOB_LAYER -0.01 // Fix for a byond bug where turf entry order no longer matters
 	else

--- a/modular_chomp/code/modules/mob/dead/observer/observer.dm
+++ b/modular_chomp/code/modules/mob/dead/observer/observer.dm
@@ -4,6 +4,7 @@
 
 /mob/observer/Destroy()
 	if(body_backup)
+		body_backup.moveToNullspace() //YEET
 		qdel(body_backup)
 		body_backup = null
 	return ..()

--- a/modular_chomp/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/human.dm
@@ -50,3 +50,12 @@
 	set desc = "Toggle glasses worn icon visibility."
 	hide_glasses = !hide_glasses
 	update_inv_glasses()
+
+/mob/living/carbon/human/verb/flip_lying()
+	set name = "Flip Resting Direction"
+	set category = "Abilities"
+	set desc = "Switch your horizontal direction while prone."
+	if(isnull(resting_dir))
+		resting_dir = FALSE
+	resting_dir = !resting_dir
+	update_transform(TRUE)

--- a/modular_chomp/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/human_defines.dm
@@ -13,6 +13,7 @@
 	var/hide_glasses = FALSE
 	var/speech_sound_enabled = TRUE
 	var/nutrition_hidden = FALSE
+	var/resting_dir = null
 
 /mob/living/carbon/human/ai_controlled
 	low_priority = TRUE

--- a/modular_chomp/code/modules/mob/living/living.dm
+++ b/modular_chomp/code/modules/mob/living/living.dm
@@ -189,5 +189,5 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 
 /mob/living/set_dir(var/new_dir)
 	. = ..()
-	if(size_multiplier != 1 || icon_scale_x != 1 && center_offset > 0 && !grabbed_by)
+	if(size_multiplier != 1 || icon_scale_x != 1 && center_offset > 0)
 		update_transform(TRUE)

--- a/modular_chomp/code/modules/mob/living/living.dm
+++ b/modular_chomp/code/modules/mob/living/living.dm
@@ -189,5 +189,5 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 
 /mob/living/set_dir(var/new_dir)
 	. = ..()
-	if(size_multiplier != 1 || icon_scale_x != 1 && center_offset > 0)
+	if(size_multiplier != 1 || icon_scale_x != 1 && center_offset > 0 && !grabbed_by)
 		update_transform(TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Yeets ghost body out of ghost and vorgan before deletion.
Remade the whole horizontal spaceman icon update code to properly work with symmetry scaling and all in a way that makes more sense as well and works much better anyway.
Made horizontal flops only assign random direction on the initial flop and added an ability verb to manually flip the resting direction at will.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed ghost bodies spamming vorgan logs with organs upon deletion.
fix: Fixed pinned grabs causing non-stop flopping on custom-size crew.
fix: Fixed janky scaling issues with horizontal humanmob sprites.
qol: Horizontal flops now only assign a random direction on the first flop.
:add: Added a manual ability verb to flip resting sprite direction at will.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
