### PR TITLE
Fixes overlays and makes food item digestion gains scale with belly nutrition percent

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -514,7 +514,7 @@
 		return
 	if(!L.client)
 		return
-	if(L.previewing_belly != src) //CHOMPEdit Start
+	if(L.previewing_belly && L.previewing_belly != src) //CHOMPEdit Start
 		return
 	if(L.previewing_belly == src && L.vore_selected != src)
 		L.previewing_belly = null

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -119,9 +119,9 @@
 			if(istype(src, /obj/item/weapon/reagent_containers/food))
 				if(ishuman(B.owner) && reagents)
 					var/mob/living/carbon/human/H = B.owner
-					reagents.trans_to_holder(H.ingested, (reagents.total_volume), 1, 0)
+					reagents.trans_to_holder(H.ingested, (reagents.total_volume), B.nutrition_percent / 100, 0)
 				else if(isliving(B.owner))
-					B.owner.nutrition += 15 * w_class
+					B.owner.nutrition += 15 * w_class * B.nutrition_percent / 100
 			qdel(src)//CHOMPEdit End
 	if(g_damage > w_class)
 		return w_class


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Food/drink items digested by vorgan item digestion now count the vorgan's nutrition percent for the reagent gains and such.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed vorgan nutrition percent not affecting food/drink reagent gains.
fix: Fixed vorgan overlays not showing up for prey.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
