### PR TITLE
Changes Swoopies to only swoop on grab, along with QOL and bugfixes

### DIFF
--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
@@ -1,6 +1,7 @@
 /mob/living/simple_mob/vore/aggressive/corrupthound/swoopie
 	name = "SWOOPIE XL"
-	desc = "A large birdlike robot with thick assets, plump belly, and a long elastic vacuum hose of a neck. Somehow still a cleanbot, even if just for its duties. Use DISARM intent to access Vac-Pack settings."
+	desc = "A large birdlike robot with thick assets, plump belly, and a long elastic vacuum hose of a neck. Somehow still a cleanbot, even if just for its duties."
+	description_info = "Use DISARM intent to access the integrated Vac-Pack settings.<br>Use GRAB intent to grab the SWOOPIE XL's neck and use it as a vaccum."
 	icon_state = "swoopie"
 	icon_living = "swoopie"
 	icon_dead = "swoopie_dead"
@@ -22,6 +23,8 @@
 	say_list_type = /datum/say_list/swoopie
 	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
 	mob_bump_flag = 0
+	player_msg = "You are a SWOOPIE XL cleaning bot! Use DISARM intent to change your integrated Vac-Pack settings, or GRAB intent to swoop stuff up! Turning off the Vac-Pack will make your grab clicks function as normal grab intent clicks."
+
 	var/static/list/crew_creatures = list(	/mob/living/simple_mob/protean_blob,
 											/mob/living/simple_mob/slime/promethean)
 	var/obj/item/device/vac_attachment/Vac
@@ -60,6 +63,7 @@
 	B.digest_messages_prey = list("Under the heat and internal pressure of the greedy machine's gutworks, you can feel the tides of the hot caustic sludge claiming the last bits of space around your body, a few more squeezes of the synthetic muscles squelching and glurking as your body finally loses its form, completely blending down and merging into the tingly sludge to fuel the mean machine.")
 	B.digest_mode = DM_DIGEST
 	B.item_digest_mode = IM_DIGEST
+	B.mode_flags = DM_FLAG_TURBOMODE | DM_FLAG_THICKBELLY //Hard to be heard from inside the swoop! Also very active belly.
 	B.digest_burn = 3
 	B.fancy_vore = 1
 	B.vore_sound = "Stomach Move"
@@ -111,9 +115,14 @@
 	B.affects_vore_sprites = FALSE
 	B.name = "Vac-Beak"
 	B.desc = "SNAP! You have been sucked up into the big synthbird's beak, the powerful vacuum within the bird roaring somewhere beyond the abyssal deep gullet hungrily gaping before you, eagerly sucking you deeper inside towards a long bulgy ride down the bird's vacuum hose of a neck!"
+	B.entrance_logs = TRUE //Exept for the maw. I think that's reasonable. -Reo
 	B.autotransferlocation = "vacuum hose"
 	B.autotransfer_max_amount = 0
 	B.autotransferwait = 60
+	B.belly_fullscreen_color2 = "#1C1C1C"
+	B.belly_fullscreen_color3 = "#292929"
+	B.belly_fullscreen_color4 = "#CCFFFF"
+	B.belly_fullscreen = "VBO_maw8" //Swoopies have beaks!!
 
 	vore_selected = B
 
@@ -124,6 +133,8 @@
 	desc = "With a mighty WHUMP, the suction of the big bird's ravenous vacuum system has sucked you up out of the embrace of its voracious main beak and into a tight bulge squeezing along the long ribbed rubbery tube leading towards the roaring doom of the synthetic bird's efficient waste disposal system."
 	digest_mode = DM_HOLD
 	item_digest_mode = IM_HOLD
+	contaminates = FALSE //Stuff doesnt get messy in the throat, the bird's gut is the messy place!
+	entrance_logs = FALSE //QOL to stop spam when stuff is getting gulped down~
 	autotransfer_enabled = TRUE
 	autotransferchance = 100
 	autotransferwait = 70
@@ -137,7 +148,9 @@
 	count_items_for_sprite = TRUE
 	item_multiplier = 10
 	health_impacts_size = FALSE
-	speedy_mob_processing = TRUE
+	//speedy_mob_processing = TRUE
+	mode_flags = DM_FLAG_TURBOMODE
+
 	size_factor_for_sprite = 5
 
 /mob/living/simple_mob/vore/aggressive/corrupthound/swoopie/Life()
@@ -155,20 +168,21 @@
 		if(!Vac.output_dest)
 			if(isbelly(vore_selected))
 				Vac.output_dest = vore_selected
-	if(istype(T) && istype(Vac) && has_AI() && Vac.loc == src)
-		if(istype(T, /turf/simulated))
-			var/turf/simulated/S = T
-			if(S.dirt > 10)
-				Vac.afterattack(S, src, 1)
-				return
-		for(var/obj/O in T)
-			if(is_type_in_list(O, edible_trash) && !O.anchored)
-				Vac.afterattack(T, src, 1)
-				return
-		for(var/mob/living/L in T)
-			if(!L.anchored || L.devourable || !L == src || !L.buckled || L.can_be_drop_prey)
-				Vac.afterattack(L, src, 1)
-				return
+	if(!(src.stat && istype(T) && istype(Vac) && has_AI() && Vac.loc == src))
+		return
+	if(istype(T, /turf/simulated))
+		var/turf/simulated/S = T
+		if(S.dirt > 10)
+			Vac.afterattack(S, src, 1)
+			return
+	for(var/obj/O in T)
+		if(is_type_in_list(O, edible_trash) && !O.anchored)
+			Vac.afterattack(T, src, 1)
+			return
+	for(var/mob/living/L in T)
+		if(!L.anchored || L.devourable || !L == src || !L.buckled || L.can_be_drop_prey)
+			Vac.afterattack(L, src, 1)
+			return
 
 /datum/say_list/swoopie
 	speak = list("Scanning for debris...", "Scanning for dirt...", "Scanning for pests...", "Squawk!")
@@ -181,12 +195,16 @@
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"] || modifiers["ctrl"] || modifiers["middle"] || modifiers["alt"])
 		return ..()
+	if(!stat) //Cant suck if we're dead...
+		return ..()
 	if(istype(Vac) && A.Adjacent(src))
 		face_atom(A)
-		if(A == src)
+		if(src.a_intent == I_DISARM && A == src) //Only if on disarm intent.
 			Vac.attack_self(src)
 			return
-		if(Vac.vac_power != 0)
+		if(istype(A, /obj/machinery/disposal)) //Dont put the nossle in the trash
+			return
+		if(src.a_intent == I_GRAB && Vac.vac_power != 0) //Only on grab intent. if someone needs to use grab intent they can just turn off the vac
 			var/resolved = Vac.resolve_attackby(A, src, click_parameters = params)
 			if(!resolved && A && Vac)
 				Vac.afterattack(A, src, 1, params)
@@ -194,6 +212,8 @@
 	. = ..()
 
 /mob/living/simple_mob/vore/aggressive/corrupthound/swoopie/attack_hand(mob/living/L)
+	if(!stat) //Make sure we're alive
+		return ..()
 	if(L.a_intent == I_DISARM && Vac)
 		Vac.attack_self(L)
 		return

--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_mob/vore/aggressive/corrupthound/swoopie
 	name = "SWOOPIE XL"
 	desc = "A large birdlike robot with thick assets, plump belly, and a long elastic vacuum hose of a neck. Somehow still a cleanbot, even if just for its duties."
-	description_info = "Use DISARM intent to access the integrated Vac-Pack settings.<br>Use GRAB intent to grab the SWOOPIE XL's neck and use it as a vaccum."
+	description_info = "Use DISARM intent to access the integrated Vac-Pack settings.<br>Use GRAB intent while targeting the head damage zone to grab the SWOOPIE XL's neck and use it as a vaccum."
 	icon_state = "swoopie"
 	icon_living = "swoopie"
 	icon_dead = "swoopie_dead"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Started out as a quick change to make swoopies' integrated vac-pack only activate when they're on grab intent, but changed to also do some QOL and bugfixes that I wanted to do a while ago but never got to.
Also Holy shit there's more changes than I thought there were after going over them again _WHEW_

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added spawn message for player swoopies that let them know how to control the suck birb
add: Moved the description part informing the player how to use swoopie's vac pack to a description_info section as well as adding information about how to use the swoopie like a normal vaccum
add: also gave swoopies a muffling belly by default
del: Removed contaminates from swoopie's neck bellies. Their belly is the messy place
qol: made swoopies' integrated vac-pack only trigger while they're on grab intent
balance: rebalanced something
qol: made swoopie's neck bellies not have entrance logs by default. This should reduce message spam when sucking down stuff.
fix: Fixed swoopies being able to suck while dead
fix: Fixed swoopies AI returning to the mob and being able to vaccum the ground while the player was dead and ghosted (also presumably fixing pure AI swoopies from doing this too)
code_imp: changed swoopies from using speedy_mob_processing to using TURBO MODE belly flags. It does the same thing, but TURBO MODE is ingame accessable without varedit, so I think that's the proper implementation that should be used going forward
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
