### PR TITLE
Adds http_request datum

### DIFF
--- a/code/__defines/rust_g.dm
+++ b/code/__defines/rust_g.dm
@@ -38,6 +38,15 @@
 #define RUST_G (__rust_g || __detect_rust_g())
 #endif
 
+// CHOMPedit Start - Rust http
+// Handle 515 call() -> call_ext() changes
+#if DM_VERSION >= 515
+#define RUSTG_CALL call_ext
+#else
+#define RUSTG_CALL call
+#endif
+// CHOMPedit End - Rust http
+
 #define RUSTG_JOB_NO_RESULTS_YET "NO RESULTS YET"
 #define RUSTG_JOB_NO_SUCH_JOB "NO SUCH JOB"
 #define RUSTG_JOB_ERROR "JOB PANICKED"
@@ -91,8 +100,8 @@
 #define RUSTG_HTTP_METHOD_PATCH "patch"
 #define RUSTG_HTTP_METHOD_HEAD "head"
 #define RUSTG_HTTP_METHOD_POST "post"
-#define rustg_http_request_blocking(method, url, body, headers) LIBCALL(RUST_G, "http_request_blocking")(method, url, body, headers)
-#define rustg_http_request_async(method, url, body, headers) LIBCALL(RUST_G, "http_request_async")(method, url, body, headers)
+#define rustg_http_request_blocking(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_blocking")(method, url, body, headers, options) // CHOMPedit - Rust HTTP Requests
+#define rustg_http_request_async(method, url, body, headers, options) RUSTG_CALL(RUST_G, "http_request_async")(method, url, body, headers, options) // CHOMPedit - Rust HTTP Requests
 #define rustg_http_check_request(req_id) LIBCALL(RUST_G, "http_check_request")(req_id)
 
 #define rustg_sql_connect_pool(options) LIBCALL(RUST_G, "sql_connect_pool")(options)

--- a/modular_chomp/code/datums/http.dm
+++ b/modular_chomp/code/datums/http.dm
@@ -1,0 +1,82 @@
+/datum/http_request
+	var/id
+	var/in_progress = FALSE
+
+	var/method
+	var/body
+	var/headers
+	var/url
+	/// If present response body will be saved to this file.
+	var/output_file
+
+	var/_raw_response
+
+/datum/http_request/proc/prepare(method, url, body = "", list/headers, output_file)
+	if (!length(headers))
+		headers = ""
+	else
+		headers = json_encode(headers)
+
+	src.method = method
+	src.url = url
+	src.body = body
+	src.headers = headers
+	src.output_file = output_file
+
+/datum/http_request/proc/execute_blocking()
+	_raw_response = rustg_http_request_blocking(method, url, body, headers, build_options())
+
+/datum/http_request/proc/begin_async()
+	if (in_progress)
+		CRASH("Attempted to re-use a request object.")
+
+	id = rustg_http_request_async(method, url, body, headers, build_options())
+
+	if (isnull(text2num(id)))
+		stack_trace("Proc error: [id]")
+		_raw_response = "Proc error: [id]"
+	else
+		in_progress = TRUE
+
+/datum/http_request/proc/build_options()
+	if(output_file)
+		return json_encode(list("output_filename"=output_file,"body_filename"=null))
+	return null
+
+/datum/http_request/proc/is_complete()
+	if (isnull(id))
+		return TRUE
+
+	if (!in_progress)
+		return TRUE
+
+	var/r = rustg_http_check_request(id)
+
+	if (r == RUSTG_JOB_NO_RESULTS_YET)
+		return FALSE
+	else
+		_raw_response = r
+		in_progress = FALSE
+		return TRUE
+
+/datum/http_request/proc/into_response()
+	var/datum/http_response/R = new()
+
+	try
+		var/list/L = json_decode(_raw_response)
+		R.status_code = L["status_code"]
+		R.headers = L["headers"]
+		R.body = L["body"]
+	catch
+		R.errored = TRUE
+		R.error = _raw_response
+
+	return R
+
+/datum/http_response
+	var/status_code
+	var/body
+	var/list/headers
+
+	var/errored = FALSE
+	var/error

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4583,6 +4583,7 @@
 #include "modular_chomp\code\_HELPERS\type2type\color.dm"
 #include "modular_chomp\code\_onclick\hud\alert.dm"
 #include "modular_chomp\code\ATMOSPHERICS\atmospherics.dm"
+#include "modular_chomp\code\datums\http.dm"
 #include "modular_chomp\code\datums\autolathe\arms.dm"
 #include "modular_chomp\code\datums\autolathe\engineering_ch.dm"
 #include "modular_chomp\code\datums\autolathe\general_ch.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This datum should make it easier to build new http (synchronous or asynchronous) requests, especially if they also should return a response from the endpoint.

There are a few examples here on how an async request could be constructed:
https://github.com/search?q=repo%3Atgstation%2Ftgstation+http_request&type=code

NOTE: Generally our rust-g should be checked over if it has any good updates or changes that could improve stuff.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: added http_request datum to properly use rust-g based http requests (including async ones).
code_imp: byond 515 support defines for rust-g definitions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
