### PR TITLE
Vore belly default variant improvement

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1276,6 +1276,7 @@
 			vessel.maximum_volume = species.blood_volume
 		fixblood()
 		species.update_attack_types() //VOREStation Edit - Required for any trait that updates unarmed_types in setup.
+		species.update_vore_belly_def_variant() //CHOMPedit - Custom species post spawn logic
 
 	// Rebuild the HUD. If they aren't logged in then login() should reinstantiate it for them.
 	update_hud()

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/species.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/species.dm
@@ -50,3 +50,11 @@
 	for(var/datum/trait/env_trait in env_traits)
 		env_trait.handle_environment_special(H)
 	return
+
+/datum/species/proc/update_vore_belly_def_variant()
+	// Determine the actual vore_belly_default_variant, if the base species in the VORE tab is set
+	switch (base_species)
+		if("Teshari")
+			vore_belly_default_variant = "T"
+		if("Unathi")
+			vore_belly_default_variant = "L"

--- a/modular_chomp/code/modules/research/designs/devices.dm
+++ b/modular_chomp/code/modules/research/designs/devices.dm
@@ -1,0 +1,6 @@
+/datum/design/item/device/floor_painter
+	id = "floor_painter"
+	req_tech = list(TECH_ENGINEERING = 2)
+	materials = list(MAT_STEEL = 3000, MAT_GLASS = 500)
+	build_path = /obj/item/device/floor_painter
+	sort_string = "TADAA"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4828,6 +4828,7 @@
 #include "modular_chomp\code\modules\reagents\reagents\toxin.dm"
 #include "modular_chomp\code\modules\recycling\v_garbosystem.dm"
 #include "modular_chomp\code\modules\research\mechfab_designs.dm"
+#include "modular_chomp\code\modules\research\designs\devices.dm"
 #include "modular_chomp\code\modules\research\designs\implants.dm"
 #include "modular_chomp\code\modules\research\designs\misc.dm"
 #include "modular_chomp\code\modules\research\designs\power_cells.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This PR adds the floor painter research design, so that players can also now make them!

Additionally, an issue has been fixed that (for example Proteans) have the wrong vore_belly_default_variant set (for example "H" even though the Icon Base is "Teshari"). That's why there is now an update/check that is ran after the species has been created.

Resolves #6247

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: added floor painter research design
qol: determines "vore_belly_default_variant" from the set base_species instead, if applicable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
