### PR TITLE
Revert "Ports Old Citcode Storage Reach"

### DIFF
--- a/code/__defines/inventory_sizes.dm
+++ b/code/__defines/inventory_sizes.dm
@@ -23,8 +23,3 @@
 #define INVENTORY_STANDARD_SPACE	ITEMSIZE_COST_NORMAL * 7 // 28
 #define INVENTORY_DUFFLEBAG_SPACE	ITEMSIZE_COST_NORMAL * 9 // 36
 #define INVENTORY_BOX_SPACE			ITEMSIZE_COST_SMALL * 7 // 14
-
-// CHOMPedit start.
-//this all needs a refactor to tg storage but for now...
-#define MAX_STORAGE_REACH 2		//maximum you can reach down to grab things from storage.
-// CHOMPedit end.

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -100,7 +100,7 @@
 	//Atoms on your person
 	// A is your location but is not a turf; or is on you (backpack); or is on something on you (box in backpack); sdepth is needed here because contents depth does not equate inventory storage depth.
 	var/sdepth = A.storage_depth(src)
-	if((!isturf(A) && A == loc) || (sdepth <= MAX_STORAGE_REACH)) // CHOMPedit: Boxes can be interacted with inside of larger inventories.
+	if((!isturf(A) && A == loc) || (sdepth != -1 && sdepth <= 1))
 		if(W)
 			var/resolved = W.resolve_attackby(A, src, click_parameters = params)
 			if(!resolved && A && W)
@@ -132,7 +132,7 @@
 	//Atoms on turfs (not on your person)
 	// A is a turf or is on a turf, or in something on a turf (pen in a box); but not something in something on a turf (pen in a box in a backpack)
 	sdepth = A.storage_depth_turf()
-	if(isturf(A) || isturf(A.loc) || (sdepth <= MAX_STORAGE_REACH)) // CHOMPedit: Storage reach depth.
+	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
 		if(A.Adjacent(src) || (W && W.attack_can_reach(src, A, W.reach)) ) // see adjacent.dm
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -27,7 +27,7 @@
 		//If it isn't on the floor. Do some checks to see if it's in our hands or a box. Otherwise give up.
 		if(istype(I.loc,/obj/item/weapon/storage))	//in a container.
 			var/sdepth = I.storage_depth(user)
-			if (sdepth > MAX_STORAGE_REACH) // CHOMPedit: Storage reach depth.
+			if (sdepth == -1 || sdepth > 1)
 				return	//too deeply nested to access
 
 			var/obj/item/weapon/storage/U = I.loc

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -55,7 +55,7 @@
 #include "code\__defines\input.dm"
 #include "code\__defines\instruments.dm"
 #include "code\__defines\integrated_circuits.dm"
-#include "code\__defines\inventory_storage.dm"
+#include "code\__defines\inventory_sizes.dm"
 #include "code\__defines\is_helpers.dm"
 #include "code\__defines\items_clothing.dm"
 #include "code\__defines\lighting.dm"


### PR DESCRIPTION
Reverts CHOMPStation2/CHOMPStation2#7182

For some unknown reason this causes the players to have infinite reach.


:cl:
fix: fixes players having infinite reach
/:cl:
