### PR TITLE
Spiders.

### DIFF
--- a/code/modules/events/horde_infestation.dm
+++ b/code/modules/events/horde_infestation.dm
@@ -25,22 +25,22 @@
 
 	if(prob(50)) //50/50 chance on spiders or metroids.
 		log_debug("Hord event, spiders selected.")
-		spawncount = rand(4 * severity, 10 * severity)	
+		spawncount = rand(4 * severity, 10 * severity)
 		sent_spiders_to_station = 0
 		spiders = TRUE
-		
+
 	else
 		log_debug("Horde event, metroids selected.")
 		spawncount = rand(2 * severity, 4 * severity)
 		metroids = TRUE
-		
-	
+
+
 /datum/event/horde_infestation/announce()
 	if(spiders) //Horrible way of doing this
 		command_announcement.Announce("Unidentified lifesigns detected coming aboard [station_name()]. Secure any exterior access, including ducting and ventilation.", "Lifesign Alert", new_sound = 'sound/AI/aliens.ogg')
 	if(metroids) //Horrible way of doing this
 		command_announcement.Announce("High-energy lifeforms detected coming aboard [station_name()]. All crew members, stay alert, and listen to security instructions.", "Lifesign Alert", new_sound = 'sound/misc/alarm1.ogg')
-		
+
 /datum/event/horde_infestation/start()
 	if(spiders)
 		for(var/obj/machinery/atmospherics/unary/vent_pump/temp_vent in machines)
@@ -58,9 +58,9 @@
 			var/obj/vent = pick(vents)
 		//CHOMPEDIT START adding spider EGGS to the possible spawns instead of singular spiderling spawns.
 			var/spawn_spiderlings = pickweight(list(
-				/obj/effect/spider/spiderling/broodling = 95,
-				/obj/effect/spider/eggcluster/broodling = 4,
-				/obj/effect/spider/eggcluster/royal/broodling = 1
+				/obj/effect/spider/spiderling/space = 95,
+				/obj/effect/spider/eggcluster/space = 4,
+				/obj/effect/spider/eggcluster/royal/space = 1
 				))
 			new spawn_spiderlings(vent.loc) //VOREStation Edit - No nurses //Oh my JESUS CHRIST, this slipped past me. Literally no nurses. Well guess what, nurses are back.
 		//CHOMPEDIT END

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -34,13 +34,13 @@
 
 	while((spawncount >= 1) && vents.len)
 		var/obj/vent = pick(vents)
-	
+
 	//CHOMPEDIT START adding spider EGGS to the possible spawns instead of singular spiderling spawns.
 		if(severity == 3)
 			var/spawn_spiderlings = pickweight(list(
-				/obj/effect/spider/spiderling/broodling = 95,
-				/obj/effect/spider/eggcluster/broodling = 4,
-				/obj/effect/spider/eggcluster/royal/broodling = 1
+				/obj/effect/spider/spiderling/space = 95,
+				/obj/effect/spider/eggcluster/space = 4,
+				/obj/effect/spider/eggcluster/royal/space = 1
 				))
 			new spawn_spiderlings(vent.loc)
 		if(severity < 3) //If the severity is less than 3, only spawn regular spiderlings

--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/animal/spider.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/animal/spider.dm
@@ -115,3 +115,97 @@
 
 	melee_damage_lower = 5
 	melee_damage_upper = 10
+
+//Hijacking this file to make new event spiders
+
+/mob/living/simple_mob/animal/giant_spider/frost/space
+	name = "giant space spider"
+	min_oxy = 0
+	max_tox = 0
+	max_co2 = 0
+
+	maxHealth = 20
+	health = 20
+
+	melee_damage_lower = 5
+	melee_damage_upper = 7
+
+/mob/living/simple_mob/animal/giant_spider/electric/space
+	name = "giant space spider"
+	min_oxy = 0
+	max_tox = 0
+	max_co2 = 0
+
+	maxHealth = 15
+	health = 15
+
+/mob/living/simple_mob/animal/giant_spider/hunter/space
+	name = "giant space spider"
+	min_oxy = 0
+	max_tox = 0
+	max_co2 = 0
+
+	maxHealth = 20
+	health = 20
+
+/mob/living/simple_mob/animal/giant_spider/lurker/space
+	maxHealth = 20
+	health = 20
+
+/mob/living/simple_mob/animal/giant_spider/nurse/space
+	name = "giant space spider"
+	min_oxy = 0
+	max_tox = 0
+	max_co2 = 0
+
+	egg_type = /obj/effect/spider/eggcluster/royal/space
+
+	maxHealth = 30
+	health = 30
+
+/mob/living/simple_mob/animal/giant_spider/pepper/space
+	name = "giant space spider"
+	min_oxy = 0
+	max_tox = 0
+	max_co2 = 0
+
+	maxHealth = 20
+	health = 20
+
+/mob/living/simple_mob/animal/giant_spider/thermic/space
+	name = "giant space spider"
+	min_oxy = 0
+	max_tox = 0
+	max_co2 = 0
+	maxHealth = 20
+	health = 20
+
+	melee_damage_lower = 5
+	melee_damage_upper = 7
+
+/mob/living/simple_mob/animal/giant_spider/tunneler/space
+	name = "giant space spider"
+	min_oxy = 0
+	max_tox = 0
+	max_co2 = 0
+	maxHealth = 20
+	health = 20
+
+/mob/living/simple_mob/animal/giant_spider/webslinger/space
+	name = "giant space spider"
+	min_oxy = 0
+	max_tox = 0
+	max_co2 = 0
+	maxHealth = 15
+	health = 15
+
+/mob/living/simple_mob/animal/giant_spider/space
+	name = "giant space spider"
+	min_oxy = 0
+	max_tox = 0
+	max_co2 = 0
+	maxHealth = 30
+	health = 30
+
+	melee_damage_lower = 5
+	melee_damage_upper = 10

--- a/modular_chomp/game/objects/effects/spiders.dm
+++ b/modular_chomp/game/objects/effects/spiders.dm
@@ -17,3 +17,20 @@
 			/mob/living/simple_mob/animal/giant_spider/frost/broodling, /mob/living/simple_mob/animal/giant_spider/electric/broodling, /mob/living/simple_mob/animal/giant_spider/lurker/broodling,
 			/mob/living/simple_mob/animal/giant_spider/pepper/broodling, /mob/living/simple_mob/animal/giant_spider/thermic/broodling, /mob/living/simple_mob/animal/giant_spider/tunneler/broodling,
 			/mob/living/simple_mob/animal/giant_spider/webslinger/broodling)
+
+//Space Spiderling
+/obj/effect/spider/eggcluster/space
+	spider_type = /obj/effect/spider/spiderling/space
+
+/obj/effect/spider/eggcluster/royal/space
+	spider_type = /obj/effect/spider/spiderling/varied/space
+
+/obj/effect/spider/spiderling/space
+	name = "brood spiderling"
+	grow_as = list(/mob/living/simple_mob/animal/giant_spider/space, /mob/living/simple_mob/animal/giant_spider/nurse/space, /mob/living/simple_mob/animal/giant_spider/hunter/space)
+
+/obj/effect/spider/spiderling/varied/space
+	grow_as = list(/mob/living/simple_mob/animal/giant_spider/space, /mob/living/simple_mob/animal/giant_spider/nurse/space, /mob/living/simple_mob/animal/giant_spider/hunter/space,
+			/mob/living/simple_mob/animal/giant_spider/frost/space, /mob/living/simple_mob/animal/giant_spider/electric/space, /mob/living/simple_mob/animal/giant_spider/lurker/space,
+			/mob/living/simple_mob/animal/giant_spider/pepper/space, /mob/living/simple_mob/animal/giant_spider/thermic/space, /mob/living/simple_mob/animal/giant_spider/tunneler/space,
+			/mob/living/simple_mob/animal/giant_spider/webslinger/space)


### PR DESCRIPTION
Fun fact: Originally, Broodling spiders are tied to a boss spawning them normally. 2nd Fun Fact: They have some built in death timer. Anyway, third spider type, should have no connect with broodling code, but has their stats. I am unsure their size.

I do intend to wack this event, or make another version with driders. Also unsure how well it functions currently.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: event spiders deleting themselves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
