### PR TITLE
Add toggle for energy and nutrition conversions

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -294,6 +294,7 @@
 					arguments = list()
 					)
 	H.verbs += /mob/living/carbon/human/proc/phase_strength_toggle //CHOMPEdit - Add gentle phasing
+	H.verbs += /mob/living/carbon/human/proc/nutrition_conversion_toggle //CHOMPEdit - Add nutrition conversion toggle
 
 /datum/species/shadekin/proc/handle_shade(var/mob/living/carbon/human/H)
 	//CHOMPEdit begin - No energy during dark respite

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -123,6 +123,7 @@
 	var/doing_phase = FALSE //CHOMPEdit - Prevent bugs when spamming phase button
 	var/manual_respite = FALSE //CHOMPEdit - Dark Respite
 	var/respite_activating = FALSE //CHOMPEdit - Dark Respite
+	var/nutrition_energy_conversion = TRUE //CHOMPEdit - Add toggle to nutrition and energy conversions
 
 /datum/species/shadekin/New()
 	..()
@@ -333,9 +334,9 @@
 		else
 			dark_gains = energy_light
 		//CHOMPEdit begin - Energy <-> nutrition conversion
-		if(get_energy(H) == 100 && dark_gains > 0)
+		if(nutrition_energy_conversion && get_energy(H) == 100 && dark_gains > 0)
 			H.nutrition += dark_gains * 5 * nutrition_conversion_scaling
-		else if(get_energy(H) < 50 && H.nutrition > 500)
+		else if(nutrition_energy_conversion && get_energy(H) < 50 && H.nutrition > 500)
 			H.nutrition -= nutrition_conversion_scaling * 50
 			dark_gains += nutrition_conversion_scaling
 		//CHOMPEdit end

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -68,7 +68,7 @@
 	for(var/thing in orange(7, src))
 		if(istype(thing, /mob/living/carbon/human))
 			var/mob/living/carbon/human/watchers = thing
-			if(watchers in oviewers(7,src))	// And they can see us...
+			if(watchers in oviewers(7,src) && watchers.species != SPECIES_SHADEKIN)	// And they can see us... //CHOMPEDIT - (And aren't themselves a shadekin)
 				if(!(watchers.stat) && !isbelly(watchers.loc) && !istype(watchers.loc, /obj/item/weapon/holder))	// And they are alive and not being held by someone...
 					watcher++	// They are watching us!
 		else if(istype(thing, /mob/living/silicon/robot))
@@ -278,6 +278,25 @@
 	else
 		to_chat(src, "<span class='notice'>Phasing toggled to Gentle. You won't damage lights, but concentrating on that incurs a short stun.</span>")
 		SK.phase_gentle = 1
+//CHOMPEdit End
+
+//CHOMPEdit Start - Toggle to Nutrition conversion
+/mob/living/carbon/human/proc/nutrition_conversion_toggle()
+	set name = "Toggle Energy <-> Nutrition conversions"
+	set desc = "Toggle dark energy and nutrition being converted into each other when full"
+	set category = "Shadekin"
+
+	var/datum/species/shadekin/SK = species
+	if(!istype(SK))
+		to_chat(src, "<span class='warning'>Only a shadekin can use that!</span>")
+		return FALSE
+
+	if(SK.nutrition_energy_conversion)
+		to_chat(src, "<span class='notice'>Nutrition and dark energy conversions disabled.</span>")
+		SK.nutrition_energy_conversion = 0
+	else
+		to_chat(src, "<span class='notice'>Nutrition and dark energy conversions enabled.</span>")
+		SK.nutrition_energy_conversion = 1
 //CHOMPEdit End
 
 //CHOMPEdit Start - Shadekin probably shouldn't be hit while phasing


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a toggle for Energy and Nutrition conversions that shadekin have.
Also adds a small buff to shadekin phasing energy costs

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: new verb for shadekin to toggle off nutrition <-> energy convversion
balance: shadekin no longer count as observers for phasing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
