### PR TITLE
Funny Breathing Traits

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
@@ -1,2 +1,13 @@
 /datum/trait/negative/deep_sleeper
 	custom_only = FALSE
+
+/datum/trait/positive/deep_breather
+	name ="Deep Breather"
+	desc = "You need more air for your lungs to properly work.."
+	cost = 1
+
+	custom_only = FALSE
+	can_take = ORGANICS
+
+	var_changes = list("minimum_breath_pressure" = 22)
+	excludes = list(/datum/trait/positive/light_breather)

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
@@ -1,10 +1,10 @@
 /datum/trait/negative/deep_sleeper
 	custom_only = FALSE
 
-/datum/trait/positive/deep_breather
+/datum/trait/negative/deep_breather
 	name ="Deep Breather"
 	desc = "You need more air for your lungs to properly work.."
-	cost = 1
+	cost = -1
 
 	custom_only = FALSE
 	can_take = ORGANICS

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -1,0 +1,8 @@
+/datum/trait/neutral/metabolism_up
+	can_take = ORGANICS
+
+/datum/trait/neutral/metabolism_down
+	can_take = ORGANICS
+
+/datum/trait/neutral/metabolism_apex
+	can_take = ORGANICS

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -15,4 +15,4 @@
 	custom_only = FALSE
 	can_take = ORGANICS
 	var_changes = list("minimum_breath_pressure" = 12)
-	excludes = list(/datum/trait/positive/deep_breather)
+	excludes = list(/datum/trait/negative/deep_breather)

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -6,3 +6,13 @@
 
 /datum/trait/positive/toxin_gut
 	custom_only = FALSE
+
+/datum/trait/positive/light_breather
+	name ="Light Breather"
+	desc = "You need less air for your lungs to properly work.."
+	cost = 1
+
+	custom_only = FALSE
+	can_take = ORGANICS
+	var_changes = list("minimum_breath_pressure" = 12)
+	excludes = list(/datum/trait/positive/deep_breather)

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4709,6 +4709,7 @@
 #include "modular_chomp\code\modules\mob\living\carbon\human\species\station\protean\protean_rig_tgui.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\human\species\station\protean\protean_species.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\human\species\station\traits\negative.dm"
+#include "modular_chomp\code\modules\mob\living\carbon\human\species\station\traits\neutral.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\human\species\station\traits\positive.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\human\species\station\traits\xenomorph_hybrid_trait.dm"
 #include "modular_chomp\code\modules\mob\living\silicon\robot\robot_movement.dm"


### PR DESCRIPTION
Adds two new traits.
One lowers how much air you need, and the other rises it. Normal - 16 pressure needed
Light - 12 pressure needed
Heavy - 22

They're all worth 1 point of their positive/negative type. The reason heavy breather is much more of a change is because I rather reduce the number of 'Hahah funny trait never comes up and is free' mindset traits.

Also messes with traits that don't work properly with synthetics.
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Two minor traits that mess with how much air your character needs to breath.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
