### PR TITLE
Makes the botany fridge persistent (lossy)

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -48074,7 +48074,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "fhn" = (
-/obj/machinery/smartfridge/produce,
+/obj/machinery/smartfridge/produce/persistent_lossy,
 /turf/simulated/wall/r_wall,
 /area/hydroponics)
 "fhH" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Remapped the smartfridge in hydroponics to be persistent, Normally mechanical persistence between rounds create unfair situations during event rounds/makes gameplay pointless for the following rounds, but in this server, food items and the kitchen are mostly fluff/roleplay over mechanics. 

This fridge will lose 35-45% of their contents between shifts, so its not like it removes botany gameplay.

I doubt having roundstart tomatoes in the station will cause too many balance issues.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
remap: Botany fridges are now semi-persistent, have fun farming!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
