### PR TITLE
Some Minor Changes

### DIFF
--- a/modular_chomp/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/modular_chomp/code/game/objects/items/weapons/storage/firstaid.dm
@@ -14,37 +14,37 @@
 
 /obj/item/weapon/storage/pill_bottle/neotane
 	name = "pill bottle (neo kelotane)"
-	desc = "Contains experimental pills."
+	desc = "Contains experimental pills, good for soothing burns but tends to mangle the flesh."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/neotane = 7)
 	wrapper_color = COLOR_ORANGE
 
 /obj/item/weapon/storage/pill_bottle/burncard
 	name = "pill bottle (burning bicard)"
-	desc = "Contains experimental pills."
+	desc = "Contains experimental pills, good for sealing cuts and bruises but is quite searing."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/burncard = 7)
 	wrapper_color = COLOR_RED
 
 /obj/item/weapon/storage/pill_bottle/flamecure
 	name = "pill bottle (Flame Cure)"
-	desc = "Contains experimental pills."
+	desc = "Contains experimental pills, good for searing shut internal wounds."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/flamecure = 7)
 	wrapper_color = COLOR_ORANGE
 
 /obj/item/weapon/storage/pill_bottle/juggernog
 	name = "pill bottle (juggernog)"
-	desc = "Contains experimental pills."
+	desc = "Contains experimental pills good for letting folks keep standing underneath relentless pummeling."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/juggernog = 7)
 	wrapper_color = COLOR_RED
 
 /obj/item/weapon/storage/pill_bottle/curea
 	name = "pill bottle (curea)"
-	desc = "Contains experimental pills."
+	desc = "Contains experimental pills, very effective for frostfly and poisonfly hunting."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/curea = 7)
 	wrapper_color = COLOR_BLUE
 
 /obj/item/weapon/storage/pill_bottle/souldew
 	name = "pill bottle (soul dew)"
-	desc = "Contains experimental pills."
+	desc = "Contains experimental pills, for feeding the dead."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/souldew = 7)
 	wrapper_color = COLOR_GREEN
 
@@ -52,7 +52,7 @@
 
 	name = "pill bottle (purifying agent)"
 
-	desc = "Contains experimental pills."
+	desc = "Contains experimental pills, having application as an anti-toxin."
 	starts_with = list(/obj/item/weapon/reagent_containers/pill/purifyingagent = 7)
 
 	wrapper_color = COLOR_GREEN

--- a/modular_chomp/code/modules/projectiles/guns/ammo.dm
+++ b/modular_chomp/code/modules/projectiles/guns/ammo.dm
@@ -5,10 +5,10 @@
 	max_ammo = 50
 
 /obj/item/ammo_magazine/s357
-	max_ammo = 15
+	max_ammo = 18
 
 /obj/item/ammo_magazine/s38
-	max_ammo = 15
+	max_ammo = 18
 
 // Makarov
 /obj/item/ammo_magazine/m38/makarov
@@ -33,7 +33,7 @@
 	max_ammo = 22
 
 /obj/item/ammo_magazine/s45
-	max_ammo = 15
+	max_ammo = 18
 
 /obj/item/ammo_magazine/m5mmcaseless
 	max_ammo = 75
@@ -96,7 +96,7 @@
 	max_ammo = 22
 
 /obj/item/ammo_magazine/s44
-	max_ammo = 15
+	max_ammo = 18
 
 /obj/item/ammo_magazine/m762
 	max_ammo = 25
@@ -227,4 +227,4 @@
 	max_ammo = 35
 
 /obj/item/ammo_magazine/s45lc
-	max_ammo = 15
+	max_ammo = 18

--- a/modular_chomp/game/machinery/turrets.dm
+++ b/modular_chomp/game/machinery/turrets.dm
@@ -1,0 +1,23 @@
+/obj/machinery/porta_turret
+	health = 40				//the turret's health
+	maxhealth = 40			//turrets maximal health.
+
+/obj/machinery/porta_turret/ai_defense
+	health = 125 // Since lasers do 40 each.
+	maxhealth = 125
+
+/obj/machinery/porta_turret/alien
+	health = 125
+	maxhealth = 125
+
+/obj/machinery/porta_turret/industrial
+	health = 100
+	maxhealth = 100
+
+/obj/machinery/porta_turret/industrial/teleport_defense
+	name = "defense turret"
+	desc = "This variant appears to be much more durable, with a rugged outer coating."
+	req_one_access = list(access_heads)
+	installation = /obj/item/weapon/gun/energy/gun/burst
+	health = 125
+	maxhealth = 125

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4833,6 +4833,7 @@
 #include "modular_chomp\code\modules\xenobio\machinery\monkey_processor.dm"
 #include "modular_chomp\game\effects\spawner.dm"
 #include "modular_chomp\game\machinery\buttons.dm"
+#include "modular_chomp\game\machinery\turrets.dm"
 #include "modular_chomp\game\objects\effects\spiders.dm"
 #include "modular_chomp\maps\overmap\aegis_carrier\aegis_objs.dm"
 #include "modular_chomp\maps\overmap\space_pois\space_areas.dm"


### PR DESCRIPTION
Adds descriptions to experimental medkit's pill bottles. Yes, searing is the word I indeed desire to be used with Flame Cure. Halves turret health since that was missed in the combat change PR. Turns speedloaders into 18 to be divisible by six,
I am going to sleep now

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Adds descriptions to experimental firstaid kit's pill bottles.
qol: Made speedloaders 18, because revolvers hold six.
fix: turrets where missed in the refactor, well their health
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
