### PR TITLE
Fixes swoopie special clicks, simplemob held ID stuff, and synth metabolism toggle

### DIFF
--- a/code/modules/mob/living/simple_mob/simple_mob_vr.dm
+++ b/code/modules/mob/living/simple_mob/simple_mob_vr.dm
@@ -73,6 +73,11 @@
 
 //For all those ID-having mobs
 /mob/living/simple_mob/GetIdCard()
+	if(get_active_hand()) //CHOMPAdd Start
+		var/obj/item/I = get_active_hand()
+		var/id = I.GetID()
+		if(id)
+			return id //CHOMPAdd End
 	if(myid)
 		return myid
 

--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -64,7 +64,7 @@
 		return
 	if(!affects_dead && M.stat == DEAD)
 		return
-	if(!affects_robots && M.isSynthetic() && M.synth_reag_processing) //CHOMPEdit
+	if(M.isSynthetic() && (!M.synth_reag_processing || !affects_robots)) //CHOMPEdit
 		return
 	if(!istype(location))
 		return

--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
@@ -163,6 +163,9 @@
 	say_got_target = list("PEST DETECTED!")
 
 /mob/living/simple_mob/vore/aggressive/corrupthound/swoopie/ClickOn(var/atom/A, var/params)
+	var/list/modifiers = params2list(params)
+	if(modifiers["shift"] || modifiers["ctrl"] || modifiers["middle"] || modifiers["alt"])
+		return ..()
 	if(istype(Vac) && A.Adjacent(src))
 		face_atom(A)
 		if(A == src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes alt/ctrl/shift/middle clicks not working on player controlled swoopies while vac is enabled.
Also fixes synth metabolism toggle not working properly.
Also fixes simplemobs being unable to use handheld ID on anything.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed special clicks not working for player-controlled swoopies while vac is powered.
fix: Fixed synth metabolism processing toggle.
fix: Fixed simplemobs being unable to use handheld ID cards.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
