### PR TITLE
Reverts a bit of #6587

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -16,7 +16,6 @@
 	name = "emergency closet"
 	desc = "It's a storage unit for emergency breathmasks and O2 tanks."
 	closet_appearance = /decl/closet_appearance/oxygen
-	anchored = 1 //CHOMPADD - No more lockers flying away!
 
 /obj/structure/closet/emcloset/Initialize()
 	switch (pickweight(list("small" = 55, "aid" = 25, "tank" = 10, "both" = 10)))
@@ -60,7 +59,6 @@
 	return ..()
 
 /obj/structure/closet/emcloset/legacy
-	anchored = 1 //CHOMPADD - No more lockers flying away!
 	starts_with = list(
 		/obj/item/weapon/tank/oxygen,
 		/obj/item/clothing/mask/gas)
@@ -72,7 +70,6 @@
 	name = "fire-safety closet"
 	desc = "It's a storage unit for fire-fighting supplies."
 	closet_appearance = /decl/closet_appearance/oxygen/fire
-	anchored = 1 //CHOMPADD - No more lockers flying away!
 
 	starts_with = list(
 		/obj/item/clothing/suit/fire,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The PR that makes oxygen tanks anchored doesn't even work properly, it doesn't prevent the lockers from flying when pressure gets changed. It served more as a borg/body dragging nerf and anti QoL more than anything. I am leaving the secure closets anchored though.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
del: Removed those rusty bolts off oxygen lockers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
