### PR TITLE
Slow digestion for food items.

### DIFF
--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -116,6 +116,12 @@
 				S.use(1)
 				digest_stage = w_class
 		else
+			if(istype(src, /obj/item/weapon/reagent_containers/food))
+				if(ishuman(B.owner) && reagents)
+					var/mob/living/carbon/human/H = B.owner
+					reagents.trans_to_holder(H.ingested, (reagents.total_volume), 1, 0)
+				else if(isliving(B.owner))
+					B.owner.nutrition += 15 * w_class
 			qdel(src)//CHOMPEdit End
 	if(g_damage > w_class)
 		return w_class
@@ -158,7 +164,7 @@
 	update_icon()
 	return FALSE
 
-/obj/item/weapon/reagent_containers/food/digest_act(atom/movable/item_storage = null)
+/*obj/item/weapon/reagent_containers/food/digest_act(atom/movable/item_storage = null) //CHOMPEdit: Included in main proc above.
 	if(isbelly(item_storage))
 		var/obj/belly/B = item_storage
 		if(ishuman(B.owner) && reagents) //CHOMPEdit Start
@@ -168,7 +174,7 @@
 			B.owner.nutrition += 15 * w_class //CHOMPEdit End
 		qdel(src)
 		return w_class
-	. = ..()
+	. = ..()*/
 
 /obj/item/weapon/holder/digest_act(atom/movable/item_storage = null)
 	for(var/mob/living/M in contents)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
ACTUAL MUSHABLE FOOD STUFFING REAL???
Gradual item digestion now also affects food items. The pred gets the contained reagents upon finishing the food item's digestion.
Also removed the 0.5x nutrition nerf of swallowed food items.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Food item digestion now uses gradual item digestion rather than instant qdel. Also reagent content no longer nerfed to half.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
