### PR TITLE
Lowering Projectile Speed

### DIFF
--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/gateway/imperion.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/gateway/imperion.dm
@@ -487,7 +487,7 @@
 	armor_penetration = 35
 	damage_type = BURN
 	check_armour = "laser"
-	speed = 4.4
+	speed = 7.0
 
 	flash_strength = 0
 
@@ -510,7 +510,7 @@
 	armor_penetration = 100
 	damage_type = BURN
 	check_armour = "laser"
-	speed = 4.4
+	speed = 4.5
 
 	flash_strength = 0
 
@@ -534,7 +534,7 @@
 	damage_type = BURN
 	check_armour = "energy"
 	agony = 50
-	speed = 8.2
+	speed = 10.0
 
 	flash_strength = 0
 

--- a/modular_chomp/code/modules/projectiles/projectile.dm
+++ b/modular_chomp/code/modules/projectiles/projectile.dm
@@ -1,0 +1,2 @@
+/obj/item/projectile
+	speed = 3.0

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4798,6 +4798,7 @@
 #include "modular_chomp\code\modules\power\cells\power_cells.dm"
 #include "modular_chomp\code\modules\projectiles\gun.dm"
 #include "modular_chomp\code\modules\projectiles\mob.dm"
+#include "modular_chomp\code\modules\projectiles\projectile.dm"
 #include "modular_chomp\code\modules\projectiles\clockwork\clockwork_guns_ch.dm"
 #include "modular_chomp\code\modules\projectiles\guns\ammo.dm"
 #include "modular_chomp\code\modules\projectiles\guns\beam.dm"


### PR DESCRIPTION
Travel time increased from 0.8 to 3.
Why?
Simple, I want combat to be more skilled base and more open to folks. No need to make uber tank char #300, just practice reaction times and such, and you'll be seeing medical a lot less...or do build uber tank #300 if that's your play style.

Granted, unsure how much of a difference this number shall make in letting folks take the dodge route more casually, but it should help.

It also makes it so you do need to lead your shots a tad more.

Oh and whilst I was at it, nerfed the speed further of one mob that is based off this entire slower moving projectile thing.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: changes projectile speed from 0.8 to 3.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
