### PR TITLE
Reduces jukebox default volume setting.

### DIFF
--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -22,6 +22,7 @@
 	active_power_usage = 100
 	circuit = /obj/item/weapon/circuitboard/jukebox
 	clicksound = 'sound/machines/buttonbeep.ogg'
+	volume = 0.5 //CHOMPEdit
 
 	// Vars for hacking
 	var/datum/wires/jukebox/wires = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
The B-shift pranksters have been lectured about the dangers of hearing damage. Default volume setting reduced from cranked to the max red zone full blare to 50%.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Jukebox default volume reduced to a more sensible level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
