### PR TITLE
Allows players to create areas without paper.

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/human.dm
@@ -59,3 +59,18 @@
 		resting_dir = FALSE
 	resting_dir = !resting_dir
 	update_transform(TRUE)
+
+
+//Formally used from a paper, gave this to everyone.
+/mob/living/carbon/human/verb/create_area()
+    set name = "Create Area"
+    set desc = "Create an area in a enclosed space, making it able to be powered by an APC."
+    set category = "IC"
+
+    if(stat || world.time < last_special)
+        to_chat(usr, "<span class='warning'>You recently tried to create an area. Wait a while before using it again.</span>")
+        return
+
+    last_special = world.time + 2 SECONDS // Antispam.
+    create_new_area(usr)
+    return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Adds a verb in the IC tab that allows players to create an area if they are in a enclosed space without a need for a paper.
If you need to make any extra modifications you'll need blueprints at that point.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Players can now create an area innately for off-station construction.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
