### PR TITLE
Altering Outsider Pods

### DIFF
--- a/modular_chomp/maps/submaps/shelters/DemonPoolV2-43x28.dmm
+++ b/modular_chomp/maps/submaps/shelters/DemonPoolV2-43x28.dmm
@@ -1,79 +1,1619 @@
-"a" = (/turf/simulated/gore,/area/survivalpod/superpose/DemonPoolV2)
-"b" = (/obj/structure/cult/talisman,/turf/simulated/floor/wood/alt{color = "red"},/area/survivalpod/superpose/DemonPoolV2)
-"c" = (/turf/simulated/floor/gorefloor,/area/survivalpod/superpose/DemonPoolV2)
-"d" = (/obj/structure/closet/crate,/obj/fiftyspawner/glass,/obj/fiftyspawner/glass,/obj/fiftyspawner/glass,/obj/fiftyspawner/glass,/obj/fiftyspawner/glass,/obj/fiftyspawner/steel,/obj/fiftyspawner/steel,/obj/fiftyspawner/steel,/obj/fiftyspawner/steel,/obj/fiftyspawner/steel,/obj/fiftyspawner/plastic,/obj/fiftyspawner/plastic,/obj/fiftyspawner/plastic,/obj/fiftyspawner/plastic,/obj/fiftyspawner/plastic,/turf/simulated/floor/cult,/area/survivalpod/superpose/DemonPoolV2)
-"e" = (/obj/structure/simple_door/cult,/turf/simulated/floor/cult,/area/survivalpod/superpose/DemonPoolV2)
-"f" = (/obj/effect/rune,/turf/simulated/floor/wood/alt{color = "red"},/area/survivalpod/superpose/DemonPoolV2)
-"g" = (/obj/structure/closet/crate,/obj/fiftyspawner/wood,/obj/fiftyspawner/wood,/obj/fiftyspawner/wood/sif,/obj/fiftyspawner/wood/sif,/obj/fiftyspawner/turcarpet,/obj/fiftyspawner/tealcarpet,/obj/fiftyspawner/sblucarpet,/obj/fiftyspawner/purcarpet,/obj/fiftyspawner/oracarpet,/obj/fiftyspawner/blucarpet,/obj/fiftyspawner/marble,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/fiftyspawner/cardboard,/obj/fiftyspawner/cardboard,/turf/simulated/floor/cult,/area/survivalpod/superpose/DemonPoolV2)
-"h" = (/turf/simulated/floor/cult,/area/survivalpod/superpose/DemonPoolV2)
-"i" = (/obj/structure/cult/tome,/turf/simulated/floor/wood/alt{color = "red"},/area/survivalpod/superpose/DemonPoolV2)
-"j" = (/obj/structure/table/fancyblack,/obj/item/trash/plate,/obj/item/organ/internal/heart,/obj/machinery/light/floortube/flicker{dir = 8; pixel_x = 5},/turf/simulated/floor/wood/alt{color = "red"},/area/survivalpod/superpose/DemonPoolV2)
-"k" = (/obj/structure/cult/pylon,/turf/simulated/floor/cult,/area/survivalpod/superpose/DemonPoolV2)
-"l" = (/obj/item/weapon/bone/ribs,/turf/simulated/floor/lava,/area/survivalpod/superpose/DemonPoolV2)
-"m" = (/obj/structure/loot_pile/surface/bones,/turf/simulated/floor/gorefloor2,/area/survivalpod/superpose/DemonPoolV2)
-"n" = (/obj/structure/cult/pylon,/turf/simulated/floor/gorefloor2,/area/survivalpod/superpose/DemonPoolV2)
-"o" = (/turf/template_noop,/area/survivalpod/superpose/DemonPoolV2)
-"p" = (/obj/structure/constructshell/cult,/turf/simulated/floor/cult,/area/survivalpod/superpose/DemonPoolV2)
-"q" = (/obj/structure/cult/pylon,/turf/simulated/floor/wood/alt{color = "red"},/area/survivalpod/superpose/DemonPoolV2)
-"r" = (/obj/structure/grille/broken/cult,/turf/simulated/floor/gorefloor,/area/survivalpod/superpose/DemonPoolV2)
-"t" = (/obj/structure/bed/chair/comfy/black{dir = 8},/turf/simulated/floor/wood/alt{color = "red"},/area/survivalpod/superpose/DemonPoolV2)
-"v" = (/obj/effect/map_effect/interval/sound_emitter/punching,/obj/effect/map_effect/interval/effect_emitter/smoke/fire,/turf/simulated/floor/lava,/area/survivalpod/superpose/DemonPoolV2)
-"w" = (/turf/simulated/wall/solidrock,/area/survivalpod/superpose/DemonPoolV2)
-"x" = (/obj/structure/bed/double/padded,/obj/item/weapon/bedsheet/browndouble,/turf/simulated/floor/carpet/gaycarpet,/area/survivalpod/superpose/DemonPoolV2)
-"y" = (/obj/structure/girder/cult,/turf/simulated/floor/gorefloor,/area/survivalpod/superpose/DemonPoolV2)
-"z" = (/obj/structure/girder/cult,/turf/simulated/floor/gorefloor2,/area/survivalpod/superpose/DemonPoolV2)
-"A" = (/obj/effect/map_effect/interval/effect_emitter/smoke/fire,/turf/simulated/floor/lava,/area/survivalpod/superpose/DemonPoolV2)
-"B" = (/obj/structure/grille/cult,/turf/simulated/floor/cult,/area/survivalpod/superpose/DemonPoolV2)
-"C" = (/obj/machinery/crystal/lava,/turf/simulated/floor/lava,/area/survivalpod/superpose/DemonPoolV2)
-"D" = (/obj/structure/table/hardwoodtable,/obj/item/weapon/flame/candle/candelabra/everburn{pixel_y = 9},/turf/simulated/floor/wood/alt{color = "red"},/area/survivalpod/superpose/DemonPoolV2)
-"E" = (/turf/simulated/wall/cult,/area/survivalpod/superpose/DemonPoolV2)
-"F" = (/obj/structure/bed/chair/comfy/black{dir = 4},/turf/simulated/floor/wood/alt{color = "red"},/area/survivalpod/superpose/DemonPoolV2)
-"G" = (/obj/structure/closet/crate,/obj/fiftyspawner/plasteel,/obj/fiftyspawner/plasteel,/obj/fiftyspawner/phoronrglass,/obj/fiftyspawner/phoronrglass,/obj/item/stack/material/lead{amount = 50},/obj/item/stack/material/lead{amount = 50},/obj/fiftyspawner/gold,/obj/fiftyspawner/phoron,/turf/simulated/floor/gorefloor2,/area/survivalpod/superpose/DemonPoolV2)
-"I" = (/turf/simulated/goreeyes,/area/survivalpod/superpose/DemonPoolV2)
-"J" = (/turf/simulated/floor/gorefloor2,/area/survivalpod/superpose/DemonPoolV2)
-"K" = (/obj/item/clothing/shoes/cult,/obj/item/clothing/suit/cultrobes/alt,/obj/item/clothing/head/helmet/space/cult,/obj/item/clothing/shoes/cult,/obj/item/clothing/suit/cultrobes/alt,/obj/item/clothing/head/helmet/space/cult,/obj/item/weapon/storage/backpack/cultpack,/obj/item/weapon/storage/backpack/cultpack,/obj/structure/closet/cabinet,/turf/simulated/floor/wood/alt{color = "red"},/area/survivalpod/superpose/DemonPoolV2)
-"M" = (/obj/structure/grille/broken/cult,/turf/simulated/floor/gorefloor2,/area/survivalpod/superpose/DemonPoolV2)
-"N" = (/obj/structure/bed/double/padded,/obj/item/weapon/bedsheet/purpledouble,/turf/simulated/floor/carpet/gaycarpet,/area/survivalpod/superpose/DemonPoolV2)
-"O" = (/obj/item/weapon/storage/backpack/messenger,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/material/knife/tacknife/survival,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/reagent_containers/hypospray/autoinjector/trauma,/obj/item/weapon/reagent_containers/hypospray/autoinjector/oxy,/obj/item/weapon/flame/lighter/random,/obj/item/weapon/storage/box/survival/space,/obj/item/device/radio,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/weapon/reagent_containers/pill/dylovene,/obj/item/weapon/reagent_containers/pill/dylovene,/obj/item/device/flashlight/maglight,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare,/obj/random/soap,/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,/obj/item/device/fbp_backup_cell,/obj/item/device/pda,/obj/item/weapon/storage/mre/menu11,/obj/item/weapon/storage/mre/menu11,/obj/item/device/starcaster_news,/obj/effect/floor_decal/spline/fancy/wood{dir = 4},/obj/item/device/suit_cooling_unit/emergency,/obj/item/device/gps,/obj/structure/closet{name = "Survival closet"},/turf/simulated/floor/cult,/area/survivalpod/superpose/DemonPoolV2)
-"P" = (/turf/simulated/floor/carpet/gaycarpet,/area/survivalpod/superpose/DemonPoolV2)
-"Q" = (/turf/simulated/floor/flesh/colour{color = red},/area/survivalpod/superpose/DemonPoolV2)
-"R" = (/obj/effect/decal/remains/deer,/turf/simulated/floor/gorefloor2,/area/survivalpod/superpose/DemonPoolV2)
-"S" = (/obj/structure/simple_door/cult,/turf/simulated/floor/gorefloor2,/area/survivalpod/superpose/DemonPoolV2)
-"T" = (/obj/random/pottedplant,/obj/structure/window/reinforced/survival_pod{dir = 1; opacity = 1},/obj/structure/curtain/black,/turf/simulated/floor/cult,/area/survivalpod/superpose/DemonPoolV2)
-"U" = (/obj/structure/grille/cult,/turf/simulated/floor/lava,/area/survivalpod/superpose/DemonPoolV2)
-"V" = (/obj/effect/gibspawner/human,/turf/simulated/floor/gorefloor2,/area/survivalpod/superpose/DemonPoolV2)
-"W" = (/turf/simulated/floor/wood/alt{color = "red"},/area/survivalpod/superpose/DemonPoolV2)
-"X" = (/obj/structure/closet/cabinet,/obj/random/curseditem,/obj/random/curseditem,/obj/item/weapon/melee/cursedblade,/obj/item/weapon/melee/cultblade,/obj/item/weapon/beartrap/hunting,/obj/item/weapon/beartrap/hunting,/obj/item/stack/material/phoron{amount = 25},/obj/item/stack/material/phoron{amount = 25},/obj/item/device/soulstone,/obj/item/device/soulstone,/obj/item/weapon/storage/belt/soulstone/full,/turf/simulated/floor/wood/alt{color = "red"},/area/survivalpod/superpose/DemonPoolV2)
-"Y" = (/turf/simulated/floor/lava,/area/survivalpod/superpose/DemonPoolV2)
-"Z" = (/obj/effect/rune,/obj/item/weapon/cat_box/black,/turf/simulated/floor/cult,/area/survivalpod/superpose/DemonPoolV2)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/simulated/gore,
+/area/survivalpod/superpose/DemonPoolV2)
+"b" = (
+/obj/structure/cult/talisman,
+/turf/simulated/floor/wood/alt{
+	color = "red"
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"c" = (
+/turf/simulated/floor/gorefloor,
+/area/survivalpod/superpose/DemonPoolV2)
+"d" = (
+/obj/structure/closet/crate,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/plastic,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/DemonPoolV2)
+"e" = (
+/obj/structure/simple_door/sandstone{
+	color = "#D35400"
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/DemonPoolV2)
+"f" = (
+/obj/effect/rune,
+/turf/simulated/floor/wood/alt{
+	color = "red"
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"g" = (
+/obj/structure/closet/crate,
+/obj/fiftyspawner/wood,
+/obj/fiftyspawner/wood,
+/obj/fiftyspawner/wood/sif,
+/obj/fiftyspawner/wood/sif,
+/obj/fiftyspawner/turcarpet,
+/obj/fiftyspawner/tealcarpet,
+/obj/fiftyspawner/sblucarpet,
+/obj/fiftyspawner/purcarpet,
+/obj/fiftyspawner/oracarpet,
+/obj/fiftyspawner/blucarpet,
+/obj/fiftyspawner/marble,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/fiftyspawner/cardboard,
+/obj/fiftyspawner/cardboard,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/DemonPoolV2)
+"h" = (
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/DemonPoolV2)
+"i" = (
+/obj/structure/cult/tome,
+/turf/simulated/floor/wood/alt{
+	color = "red"
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"j" = (
+/obj/structure/table/fancyblack,
+/obj/item/trash/plate,
+/obj/item/organ/internal/heart,
+/obj/machinery/light/floortube/flicker{
+	dir = 8;
+	pixel_x = 5
+	},
+/turf/simulated/floor/wood/alt{
+	color = "red"
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"k" = (
+/obj/structure/cult/pylon,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/DemonPoolV2)
+"l" = (
+/obj/item/weapon/bone/ribs,
+/turf/simulated/floor/lava,
+/area/survivalpod/superpose/DemonPoolV2)
+"m" = (
+/obj/structure/loot_pile/surface/bones,
+/turf/simulated/floor/gorefloor2,
+/area/survivalpod/superpose/DemonPoolV2)
+"n" = (
+/obj/structure/cult/pylon,
+/turf/simulated/floor/gorefloor2,
+/area/survivalpod/superpose/DemonPoolV2)
+"o" = (
+/turf/template_noop,
+/area/survivalpod/superpose/DemonPoolV2)
+"p" = (
+/obj/structure/constructshell/cult,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/DemonPoolV2)
+"q" = (
+/obj/structure/cult/pylon,
+/turf/simulated/floor/wood/alt{
+	color = "red"
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"r" = (
+/obj/structure/grille/broken/cult,
+/turf/simulated/floor/gorefloor,
+/area/survivalpod/superpose/DemonPoolV2)
+"t" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/wood/alt{
+	color = "red"
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"v" = (
+/obj/effect/map_effect/interval/sound_emitter/punching,
+/obj/effect/map_effect/interval/effect_emitter/smoke/fire,
+/turf/simulated/floor/lava,
+/area/survivalpod/superpose/DemonPoolV2)
+"w" = (
+/turf/simulated/wall/solidrock,
+/area/survivalpod/superpose/DemonPoolV2)
+"x" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/browndouble,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/survivalpod/superpose/DemonPoolV2)
+"y" = (
+/obj/structure/girder/cult,
+/turf/simulated/floor/gorefloor,
+/area/survivalpod/superpose/DemonPoolV2)
+"z" = (
+/obj/structure/girder/cult,
+/turf/simulated/floor/gorefloor2,
+/area/survivalpod/superpose/DemonPoolV2)
+"A" = (
+/obj/effect/map_effect/interval/effect_emitter/smoke/fire,
+/turf/simulated/floor/lava,
+/area/survivalpod/superpose/DemonPoolV2)
+"B" = (
+/obj/structure/grille/cult,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/DemonPoolV2)
+"C" = (
+/obj/machinery/crystal/lava,
+/turf/simulated/floor/lava,
+/area/survivalpod/superpose/DemonPoolV2)
+"D" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/weapon/flame/candle/candelabra/everburn{
+	pixel_y = 9
+	},
+/turf/simulated/floor/wood/alt{
+	color = "red"
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"E" = (
+/turf/simulated/wall/cult,
+/area/survivalpod/superpose/DemonPoolV2)
+"F" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt{
+	color = "red"
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"G" = (
+/obj/structure/closet/crate,
+/obj/fiftyspawner/plasteel,
+/obj/fiftyspawner/plasteel,
+/obj/fiftyspawner/phoronrglass,
+/obj/fiftyspawner/phoronrglass,
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/obj/item/stack/material/lead{
+	amount = 50
+	},
+/obj/fiftyspawner/gold,
+/obj/fiftyspawner/phoron,
+/turf/simulated/floor/gorefloor2,
+/area/survivalpod/superpose/DemonPoolV2)
+"I" = (
+/turf/simulated/goreeyes,
+/area/survivalpod/superpose/DemonPoolV2)
+"J" = (
+/turf/simulated/floor/gorefloor2,
+/area/survivalpod/superpose/DemonPoolV2)
+"K" = (
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/suit/cultrobes/alt,
+/obj/item/clothing/head/helmet/space/cult,
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/suit/cultrobes/alt,
+/obj/item/clothing/head/helmet/space/cult,
+/obj/item/weapon/storage/backpack/cultpack,
+/obj/item/weapon/storage/backpack/cultpack,
+/obj/structure/closet/cabinet,
+/turf/simulated/floor/wood/alt{
+	color = "red"
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"M" = (
+/obj/structure/grille/broken/cult,
+/turf/simulated/floor/gorefloor2,
+/area/survivalpod/superpose/DemonPoolV2)
+"N" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/purpledouble,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/survivalpod/superpose/DemonPoolV2)
+"O" = (
+/obj/item/weapon/storage/backpack/messenger,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/material/knife/tacknife/survival,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/trauma,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/oxy,
+/obj/item/weapon/flame/lighter/random,
+/obj/item/weapon/storage/box/survival/space,
+/obj/item/device/radio,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/weapon/reagent_containers/pill/dylovene,
+/obj/item/weapon/reagent_containers/pill/dylovene,
+/obj/item/device/flashlight/maglight,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/random/soap,
+/obj/item/weapon/gun/energy/locked/frontier/holdout/unlocked,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/pda,
+/obj/item/weapon/storage/mre/menu11,
+/obj/item/weapon/storage/mre/menu11,
+/obj/item/device/starcaster_news,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/device/gps,
+/obj/structure/closet{
+	name = "Survival closet"
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/DemonPoolV2)
+"P" = (
+/turf/simulated/floor/carpet/gaycarpet,
+/area/survivalpod/superpose/DemonPoolV2)
+"Q" = (
+/turf/simulated/floor/flesh/colour{
+	color = red
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"R" = (
+/obj/effect/decal/remains/deer,
+/turf/simulated/floor/gorefloor2,
+/area/survivalpod/superpose/DemonPoolV2)
+"S" = (
+/obj/structure/simple_door/sandstone{
+	color = "#D35400"
+	},
+/turf/simulated/floor/gorefloor2,
+/area/survivalpod/superpose/DemonPoolV2)
+"T" = (
+/obj/random/pottedplant,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1;
+	opacity = 1
+	},
+/obj/structure/curtain/black,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/DemonPoolV2)
+"U" = (
+/obj/structure/grille/cult,
+/turf/simulated/floor/lava,
+/area/survivalpod/superpose/DemonPoolV2)
+"V" = (
+/obj/effect/gibspawner/human,
+/turf/simulated/floor/gorefloor2,
+/area/survivalpod/superpose/DemonPoolV2)
+"W" = (
+/turf/simulated/floor/wood/alt{
+	color = "red"
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"X" = (
+/obj/structure/closet/cabinet,
+/obj/random/curseditem,
+/obj/random/curseditem,
+/obj/item/weapon/melee/cursedblade,
+/obj/item/weapon/melee/cultblade,
+/obj/item/weapon/beartrap/hunting,
+/obj/item/weapon/beartrap/hunting,
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/item/device/soulstone,
+/obj/item/device/soulstone,
+/obj/item/weapon/storage/belt/soulstone/full,
+/turf/simulated/floor/wood/alt{
+	color = "red"
+	},
+/area/survivalpod/superpose/DemonPoolV2)
+"Y" = (
+/turf/simulated/floor/lava,
+/area/survivalpod/superpose/DemonPoolV2)
+"Z" = (
+/obj/effect/rune,
+/obj/item/weapon/cat_box/black,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/DemonPoolV2)
 
 (1,1,1) = {"
-owwwoowowowwwwwwwoowoowowwwowwwoowwwwooowoo
-wwwawwawawaaaaaaawwawwEwaaawaaawwaaaawwwawo
-owaaaaaaaaaaYYJJaaaaaaaaaEaaaaaaaUUaYaaaaaw
-wwaaJJJJJaaaYJJnJJJaaaaInJJJJJJccccUYYYCEaw
-wwaaJJYYJJJaJJJJJJJJaaJJJJpcpcpcpcpcykyYAaw
-wwaaJYYYYJJIJJcccJJJVaJcchhhhhhhhhhhhZkYaaw
-owwaYYvlYJJJyQQQQcRJJIccQcpJpJpcpcpcykyYawo
-owwaYYYYYJJcQQccQQcJJJcQcJJJmJJJcccUYYYCaaw
-wwwaJYYYVJMcQcJJyQcJJJcccJVIaIIIUUUUYYYYaaw
-owwaJJJJJRcQQcJVJQQcJccQJJJJJJJIIaIaaYYYawo
-owwaJJJJJJcQccJJJcQcccQQcccccccccJJGaaYYaaw
-oowaaaaIJcQQcJJIJcQzcQcJQQQccQQcQJJJJYYYYaw
-oowaaaaJJcQczJJrJcQQQccJcccccJcJQQcJJJAYaaw
-owaaaaJJJQQcJJJIJccQQcEEEBEEeEBEEQcQJJYYawo
-wwaaaJJJzQccJJmaJJcQccEOhhEhhKDKEEJQcJJJawo
-wwaaJJJccQccJJaaJJcQccEhhhEhhWWWiEcczJJJawo
-wwaJJJJETeTEJaaaJJyQQcEEhhehkfqWbBcQccJJawo
-owaJJJJEhhhEEEaaJJJQQccEhhEhhWWWiEJQQcRJawo
-owaJEEEEWWWPNEaaJJJcQQcEEBEEBEEBEEJQQcJaaaw
-owaJEdgEDWWPxEaaJJRJcQQQcJccccJJcJcQQcJaaaw
-owwaEhheWWWWWEaaJJJJVJcyQQQQQQQycQQQccJJaaw
-owwaEhhEXFjjtEaaaaaIJJJJcJQQccQQQQcJJJJJaaw
-oowaEEEEEEEEEEaaaaaaaJJJJJEccJccccJJJJJaawo
-oowwaaaaaaaaaaaaaaaawJJJJaaJEJJJMEJJJIaaawo
-ooowaaaaaaaaaaaaawwwwSSwaaaaaaaaaaaaaaaaawo
-oooowwwwwwwwwwwwwwwwooowwwwaaawwwaawwwwwawo
-ooooowwoooowwwwwwowwoooowwwwwwwowwwwoooowoo
-oooooooooooowwooooowooooowooooooooooooooooo
+o
+w
+o
+w
+w
+w
+o
+o
+w
+o
+o
+o
+o
+o
+w
+w
+w
+o
+o
+o
+o
+o
+o
+o
+o
+o
+o
+o
+"}
+(2,1,1) = {"
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+w
+o
+o
+w
+w
+w
+w
+w
+w
+w
+w
+w
+o
+o
+o
+o
+o
+o
+"}
+(3,1,1) = {"
+w
+w
+a
+a
+a
+a
+w
+w
+w
+w
+w
+w
+w
+a
+a
+a
+a
+a
+a
+a
+w
+w
+w
+w
+o
+o
+o
+o
+"}
+(4,1,1) = {"
+w
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+J
+J
+J
+J
+a
+a
+a
+w
+w
+o
+o
+o
+"}
+(5,1,1) = {"
+o
+w
+a
+J
+J
+J
+Y
+Y
+J
+J
+J
+a
+a
+a
+a
+J
+J
+J
+E
+E
+E
+E
+E
+a
+a
+w
+o
+o
+"}
+(6,1,1) = {"
+o
+w
+a
+J
+J
+Y
+Y
+Y
+Y
+J
+J
+a
+a
+a
+J
+J
+J
+J
+E
+d
+h
+h
+E
+a
+a
+w
+w
+o
+"}
+(7,1,1) = {"
+w
+a
+a
+J
+Y
+Y
+v
+Y
+Y
+J
+J
+a
+a
+J
+J
+J
+J
+J
+E
+g
+h
+h
+E
+a
+a
+w
+w
+o
+"}
+(8,1,1) = {"
+o
+w
+a
+J
+Y
+Y
+l
+Y
+Y
+J
+J
+I
+J
+J
+J
+c
+E
+E
+E
+E
+e
+E
+E
+a
+a
+w
+o
+o
+"}
+(9,1,1) = {"
+w
+a
+a
+J
+J
+Y
+Y
+Y
+V
+J
+J
+J
+J
+J
+z
+c
+T
+h
+W
+D
+W
+X
+E
+a
+a
+w
+o
+o
+"}
+(10,1,1) = {"
+o
+w
+a
+a
+J
+J
+J
+J
+J
+R
+J
+c
+c
+Q
+Q
+Q
+e
+h
+W
+W
+W
+F
+E
+a
+a
+w
+o
+o
+"}
+(11,1,1) = {"
+w
+a
+a
+a
+J
+J
+J
+J
+M
+c
+c
+Q
+Q
+Q
+c
+c
+T
+h
+W
+W
+W
+j
+E
+a
+a
+w
+o
+o
+"}
+(12,1,1) = {"
+w
+a
+a
+a
+a
+I
+J
+c
+c
+Q
+Q
+Q
+c
+c
+c
+c
+E
+E
+P
+P
+W
+j
+E
+a
+a
+w
+w
+o
+"}
+(13,1,1) = {"
+w
+a
+Y
+Y
+J
+J
+y
+Q
+Q
+Q
+c
+c
+z
+J
+J
+J
+J
+E
+N
+x
+W
+t
+E
+a
+a
+w
+w
+w
+"}
+(14,1,1) = {"
+w
+a
+Y
+J
+J
+J
+Q
+Q
+c
+c
+c
+J
+J
+J
+J
+J
+a
+E
+E
+E
+E
+E
+E
+a
+a
+w
+w
+w
+"}
+(15,1,1) = {"
+w
+a
+J
+J
+J
+c
+Q
+c
+J
+J
+J
+J
+J
+J
+m
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+w
+w
+o
+"}
+(16,1,1) = {"
+w
+a
+J
+n
+J
+c
+Q
+c
+J
+V
+J
+I
+r
+I
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+w
+w
+o
+"}
+(17,1,1) = {"
+w
+a
+a
+J
+J
+c
+Q
+Q
+y
+J
+J
+J
+J
+J
+J
+J
+J
+J
+J
+J
+J
+a
+a
+a
+a
+w
+w
+o
+"}
+(18,1,1) = {"
+o
+w
+a
+J
+J
+J
+c
+Q
+Q
+Q
+c
+c
+c
+c
+J
+J
+J
+J
+J
+J
+J
+a
+a
+a
+w
+w
+o
+o
+"}
+(19,1,1) = {"
+o
+w
+a
+J
+J
+J
+R
+c
+c
+Q
+Q
+Q
+Q
+c
+c
+c
+y
+J
+J
+R
+J
+a
+a
+a
+w
+w
+w
+o
+"}
+(20,1,1) = {"
+w
+a
+a
+a
+J
+J
+J
+J
+J
+c
+c
+z
+Q
+Q
+Q
+Q
+Q
+Q
+c
+J
+J
+I
+a
+a
+w
+w
+w
+w
+"}
+(21,1,1) = {"
+o
+w
+a
+a
+a
+V
+J
+J
+J
+J
+c
+c
+Q
+Q
+c
+c
+Q
+Q
+Q
+c
+V
+J
+a
+w
+w
+o
+o
+o
+"}
+(22,1,1) = {"
+o
+w
+a
+a
+a
+a
+I
+J
+J
+c
+c
+Q
+c
+c
+c
+c
+c
+c
+Q
+Q
+J
+J
+J
+J
+S
+o
+o
+o
+"}
+(23,1,1) = {"
+w
+E
+a
+a
+J
+J
+c
+c
+c
+c
+Q
+c
+c
+E
+E
+E
+E
+c
+c
+Q
+c
+J
+J
+J
+S
+o
+o
+o
+"}
+(24,1,1) = {"
+o
+w
+a
+I
+J
+c
+c
+Q
+c
+Q
+Q
+J
+J
+E
+O
+h
+E
+E
+E
+Q
+y
+J
+J
+J
+w
+w
+o
+o
+"}
+(25,1,1) = {"
+w
+a
+a
+n
+J
+c
+Q
+c
+c
+J
+c
+Q
+c
+E
+h
+h
+h
+h
+E
+c
+Q
+c
+J
+J
+a
+w
+w
+o
+"}
+(26,1,1) = {"
+w
+a
+E
+J
+J
+h
+c
+J
+J
+J
+c
+Q
+c
+B
+h
+h
+h
+h
+B
+J
+Q
+J
+J
+a
+a
+w
+w
+w
+"}
+(27,1,1) = {"
+w
+a
+a
+J
+p
+h
+p
+J
+V
+J
+c
+Q
+c
+E
+E
+E
+e
+E
+E
+c
+Q
+Q
+E
+a
+a
+w
+w
+o
+"}
+(28,1,1) = {"
+o
+w
+a
+J
+c
+h
+J
+J
+I
+J
+c
+c
+c
+E
+h
+h
+h
+h
+E
+c
+Q
+Q
+c
+J
+a
+a
+w
+o
+"}
+(29,1,1) = {"
+w
+a
+a
+J
+p
+h
+p
+m
+a
+J
+c
+c
+c
+e
+h
+h
+k
+h
+B
+c
+Q
+c
+c
+E
+a
+a
+w
+o
+"}
+(30,1,1) = {"
+w
+a
+a
+J
+c
+h
+J
+J
+I
+J
+c
+Q
+J
+E
+K
+W
+f
+W
+E
+c
+Q
+c
+J
+J
+a
+a
+w
+o
+"}
+(31,1,1) = {"
+w
+a
+a
+J
+p
+h
+p
+J
+I
+J
+c
+Q
+c
+B
+D
+W
+q
+W
+E
+J
+Q
+Q
+c
+J
+a
+w
+w
+o
+"}
+(32,1,1) = {"
+o
+w
+a
+c
+c
+h
+c
+J
+I
+I
+c
+c
+J
+E
+K
+W
+W
+W
+B
+J
+y
+Q
+c
+J
+a
+w
+o
+o
+"}
+(33,1,1) = {"
+o
+w
+a
+c
+p
+h
+p
+c
+U
+I
+c
+Q
+Q
+E
+E
+i
+b
+i
+E
+c
+c
+Q
+c
+M
+a
+w
+w
+o
+"}
+(34,1,1) = {"
+w
+a
+U
+c
+c
+h
+c
+c
+U
+a
+J
+J
+Q
+Q
+E
+E
+B
+E
+E
+J
+Q
+Q
+c
+E
+a
+a
+w
+o
+"}
+(35,1,1) = {"
+w
+a
+U
+c
+p
+h
+p
+c
+U
+I
+J
+J
+c
+c
+J
+c
+c
+J
+J
+c
+Q
+c
+J
+J
+a
+a
+w
+o
+"}
+(36,1,1) = {"
+w
+a
+a
+U
+c
+h
+c
+U
+U
+a
+G
+J
+J
+Q
+Q
+c
+Q
+Q
+Q
+Q
+Q
+J
+J
+J
+a
+w
+w
+o
+"}
+(37,1,1) = {"
+w
+a
+Y
+Y
+y
+h
+y
+Y
+Y
+a
+a
+J
+J
+J
+c
+z
+c
+Q
+Q
+Q
+c
+J
+J
+J
+a
+w
+o
+o
+"}
+(38,1,1) = {"
+o
+w
+a
+Y
+k
+Z
+k
+Y
+Y
+Y
+a
+Y
+J
+J
+J
+J
+c
+c
+c
+c
+c
+J
+J
+I
+a
+w
+o
+o
+"}
+(39,1,1) = {"
+o
+w
+a
+Y
+y
+k
+y
+Y
+Y
+Y
+Y
+Y
+A
+Y
+J
+J
+J
+R
+J
+J
+J
+J
+J
+a
+a
+w
+o
+o
+"}
+(40,1,1) = {"
+o
+w
+a
+C
+Y
+Y
+Y
+C
+Y
+Y
+Y
+Y
+Y
+Y
+J
+J
+J
+J
+a
+a
+J
+J
+a
+a
+a
+w
+o
+o
+"}
+(41,1,1) = {"
+w
+a
+a
+E
+A
+a
+a
+a
+a
+a
+a
+Y
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+w
+o
+"}
+(42,1,1) = {"
+o
+w
+a
+a
+a
+a
+w
+a
+a
+w
+a
+a
+a
+w
+w
+w
+w
+w
+a
+a
+a
+a
+w
+w
+w
+w
+o
+o
+"}
+(43,1,1) = {"
+o
+o
+w
+w
+w
+w
+o
+w
+w
+o
+w
+w
+w
+o
+o
+o
+o
+o
+w
+w
+w
+w
+o
+o
+o
+o
+o
+o
 "}

--- a/modular_chomp/maps/submaps/shelters/MechFabShip-27x24.dmm
+++ b/modular_chomp/maps/submaps/shelters/MechFabShip-27x24.dmm
@@ -1,194 +1,2492 @@
-"al" = (/obj/structure/toilet{pixel_y = 12},/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/MechFabShip)
-"ao" = (/obj/structure/closet/walllocker/emerglocker/south,/obj/structure/table/rack/shelf/steel,/obj/structure/ship_munition/disperser_charge/explosive,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"aq" = (/obj/machinery/sleeper/survival_pod,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"at" = (/obj/structure/closet/walllocker_double/medical/west,/obj/item/weapon/storage/firstaid,/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/toxin,/obj/item/weapon/storage/firstaid/o2,/obj/item/roller,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MechFabShip)
-"aF" = (/obj/structure/salvageable/console_os,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"aG" = (/obj/machinery/transhuman/resleever,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"bb" = (/obj/machinery/disperser/back{dir = 1},/obj/structure/ship_munition/disperser_charge/explosive,/obj/structure/sign/department/shield{pixel_x = 32},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"bk" = (/obj/item/device/gps/computer,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"bI" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MechFabShip)
-"bL" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/cryopod/robot/door/gateway,/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/light/poi{dir = 1},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"bP" = (/obj/structure/ship_munition/disperser_charge/explosive,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"cM" = (/obj/item/weapon/weldingtool/largetank,/obj/item/weapon/tool/crowbar,/obj/item/weapon/tool/screwdriver,/obj/item/weapon/storage/firstaid/surgery,/obj/structure/table/steel_reinforced,/obj/item/stack/nanopaste/advanced,/obj/item/stack/nanopaste/advanced,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"dh" = (/obj/effect/floor_decal/industrial/warning,/obj/effect/floor_decal/techfloor/orange{dir = 1},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"dz" = (/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"eb" = (/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 4},/obj/structure/fuel_port{pixel_x = 30},/obj/machinery/light/small/emergency{dir = 4},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"eM" = (/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/cryofeed{dir = 4},/turf/simulated/floor/greengrid/nitrogen,/area/survivalpod/superpose/MechFabShip)
-"eP" = (/obj/machinery/atmospherics/portables_connector,/obj/machinery/portable_atmospherics/canister/air,/obj/machinery/light/small/emergency{dir = 1},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"fR" = (/obj/machinery/disperser/back{dir = 1},/obj/structure/ship_munition/disperser_charge/mining,/obj/structure/sign/department/shield{pixel_x = -32},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"gv" = (/obj/machinery/computer/transhuman/resleeving{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/light/poi,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"gD" = (/obj/machinery/meter,/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"gH" = (/obj/item/device/kit/paint/gygax/darkgygax,/obj/item/device/kit/paint/gygax/recitence,/obj/item/device/kit/paint/durand,/obj/item/device/kit/paint/durand/phazon,/obj/item/device/kit/paint/durand/seraph,/obj/structure/table/rack/shelf/steel,/obj/effect/floor_decal/industrial/hatch/yellow,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/MechFabShip)
-"gZ" = (/obj/machinery/mech_recharger,/obj/mecha/combat/phazon/old,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/MechFabShip)
-"hu" = (/obj/machinery/cryopod/robot{base_icon_state = "borg_pod_closed"; dir = 4; icon = 'icons/obj/structures.dmi'; icon_state = "borg_pod_closed"; occupied_icon_state = "borg_pod_opened"},/obj/effect/floor_decal/techfloor{dir = 1},/obj/structure/sign/department/drones{pixel_y = 32},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"hz" = (/obj/effect/floor_decal/techfloor{dir = 4},/obj/structure/closet/walllocker/emerglocker/east,/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MechFabShip)
-"hH" = (/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MechFabShip)
-"hI" = (/obj/machinery/door/airlock/glass_centcom{name = "RnD and Fabrication"},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechFabShip)
-"hJ" = (/obj/structure/closet/walllocker_double/hydrant/east,/obj/effect/floor_decal/industrial/warning,/obj/effect/floor_decal/techfloor/orange/corner{dir = 1},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"it" = (/obj/structure/salvageable/server_os,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"iw" = (/obj/item/device/kit/paint/ripley/death,/obj/item/device/kit/paint/ripley/flames_blue,/obj/item/device/kit/paint/ripley/flames_red,/obj/item/device/kit/paint/ripley,/obj/structure/table/rack/shelf/steel,/obj/machinery/button/remote/airlock{desiredstate = 1; dir = 1; id = "kalipso_hatch"; name = "Rear Hatch Control"; pixel_y = -29; specialfunctions = 4},/obj/effect/floor_decal/industrial/hatch/yellow,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/MechFabShip)
-"iC" = (/turf/template_noop,/area/template_noop)
-"iD" = (/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "fridge_sci"; icon_contents = "chem"; icon_state = "fridge_sci"; name = "Advanced storage"; pixel_y = 0},/obj/item/weapon/stock_parts/micro_laser/ultra,/obj/item/weapon/stock_parts/micro_laser/ultra,/obj/item/weapon/stock_parts/micro_laser/ultra,/obj/item/weapon/stock_parts/micro_laser/ultra,/obj/item/weapon/stock_parts/micro_laser/ultra,/obj/item/weapon/stock_parts/matter_bin/super,/obj/item/weapon/stock_parts/matter_bin/super,/obj/item/weapon/stock_parts/matter_bin/super,/obj/item/weapon/stock_parts/matter_bin/super,/obj/item/weapon/stock_parts/matter_bin/super,/obj/item/weapon/stock_parts/manipulator/pico,/obj/item/weapon/stock_parts/manipulator/pico,/obj/item/weapon/stock_parts/manipulator/pico,/obj/item/weapon/stock_parts/manipulator/pico,/obj/item/weapon/stock_parts/manipulator/pico,/obj/item/weapon/stock_parts/console_screen,/obj/item/weapon/stock_parts/console_screen,/obj/item/weapon/stock_parts/console_screen,/obj/item/weapon/stock_parts/console_screen,/obj/item/weapon/stock_parts/console_screen,/obj/item/weapon/stock_parts/capacitor/super,/obj/item/weapon/stock_parts/capacitor/super,/obj/item/weapon/stock_parts/capacitor/super,/obj/item/weapon/stock_parts/capacitor/super,/obj/item/weapon/stock_parts/capacitor/super,/obj/item/weapon/stock_parts/motor,/obj/item/weapon/stock_parts/motor,/obj/item/weapon/stock_parts/motor,/obj/item/weapon/stock_parts/motor,/obj/item/weapon/stock_parts/motor,/obj/item/weapon/stock_parts/scanning_module/phasic,/obj/item/weapon/stock_parts/scanning_module/phasic,/obj/item/weapon/stock_parts/scanning_module/phasic,/obj/item/weapon/stock_parts/scanning_module/phasic,/obj/item/weapon/stock_parts/scanning_module/phasic,/obj/item/weapon/stock_parts/scanning_module/phasic,/obj/item/weapon/stock_parts/spring,/obj/item/weapon/stock_parts/spring,/obj/item/weapon/stock_parts/spring,/obj/item/weapon/stock_parts/spring,/obj/item/weapon/stock_parts/spring,/obj/item/weapon/stock_parts/spring,/obj/item/weapon/stock_parts/subspace/amplifier,/obj/item/weapon/stock_parts/subspace/amplifier,/obj/item/weapon/stock_parts/subspace/analyzer,/obj/item/weapon/stock_parts/subspace/analyzer,/obj/item/weapon/stock_parts/subspace/ansible,/obj/item/weapon/stock_parts/subspace/ansible,/obj/item/weapon/stock_parts/subspace/crystal,/obj/item/weapon/stock_parts/subspace/crystal,/obj/item/weapon/stock_parts/subspace/sub_filter,/obj/item/weapon/stock_parts/subspace/sub_filter,/obj/item/weapon/stock_parts/subspace/transmitter,/obj/item/weapon/stock_parts/subspace/transmitter,/obj/item/weapon/stock_parts/subspace/treatment,/obj/item/weapon/stock_parts/subspace/treatment,/obj/item/stack/cable_coil,/obj/item/stack/cable_coil,/obj/item/clothing/glasses/welding,/obj/item/clothing/glasses/welding,/obj/item/device/bodysnatcher,/obj/item/weapon/card/emag,/obj/item/weapon/card/emag,/obj/item/weapon/cell/super,/obj/item/weapon/cell/super,/obj/item/weapon/cell/device/super,/obj/item/weapon/cell/device/super,/obj/effect/floor_decal/industrial/outline/yellow,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/effect/floor_decal/techfloor{dir = 8},/obj/machinery/light/poi{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"iI" = (/obj/structure/sign/warning/vacuum,/turf/simulated/wall/skipjack,/area/survivalpod/superpose/MechFabShip)
-"iK" = (/obj/machinery/computer/operating{dir = 8; name = "Robotics Operating Computer"},/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor{dir = 4},/obj/machinery/light/poi{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"iU" = (/obj/structure/salvageable/computer_os,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"jl" = (/obj/machinery/atmospherics/pipe/tank/phoron/full,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/sign/atmos/phoron{pixel_x = 32},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"jx" = (/obj/structure/salvageable/implant_container_os,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"jE" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/closet/walllocker/emerglocker/north,/obj/effect/floor_decal/techfloor/orange,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"kr" = (/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/cryofeed,/turf/simulated/floor/greengrid/nitrogen,/area/survivalpod/superpose/MechFabShip)
-"kz" = (/obj/structure/salvageable/console_broken_os,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"kH" = (/obj/structure/window/plastitanium/full,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/grille/rustic{health = 25; name = "reinforced grille"},/obj/machinery/door/blast/regular{id = "kalipsoshutters"; name = "Kalipso Blast Shielding"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"kJ" = (/obj/structure/closet/walllocker_double/kitchen/east{name = "Ration Cabinet"},/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/device/radio{pixel_x = -5; pixel_y = 5},/obj/item/device/radio{pixel_x = -5; pixel_y = 5},/obj/item/device/radio{pixel_x = 5; pixel_y = 5},/obj/item/device/radio{pixel_x = 5; pixel_y = 5},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MechFabShip)
-"lC" = (/obj/machinery/atmospherics/portables_connector,/obj/machinery/portable_atmospherics/canister/phoron,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"lK" = (/obj/structure/ship_munition/disperser_charge/mining,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"lZ" = (/obj/machinery/space_heater,/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"mf" = (/obj/structure/bed/chair/bay/comfy/captain{dir = 1},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MechFabShip)
-"mG" = (/obj/structure/sign/kiddieplaque{name = "Kalipso: Modular fabrication shuttle"; pixel_x = 32},/turf/template_noop,/area/template_noop)
-"ny" = (/obj/effect/floor_decal/industrial/loading,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/MechFabShip)
-"nJ" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 5},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"oz" = (/obj/structure/table/steel_reinforced,/obj/item/weapon/storage/part_replacer/adv/discount_bluespace,/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MechFabShip)
-"oS" = (/obj/structure/table/steel_reinforced,/obj/item/device/defib_kit/jumper_kit/loaded,/obj/item/device/defib_kit/jumper_kit/loaded,/obj/item/device/mmi,/obj/item/device/mmi,/obj/item/device/mmi,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"ph" = (/turf/simulated/wall/skipjack,/area/survivalpod/superpose/MechFabShip)
-"py" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/reagent_dispensers/acid{pixel_y = 30},/obj/machinery/computer/mecha,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"pR" = (/obj/structure/window/plastitanium/full,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod,/obj/structure/grille/rustic{health = 25; name = "reinforced grille"},/obj/machinery/door/blast/regular{dir = 4; id = "kalipsoshutters"; name = "Kalipso Blast Shielding"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"qf" = (/obj/effect/floor_decal/techfloor/corner{dir = 6},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"qk" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor/corner{dir = 5},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"qK" = (/obj/machinery/computer/rdconsole/core,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"qU" = (/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/industrial/warning,/obj/machinery/portable_atmospherics/canister/phoron,/obj/effect/floor_decal/techfloor/orange/corner{dir = 4},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"qX" = (/obj/structure/table/steel_reinforced,/obj/machinery/cell_charger,/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MechFabShip)
-"qY" = (/obj/machinery/vending/robotics{emagged = 1; req_access = null},/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/light/poi{dir = 1},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"rr" = (/obj/machinery/transhuman/synthprinter,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"rR" = (/obj/effect/catwalk_plated/dark,/obj/structure/sign/department/cargo_dock{pixel_x = -32},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"rZ" = (/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MechFabShip)
-"sd" = (/obj/machinery/access_button{master_tag = null; pixel_y = 27; req_one_access = null},/obj/effect/map_helper/airlock/door/int_door,/obj/effect/map_helper/airlock/button/int_button,/obj/machinery/door/airlock/hatch,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechFabShip)
-"sK" = (/obj/structure/closet/walllocker/emerglocker{pixel_x = 24; pixel_y = 32},/obj/machinery/button/remote/blast_door{dir = 8; id = "kalipsoshutters"; name = "Emergency Lockdown"; pixel_x = 28},/obj/machinery/light/poi{dir = 4},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MechFabShip)
-"te" = (/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"tk" = (/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MechFabShip)
-"tC" = (/obj/machinery/mech_recharger,/obj/mecha/combat/gygax/old,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/MechFabShip)
-"uU" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 10},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/techfloor/orange,/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/door/window/survival_pod{dir = 1},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"vb" = (/obj/structure/window/reinforced/survival_pod{opacity = 1},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/machinery/r_n_d/server/robotics,/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/MechFabShip)
-"vt" = (/obj/machinery/power/generator{anchored = 1; dir = 8},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MechFabShip)
-"vC" = (/obj/machinery/power/terminal{dir = 8},/obj/structure/cable/green,/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"vO" = (/obj/effect/floor_decal/techfloor,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MechFabShip)
-"ws" = (/obj/machinery/airlock_sensor{dir = 1; id_tag = null; pixel_y = -27},/obj/effect/map_helper/airlock/sensor/chamber_sensor,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"wy" = (/obj/machinery/computer/ship/disperser,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"yh" = (/obj/structure/bed/pod,/obj/item/weapon/bedsheet/captain,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MechFabShip)
-"yH" = (/obj/effect/floor_decal/techfloor/corner,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"yN" = (/obj/structure/bed/chair/bay/shuttle{dir = 4},/obj/machinery/light/poi{dir = 8},/obj/structure/closet/walllocker/emerglocker/west,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"yS" = (/obj/machinery/atmospherics/unary/engine/biggest{dir = 1},/turf/template_noop,/area/template_noop)
-"zd" = (/obj/structure/bed/pod,/obj/item/weapon/bedsheet/ce,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MechFabShip)
-"zj" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 4},/obj/machinery/floodlight,/obj/effect/floor_decal/techfloor/orange{dir = 4},/obj/machinery/light/small/emergency{dir = 8},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"zC" = (/obj/machinery/autolathe{hacked = 1},/obj/effect/floor_decal/techfloor{dir = 8},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"zN" = (/obj/structure/table/survival_pod,/obj/machinery/microwave{pixel_y = 6},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"zU" = (/obj/machinery/atmospherics/pipe/simple/visible/green{dir = 9},/obj/effect/floor_decal/industrial/warning,/obj/effect/floor_decal/techfloor/orange{dir = 1},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"AK" = (/obj/machinery/recharger/wallcharger{pixel_x = 4; pixel_y = -30},/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MechFabShip)
-"Bf" = (/obj/machinery/meter,/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/structure/closet/walllocker_double/hydrant/east,/obj/structure/closet/walllocker/emerglocker/south,/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Bk" = (/obj/structure/closet/walllocker/emerglocker/south,/obj/structure/table/rack/shelf/steel,/obj/structure/ship_munition/disperser_charge/mining,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"Bz" = (/obj/effect/catwalk_plated/dark,/obj/item/weapon/banner/blue,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"BA" = (/obj/structure/table/rack/shelf/steel,/obj/item/trash/rkibble{pixel_x = 8},/obj/item/trash/rkibble{pixel_x = -7},/obj/item/trash/rkibble{pixel_x = -7; pixel_y = 14},/obj/item/trash/rkibble{pixel_x = 8; pixel_y = 14},/obj/item/trash/rkibble{pixel_x = 8; pixel_y = 14},/obj/item/trash/rkibble{pixel_x = -7; pixel_y = 14},/obj/item/trash/rkibble{pixel_x = -7},/obj/item/trash/rkibble{pixel_x = 8},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MechFabShip)
-"BY" = (/obj/effect/catwalk_plated/dark,/obj/machinery/shipsensors,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"Cu" = (/obj/machinery/door/airlock/multi_tile/metal/mait{icon_state = "door_locked"; id_tag = "kalipso_hatch"; locked = 1; name = "Cargo Hold"},/obj/machinery/door/blast/regular{dir = 4; id = "kalipsoshutters"; name = "Kalipso Blast Shielding"},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechFabShip)
-"CV" = (/obj/effect/floor_decal/techfloor/orange{dir = 8},/obj/machinery/light/small/emergency{dir = 4},/obj/structure/sign/department/eng{pixel_x = 32},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"CY" = (/obj/effect/catwalk_plated/dark,/obj/structure/sign/department/cargo_dock{pixel_x = 32},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Di" = (/obj/effect/catwalk_plated/dark,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Dj" = (/obj/machinery/r_n_d/protolathe,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"Dm" = (/obj/structure/salvageable/machine{name = "Life Support Console"},/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/light/poi{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"DF" = (/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MechFabShip)
-"DS" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 1},/obj/machinery/embedded_controller/radio/airlock/airlock_controller{dir = 1; frequency = 1331; id_tag = "kalipso_shuttle"; pixel_y = -26},/obj/effect/map_helper/airlock/atmos/chamber_pump,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Ey" = (/obj/machinery/door/airlock/glass_centcom{name = "Port Cannons"},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechFabShip)
-"FC" = (/obj/structure/window/plastitanium/full,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod,/obj/structure/grille/rustic{health = 25; name = "reinforced grille"},/obj/machinery/door/blast/regular{dir = 4; id = "kalipsoshutters"; name = "Kalipso Blast Shielding"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"Gl" = (/obj/machinery/access_button{master_tag = null; pixel_y = 27; req_one_access = null},/obj/effect/map_helper/airlock/door/ext_door,/obj/effect/map_helper/airlock/button/ext_button,/obj/machinery/door/airlock/hatch,/obj/machinery/door/blast/regular{id = "kalipsoshutters"; name = "Kalipso Blast Shielding"},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechFabShip)
-"Gr" = (/obj/machinery/power/smes/buildable/hybrid,/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/industrial/warning,/obj/structure/sign/electricshock{pixel_x = -32},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"GQ" = (/obj/machinery/atmospherics/pipe/tank/air{dir = 4},/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/light/small/emergency{dir = 8},/obj/structure/sign/atmos/air{pixel_x = -32},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"GS" = (/obj/machinery/door/airlock/glass_centcom{name = "Starboard Wing Atmos"},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechFabShip)
-"He" = (/obj/structure/bed/chair/bay/shuttle{dir = 4},/obj/structure/closet/walllocker/medical/west,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"HC" = (/obj/machinery/mecha_part_fabricator,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"HE" = (/obj/item/weapon/stool/padded,/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MechFabShip)
-"HS" = (/obj/machinery/door/airlock/glass_centcom{name = "Starboard Cannon"},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechFabShip)
-"Ic" = (/obj/structure/reagent_dispensers/fueltank/high,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"IS" = (/obj/structure/closet/emcloset,/obj/machinery/light/poi{dir = 1},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MechFabShip)
-"Jv" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/techfloor/orange,/obj/effect/floor_decal/techfloor/corner{dir = 5},/obj/structure/sign/electricshock{pixel_y = 32},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"JW" = (/obj/structure/salvageable/console_os{name = "Turret control console"},/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/light/poi{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"JX" = (/obj/machinery/recharger/wallcharger{pixel_x = 4; pixel_y = -30},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MechFabShip)
-"KC" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"KR" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 4},/obj/effect/map_helper/airlock/atmos/chamber_pump,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Lg" = (/obj/machinery/atmospherics/portables_connector,/obj/machinery/portable_atmospherics/canister/phoron,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor/corner{dir = 9},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"LN" = (/obj/structure/window/reinforced/survival_pod,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MechFabShip)
-"Ms" = (/obj/machinery/smartfridge/survival_pod,/obj/item/weapon/tape_roll,/obj/item/sticky_pad/random,/obj/item/weapon/pen/blue,/obj/item/weapon/pen/blue,/obj/item/fulton_core,/obj/item/fulton_core,/obj/item/extraction_pack,/obj/item/extraction_pack,/obj/item/modular_computer/laptop/preset/custom_loadout/standard,/obj/item/weapon/pickaxe/hand,/obj/item/device/flashlight/color/yellow,/obj/item/device/flashlight/color/orange,/obj/item/device/threadneedle,/obj/item/device/radio,/obj/item/device/radio,/obj/item/device/radio,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/flame/lighter/zippo,/obj/item/weapon/flame/lighter/zippo,/obj/item/device/flashlight/lantern,/obj/random/soap,/obj/random/soap,/obj/item/weapon/towel/random,/obj/item/weapon/towel/random,/obj/item/bodybag/cryobag,/obj/item/bodybag/cryobag,/obj/item/weapon/storage/pill_bottle/spaceacillin,/obj/item/weapon/storage/pill_bottle/antitox,/obj/item/device/healthanalyzer,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/storage/firstaid/o2,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/stack/nanopaste,/obj/item/device/suit_cooling_unit/emergency,/obj/item/device/suit_cooling_unit/emergency,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,/obj/item/weapon/storage/toolbox/brass,/obj/item/weapon/storage/box/survival/space,/obj/item/weapon/storage/box/survival/space,/obj/item/weapon/storage/box/survival/space,/obj/item/weapon/storage/pill_bottle/dice_nerd,/obj/item/weapon/storage/box/flare,/obj/item/weapon/storage/box/khcrystal,/obj/item/weapon/storage/box/khcrystal,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/stack/marker_beacon/ten,/obj/item/device/starcaster_news,/obj/item/device/mapping_unit,/obj/item/weapon/storage/box/dosimeter,/obj/item/device/gps,/obj/item/device/gps,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/cell/device/hyper,/obj/item/device/pda,/obj/item/device/pda,/obj/item/weapon/card/id/external,/obj/item/weapon/card/id/external,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/gun/energy/locked/phasegun/pistol,/obj/item/weapon/gun/energy/locked/phasegun,/obj/item/weapon/cell/device/weapon{pixel_x = -2; pixel_y = -2},/obj/item/weapon/cell/device/weapon{pixel_x = -2; pixel_y = -2},/obj/item/clothing/accessory/permit/gun,/obj/item/clothing/accessory/permit/gun,/obj/item/weapon/material/knife/machete,/obj/item/weapon/material/fishing_net,/obj/item/weapon/storage/backpack/sport,/obj/item/weapon/storage/backpack/sport,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/weapon/storage/belt,/obj/item/clothing/accessory/poncho/thermal,/obj/machinery/light/poi{dir = 1},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MechFabShip)
-"Mv" = (/obj/machinery/door/blast/regular{dir = 4; id = "kalipsoshutters"; name = "Kalipso Blast Shielding"},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechFabShip)
-"MZ" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/techfloor/orange/corner{dir = 8},/obj/effect/floor_decal/techfloor/corner{dir = 9},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Nr" = (/obj/structure/window/reinforced/survival_pod{opacity = 1},/obj/machinery/r_n_d/server/core,/obj/structure/window/reinforced/survival_pod{dir = 4; opacity = 1},/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/MechFabShip)
-"ND" = (/obj/structure/sign/deck1,/turf/simulated/wall/skipjack,/area/survivalpod/superpose/MechFabShip)
-"Oo" = (/obj/item/weapon/stool/padded,/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MechFabShip)
-"Ov" = (/obj/machinery/optable{name = "Robotics Operating Table"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"OO" = (/obj/structure/bed/pod,/obj/item/weapon/bedsheet/hos,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MechFabShip)
-"Py" = (/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "fridge_sci"; icon_contents = "chem"; icon_state = "fridge_sci"; name = "Advanced storage"; pixel_y = 0},/obj/item/stack/material/durasteel{material = 50},/obj/item/stack/material/durasteel{material = 50},/obj/item/stack/material/phoron{material = 50},/obj/item/stack/material/phoron{material = 50},/obj/item/stack/material/diamond{material = 15},/obj/item/stack/material/gold{material = 25},/obj/item/stack/material/lead{material = 25},/obj/item/stack/material/plastic{material = 50},/obj/item/stack/material/plastic{material = 50},/obj/item/stack/material/platinum{matter = 25},/obj/item/stack/material/silver{material = 25},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/uranium{material = 25},/obj/item/stack/rods{amount = 50},/obj/item/weapon/storage/toolbox/syndicate/powertools,/obj/item/weapon/storage/toolbox/syndicate/powertools,/obj/item/clothing/head/welding/demon,/obj/item/clothing/head/welding/knight,/obj/item/weapon/storage/toolbox/electrical{pixel_x = 1; pixel_y = 6},/obj/item/weapon/storage/toolbox/electrical{pixel_x = 1; pixel_y = 6},/obj/item/device/robotanalyzer,/obj/item/device/robotanalyzer,/obj/item/weapon/cell/super,/obj/item/weapon/cell/super,/obj/item/weapon/cell/device/super,/obj/item/weapon/cell/device/super,/obj/effect/floor_decal/industrial/outline/yellow,/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/glass/reinforced{amount = 50},/obj/item/stack/material/glass/reinforced{amount = 50},/obj/item/stack/material/glass/reinforced{amount = 50},/obj/item/stack/material/glass/reinforced{amount = 50},/obj/item/stack/material/glass{amount = 50; pixel_x = 3; pixel_y = 3},/obj/item/stack/material/glass{amount = 50; pixel_x = 3; pixel_y = 3},/obj/item/stack/material/glass{amount = 50; pixel_x = 3; pixel_y = 3},/obj/item/stack/material/glass{amount = 50; pixel_x = 3; pixel_y = 3},/obj/item/stack/material/glass{amount = 50; pixel_x = 3; pixel_y = 3},/obj/item/stack/material/glass{amount = 50; pixel_x = 3; pixel_y = 3},/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"PH" = (/obj/structure/window/reinforced/survival_pod{opacity = 1},/obj/structure/prop/blackbox/salamander_wreck,/obj/structure/sign/department/rnd{pixel_y = 32},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/MechFabShip)
-"PP" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1; dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MechFabShip)
-"Qs" = (/obj/machinery/door/airlock/glass_centcom{id_tag = "kalipsobolt"; name = "Bridge"},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechFabShip)
-"QE" = (/obj/machinery/r_n_d/circuit_imprinter,/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"QJ" = (/obj/machinery/disperser/middle{dir = 1},/obj/structure/window/reinforced/survival_pod,/obj/effect/catwalk_plated/dark,/obj/machinery/door/blast/regular{dir = 4; id = "kalipsoshutters"; name = "Kalipso Blast Shielding"},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Rg" = (/obj/structure/shuttle/engine/router,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Ro" = (/obj/item/trash/rkibble{pixel_x = 8; pixel_y = 14},/obj/structure/table/rack/shelf/steel,/obj/item/trash/rkibble{pixel_x = 8},/obj/item/trash/rkibble{pixel_x = -7; pixel_y = 14},/obj/item/trash/rkibble{pixel_x = -7},/obj/item/trash/rkibble{pixel_x = 8; pixel_y = 14},/obj/item/trash/rkibble{pixel_x = -7; pixel_y = 14},/obj/item/trash/rkibble{pixel_x = -7},/obj/item/trash/rkibble{pixel_x = 8},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MechFabShip)
-"RE" = (/obj/machinery/recharge_station,/obj/effect/floor_decal/techfloor/corner{dir = 5},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"SE" = (/obj/item/weapon/stool/padded,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MechFabShip)
-"SW" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/r_n_d/circuit_imprinter,/obj/item/weapon/reagent_containers/glass/beaker/large,/obj/structure/sign/department/robo{pixel_y = 32},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"Ta" = (/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/portable_atmospherics/canister/phoron/cold,/obj/effect/floor_decal/techfloor/orange/corner,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Th" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/mecha_part_fabricator/pros,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"TI" = (/obj/structure/bed/chair/bay/shuttle{dir = 8},/obj/machinery/light/poi{dir = 4},/obj/structure/closet/walllocker/emerglocker/east,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"Ud" = (/obj/effect/floor_decal/techfloor/corner{dir = 10},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"Uj" = (/obj/machinery/atmospherics/pipe/simple/visible/cyan,/obj/effect/floor_decal/industrial/warning,/obj/effect/floor_decal/techfloor/orange{dir = 1},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"UI" = (/obj/effect/floor_decal/industrial/loading{dir = 1},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/MechFabShip)
-"UL" = (/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"Vf" = (/obj/structure/closet/walllocker/emerglocker{pixel_x = -25; pixel_y = 32},/mob/living/simple_mob/animal/passive/dog/corgi/Lisa{name = "Shepiffany"},/obj/structure/dogbed,/obj/machinery/light/poi{dir = 8},/obj/machinery/button/remote/airlock{dir = 4; id = "kalipsobolt"; name = "Bridge Lock Down"; pixel_x = -28; specialfunctions = 4},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MechFabShip)
-"Vj" = (/obj/machinery/r_n_d/protolathe,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"VZ" = (/obj/effect/floor_decal/industrial/hatch/yellow,/obj/structure/foodcart,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/MechFabShip)
-"Wl" = (/obj/structure/bed/chair/bay/shuttle{dir = 8},/obj/structure/closet/walllocker/medical/east,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"WE" = (/obj/structure/sign/ironhammer,/turf/simulated/wall/skipjack,/area/survivalpod/superpose/MechFabShip)
-"WG" = (/obj/machinery/shower{dir = 4},/obj/structure/curtain/open/shower/security,/obj/machinery/door/window/survival_pod{dir = 2},/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/MechFabShip)
-"WQ" = (/obj/effect/floor_decal/techfloor/corner{dir = 8},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MechFabShip)
-"WY" = (/obj/structure/window/plastitanium/full,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod,/obj/structure/grille/rustic{health = 25; name = "reinforced grille"},/obj/machinery/door/blast/regular{dir = 4; id = "kalipsoshutters"; name = "Kalipso Blast Shielding"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"Xe" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/door/window/survival_pod{dir = 1},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Xm" = (/obj/structure/prop/fake_ai{name = "k@1iPs0"},/obj/structure/sign/department/commander{pixel_y = -32},/turf/simulated/floor/greengrid/nitrogen,/area/survivalpod/superpose/MechFabShip)
-"Xx" = (/obj/structure/window/plastitanium/full,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod,/obj/structure/grille/rustic{health = 25; name = "reinforced grille"},/obj/machinery/door/blast/regular{id = "kalipsoshutters"; name = "Kalipso Blast Shielding"},/obj/structure/window/reinforced/survival_pod{dir = 1},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"Yb" = (/obj/machinery/door/airlock/glass_centcom{name = "Port Wing Engine"},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechFabShip)
-"Yj" = (/obj/effect/floor_decal/techfloor{dir = 8},/obj/structure/closet/walllocker/emerglocker/west,/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MechFabShip)
-"Yl" = (/obj/structure/fans,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"Yo" = (/obj/machinery/power/port_gen/pacman{anchored = 1},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Yt" = (/obj/machinery/r_n_d/destructive_analyzer,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"YM" = (/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MechFabShip)
-"YP" = (/obj/machinery/disperser/front{dir = 1},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"Zg" = (/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/MechFabShip)
-"Zm" = (/obj/effect/floor_decal/techfloor,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
-"Zs" = (/obj/structure/bed/chair/bay/comfy/black{dir = 1},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/MechFabShip)
-"Zt" = (/obj/structure/shuttle/engine/heater,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/door/blast/regular{dir = 4; id = "kalipsoshutters"; name = "Kalipso Blast Shielding"},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechFabShip)
-"ZE" = (/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MechFabShip)
-"ZH" = (/obj/machinery/recharge_station,/obj/effect/floor_decal/techfloor/corner{dir = 9},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechFabShip)
-"ZY" = (/obj/structure/window/plastitanium/full,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod,/obj/structure/grille/rustic{health = 25; name = "reinforced grille"},/obj/machinery/door/blast/regular{id = "kalipsoshutters"; name = "Kalipso Blast Shielding"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/MechFabShip)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"al" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/MechFabShip)
+"ao" = (
+/obj/structure/closet/walllocker/emerglocker/south,
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/ship_munition/disperser_charge/explosive,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"aq" = (
+/obj/machinery/sleeper/survival_pod,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"at" = (
+/obj/structure/closet/walllocker_double/medical/west,
+/obj/item/weapon/storage/firstaid,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/roller,
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/MechFabShip)
+"aF" = (
+/obj/structure/salvageable/console_os,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"aG" = (
+/obj/machinery/transhuman/resleever,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"bb" = (
+/obj/machinery/disperser/back{
+	dir = 1
+	},
+/obj/structure/ship_munition/disperser_charge/explosive,
+/obj/structure/sign/department/shield{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"bk" = (
+/obj/item/device/gps/computer,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"bI" = (
+/obj/machinery/atmospherics/binary/circulator{
+	anchored = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MechFabShip)
+"bL" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/cryopod/robot/door/gateway,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"bP" = (
+/obj/structure/ship_munition/disperser_charge/explosive,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"cM" = (
+/obj/item/weapon/weldingtool/largetank,
+/obj/item/weapon/tool/crowbar,
+/obj/item/weapon/tool/screwdriver,
+/obj/item/weapon/storage/firstaid/surgery,
+/obj/structure/table/steel_reinforced,
+/obj/item/stack/nanopaste/advanced,
+/obj/item/stack/nanopaste/advanced,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"dh" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"dz" = (
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"eb" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 4
+	},
+/obj/structure/fuel_port{
+	pixel_x = 30
+	},
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"eM" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/cryofeed{
+	dir = 4
+	},
+/turf/simulated/floor/greengrid/nitrogen,
+/area/survivalpod/superpose/MechFabShip)
+"eP" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/light/small/emergency{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"fR" = (
+/obj/machinery/disperser/back{
+	dir = 1
+	},
+/obj/structure/ship_munition/disperser_charge/mining,
+/obj/structure/sign/department/shield{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"gv" = (
+/obj/machinery/computer/transhuman/resleeving{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/poi,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"gD" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"gH" = (
+/obj/item/device/kit/paint/gygax/darkgygax,
+/obj/item/device/kit/paint/gygax/recitence,
+/obj/item/device/kit/paint/durand,
+/obj/item/device/kit/paint/durand/phazon,
+/obj/item/device/kit/paint/durand/seraph,
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/MechFabShip)
+"hu" = (
+/obj/machinery/cryopod/robot{
+	base_icon_state = "borg_pod_closed";
+	dir = 4;
+	icon = 'icons/obj/structures.dmi';
+	icon_state = "borg_pod_closed";
+	occupied_icon_state = "borg_pod_opened"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/sign/department/drones{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"hz" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/emerglocker/east,
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MechFabShip)
+"hH" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MechFabShip)
+"hI" = (
+/obj/machinery/door/airlock/glass_centcom{
+	name = "RnD and Fabrication"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechFabShip)
+"hJ" = (
+/obj/structure/closet/walllocker_double/hydrant/east,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/techfloor/orange/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"it" = (
+/obj/structure/salvageable/server_os,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"iw" = (
+/obj/item/device/kit/paint/ripley/death,
+/obj/item/device/kit/paint/ripley/flames_blue,
+/obj/item/device/kit/paint/ripley/flames_red,
+/obj/item/device/kit/paint/ripley,
+/obj/structure/table/rack/shelf/steel,
+/obj/machinery/button/remote/airlock{
+	desiredstate = 1;
+	dir = 1;
+	id = "kalipso_hatch";
+	name = "Rear Hatch Control";
+	pixel_y = -29;
+	specialfunctions = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/MechFabShip)
+"iC" = (
+/turf/template_noop,
+/area/template_noop)
+"iD" = (
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "fridge_sci";
+	icon_contents = "chem";
+	icon_state = "fridge_sci";
+	name = "Advanced storage";
+	pixel_y = 0
+	},
+/obj/item/weapon/stock_parts/micro_laser/ultra,
+/obj/item/weapon/stock_parts/micro_laser/ultra,
+/obj/item/weapon/stock_parts/micro_laser/ultra,
+/obj/item/weapon/stock_parts/micro_laser/ultra,
+/obj/item/weapon/stock_parts/micro_laser/ultra,
+/obj/item/weapon/stock_parts/matter_bin/super,
+/obj/item/weapon/stock_parts/matter_bin/super,
+/obj/item/weapon/stock_parts/matter_bin/super,
+/obj/item/weapon/stock_parts/matter_bin/super,
+/obj/item/weapon/stock_parts/matter_bin/super,
+/obj/item/weapon/stock_parts/manipulator/pico,
+/obj/item/weapon/stock_parts/manipulator/pico,
+/obj/item/weapon/stock_parts/manipulator/pico,
+/obj/item/weapon/stock_parts/manipulator/pico,
+/obj/item/weapon/stock_parts/manipulator/pico,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/capacitor/super,
+/obj/item/weapon/stock_parts/capacitor/super,
+/obj/item/weapon/stock_parts/capacitor/super,
+/obj/item/weapon/stock_parts/capacitor/super,
+/obj/item/weapon/stock_parts/capacitor/super,
+/obj/item/weapon/stock_parts/motor,
+/obj/item/weapon/stock_parts/motor,
+/obj/item/weapon/stock_parts/motor,
+/obj/item/weapon/stock_parts/motor,
+/obj/item/weapon/stock_parts/motor,
+/obj/item/weapon/stock_parts/scanning_module/phasic,
+/obj/item/weapon/stock_parts/scanning_module/phasic,
+/obj/item/weapon/stock_parts/scanning_module/phasic,
+/obj/item/weapon/stock_parts/scanning_module/phasic,
+/obj/item/weapon/stock_parts/scanning_module/phasic,
+/obj/item/weapon/stock_parts/scanning_module/phasic,
+/obj/item/weapon/stock_parts/spring,
+/obj/item/weapon/stock_parts/spring,
+/obj/item/weapon/stock_parts/spring,
+/obj/item/weapon/stock_parts/spring,
+/obj/item/weapon/stock_parts/spring,
+/obj/item/weapon/stock_parts/spring,
+/obj/item/weapon/stock_parts/subspace/amplifier,
+/obj/item/weapon/stock_parts/subspace/amplifier,
+/obj/item/weapon/stock_parts/subspace/analyzer,
+/obj/item/weapon/stock_parts/subspace/analyzer,
+/obj/item/weapon/stock_parts/subspace/ansible,
+/obj/item/weapon/stock_parts/subspace/ansible,
+/obj/item/weapon/stock_parts/subspace/crystal,
+/obj/item/weapon/stock_parts/subspace/crystal,
+/obj/item/weapon/stock_parts/subspace/sub_filter,
+/obj/item/weapon/stock_parts/subspace/sub_filter,
+/obj/item/weapon/stock_parts/subspace/transmitter,
+/obj/item/weapon/stock_parts/subspace/transmitter,
+/obj/item/weapon/stock_parts/subspace/treatment,
+/obj/item/weapon/stock_parts/subspace/treatment,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/obj/item/device/bodysnatcher,
+/obj/item/weapon/card/emag,
+/obj/item/weapon/card/emag,
+/obj/item/weapon/cell/super,
+/obj/item/weapon/cell/super,
+/obj/item/weapon/cell/device/super,
+/obj/item/weapon/cell/device/super,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/light/poi{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"iI" = (
+/obj/structure/sign/warning/vacuum,
+/turf/simulated/wall/skipjack,
+/area/survivalpod/superpose/MechFabShip)
+"iK" = (
+/obj/machinery/computer/operating{
+	dir = 8;
+	name = "Robotics Operating Computer"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/light/poi{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"iU" = (
+/obj/structure/salvageable/computer_os,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"jl" = (
+/obj/machinery/atmospherics/pipe/tank/phoron/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/atmos/phoron{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"jx" = (
+/obj/structure/salvageable/implant_container_os,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"jE" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/closet/walllocker/emerglocker/north,
+/obj/effect/floor_decal/techfloor/orange,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"kr" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/cryofeed,
+/turf/simulated/floor/greengrid/nitrogen,
+/area/survivalpod/superpose/MechFabShip)
+"kz" = (
+/obj/structure/salvageable/console_broken_os,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"kH" = (
+/obj/structure/window/plastitanium/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/grille/rustic{
+	health = 25;
+	name = "reinforced grille"
+	},
+/obj/machinery/door/blast/regular{
+	id = "kalipsoshutters";
+	name = "Kalipso Blast Shielding"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"kJ" = (
+/obj/structure/closet/walllocker_double/kitchen/east{
+	name = "Ration Cabinet"
+	},
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/MechFabShip)
+"lC" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"lK" = (
+/obj/structure/ship_munition/disperser_charge/mining,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"lZ" = (
+/obj/machinery/space_heater,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"mf" = (
+/obj/structure/bed/chair/bay/comfy/captain{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/MechFabShip)
+"mG" = (
+/obj/structure/sign/kiddieplaque{
+	name = "Kalipso: Modular fabrication shuttle";
+	pixel_x = 32
+	},
+/turf/template_noop,
+/area/template_noop)
+"ny" = (
+/obj/effect/floor_decal/industrial/loading,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/MechFabShip)
+"nJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"oz" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/part_replacer/adv/discount_bluespace,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MechFabShip)
+"oS" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/defib_kit/jumper_kit/loaded,
+/obj/item/device/defib_kit/jumper_kit/loaded,
+/obj/item/device/mmi,
+/obj/item/device/mmi,
+/obj/item/device/mmi,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"ph" = (
+/turf/simulated/wall/skipjack,
+/area/survivalpod/superpose/MechFabShip)
+"py" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/reagent_dispensers/acid{
+	pixel_y = 30
+	},
+/obj/machinery/computer/mecha,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"pR" = (
+/obj/structure/window/plastitanium/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/grille/rustic{
+	health = 25;
+	name = "reinforced grille"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "kalipsoshutters";
+	name = "Kalipso Blast Shielding"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"qf" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 6
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"qk" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"qK" = (
+/obj/machinery/computer/rdconsole/core,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"qU" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/effect/floor_decal/techfloor/orange/corner{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"qX" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/cell_charger,
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MechFabShip)
+"qY" = (
+/obj/machinery/vending/robotics{
+	emagged = 1;
+	req_access = null
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"rr" = (
+/obj/machinery/transhuman/synthprinter,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"rR" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/sign/department/cargo_dock{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"rZ" = (
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MechFabShip)
+"sd" = (
+/obj/machinery/access_button{
+	master_tag = null;
+	pixel_y = 27;
+	req_one_access = null
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/effect/map_helper/airlock/button/int_button,
+/obj/machinery/door/airlock/hatch,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechFabShip)
+"sK" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = 24;
+	pixel_y = 32
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "kalipsoshutters";
+	name = "Emergency Lockdown";
+	pixel_x = 28
+	},
+/obj/machinery/light/poi{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/MechFabShip)
+"te" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"tk" = (
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MechFabShip)
+"tC" = (
+/obj/machinery/mech_recharger,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/MechFabShip)
+"uU" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/orange,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"vb" = (
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/machinery/r_n_d/server/robotics,
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/MechFabShip)
+"vt" = (
+/obj/machinery/power/generator{
+	anchored = 1;
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MechFabShip)
+"vC" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/green,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"vO" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MechFabShip)
+"ws" = (
+/obj/machinery/airlock_sensor{
+	dir = 1;
+	id_tag = null;
+	pixel_y = -27
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"wy" = (
+/obj/machinery/computer/ship/disperser,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"yh" = (
+/obj/structure/bed/pod,
+/obj/item/weapon/bedsheet/captain,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MechFabShip)
+"yH" = (
+/obj/effect/floor_decal/techfloor/corner,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"yN" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 4
+	},
+/obj/machinery/light/poi{
+	dir = 8
+	},
+/obj/structure/closet/walllocker/emerglocker/west,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"yS" = (
+/obj/machinery/atmospherics/unary/engine/biggest{
+	dir = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"zd" = (
+/obj/structure/bed/pod,
+/obj/item/weapon/bedsheet/ce,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MechFabShip)
+"zj" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/floodlight,
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 4
+	},
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"zC" = (
+/obj/machinery/autolathe{
+	hacked = 1
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"zN" = (
+/obj/structure/table/survival_pod,
+/obj/machinery/microwave{
+	pixel_y = 6
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"zU" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"AK" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -30
+	},
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MechFabShip)
+"Bf" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/closet/walllocker_double/hydrant/east,
+/obj/structure/closet/walllocker/emerglocker/south,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Bk" = (
+/obj/structure/closet/walllocker/emerglocker/south,
+/obj/structure/table/rack/shelf/steel,
+/obj/structure/ship_munition/disperser_charge/mining,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"Bz" = (
+/obj/effect/catwalk_plated/dark,
+/obj/item/weapon/banner/blue,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"BA" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/trash/rkibble{
+	pixel_x = 8
+	},
+/obj/item/trash/rkibble{
+	pixel_x = -7
+	},
+/obj/item/trash/rkibble{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/obj/item/trash/rkibble{
+	pixel_x = 8;
+	pixel_y = 14
+	},
+/obj/item/trash/rkibble{
+	pixel_x = 8;
+	pixel_y = 14
+	},
+/obj/item/trash/rkibble{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/obj/item/trash/rkibble{
+	pixel_x = -7
+	},
+/obj/item/trash/rkibble{
+	pixel_x = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MechFabShip)
+"BY" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/shipsensors,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Cu" = (
+/obj/machinery/door/airlock/multi_tile/metal/mait{
+	icon_state = "door_locked";
+	id_tag = "kalipso_hatch";
+	locked = 1;
+	name = "Cargo Hold"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "kalipsoshutters";
+	name = "Kalipso Blast Shielding"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechFabShip)
+"CV" = (
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 8
+	},
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/obj/structure/sign/department/eng{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"CY" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/sign/department/cargo_dock{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Di" = (
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Dj" = (
+/obj/machinery/r_n_d/protolathe,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"Dm" = (
+/obj/structure/salvageable/machine{
+	name = "Life Support Console"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/light/poi{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"DF" = (
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MechFabShip)
+"DS" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 1;
+	frequency = 1331;
+	id_tag = "kalipso_shuttle";
+	pixel_y = -26
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Ey" = (
+/obj/machinery/door/airlock/glass_centcom{
+	name = "Port Cannons"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechFabShip)
+"FC" = (
+/obj/structure/window/plastitanium/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/grille/rustic{
+	health = 25;
+	name = "reinforced grille"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "kalipsoshutters";
+	name = "Kalipso Blast Shielding"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Gl" = (
+/obj/machinery/access_button{
+	master_tag = null;
+	pixel_y = 27;
+	req_one_access = null
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/effect/map_helper/airlock/button/ext_button,
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/blast/regular{
+	id = "kalipsoshutters";
+	name = "Kalipso Blast Shielding"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechFabShip)
+"Gr" = (
+/obj/machinery/power/smes/buildable/hybrid,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/sign/electricshock{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"GQ" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/obj/structure/sign/atmos/air{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"GS" = (
+/obj/machinery/door/airlock/glass_centcom{
+	name = "Starboard Wing Atmos"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechFabShip)
+"He" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/medical/west,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"HC" = (
+/obj/machinery/mecha_part_fabricator,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"HE" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MechFabShip)
+"HS" = (
+/obj/machinery/door/airlock/glass_centcom{
+	name = "Starboard Cannon"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechFabShip)
+"Ic" = (
+/obj/structure/reagent_dispensers/fueltank/high,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"IS" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MechFabShip)
+"Jv" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/orange,
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
+	},
+/obj/structure/sign/electricshock{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"JW" = (
+/obj/structure/salvageable/console_os{
+	name = "Turret control console"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/light/poi{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"JX" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -30
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MechFabShip)
+"KC" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"KR" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Lg" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"LN" = (
+/obj/structure/window/reinforced/survival_pod,
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/MechFabShip)
+"Ms" = (
+/obj/machinery/smartfridge/survival_pod,
+/obj/item/weapon/tape_roll,
+/obj/item/sticky_pad/random,
+/obj/item/weapon/pen/blue,
+/obj/item/weapon/pen/blue,
+/obj/item/fulton_core,
+/obj/item/fulton_core,
+/obj/item/extraction_pack,
+/obj/item/extraction_pack,
+/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
+/obj/item/weapon/pickaxe/hand,
+/obj/item/device/flashlight/color/yellow,
+/obj/item/device/flashlight/color/orange,
+/obj/item/device/threadneedle,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/flame/lighter/zippo,
+/obj/item/weapon/flame/lighter/zippo,
+/obj/item/device/flashlight/lantern,
+/obj/random/soap,
+/obj/random/soap,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/weapon/storage/pill_bottle/spaceacillin,
+/obj/item/weapon/storage/pill_bottle/antitox,
+/obj/item/device/healthanalyzer,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/stack/nanopaste,
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,
+/obj/item/weapon/storage/toolbox/brass,
+/obj/item/weapon/storage/box/survival/space,
+/obj/item/weapon/storage/box/survival/space,
+/obj/item/weapon/storage/box/survival/space,
+/obj/item/weapon/storage/pill_bottle/dice_nerd,
+/obj/item/weapon/storage/box/flare,
+/obj/item/weapon/storage/box/khcrystal,
+/obj/item/weapon/storage/box/khcrystal,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/stack/marker_beacon/ten,
+/obj/item/device/starcaster_news,
+/obj/item/device/mapping_unit,
+/obj/item/weapon/storage/box/dosimeter,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/device/pda,
+/obj/item/device/pda,
+/obj/item/weapon/card/id/external,
+/obj/item/weapon/card/id/external,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/gun/energy/locked/phasegun/pistol,
+/obj/item/weapon/gun/energy/locked/phasegun,
+/obj/item/weapon/cell/device/weapon{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/cell/device/weapon{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/weapon/material/knife/machete,
+/obj/item/weapon/material/fishing_net,
+/obj/item/weapon/storage/backpack/sport,
+/obj/item/weapon/storage/backpack/sport,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/weapon/storage/belt,
+/obj/item/clothing/accessory/poncho/thermal,
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MechFabShip)
+"Mv" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "kalipsoshutters";
+	name = "Kalipso Blast Shielding"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechFabShip)
+"MZ" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor/orange/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Nr" = (
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/obj/machinery/r_n_d/server/core,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	opacity = 1
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/MechFabShip)
+"ND" = (
+/obj/structure/sign/deck1,
+/turf/simulated/wall/skipjack,
+/area/survivalpod/superpose/MechFabShip)
+"Oo" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MechFabShip)
+"Ov" = (
+/obj/machinery/optable{
+	name = "Robotics Operating Table"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"OO" = (
+/obj/structure/bed/pod,
+/obj/item/weapon/bedsheet/hos,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MechFabShip)
+"Py" = (
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "fridge_sci";
+	icon_contents = "chem";
+	icon_state = "fridge_sci";
+	name = "Advanced storage";
+	pixel_y = 0
+	},
+/obj/item/stack/material/durasteel{
+	material = 50
+	},
+/obj/item/stack/material/durasteel{
+	material = 50
+	},
+/obj/item/stack/material/phoron{
+	material = 50
+	},
+/obj/item/stack/material/phoron{
+	material = 50
+	},
+/obj/item/stack/material/diamond{
+	material = 15
+	},
+/obj/item/stack/material/gold{
+	material = 25
+	},
+/obj/item/stack/material/lead{
+	material = 25
+	},
+/obj/item/stack/material/plastic{
+	material = 50
+	},
+/obj/item/stack/material/plastic{
+	material = 50
+	},
+/obj/item/stack/material/platinum{
+	matter = 25
+	},
+/obj/item/stack/material/silver{
+	material = 25
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/uranium{
+	material = 25
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/weapon/storage/toolbox/syndicate/powertools,
+/obj/item/weapon/storage/toolbox/syndicate/powertools,
+/obj/item/clothing/head/welding/demon,
+/obj/item/clothing/head/welding/knight,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/device/robotanalyzer,
+/obj/item/device/robotanalyzer,
+/obj/item/weapon/cell/super,
+/obj/item/weapon/cell/super,
+/obj/item/weapon/cell/device/super,
+/obj/item/weapon/cell/device/super,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/glass/reinforced{
+	amount = 50
+	},
+/obj/item/stack/material/glass/reinforced{
+	amount = 50
+	},
+/obj/item/stack/material/glass/reinforced{
+	amount = 50
+	},
+/obj/item/stack/material/glass/reinforced{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"PH" = (
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/obj/structure/prop/blackbox/salamander_wreck,
+/obj/structure/sign/department/rnd{
+	pixel_y = 32
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/MechFabShip)
+"PP" = (
+/obj/machinery/atmospherics/binary/circulator{
+	anchored = 1;
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MechFabShip)
+"Qs" = (
+/obj/machinery/door/airlock/glass_centcom{
+	id_tag = "kalipsobolt";
+	name = "Bridge"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechFabShip)
+"QE" = (
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"QJ" = (
+/obj/machinery/disperser/middle{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "kalipsoshutters";
+	name = "Kalipso Blast Shielding"
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Rg" = (
+/obj/structure/shuttle/engine/router,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Ro" = (
+/obj/item/trash/rkibble{
+	pixel_x = 8;
+	pixel_y = 14
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/trash/rkibble{
+	pixel_x = 8
+	},
+/obj/item/trash/rkibble{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/obj/item/trash/rkibble{
+	pixel_x = -7
+	},
+/obj/item/trash/rkibble{
+	pixel_x = 8;
+	pixel_y = 14
+	},
+/obj/item/trash/rkibble{
+	pixel_x = -7;
+	pixel_y = 14
+	},
+/obj/item/trash/rkibble{
+	pixel_x = -7
+	},
+/obj/item/trash/rkibble{
+	pixel_x = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MechFabShip)
+"RE" = (
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"SE" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MechFabShip)
+"SW" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/structure/sign/department/robo{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"Ta" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/portable_atmospherics/canister/phoron/cold,
+/obj/effect/floor_decal/techfloor/orange/corner,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Th" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/mecha_part_fabricator/pros,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"TI" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 8
+	},
+/obj/machinery/light/poi{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/emerglocker/east,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Ud" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 10
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Uj" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/techfloor/orange{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"UI" = (
+/obj/effect/floor_decal/industrial/loading{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/MechFabShip)
+"UL" = (
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Vf" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -25;
+	pixel_y = 32
+	},
+/mob/living/simple_mob/animal/passive/dog/corgi/Lisa{
+	name = "Shepiffany"
+	},
+/obj/structure/dogbed,
+/obj/machinery/light/poi{
+	dir = 8
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 4;
+	id = "kalipsobolt";
+	name = "Bridge Lock Down";
+	pixel_x = -28;
+	specialfunctions = 4
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/MechFabShip)
+"Vj" = (
+/obj/machinery/r_n_d/protolathe,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"VZ" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/foodcart,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/MechFabShip)
+"Wl" = (
+/obj/structure/bed/chair/bay/shuttle{
+	dir = 8
+	},
+/obj/structure/closet/walllocker/medical/east,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"WE" = (
+/obj/structure/sign/ironhammer,
+/turf/simulated/wall/skipjack,
+/area/survivalpod/superpose/MechFabShip)
+"WG" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/curtain/open/shower/security,
+/obj/machinery/door/window/survival_pod{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/MechFabShip)
+"WQ" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MechFabShip)
+"WY" = (
+/obj/structure/window/plastitanium/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/grille/rustic{
+	health = 25;
+	name = "reinforced grille"
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "kalipsoshutters";
+	name = "Kalipso Blast Shielding"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Xe" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Xm" = (
+/obj/structure/prop/fake_ai{
+	name = "k@1iPs0"
+	},
+/obj/structure/sign/department/commander{
+	pixel_y = -32
+	},
+/turf/simulated/floor/greengrid/nitrogen,
+/area/survivalpod/superpose/MechFabShip)
+"Xx" = (
+/obj/structure/window/plastitanium/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/grille/rustic{
+	health = 25;
+	name = "reinforced grille"
+	},
+/obj/machinery/door/blast/regular{
+	id = "kalipsoshutters";
+	name = "Kalipso Blast Shielding"
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Yb" = (
+/obj/machinery/door/airlock/glass_centcom{
+	name = "Port Wing Engine"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechFabShip)
+"Yj" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/closet/walllocker/emerglocker/west,
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MechFabShip)
+"Yl" = (
+/obj/structure/fans,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Yo" = (
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Yt" = (
+/obj/machinery/r_n_d/destructive_analyzer,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"YM" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MechFabShip)
+"YP" = (
+/obj/machinery/disperser/front{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Zg" = (
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/MechFabShip)
+"Zm" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
+"Zs" = (
+/obj/structure/bed/chair/bay/comfy/black{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/MechFabShip)
+"Zt" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "kalipsoshutters";
+	name = "Kalipso Blast Shielding"
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechFabShip)
+"ZE" = (
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/MechFabShip)
+"ZH" = (
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechFabShip)
+"ZY" = (
+/obj/structure/window/plastitanium/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/grille/rustic{
+	health = 25;
+	name = "reinforced grille"
+	},
+/obj/machinery/door/blast/regular{
+	id = "kalipsoshutters";
+	name = "Kalipso Blast Shielding"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/MechFabShip)
 
 (1,1,1) = {"
-iCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCiC
-iCiCiCiCiCiCiCiCiCiCphiCiCiCiCiCphiCiCiCiCiCiCiCiCiCiC
-iCiCiCiCiCiCiCYPiCiCphFCWYWYWYpRphiCiCYPiCiCiCiCiCiCiC
-iCiCiCiCiCiCphQJFCpRphjxkzaFiUitphFCpRQJphiCiCiCiCiCiC
-iCiCiCiCiCphphfRwyJWphVfmfZEmfsKphDmwybbphphiCiCiCiCiC
-iCiCiCiCiCiCkHlKZsZgQsZELNLNLNZEQsZgZsbPkHiCiCiCiCiCiC
-iCiCiCiCiCiCZYlKZgBkphatkrXmeMkJphaoZgbPZYiCiCiCiCiCiC
-iCiCiCiCiCphphphEyphphphphphphphphphHSphphphiCiCiCiCiC
-iCiCiCiCiCiCBYphYjDFvbPHNrqYzCSWpytkhzphiCiCiCiCiCiCiC
-iCiCiCiCiCiCiCXxIcDFqXqKozrZhHtkHEtkPyXxiCiCiCiCiCiCiC
-iCiCiCiCiCiCiCphiDDFDFOoYMrZHCThtkOviKphiCiCiCiCiCiCiC
-iCiCiCiCiCiCiCXxVjDFDFDFYMSEhHtktkHEcMXxiCiCiCiCiCiCiC
-iCiCiCphphphphphQEAKDFYtDjgvaGrrtkJXoSphphphphphiCiCiC
-iCiCphphePiIISphphphhIphphphphphhIphphphYlMsbkphphiCiC
-iCiCphKRgDphrZRophHeULREhubLhuZHULWlphalaqrZrZOOphiCiC
-iCiCGlwsDSsdrZBAphyNULULULULULULULTIphWGzNrZrZyhXxiCiC
-iCphphphphphvOWQYbqfZmZmZmZmZmZmZmUdGSyHZmWQrZzdphphiC
-iCphphTajEJvuUMZphgZUIUIVZiwgHnynytCphqkXeLglCjlphphiC
-iCiCphzjbIvtPPCVphphCuMvNDphNDCuMvphphGQKCnJteebphiCiC
-iCiCphqUzUdhUjhJphphrRDiDiDiDiDiCYphphGrvCYolZBfphiCiC
-iCiCphphZtZtZtphphBzDiDiDiDiDiDiDiBzphphZtZtZtphphiCiC
-iCphphRgdzdzdzRgphWEiCiCiCiCiCiCmGphphRgdzdzdzRgphphiC
-iCphiCiCiCiCiCiCiCphiCiCiCiCiCiCiCphiCiCiCiCiCiCiCphiC
-iCiCiCiCySiCiCiCiCiCiCiCiCiCiCiCiCiCiCiCySiCiCiCiCiCiC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+"}
+(2,1,1) = {"
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+ph
+ph
+iC
+iC
+iC
+ph
+ph
+iC
+"}
+(3,1,1) = {"
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+ph
+ph
+Gl
+ph
+ph
+ph
+ph
+ph
+ph
+iC
+iC
+"}
+(4,1,1) = {"
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+ph
+ph
+KR
+ws
+ph
+Ta
+zj
+qU
+ph
+Rg
+iC
+iC
+"}
+(5,1,1) = {"
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+ph
+eP
+gD
+DS
+ph
+jE
+bI
+zU
+Zt
+dz
+iC
+yS
+"}
+(6,1,1) = {"
+iC
+iC
+iC
+iC
+ph
+iC
+iC
+ph
+iC
+iC
+iC
+iC
+ph
+iI
+ph
+sd
+ph
+Jv
+vt
+dh
+Zt
+dz
+iC
+iC
+"}
+(7,1,1) = {"
+iC
+iC
+iC
+ph
+ph
+kH
+ZY
+ph
+BY
+iC
+iC
+iC
+ph
+IS
+rZ
+rZ
+vO
+uU
+PP
+Uj
+Zt
+dz
+iC
+iC
+"}
+(8,1,1) = {"
+iC
+iC
+YP
+QJ
+fR
+lK
+lK
+ph
+ph
+Xx
+ph
+Xx
+ph
+ph
+Ro
+BA
+WQ
+MZ
+CV
+hJ
+ph
+Rg
+iC
+iC
+"}
+(9,1,1) = {"
+iC
+iC
+iC
+FC
+wy
+Zs
+Zg
+Ey
+Yj
+Ic
+iD
+Vj
+QE
+ph
+ph
+ph
+Yb
+ph
+ph
+ph
+ph
+ph
+iC
+iC
+"}
+(10,1,1) = {"
+iC
+iC
+iC
+pR
+JW
+Zg
+Bk
+ph
+DF
+DF
+DF
+DF
+AK
+ph
+He
+yN
+qf
+tC
+ph
+ph
+Bz
+WE
+ph
+iC
+"}
+(11,1,1) = {"
+iC
+ph
+ph
+ph
+ph
+Qs
+ph
+ph
+vb
+qX
+DF
+DF
+DF
+hI
+UL
+UL
+Zm
+UI
+Cu
+rR
+Di
+iC
+iC
+iC
+"}
+(12,1,1) = {"
+iC
+iC
+FC
+jx
+Vf
+ZE
+at
+ph
+PH
+qK
+Oo
+DF
+Yt
+ph
+RE
+UL
+Zm
+UI
+Mv
+Di
+Di
+iC
+iC
+iC
+"}
+(13,1,1) = {"
+iC
+iC
+WY
+kz
+mf
+LN
+kr
+ph
+Nr
+oz
+YM
+YM
+Dj
+ph
+hu
+UL
+Zm
+VZ
+ND
+Di
+Di
+iC
+iC
+iC
+"}
+(14,1,1) = {"
+iC
+iC
+WY
+aF
+ZE
+LN
+Xm
+ph
+qY
+rZ
+rZ
+SE
+gv
+ph
+bL
+UL
+Zm
+iw
+ph
+Di
+Di
+iC
+iC
+iC
+"}
+(15,1,1) = {"
+iC
+iC
+WY
+iU
+mf
+LN
+eM
+ph
+zC
+hH
+HC
+hH
+aG
+ph
+hu
+UL
+Zm
+gH
+ND
+Di
+Di
+iC
+iC
+iC
+"}
+(16,1,1) = {"
+iC
+iC
+pR
+it
+sK
+ZE
+kJ
+ph
+SW
+tk
+Th
+tk
+rr
+ph
+ZH
+UL
+Zm
+ny
+Cu
+Di
+Di
+iC
+iC
+iC
+"}
+(17,1,1) = {"
+iC
+ph
+ph
+ph
+ph
+Qs
+ph
+ph
+py
+HE
+tk
+tk
+tk
+hI
+UL
+UL
+Zm
+ny
+Mv
+CY
+Di
+mG
+iC
+iC
+"}
+(18,1,1) = {"
+iC
+iC
+iC
+FC
+Dm
+Zg
+ao
+ph
+tk
+tk
+Ov
+HE
+JX
+ph
+Wl
+TI
+Ud
+tC
+ph
+ph
+Bz
+ph
+ph
+iC
+"}
+(19,1,1) = {"
+iC
+iC
+iC
+pR
+wy
+Zs
+Zg
+HS
+hz
+Py
+iK
+cM
+oS
+ph
+ph
+ph
+GS
+ph
+ph
+ph
+ph
+ph
+iC
+iC
+"}
+(20,1,1) = {"
+iC
+iC
+YP
+QJ
+bb
+bP
+bP
+ph
+ph
+Xx
+ph
+Xx
+ph
+ph
+al
+WG
+yH
+qk
+GQ
+Gr
+ph
+Rg
+iC
+iC
+"}
+(21,1,1) = {"
+iC
+iC
+iC
+ph
+ph
+kH
+ZY
+ph
+iC
+iC
+iC
+iC
+ph
+Yl
+aq
+zN
+Zm
+Xe
+KC
+vC
+Zt
+dz
+iC
+yS
+"}
+(22,1,1) = {"
+iC
+iC
+iC
+iC
+ph
+iC
+iC
+ph
+iC
+iC
+iC
+iC
+ph
+Ms
+rZ
+rZ
+WQ
+Lg
+nJ
+Yo
+Zt
+dz
+iC
+iC
+"}
+(23,1,1) = {"
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+ph
+bk
+rZ
+rZ
+rZ
+lC
+te
+lZ
+Zt
+dz
+iC
+iC
+"}
+(24,1,1) = {"
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+ph
+ph
+OO
+yh
+zd
+jl
+eb
+Bf
+ph
+Rg
+iC
+iC
+"}
+(25,1,1) = {"
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+ph
+ph
+Xx
+ph
+ph
+ph
+ph
+ph
+ph
+iC
+iC
+"}
+(26,1,1) = {"
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+ph
+ph
+iC
+iC
+iC
+ph
+ph
+iC
+"}
+(27,1,1) = {"
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
+iC
 "}

--- a/modular_chomp/maps/submaps/shelters/MechStorageFab-32x24.dmm
+++ b/modular_chomp/maps/submaps/shelters/MechStorageFab-32x24.dmm
@@ -1,170 +1,1962 @@
-"ak" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MechStorageFab)
-"av" = (/obj/structure/salvageable/computer,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"ax" = (/obj/structure/table/rack/shelf/steel,/obj/item/mecha_parts/mecha_equipment/cloak,/obj/item/mecha_parts/mecha_equipment/tool/jetpack,/obj/item/mecha_parts/mecha_equipment/tool/passenger,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"aI" = (/obj/machinery/portable_atmospherics/canister/air,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"ba" = (/obj/machinery/power/port_gen/pacman,/obj/structure/cable,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"bE" = (/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechStorageFab)
-"bQ" = (/obj/random/maintenance,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"ca" = (/obj/structure/table/rack/shelf/steel,/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster,/obj/item/mecha_parts/mecha_equipment/repair_droid,/obj/item/mecha_parts/mecha_equipment/tool/passenger,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/clusterbang,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"cS" = (/obj/structure/window/reinforced/survival_pod,/obj/machinery/field_generator{anchored = 1; state = 1},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MechStorageFab)
-"df" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"dt" = (/obj/structure/bed/double/padded,/turf/simulated/floor/wood/sif/broken,/area/survivalpod/superpose/MechStorageFab)
-"dA" = (/obj/machinery/icecream_vat,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"dG" = (/turf/template_noop,/area/template_noop)
-"dH" = (/obj/random/maintenance,/obj/random/maintenance/engineering,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"ea" = (/obj/structure/table/reinforced,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"ez" = (/obj/structure/curtain/black{icon_state = "open"; layer = 2; name = "privacy curtain"; opacity = 0},/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MechStorageFab)
-"fq" = (/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MechStorageFab)
-"gG" = (/obj/machinery/fusion_fuel_compressor,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"gT" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 6},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"ho" = (/obj/structure/reagent_dispensers/fueltank/high,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"hr" = (/obj/structure/table/reinforced,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"hK" = (/obj/structure/reagent_dispensers/watertank/high,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"ij" = (/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/machinery/power/apc/alarms_hidden{dir = 8; pixel_x = -24},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"in" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/door/airlock/maintenance/common,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"iH" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/alarm/alarms_hidden{dir = 1; pixel_y = -22},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"jq" = (/obj/mecha/working/hoverpod/shuttlecraft{dir = 8},/turf/template_noop,/area/template_noop)
-"ju" = (/obj/structure/salvageable/bliss,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"kd" = (/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechStorageFab)
-"lc" = (/obj/random/maintenance/engineering,/obj/structure/bed/chair{dir = 8},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"lk" = (/obj/structure/table/rack/shelf/steel,/obj/item/mecha_parts/component/hull/lightweight,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot,/obj/item/mecha_parts/mecha_equipment/weapon/phoron_bore,/obj/item/mecha_parts/mecha_equipment/weapon/energy/taser/rigged,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"ly" = (/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"lA" = (/obj/random/maintenance/engineering,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"lX" = (/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/machinery/ion_engine,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechStorageFab)
-"mB" = (/obj/structure/table/steel_reinforced,/obj/item/weapon/storage/briefcase/inflatable{pixel_y = 3},/obj/item/weapon/storage/toolbox/syndicate/powertools,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"nc" = (/obj/structure/bed/double/padded,/obj/item/weapon/bedsheet/rainbowdouble,/obj/machinery/partyalarm{pixel_y = -18},/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MechStorageFab)
-"nh" = (/obj/structure/table/rack/shelf/steel,/obj/item/mecha_parts/component/armor/alien,/obj/item/mecha_parts/mecha_equipment/crisis_drone/rad,/obj/item/mecha_parts/mecha_equipment/tool/passenger,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/rigged,/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy/rigged,/obj/item/mecha_parts/mecha_equipment/weapon/energy/medigun,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"ns" = (/obj/machinery/vending/tool{emagged = 1},/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"nz" = (/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"nH" = (/obj/machinery/atmospherics/pipe/manifold/hidden,/obj/random/junk,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"nJ" = (/obj/machinery/atmospherics/unary/vent_pump/on,/obj/machinery/alarm/alarms_hidden{dir = 4; pixel_x = -22},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"nZ" = (/obj/machinery/atmospherics/pipe/manifold/hidden,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"oh" = (/obj/machinery/door/airlock/maintenance/int,/obj/structure/fans/hardlight,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"oW" = (/obj/machinery/sleeper{dir = 4},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"pw" = (/obj/random/junk,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"pA" = (/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"qa" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/loot_pile/mecha/marauder/mauler,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechStorageFab)
-"qb" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechStorageFab)
-"qf" = (/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"qp" = (/obj/structure/curtain/black{icon_state = "open"; layer = 2; name = "privacy curtain"; opacity = 0},/turf/simulated/floor/wood/sif/broken,/area/survivalpod/superpose/MechStorageFab)
-"qy" = (/obj/structure/cable/green{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"qE" = (/obj/machinery/autolathe{hacked = 1; name = "hacked autolathe"},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"qY" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"rj" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/machinery/alarm/alarms_hidden{dir = 4; pixel_x = -22},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"rl" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"rp" = (/obj/random/maintenance,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"rM" = (/obj/machinery/door/airlock/maintenance/common,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"sd" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"sk" = (/obj/random/junk,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"sK" = (/obj/vehicle/boat{dir = 8},/obj/structure/lattice,/turf/template_noop,/area/survivalpod/superpose/MechStorageFab)
-"tl" = (/obj/machinery/floorlayer,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"to" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9},/obj/machinery/gear_dispenser/suit_old,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"tw" = (/turf/simulated/floor/plating/external,/area/template_noop)
-"tH" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 8},/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"tK" = (/obj/effect/wingrille_spawn/reinforced,/obj/structure/fans/hardlight,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"tO" = (/obj/structure/table/rack/shelf/steel,/obj/item/mecha_parts/mecha_equipment/generator/nuclear,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/explosive/rigged,/obj/item/mecha_parts/mecha_equipment/weapon/energy/ion/rigged,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"tV" = (/obj/structure/table/rack/shelf/steel,/obj/item/mecha_parts/component/gas/reinforced,/obj/item/mecha_parts/mecha_equipment/hardpoint_actuator,/obj/item/mecha_parts/mecha_equipment/tesla_energy_relay,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/cannon,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/rigged,/obj/item/mecha_parts/mecha_equipment/wormhole_generator,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"tW" = (/obj/structure/closet/walllocker_double/kitchen/north{dir = 8; name = "Ration Cabinet"; pixel_x = -32; pixel_y = 0},/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/device/radio{pixel_x = -5; pixel_y = 5},/obj/item/device/radio{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"us" = (/obj/machinery/artifact_scanpad,/obj/effect/simple_portal/linked,/obj/effect/map_effect/interval/effect_emitter/sparks,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MechStorageFab)
-"uJ" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/structure/closet/jcloset,/obj/item/weapon/mop,/obj/structure/mopbucket,/obj/item/weapon/reagent_containers/glass/bucket,/obj/item/weapon/reagent_containers/spray/cleaner,/obj/item/weapon/reagent_containers/spray/cleaner,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"vG" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/loot_pile/mecha/odysseus/murdysseus,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechStorageFab)
-"wg" = (/obj/random/junk,/obj/random/maintenance,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"wU" = (/obj/structure/salvageable/server,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"yc" = (/obj/machinery/feeder,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"yF" = (/obj/structure/lattice,/turf/template_noop,/area/template_noop)
-"yH" = (/obj/machinery/door/airlock/maintenance/engi{req_one_access = null},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"zb" = (/obj/structure/salvageable/autolathe,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"Ah" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/cryofeed{dir = 1},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechStorageFab)
-"Ao" = (/turf/simulated/wall/skipjack,/area/survivalpod/superpose/MechStorageFab)
-"Ar" = (/obj/structure/cable{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"Au" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/loot_pile/mecha/gygax/dark/adv,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechStorageFab)
-"AD" = (/obj/effect/wingrille_spawn/reinforced,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"BC" = (/obj/machinery/portable_atmospherics/canister/air,/obj/machinery/atmospherics/portables_connector,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"CN" = (/obj/structure/cryofeed{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 4},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechStorageFab)
-"Df" = (/obj/machinery/alarm/alarms_hidden{dir = 4; pixel_x = -22},/obj/item/pizzavoucher,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"Dr" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/alarm/alarms_hidden{pixel_y = 22},/obj/random/maintenance,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"DV" = (/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"EE" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/mecha/combat/gygax/old,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechStorageFab)
-"EY" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/loot_pile/mecha/gygax/medgax,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechStorageFab)
-"Ga" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 5},/obj/random/maintenance/engineering,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"Go" = (/obj/machinery/power/smes/buildable/hybrid,/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"GI" = (/obj/structure/table/rack/shelf/steel,/obj/item/mecha_parts/mecha_equipment/combat_shield,/obj/item/mecha_parts/mecha_equipment/repair_droid,/obj/item/mecha_parts/mecha_equipment/tool/sleeper,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/mortar,/obj/item/mecha_parts/mecha_equipment/weapon/energy/flamer/rigged,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"GX" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/obj/random/maintenance,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"Ib" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"IE" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/mecha/combat/marauder/old,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechStorageFab)
-"IN" = (/obj/item/weapon/bedsheet/piratedouble,/obj/structure/curtain/black{icon_state = "open"; layer = 2; name = "privacy curtain"; opacity = 0},/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MechStorageFab)
-"IS" = (/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"IX" = (/obj/machinery/power/terminal,/obj/structure/cable{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"Jh" = (/obj/structure/closet/secure_closet/engineering_electrical{req_access = null},/obj/random/maintenance,/obj/random/maintenance,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"Jo" = (/obj/machinery/atmospherics/valve{dir = 8},/obj/structure/dispenser{phorontanks = 0},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"JE" = (/obj/machinery/atmospherics/binary/passive_gate{dir = 8; regulate_mode = 0; unlocked = 1},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"JR" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/mecha/combat/phazon/old,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechStorageFab)
-"JT" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/loot_pile/mecha/durand,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechStorageFab)
-"JV" = (/obj/structure/closet/walllocker_double/north,/obj/item/device/gps,/obj/item/sticky_pad/random,/obj/item/device/starcaster_news,/obj/item/weapon/pen/blue,/obj/item/device/pda,/obj/item/weapon/card/id/external,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/gun/energy/locked/phasegun/pistol,/obj/item/weapon/material/knife/tacknife/survival,/obj/item/clothing/accessory/permit/gun,/obj/item/device/camera,/obj/item/device/binoculars,/obj/item/device/threadneedle,/obj/random/soap,/obj/item/weapon/towel/random,/obj/item/bodybag/cryobag,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/color/yellow,/obj/item/device/radio,/obj/item/device/radio,/obj/item/weapon/flame/lighter/random,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/device/suit_cooling_unit/emergency,/obj/item/stack/nanopaste,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,/obj/item/weapon/storage/backpack/messenger,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/clothing/accessory/poncho/thermal,/obj/item/weapon/storage/box/survival/comp,/obj/item/weapon/storage/toolbox/brass,/obj/item/weapon/storage/box/khcrystal,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"Ke" = (/obj/machinery/robotic_fabricator,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"Kt" = (/obj/machinery/alarm/alarms_hidden{dir = 8; pixel_x = 22},/obj/machinery/holoplant,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"KE" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9},/obj/random/maintenance,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"KN" = (/obj/machinery/sleep_console{dir = 4},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"Lh" = (/obj/structure/closet/crate,/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil/green,/obj/item/stack/cable_coil/blue,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/turf/simulated/floor/plating,/area/survivalpod/superpose/MechStorageFab)
-"Lp" = (/obj/structure/table/reinforced,/obj/machinery/cell_charger,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"Ls" = (/obj/random/maintenance/engineering,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"Ma" = (/obj/structure/closet/walllocker_double/kitchen/north{dir = 8; name = "Ration Cabinet"; pixel_x = -32; pixel_y = 0},/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/device/radio{pixel_x = -5; pixel_y = 5},/obj/item/device/radio{pixel_x = 5; pixel_y = 5},/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"Ml" = (/obj/structure/table/rack/shelf/steel,/obj/item/mecha_parts/component/armor/military,/obj/item/mecha_parts/component/gas/reinforced,/obj/item/mecha_parts/mecha_equipment/omni_shield,/obj/item/mecha_parts/mecha_equipment/tool/jetpack,/obj/item/mecha_parts/mecha_equipment/tool/passenger,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/cannon,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"Mx" = (/obj/structure/closet/walllocker_double/kitchen/north{dir = 8; name = "Ration Cabinet"; pixel_x = -32; pixel_y = 0},/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/device/radio{pixel_x = -5; pixel_y = 5},/obj/item/device/radio{pixel_x = 5; pixel_y = 5},/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"MA" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 1},/obj/random/junk,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"MB" = (/obj/structure/closet/crate,/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/fiftyspawner/blucarpet,/obj/fiftyspawner/oracarpet,/obj/fiftyspawner/purcarpet,/obj/fiftyspawner/sblucarpet,/obj/fiftyspawner/tealcarpet,/obj/fiftyspawner/turcarpet,/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/algae{amount = 50},/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/lead{amount = 30},/obj/item/stack/material/plasteel{amount = 30; pixel_y = 5},/obj/item/stack/material/resin{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor/plating,/area/survivalpod/superpose/MechStorageFab)
-"Ni" = (/turf/template_noop,/area/survivalpod/superpose/MechStorageFab)
-"Oc" = (/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/machinery/atmospherics/binary/circulator{anchored = 1},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechStorageFab)
-"Of" = (/obj/structure/salvageable/console_os{dir = 4},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"Os" = (/obj/machinery/vending/engivend{emagged = 1},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"OF" = (/obj/mecha/combat/fighter/gunpod/recon{dir = 8},/turf/template_noop,/area/template_noop)
-"Pt" = (/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"Qo" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"RS" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 6},/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/tank/emergency/oxygen/double{pixel_y = 6},/obj/item/weapon/tank/emergency/oxygen/double{pixel_y = 6},/obj/item/weapon/tank/emergency/oxygen/double{pixel_y = 6},/obj/item/weapon/tank/emergency/oxygen/double{pixel_y = 6},/obj/item/weapon/tank/emergency/oxygen/double{pixel_y = 6},/obj/structure/table/rack/shelf/steel,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"Sw" = (/obj/machinery/door/window/survival_pod{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MechStorageFab)
-"Sz" = (/obj/vehicle/boat/dragon/sifwood{dir = 8},/obj/structure/lattice,/turf/template_noop,/area/template_noop)
-"SM" = (/obj/structure/table/reinforced,/obj/machinery/alarm/alarms_hidden{pixel_y = 22},/obj/machinery/cell_charger,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"TK" = (/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"Ut" = (/obj/structure/closet/secure_closet/engineering_welding{req_access = null},/obj/random/maintenance,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"Vb" = (/obj/machinery/atmospherics/pipe/tank/air,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"Vu" = (/obj/machinery/power/shield_generator/charged,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"Vx" = (/obj/structure/table/steel_reinforced,/obj/item/weapon/storage/briefcase/inflatable{pixel_y = 3},/obj/item/weapon/storage/toolbox/electrical,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"VT" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"We" = (/obj/random/maintenance/engineering,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MechStorageFab)
-"Wo" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 10},/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
-"XH" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/door/airlock/maintenance/rnd{req_one_access = null},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"XX" = (/obj/machinery/atmospherics/pipe/simple/hidden,/obj/machinery/door/airlock/maintenance/engi{req_one_access = null},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"Yd" = (/obj/machinery/portable_atmospherics/canister/phoron,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MechStorageFab)
-"Yl" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/loot_pile/mecha/phazon,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MechStorageFab)
-"YB" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 5},/obj/structure/table/steel_reinforced,/obj/item/weapon/storage/briefcase/inflatable{pixel_y = 3},/obj/item/weapon/storage/toolbox/mechanical,/obj/item/pizzavoucher,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"YI" = (/obj/structure/salvageable/console_os{dir = 4},/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"Zj" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/field_generator{anchored = 1; state = 1},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MechStorageFab)
-"ZA" = (/obj/random/maintenance/security,/obj/structure/table/reinforced,/turf/simulated/floor/tiled/steel_dirty,/area/survivalpod/superpose/MechStorageFab)
-"ZG" = (/obj/machinery/fitness/heavy/lifter,/turf/simulated/floor/tiled/asteroid_steel,/area/survivalpod/superpose/MechStorageFab)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ak" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MechStorageFab)
+"av" = (
+/obj/structure/salvageable/computer,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"ax" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/mecha_equipment/cloak,
+/obj/item/mecha_parts/mecha_equipment/tool/jetpack,
+/obj/item/mecha_parts/mecha_equipment/tool/passenger,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"aI" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"ba" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"bE" = (
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechStorageFab)
+"bQ" = (
+/obj/random/maintenance,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"ca" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster,
+/obj/item/mecha_parts/mecha_equipment/repair_droid,
+/obj/item/mecha_parts/mecha_equipment/tool/passenger,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/clusterbang,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"cS" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/machinery/field_generator{
+	anchored = 1;
+	state = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MechStorageFab)
+"df" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"dt" = (
+/obj/structure/bed/double/padded,
+/turf/simulated/floor/wood/sif/broken,
+/area/survivalpod/superpose/MechStorageFab)
+"dA" = (
+/obj/machinery/icecream_vat,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"dG" = (
+/turf/template_noop,
+/area/template_noop)
+"dH" = (
+/obj/random/maintenance,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"ea" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"ez" = (
+/obj/structure/curtain/black{
+	icon_state = "open";
+	layer = 2;
+	name = "privacy curtain";
+	opacity = 0
+	},
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MechStorageFab)
+"fq" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MechStorageFab)
+"gG" = (
+/obj/machinery/fusion_fuel_compressor,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"gT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"ho" = (
+/obj/structure/reagent_dispensers/fueltank/high,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"hr" = (
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"hK" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"ij" = (
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/alarms_hidden{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"in" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"iH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"jq" = (
+/obj/mecha/working/hoverpod/shuttlecraft{
+	dir = 8
+	},
+/turf/template_noop,
+/area/template_noop)
+"ju" = (
+/obj/structure/salvageable/bliss,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"kd" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechStorageFab)
+"lc" = (
+/obj/random/maintenance/engineering,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"lk" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/component/hull/lightweight,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot,
+/obj/item/mecha_parts/mecha_equipment/weapon/phoron_bore,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/taser/rigged,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"ly" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"lA" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"lX" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/ion_engine,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechStorageFab)
+"mB" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/toolbox/syndicate/powertools,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"nc" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/rainbowdouble,
+/obj/machinery/partyalarm{
+	pixel_y = -18
+	},
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MechStorageFab)
+"nh" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/component/armor/alien,
+/obj/item/mecha_parts/mecha_equipment/crisis_drone/rad,
+/obj/item/mecha_parts/mecha_equipment/tool/passenger,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg/rigged,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy/rigged,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/medigun,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"ns" = (
+/obj/machinery/vending/tool{
+	emagged = 1
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"nz" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"nH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/random/junk,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"nJ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/alarm/alarms_hidden{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"nZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"oh" = (
+/obj/machinery/door/airlock/maintenance/int,
+/obj/structure/fans/hardlight,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"oW" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"pw" = (
+/obj/random/junk,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"pA" = (
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"qa" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/loot_pile/mecha/marauder/mauler,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechStorageFab)
+"qb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechStorageFab)
+"qf" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"qp" = (
+/obj/structure/curtain/black{
+	icon_state = "open";
+	layer = 2;
+	name = "privacy curtain";
+	opacity = 0
+	},
+/turf/simulated/floor/wood/sif/broken,
+/area/survivalpod/superpose/MechStorageFab)
+"qy" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"qE" = (
+/obj/machinery/autolathe{
+	hacked = 1;
+	name = "hacked autolathe"
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"qY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"rj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"rl" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"rp" = (
+/obj/random/maintenance,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"rM" = (
+/obj/machinery/door/airlock/maintenance/common,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"sd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"sk" = (
+/obj/random/junk,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"sK" = (
+/obj/vehicle/boat{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/survivalpod/superpose/MechStorageFab)
+"tl" = (
+/obj/machinery/floorlayer,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"to" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/obj/machinery/gear_dispenser/suit_old,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"tw" = (
+/turf/simulated/floor/plating/external,
+/area/template_noop)
+"tH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"tK" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/fans/hardlight,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"tO" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/mecha_equipment/generator/nuclear,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/explosive/rigged,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/ion/rigged,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"tV" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/component/gas/reinforced,
+/obj/item/mecha_parts/mecha_equipment/hardpoint_actuator,
+/obj/item/mecha_parts/mecha_equipment/tesla_energy_relay,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/cannon,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/rigged,
+/obj/item/mecha_parts/mecha_equipment/wormhole_generator,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"tW" = (
+/obj/structure/closet/walllocker_double/kitchen/north{
+	dir = 8;
+	name = "Ration Cabinet";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"us" = (
+/obj/machinery/artifact_scanpad,
+/obj/effect/simple_portal/linked,
+/obj/effect/map_effect/interval/effect_emitter/sparks,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MechStorageFab)
+"uJ" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/closet/jcloset,
+/obj/item/weapon/mop,
+/obj/structure/mopbucket,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"vG" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/loot_pile/mecha/odysseus/murdysseus,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechStorageFab)
+"wg" = (
+/obj/random/junk,
+/obj/random/maintenance,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"wU" = (
+/obj/structure/salvageable/server,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"yc" = (
+/obj/machinery/feeder,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"yF" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"yH" = (
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"zb" = (
+/obj/structure/salvageable/autolathe,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Ah" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/cryofeed{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechStorageFab)
+"Ao" = (
+/turf/simulated/wall/skipjack,
+/area/survivalpod/superpose/MechStorageFab)
+"Ar" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"Au" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/loot_pile/mecha/gygax/dark/adv,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechStorageFab)
+"AD" = (
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"BC" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"CN" = (
+/obj/structure/cryofeed{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechStorageFab)
+"Df" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/item/pizzavoucher,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Dr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 22
+	},
+/obj/random/maintenance,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"DV" = (
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"EE" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/mecha/combat/gygax/old,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechStorageFab)
+"EY" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/loot_pile/mecha/gygax/medgax,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechStorageFab)
+"Ga" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"Go" = (
+/obj/machinery/power/smes/buildable/hybrid,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"GI" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/mecha_equipment/combat_shield,
+/obj/item/mecha_parts/mecha_equipment/repair_droid,
+/obj/item/mecha_parts/mecha_equipment/tool/sleeper,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/mortar,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/flamer/rigged,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"GX" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/random/maintenance,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"Ib" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"IE" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/loot_pile/mecha/marauder,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechStorageFab)
+"IN" = (
+/obj/item/weapon/bedsheet/piratedouble,
+/obj/structure/curtain/black{
+	icon_state = "open";
+	layer = 2;
+	name = "privacy curtain";
+	opacity = 0
+	},
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MechStorageFab)
+"IS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"IX" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"Jh" = (
+/obj/structure/closet/secure_closet/engineering_electrical{
+	req_access = null
+	},
+/obj/random/maintenance,
+/obj/random/maintenance,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"Jo" = (
+/obj/machinery/atmospherics/valve{
+	dir = 8
+	},
+/obj/structure/dispenser{
+	phorontanks = 0
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"JE" = (
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 8;
+	regulate_mode = 0;
+	unlocked = 1
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"JT" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/loot_pile/mecha/durand,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechStorageFab)
+"JV" = (
+/obj/structure/closet/walllocker_double/north,
+/obj/item/device/gps,
+/obj/item/sticky_pad/random,
+/obj/item/device/starcaster_news,
+/obj/item/weapon/pen/blue,
+/obj/item/device/pda,
+/obj/item/weapon/card/id/external,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/gun/energy/locked/phasegun/pistol,
+/obj/item/weapon/material/knife/tacknife/survival,
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/device/camera,
+/obj/item/device/binoculars,
+/obj/item/device/threadneedle,
+/obj/random/soap,
+/obj/item/weapon/towel/random,
+/obj/item/bodybag/cryobag,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/color/yellow,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/weapon/flame/lighter/random,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/stack/nanopaste,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,
+/obj/item/weapon/storage/backpack/messenger,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/clothing/accessory/poncho/thermal,
+/obj/item/weapon/storage/box/survival/comp,
+/obj/item/weapon/storage/toolbox/brass,
+/obj/item/weapon/storage/box/khcrystal,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Ke" = (
+/obj/machinery/robotic_fabricator,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Kt" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/machinery/holoplant,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"KE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/obj/random/maintenance,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"KN" = (
+/obj/machinery/sleep_console{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Lh" = (
+/obj/structure/closet/crate,
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/blue,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechStorageFab)
+"Lp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Ls" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Ma" = (
+/obj/structure/closet/walllocker_double/kitchen/north{
+	dir = 8;
+	name = "Ration Cabinet";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"Ml" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/component/armor/military,
+/obj/item/mecha_parts/component/gas/reinforced,
+/obj/item/mecha_parts/mecha_equipment/omni_shield,
+/obj/item/mecha_parts/mecha_equipment/tool/jetpack,
+/obj/item/mecha_parts/mecha_equipment/tool/passenger,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/cannon,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"Mx" = (
+/obj/structure/closet/walllocker_double/kitchen/north{
+	dir = 8;
+	name = "Ration Cabinet";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"MA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/random/junk,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"MB" = (
+/obj/structure/closet/crate,
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/fiftyspawner/blucarpet,
+/obj/fiftyspawner/oracarpet,
+/obj/fiftyspawner/purcarpet,
+/obj/fiftyspawner/sblucarpet,
+/obj/fiftyspawner/tealcarpet,
+/obj/fiftyspawner/turcarpet,
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/algae{
+	amount = 50
+	},
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/lead{
+	amount = 30
+	},
+/obj/item/stack/material/plasteel{
+	amount = 30;
+	pixel_y = 5
+	},
+/obj/item/stack/material/resin{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/MechStorageFab)
+"Ni" = (
+/turf/template_noop,
+/area/survivalpod/superpose/MechStorageFab)
+"Oc" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/atmospherics/binary/circulator{
+	anchored = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechStorageFab)
+"Of" = (
+/obj/structure/salvageable/console_os{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Os" = (
+/obj/machinery/vending/engivend{
+	emagged = 1
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"OF" = (
+/obj/mecha/combat/fighter/gunpod/recon{
+	dir = 8
+	},
+/turf/template_noop,
+/area/template_noop)
+"Pt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Qo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"RS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double{
+	pixel_y = 6
+	},
+/obj/item/weapon/tank/emergency/oxygen/double{
+	pixel_y = 6
+	},
+/obj/item/weapon/tank/emergency/oxygen/double{
+	pixel_y = 6
+	},
+/obj/item/weapon/tank/emergency/oxygen/double{
+	pixel_y = 6
+	},
+/obj/item/weapon/tank/emergency/oxygen/double{
+	pixel_y = 6
+	},
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"Sw" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MechStorageFab)
+"Sz" = (
+/obj/vehicle/boat/dragon/sifwood{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"SM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 22
+	},
+/obj/machinery/cell_charger,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"TK" = (
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"Ut" = (
+/obj/structure/closet/secure_closet/engineering_welding{
+	req_access = null
+	},
+/obj/random/maintenance,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"Vb" = (
+/obj/machinery/atmospherics/pipe/tank/air,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"Vu" = (
+/obj/machinery/power/shield_generator/charged,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Vx" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/toolbox/electrical,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"VT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"We" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechStorageFab)
+"Wo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"XH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"XX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"Yd" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"Yl" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/loot_pile/mecha/phazon,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MechStorageFab)
+"YB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/briefcase/inflatable{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/pizzavoucher,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"YI" = (
+/obj/structure/salvageable/console_os{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"Zj" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/field_generator{
+	anchored = 1;
+	state = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MechStorageFab)
+"ZA" = (
+/obj/random/maintenance/security,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"ZG" = (
+/obj/machinery/fitness/heavy/lifter,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
 
 (1,1,1) = {"
-dGdGdGdGdGdGdGdGdGdGdGdGyFdGyFdGtwtwtwdGdGdGdGdGdGdGtwtwdGdGdGdG
-yFyFdGdGyFyFyFyFyFyFyFdGdGdGdGdGtwtwtwdGdGdGyFtwtwtwyFyFyFyFyFyF
-dGAoAoAoAoAoAoAoAoAoAoAoAoAodGdGtwdGdGdGyFdGdGtwtwtwdGtwtwtwdGdG
-dGsKDVDVDVDVDVDVDVnhGIMllkAoAotKAoAoAotKtKtKAoAoAoAoAoAoAoAodGyF
-dGdGdGdGdGdGdGdGDVDVDVDVDVAoJTDVYlDVAoYdaIBCVbAoUtpAakZjAhAotwyF
-dGdGdGdGdGdGjqdGDVAoAoAoAoAoJRDVEYDVAoYdDVGaIbAoJhpASwusOcAotwyF
-dGdGdGyFyFyFyFyFDVAobEkdbEAoAuDVvGlAAogTJEJotoAoMxpAfqcSlXAodGyF
-dGdGdGdGdGdGdGdGDVohbEbEWeohTKTKqfLsAoXXADADADAonJskDVTKTKAoyFyF
-dGdGdGdGdGdGdGdGDVAoAoADAoAoVxmBYBdfDrnHQodfMAXHKETKTKycdAAotwyF
-dGdGdGyFyFyFyFyFDVAoavjuzbAoAoADADAoAoAoAoAoPtAoAoADAoAoAoAotwyF
-dGdGdGdGdGdGdGdGDVtKeapATKADKNoWrpSMLpqEJVAoISAopApApAbQtlAotwdG
-dGdGdGdGdGdGdGdGDVtKOflcskrMpADVlAbQLsGXQoinIbADnzTKakZjCNAoyFdG
-dGdGdGyFyFyFyFyFDVtKwUTKpAADDVpwpwpwpwTKpAAoPtAoMaDVSwusOcAoyFdG
-dGdGdGdGdGdGdGdGDVtKYIdHKtAoezAoqpAoezAoINAotHXHsdpwfqcSlXAodGyF
-dGdGdGdGdGdGdGdGDVtKZALspAAodtAoncAodtAodtAoPtAoDfpApApAgGAotwyF
-dGdGdGyFyFyFyFyFDVAohrTKKeAoAoAoAoAoAoAoAoAolyAoAoADAoAoAoAotwyF
-dGdGdGdGdGdGdGdGDVAoAoADAoAoOsnsRSqYiHdfqYdfnZXHWopAZGpAZGAotwyF
-dGdGdGdGdGdGOFdGDVohbEbEbEohTKTKVTpAAoADADADyHAorjwgpArpDVAodGyF
-dGdGdGyFyFyFyFyFDVAobEqbbEAoqaDVAuDVAoijMBLhDVAotWpAakZjCNAotwyF
-dGdGdGdGdGdGdGyFDVAoAoAoAoAoIElAvGDVAohKrlIXArAoVuDVSwusOcAotwyF
-dGdGSzyFyFyFyFyFDVtVaxtOcaAoYlDVEEDVAohoqyGobaAouJTKfqcSlXAotwdG
-dGNiDVDVDVDVDVDVDVDVDVDVDVAoAotKAoAoAotKtKtKAoAoAoAoAoAoAoAotwdG
-dGAoAoAoAoAoAoAoAoAoAoAoAoAotwtwtwtwtwtwtwtwyFtwtwtwtwdGtwtwdGdG
-yFyFyFyFdGdGyFyFyFdGdGyFdGdGtwdGtwtwtwdGtwtwyFtwtwtwtwyFtwtwyFyF
+dG
+yF
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+yF
+"}
+(2,1,1) = {"
+dG
+yF
+Ao
+sK
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+Ni
+Ao
+yF
+"}
+(3,1,1) = {"
+dG
+dG
+Ao
+DV
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+dG
+Sz
+DV
+Ao
+yF
+"}
+(4,1,1) = {"
+dG
+dG
+Ao
+DV
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+yF
+DV
+Ao
+yF
+"}
+(5,1,1) = {"
+dG
+yF
+Ao
+DV
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+yF
+DV
+Ao
+dG
+"}
+(6,1,1) = {"
+dG
+yF
+Ao
+DV
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+yF
+DV
+Ao
+dG
+"}
+(7,1,1) = {"
+dG
+yF
+Ao
+DV
+dG
+jq
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+OF
+yF
+dG
+yF
+DV
+Ao
+yF
+"}
+(8,1,1) = {"
+dG
+yF
+Ao
+DV
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+dG
+dG
+yF
+yF
+yF
+DV
+Ao
+yF
+"}
+(9,1,1) = {"
+dG
+yF
+Ao
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+DV
+Ao
+yF
+"}
+(10,1,1) = {"
+dG
+yF
+Ao
+nh
+DV
+Ao
+Ao
+oh
+Ao
+Ao
+tK
+tK
+tK
+tK
+tK
+Ao
+Ao
+oh
+Ao
+Ao
+tV
+DV
+Ao
+dG
+"}
+(11,1,1) = {"
+dG
+yF
+Ao
+GI
+DV
+Ao
+bE
+bE
+Ao
+av
+ea
+Of
+wU
+YI
+ZA
+hr
+Ao
+bE
+bE
+Ao
+ax
+DV
+Ao
+dG
+"}
+(12,1,1) = {"
+dG
+dG
+Ao
+Ml
+DV
+Ao
+kd
+bE
+AD
+ju
+pA
+lc
+TK
+dH
+Ls
+TK
+AD
+bE
+qb
+Ao
+tO
+DV
+Ao
+yF
+"}
+(13,1,1) = {"
+yF
+dG
+Ao
+lk
+DV
+Ao
+bE
+We
+Ao
+zb
+TK
+sk
+pA
+Kt
+pA
+Ke
+Ao
+bE
+bE
+Ao
+ca
+DV
+Ao
+dG
+"}
+(14,1,1) = {"
+dG
+dG
+Ao
+Ao
+Ao
+Ao
+Ao
+oh
+Ao
+Ao
+AD
+rM
+AD
+Ao
+Ao
+Ao
+Ao
+oh
+Ao
+Ao
+Ao
+Ao
+Ao
+dG
+"}
+(15,1,1) = {"
+yF
+dG
+dG
+Ao
+JT
+Yl
+Au
+TK
+Vx
+Ao
+KN
+pA
+DV
+ez
+dt
+Ao
+Os
+TK
+qa
+IE
+Yl
+Ao
+tw
+tw
+"}
+(16,1,1) = {"
+dG
+dG
+dG
+tK
+DV
+DV
+DV
+TK
+mB
+AD
+oW
+DV
+pw
+Ao
+Ao
+Ao
+ns
+TK
+DV
+lA
+DV
+tK
+tw
+dG
+"}
+(17,1,1) = {"
+tw
+tw
+tw
+Ao
+Yl
+EY
+vG
+qf
+YB
+AD
+rp
+lA
+pw
+qp
+nc
+Ao
+RS
+VT
+Au
+vG
+EE
+Ao
+tw
+tw
+"}
+(18,1,1) = {"
+tw
+tw
+dG
+Ao
+DV
+DV
+lA
+Ls
+df
+Ao
+SM
+bQ
+pw
+Ao
+Ao
+Ao
+qY
+pA
+DV
+DV
+DV
+Ao
+tw
+tw
+"}
+(19,1,1) = {"
+tw
+tw
+dG
+Ao
+Ao
+Ao
+Ao
+Ao
+Dr
+Ao
+Lp
+Ls
+pw
+ez
+dt
+Ao
+iH
+Ao
+Ao
+Ao
+Ao
+Ao
+tw
+tw
+"}
+(20,1,1) = {"
+dG
+dG
+dG
+tK
+Yd
+Yd
+gT
+XX
+nH
+Ao
+qE
+GX
+TK
+Ao
+Ao
+Ao
+df
+AD
+ij
+hK
+ho
+tK
+tw
+dG
+"}
+(21,1,1) = {"
+dG
+dG
+yF
+tK
+aI
+DV
+JE
+AD
+Qo
+Ao
+JV
+Qo
+pA
+IN
+dt
+Ao
+qY
+AD
+MB
+rl
+qy
+tK
+tw
+tw
+"}
+(22,1,1) = {"
+dG
+dG
+dG
+tK
+BC
+Ga
+Jo
+AD
+df
+Ao
+Ao
+in
+Ao
+Ao
+Ao
+Ao
+df
+AD
+Lh
+IX
+Go
+tK
+tw
+tw
+"}
+(23,1,1) = {"
+dG
+yF
+dG
+Ao
+Vb
+Ib
+to
+AD
+MA
+Pt
+IS
+Ib
+Pt
+tH
+Pt
+ly
+nZ
+yH
+DV
+Ar
+ba
+Ao
+yF
+yF
+"}
+(24,1,1) = {"
+dG
+tw
+tw
+Ao
+Ao
+Ao
+Ao
+Ao
+XH
+Ao
+Ao
+AD
+Ao
+XH
+Ao
+Ao
+XH
+Ao
+Ao
+Ao
+Ao
+Ao
+tw
+tw
+"}
+(25,1,1) = {"
+dG
+tw
+tw
+Ao
+Ut
+Jh
+Mx
+nJ
+KE
+Ao
+pA
+nz
+Ma
+sd
+Df
+Ao
+Wo
+rj
+tW
+Vu
+uJ
+Ao
+tw
+tw
+"}
+(26,1,1) = {"
+dG
+tw
+tw
+Ao
+pA
+pA
+pA
+sk
+TK
+AD
+pA
+TK
+DV
+pw
+pA
+AD
+pA
+wg
+pA
+DV
+TK
+Ao
+tw
+tw
+"}
+(27,1,1) = {"
+tw
+yF
+dG
+Ao
+ak
+Sw
+fq
+DV
+TK
+Ao
+pA
+ak
+Sw
+fq
+pA
+Ao
+ZG
+pA
+ak
+Sw
+fq
+Ao
+tw
+tw
+"}
+(28,1,1) = {"
+tw
+yF
+tw
+Ao
+Zj
+us
+cS
+TK
+yc
+Ao
+bQ
+Zj
+us
+cS
+pA
+Ao
+pA
+rp
+Zj
+us
+cS
+Ao
+dG
+yF
+"}
+(29,1,1) = {"
+dG
+yF
+tw
+Ao
+Ah
+Oc
+lX
+TK
+dA
+Ao
+tl
+CN
+Oc
+lX
+gG
+Ao
+ZG
+DV
+CN
+Oc
+lX
+Ao
+tw
+tw
+"}
+(30,1,1) = {"
+dG
+yF
+tw
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+Ao
+tw
+tw
+"}
+(31,1,1) = {"
+dG
+yF
+dG
+dG
+tw
+tw
+dG
+yF
+tw
+tw
+tw
+yF
+yF
+dG
+tw
+tw
+tw
+dG
+tw
+tw
+tw
+tw
+dG
+yF
+"}
+(32,1,1) = {"
+dG
+yF
+dG
+yF
+yF
+yF
+yF
+yF
+yF
+yF
+dG
+dG
+dG
+yF
+yF
+yF
+yF
+yF
+yF
+yF
+dG
+dG
+dG
+yF
 "}

--- a/modular_chomp/maps/submaps/shelters/TradingShip-40x22.dmm
+++ b/modular_chomp/maps/submaps/shelters/TradingShip-40x22.dmm
@@ -1,223 +1,3027 @@
-"aa" = (/obj/machinery/button/remote/blast_door{id = "tradestarshutters"; name = "remote shutter control"; pixel_x = 30; req_access = list(160)},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"aA" = (/obj/structure/shuttle/engine/propulsion{dir = 4; icon_state = "propulsion_l"},/turf/simulated/shuttle/plating/airless/carry,/area/survivalpod/superpose/TradingShip)
-"aP" = (/obj/effect/floor_decal/industrial/warning{dir = 10},/obj/structure/largecrate/animal/corgi,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"bf" = (/obj/structure/table/standard,/obj/item/stack/cable_coil,/obj/item/stack/cable_coil,/obj/item/clothing/gloves/yellow,/obj/item/clothing/gloves/yellow,/obj/item/clothing/gloves/yellow,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"bk" = (/obj/effect/floor_decal/industrial/warning{dir = 6},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"bm" = (/obj/structure/table/standard,/obj/item/clothing/suit/space/void/merc,/obj/item/clothing/suit/space/void/merc,/obj/item/clothing/suit/space/void/merc,/obj/item/clothing/shoes/magboots,/obj/item/clothing/shoes/magboots,/obj/item/clothing/shoes/magboots,/obj/item/clothing/head/helmet/space/void/merc,/obj/item/clothing/head/helmet/space/void/merc,/obj/item/clothing/head/helmet/space/void/merc,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"ca" = (/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/phoron,/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "fridge_sci"; icon_contents = "chem"; icon_state = "fridge_sci"; name = "Phoron storage"; pixel_y = 0},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"cC" = (/obj/machinery/atmospherics/pipe/simple/visible{dir = 10},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"cM" = (/obj/machinery/vending/medical{pixel_y = -32; req_access = null},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"cV" = (/obj/effect/floor_decal/industrial/warning{dir = 5},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"cX" = (/obj/structure/window/reinforced{dir = 1},/obj/machinery/door/blast/shutters{density = 0; dir = 2; icon_state = "shutter0"; id = "tradeportshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced,/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"ds" = (/obj/machinery/atmospherics/unary/engine/bigger{dir = 8},/turf/simulated/shuttle/plating/airless/carry,/area/survivalpod/superpose/TradingShip)
-"dy" = (/obj/machinery/atmospherics/pipe/manifold/visible{dir = 1},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"dP" = (/obj/effect/floor_decal/industrial/warning,/obj/structure/closet/crate/secure/loot,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"dY" = (/obj/machinery/light{dir = 4},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"dZ" = (/obj/structure/table/steel_reinforced,/obj/item/weapon/cell/high,/obj/item/weapon/cell/high,/obj/item/weapon/cell/hyper,/obj/item/weapon/cell/potato,/obj/structure/window/reinforced,/obj/item/weapon/cell/slime,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"es" = (/obj/structure/table/standard,/obj/item/stack/material/steel{amount = 2},/obj/item/stack/material/steel{amount = 2},/obj/item/stack/material/glass{amount = 15},/obj/item/stack/material/glass{amount = 15},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"eE" = (/obj/machinery/door/airlock/multi_tile/glass{dir = 2; req_access = null},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"eS" = (/obj/structure/table/rack,/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/item/device/kit/paint/ripley/death,/obj/item/device/kit/paint/ripley/flames_blue,/obj/item/device/kit/paint/ripley/flames_red,/obj/item/device/kit/paint/ripley,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"fe" = (/obj/machinery/mineral/mint{emagged = 1},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"fm" = (/obj/structure/bed/chair/comfy/black,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"fG" = (/obj/machinery/vending/cigarette{name = "hacked cigarette machine"; prices = list(); products = list(/obj/item/weapon/storage/fancy/cigarettes=10,/obj/item/weapon/storage/box/matches=10,/obj/item/weapon/flame/lighter/zippo=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"fJ" = (/obj/machinery/door/airlock/silver{name = "Restroom"},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/TradingShip)
-"fP" = (/obj/vehicle/train/engine,/obj/machinery/light{dir = 8},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"fU" = (/obj/machinery/door/window/northright{name = "Cargo Hold"; req_access = list(160)},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"gq" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"gA" = (/obj/machinery/light{dir = 8},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"gJ" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"hm" = (/obj/structure/table/steel_reinforced,/obj/machinery/button/remote/blast_door{id = "tradebridgeshutters"; name = "remote shutter control"; pixel_x = 30; req_access = list(150)},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"hx" = (/obj/structure/window/reinforced,/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "trade"; name = "Shop Shutters"; opacity = 0},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"hI" = (/obj/structure/closet,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"hK" = (/obj/machinery/autolathe{desc = "Your typical Autolathe. It appears to have much more options than your regular one, however..."; emagged = 1; hacked = 1; name = "Unlocked Autolathe"},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"ia" = (/obj/machinery/optable,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"jA" = (/obj/structure/fans/hardlight,/obj/machinery/door/airlock/multi_tile/metal/mait,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"jH" = (/obj/structure/table/standard,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"kd" = (/obj/machinery/atmospherics/pipe/simple/visible,/obj/machinery/meter,/obj/structure/largecrate/animal/cat,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"kw" = (/obj/machinery/embedded_controller/radio/simple_docking_controller{dir = 4; frequency = 1380; id_tag = "trade_shuttle"; pixel_x = -25; req_one_access = list(101); tag_door = "trade_shuttle_hatch"},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"kx" = (/obj/structure/frame/computer,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"kB" = (/obj/machinery/button/remote/blast_door{id = "tradeportshutters"; name = "remote shutter control"; pixel_x = 30; req_access = list(160)},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"kD" = (/obj/effect/floor_decal/industrial/warning{dir = 9},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"kO" = (/obj/machinery/door/window/northleft{name = "Cargo Hold"; req_access = list(160)},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"kU" = (/obj/machinery/access_button{master_tag = null; pixel_x = 27; pixel_y = -7; req_one_access = null},/obj/machinery/door/airlock/external{frequency = null; icon_state = "door_locked"; id_tag = null; locked = 1; name = "Ship Hatch"; req_access = null},/obj/structure/fans/hardlight,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"kV" = (/obj/structure/table/woodentable,/obj/item/weapon/card/id/external{access = list(160)},/obj/item/weapon/card/id/external{access = list(160)},/obj/item/weapon/card/id/external{access = list(160)},/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"lm" = (/obj/structure/closet/walllocker_double/north,/obj/item/device/gps,/obj/item/sticky_pad/random,/obj/item/device/starcaster_news,/obj/item/weapon/pen/blue,/obj/item/device/pda,/obj/item/weapon/card/id/external,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/gun/energy/locked/phasegun/pistol,/obj/item/weapon/material/knife/tacknife/survival,/obj/item/clothing/accessory/permit/gun,/obj/item/device/camera,/obj/item/device/binoculars,/obj/item/device/threadneedle,/obj/random/soap,/obj/item/weapon/towel/random,/obj/item/bodybag/cryobag,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/color/yellow,/obj/item/device/radio,/obj/item/device/radio,/obj/item/weapon/flame/lighter/random,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/device/suit_cooling_unit/emergency,/obj/item/stack/nanopaste,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,/obj/item/weapon/storage/backpack/messenger,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/clothing/accessory/poncho/thermal,/obj/item/weapon/storage/box/survival/comp,/obj/item/weapon/storage/toolbox/brass,/obj/item/weapon/storage/box/khcrystal,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"lv" = (/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "tradeportshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"lQ" = (/obj/structure/fans/hardlight,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"lW" = (/obj/structure/table/standard,/obj/item/weapon/storage/toolbox/mechanical,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"md" = (/obj/structure/salvageable/console_os{dir = 4},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"mi" = (/obj/structure/window/reinforced,/obj/machinery/door/blast/shutters{density = 0; icon_state = "shutter0"; id = "tradestarshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"mF" = (/obj/structure/mirror{pixel_y = 28},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/TradingShip)
-"mJ" = (/obj/structure/table/standard,/obj/item/clothing/gloves/sterile/latex,/obj/item/clothing/mask/surgical,/obj/item/weapon/surgical/retractor{pixel_y = 6},/obj/item/weapon/surgical/scalpel,/obj/item/weapon/surgical/surgicaldrill,/obj/item/weapon/surgical/circular_saw,/obj/item/stack/nanopaste,/obj/item/weapon/surgical/hemostat{pixel_y = 4},/obj/item/weapon/surgical/cautery{pixel_y = 4},/obj/item/weapon/surgical/FixOVein{pixel_x = -6; pixel_y = 1},/obj/item/stack/medical/advanced/bruise_pack,/obj/item/weapon/surgical/bonesetter,/obj/item/weapon/surgical/bonegel{pixel_x = 4; pixel_y = 3},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"mK" = (/obj/machinery/light{dir = 1},/obj/structure/bookcase,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"mR" = (/obj/item/weapon/paper_bin{pixel_x = -3; pixel_y = 8},/obj/item/weapon/pen{pixel_y = 4},/obj/machinery/light,/obj/structure/table/glass,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"mY" = (/obj/structure/table/steel_reinforced,/obj/item/weapon/coin/uranium,/obj/item/weapon/coin/silver,/obj/item/weapon/coin/platinum,/obj/item/weapon/coin/phoron,/obj/item/weapon/coin/iron,/obj/item/weapon/coin/gold,/obj/item/weapon/coin/diamond,/obj/structure/window/reinforced,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"nh" = (/obj/machinery/door/airlock/external{frequency = null; icon_state = "door_locked"; id_tag = null; locked = 1; name = "Ship Hatch"; req_access = null},/obj/machinery/atmospherics/pipe/simple/visible,/obj/structure/fans/hardlight,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"nC" = (/obj/structure/table/steel_reinforced,/obj/item/clothing/head/bearpelt,/obj/item/clothing/head/bowler,/obj/item/clothing/head/caphat/cap,/obj/item/clothing/head/beaverhat,/obj/item/clothing/head/beret/centcom,/obj/item/clothing/head/beret/sec,/obj/item/clothing/head/collectable/kitty,/obj/item/clothing/head/collectable/kitty,/obj/item/clothing/head/collectable/kitty,/obj/item/clothing/head/collectable/rabbitears,/obj/item/clothing/head/collectable/rabbitears,/obj/item/clothing/head/collectable/rabbitears,/obj/item/clothing/head/collectable/petehat,/obj/item/clothing/head/collectable/pirate,/obj/item/clothing/head/collectable/wizard,/obj/item/clothing/head/collectable/xenom,/obj/item/clothing/head/pin/flower/violet,/obj/item/clothing/head/pin/flower/blue,/obj/item/clothing/head/pin/flower/orange,/obj/item/clothing/head/pin/flower/pink,/obj/item/clothing/head/justice,/obj/item/clothing/head/justice/blue,/obj/item/clothing/head/justice/green,/obj/item/clothing/head/justice/pink,/obj/item/clothing/head/justice/yellow,/obj/item/clothing/head/philosopher_wig,/obj/item/clothing/head/plaguedoctorhat,/obj/item/clothing/head/xenos,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"nD" = (/obj/structure/table/steel_reinforced,/obj/random/firstaid,/obj/random/firstaid,/obj/random/firstaid,/obj/random/firstaid,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"nT" = (/obj/machinery/vending/sovietsoda,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"nW" = (/obj/machinery/vending/snack{name = "hacked Getmore Chocolate Corp"; prices = list()},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"oi" = (/obj/structure/table/steel_reinforced,/obj/random/medical,/obj/random/medical,/obj/random/medical,/obj/random/medical,/obj/structure/window/reinforced,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"pl" = (/obj/machinery/door/airlock/glass_engineering{name = "Engineering"; req_access = null; req_one_access = null},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"pr" = (/obj/machinery/door/airlock/silver{name = "Toilet"},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/TradingShip)
-"pU" = (/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "tradestarshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"qc" = (/obj/structure/table/woodentable,/obj/item/weapon/paper_bin{pixel_x = -3; pixel_y = 8},/obj/item/weapon/pen{pixel_y = 4},/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"qo" = (/obj/machinery/door/blast/shutters{density = 0; dir = 2; icon_state = "shutter0"; id = "tradebridgeshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"qz" = (/obj/effect/floor_decal/industrial/warning,/obj/structure/largecrate/animal/corgi,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"qT" = (/obj/machinery/door/window/southright{name = "Cargo Hold"; req_access = list(160)},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"qV" = (/obj/effect/floor_decal/industrial/warning{dir = 9},/obj/structure/largecrate/animal/cat,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"rf" = (/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"rg" = (/obj/structure/flora/pottedplant{icon_state = "plant-10"},/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"ri" = (/obj/machinery/door/airlock/command{name = "Captain's Quarters"; req_access = null; req_one_access = null},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"rq" = (/obj/machinery/door/blast/shutters{density = 0; icon_state = "shutter0"; id = "tradebridgeshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"rx" = (/obj/machinery/door/window/westright{name = "Storefront"; req_access = list(160)},/obj/structure/table/marble,/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "trade"; name = "Shop Shutters"; opacity = 0},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/TradingShip)
-"rG" = (/obj/structure/window/reinforced{dir = 1},/obj/machinery/door/blast/shutters{density = 0; dir = 2; icon_state = "shutter0"; id = "tradeportshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"se" = (/obj/structure/curtain/open/shower,/obj/machinery/shower{pixel_y = 3},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/TradingShip)
-"sh" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/closet/crate/secure/loot,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"sj" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"sT" = (/obj/machinery/bodyscanner{dir = 8},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"th" = (/obj/machinery/iv_drip,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"tu" = (/obj/structure/sink{dir = 8; pixel_x = -12; pixel_y = 2},/obj/machinery/light/small,/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/TradingShip)
-"tx" = (/obj/machinery/door/airlock/command{name = "Bridge"; req_access = null; req_one_access = null},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"tN" = (/obj/structure/bed/chair/office/dark{dir = 8},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/TradingShip)
-"tQ" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced,/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"tX" = (/obj/effect/floor_decal/industrial/warning,/obj/structure/largecrate/hoverpod,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"ua" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/glasses/square,/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"uo" = (/obj/structure/closet/crate,/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/fiftyspawner/blucarpet,/obj/fiftyspawner/oracarpet,/obj/fiftyspawner/purcarpet,/obj/fiftyspawner/sblucarpet,/obj/fiftyspawner/tealcarpet,/obj/fiftyspawner/turcarpet,/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/algae{amount = 50},/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/lead{amount = 30},/obj/item/stack/material/plasteel{amount = 30; pixel_y = 5},/obj/item/stack/material/resin{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"uv" = (/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"uA" = (/obj/structure/table/rack,/obj/effect/floor_decal/industrial/warning,/obj/item/device/kit/paint/gygax/darkgygax,/obj/item/device/kit/paint/gygax/recitence,/obj/item/device/kit/paint/durand,/obj/item/device/kit/paint/durand/phazon,/obj/item/device/kit/paint/durand/seraph,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"uL" = (/obj/machinery/light,/obj/structure/table/standard,/obj/item/weapon/soap,/obj/item/weapon/towel{color = "#0000FF"},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"uR" = (/obj/structure/toilet,/obj/machinery/light/small{dir = 1},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/TradingShip)
-"vs" = (/obj/effect/floor_decal/industrial/warning{dir = 10},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"vC" = (/obj/machinery/vending/assist{contraband = null; name = "Old Vending Machine"; products = list(/obj/item/device/assembly/prox_sensor=5,/obj/item/device/assembly/signaler=4,/obj/item/device/assembly/infra=4,/obj/item/device/assembly/prox_sensor=4,/obj/item/weapon/handcuffs=8,/obj/item/device/flash=4,/obj/item/weapon/cartridge/signal=4,/obj/item/clothing/glasses/sunglasses=4)},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"vL" = (/obj/machinery/vending/boozeomat{req_access = null},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"vM" = (/obj/structure/bed/chair{dir = 4},/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"wn" = (/obj/structure/flora/pottedplant{icon_state = "plant-22"},/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"wz" = (/obj/machinery/atmospherics/pipe/simple/visible,/obj/machinery/door/airlock/external{frequency = null; icon_state = "door_locked"; id_tag = null; locked = 1; name = "Ship Hatch"; req_access = null},/obj/machinery/access_button{dir = 1; master_tag = null; pixel_x = -27; pixel_y = 7; req_one_access = null},/obj/structure/fans/hardlight,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"wT" = (/obj/machinery/door/window/southleft{name = "Cargo Hold"; req_access = list(160)},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"xd" = (/obj/structure/table/steel_reinforced,/obj/random/tech_supply,/obj/random/tech_supply,/obj/random/tech_supply,/obj/random/tech_supply,/obj/random/tech_supply,/obj/random/tech_supply,/obj/item/weapon/weldpack,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"xi" = (/obj/structure/table/steel_reinforced,/obj/item/weapon/inflatable_duck,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/obj/random/tech_supply/nofail,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"xz" = (/obj/structure/window/reinforced,/obj/machinery/door/blast/shutters{density = 0; icon_state = "shutter0"; id = "tradestarshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"xF" = (/obj/structure/closet/wardrobe/pjs,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"xM" = (/obj/machinery/light/small{dir = 4},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"xZ" = (/obj/structure/filingcabinet/filingcabinet,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"yw" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/rd,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"yx" = (/obj/structure/table/steel_reinforced,/obj/item/weapon/rig/internalaffairs,/obj/item/clothing/head/helmet/space/void/wizard,/obj/item/clothing/suit/space/void/wizard,/obj/item/device/survivalcapsule/luxury,/obj/item/device/survivalcapsule/luxurybar,/obj/item/device/survivalcapsule/tabiranth,/obj/item/device/survivalcapsule,/obj/item/device/survivalcapsule,/obj/item/device/survivalcapsule,/obj/item/device/survivalcapsule/luxury,/obj/item/device/survivalcapsule/luxury,/obj/item/device/survivalcapsule/superpose,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"yN" = (/obj/machinery/photocopier,/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"yS" = (/obj/structure/closet/crate,/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil/green,/obj/item/stack/cable_coil/blue,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"zh" = (/obj/machinery/light{dir = 1},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"zN" = (/obj/machinery/button/remote/blast_door{id = "trade"; name = "Shop Shutters"; pixel_y = -26},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/TradingShip)
-"Au" = (/obj/structure/shuttle/engine/propulsion{dir = 4; icon_state = "propulsion_r"},/turf/simulated/shuttle/plating/airless/carry,/area/survivalpod/superpose/TradingShip)
-"AL" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 1; id_tag = null},/obj/machinery/embedded_controller/radio/airlock/airlock_controller{dir = 4; frequency = 1331; id_tag = "trade2_control"; pixel_x = -25; req_access = list(150); tag_airpump = null; tag_chamber_sensor = null; tag_exterior_door = null; tag_interior_door = null},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"AR" = (/obj/structure/closet/walllocker/emerglocker{pixel_y = -32},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Be" = (/obj/structure/shuttle/engine/heater{dir = 4},/turf/simulated/shuttle/plating/airless,/area/survivalpod/superpose/TradingShip)
-"BH" = (/obj/structure/table/steel_reinforced,/obj/item/clothing/gloves/black,/obj/item/clothing/gloves/blue,/obj/item/clothing/gloves/brown,/obj/item/clothing/gloves/captain,/obj/item/clothing/gloves/combat,/obj/item/clothing/gloves/green,/obj/item/clothing/gloves/grey,/obj/item/clothing/gloves/light_brown,/obj/item/clothing/gloves/purple,/obj/item/clothing/gloves/rainbow,/obj/item/clothing/gloves/swat,/obj/item/clothing/gloves/white,/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"BU" = (/obj/structure/bed/chair,/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"Cu" = (/obj/structure/bed/chair/comfy/black{dir = 1},/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"CV" = (/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/TradingShip)
-"DT" = (/obj/machinery/light,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"DX" = (/obj/structure/table/steel_reinforced,/obj/random/tool,/obj/random/tool,/obj/random/tool,/obj/random/tool,/obj/random/tool,/obj/item/slimepotion/stabilizer,/obj/item/slimepotion/steroid,/obj/item/slimepotion/unity,/obj/item/slimepotion/friendship,/obj/item/slimepotion/friendship,/obj/item/slimepotion/feeding,/obj/item/slimepotion/docility,/obj/item/slimepotion/enhancer,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"EK" = (/obj/machinery/door/airlock/silver{name = "Sleeping"},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"ET" = (/obj/structure/undies_wardrobe,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Fy" = (/obj/structure/table/woodentable,/obj/item/weapon/card/id/casino{desc = "An alien id card with strange glowing markings."; icon_state = "changeling"; name = "Alien id"},/obj/item/weapon/card/id/casino{desc = "An alien id card with strange glowing markings."; icon_state = "changeling"; name = "Alien id"},/obj/item/weapon/card/id/casino{desc = "An alien id card with strange glowing markings."; icon_state = "changeling"; name = "Alien id"},/obj/item/weapon/card/id/casino{desc = "An alien id card with strange glowing markings."; icon_state = "changeling"; name = "Alien id"},/obj/item/weapon/card/id/casino{desc = "An alien id card with strange glowing markings."; icon_state = "changeling"; name = "Alien id"},/obj/item/weapon/card/id/casino{desc = "An alien id card with strange glowing markings."; icon_state = "changeling"; name = "Alien id"},/obj/item/weapon/card/id/casino{desc = "An alien id card with strange glowing markings."; icon_state = "changeling"; name = "Alien id"},/obj/item/weapon/card/id/casino{desc = "An alien id card with strange glowing markings."; icon_state = "changeling"; name = "Alien id"},/obj/item/weapon/card/id/casino{desc = "An alien id card with strange glowing markings."; icon_state = "changeling"; name = "Alien id"},/obj/item/weapon/card/id/casino{desc = "An alien id card with strange glowing markings."; icon_state = "changeling"; name = "Alien id"},/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"FL" = (/obj/machinery/door/window/westleft{name = "Storefront"; req_access = list(160)},/obj/structure/window/reinforced,/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "trade"; name = "Shop Shutters"; opacity = 0},/obj/structure/table/marble,/obj/machinery/cash_register/civilian{dir = 4},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/TradingShip)
-"FW" = (/obj/machinery/door/airlock/external{frequency = null; icon_state = "door_locked"; id_tag = null; locked = 1; name = "Ship Hatch"; req_access = null},/obj/structure/fans/hardlight,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"Gb" = (/obj/machinery/light,/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"Gk" = (/obj/structure/table/standard,/obj/machinery/chemical_dispenser/bar_alc/full,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"GN" = (/obj/machinery/light/small{dir = 4},/obj/machinery/airlock_sensor{dir = 8; id_tag = null; pixel_x = 27},/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 1; id_tag = null},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"GS" = (/obj/effect/floor_decal/industrial/warning{dir = 6},/obj/mecha/working/ripley/firefighter,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"GU" = (/obj/machinery/light{dir = 4},/obj/machinery/vending/foodstuffing,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Hh" = (/obj/structure/table/steel_reinforced,/obj/random/action_figure,/obj/random/action_figure,/obj/random/action_figure,/obj/random/action_figure,/obj/random/action_figure,/obj/random/action_figure,/obj/random/curseditem,/obj/random/curseditem,/obj/random/curseditem,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Hp" = (/obj/structure/table/standard,/obj/item/weapon/storage/box/donkpockets,/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"HB" = (/obj/machinery/atmospherics/pipe/simple/visible,/obj/structure/closet/crate/solar,/obj/machinery/light{dir = 8},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"HC" = (/obj/structure/table/standard,/obj/machinery/microwave,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"HP" = (/obj/structure/closet/walllocker/emerglocker{pixel_y = 32},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Ii" = (/obj/machinery/computer/arcade/battle,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"IL" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"Jg" = (/obj/structure/window/reinforced,/obj/machinery/door/blast/shutters{density = 0; icon_state = "shutter0"; id = "tradestarshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"JF" = (/obj/machinery/vending/foodasian,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"JI" = (/obj/structure/window/reinforced{dir = 1},/obj/machinery/door/blast/shutters{density = 0; dir = 2; icon_state = "shutter0"; id = "tradeportshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced,/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"JN" = (/obj/machinery/body_scanconsole,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Km" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/largecrate/animal/cow,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Ko" = (/obj/structure/table/glass,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Kv" = (/obj/structure/table/steel_reinforced,/obj/item/weapon/lipstick/black,/obj/item/weapon/lipstick/jade,/obj/item/weapon/lipstick/purple,/obj/item/weapon/lipstick,/obj/item/weapon/lipstick/random,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Lp" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/table/steel_reinforced,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Lt" = (/obj/structure/table/steel_reinforced,/obj/item/clothing/under/cheongsam,/obj/item/clothing/under/hosformalmale,/obj/item/clothing/under/hosformalfem,/obj/item/clothing/under/harness,/obj/item/clothing/under/gladiator,/obj/item/clothing/under/ert,/obj/item/clothing/under/schoolgirl,/obj/item/clothing/under/redcoat,/obj/item/clothing/under/sexymime,/obj/item/clothing/under/sexyclown,/obj/item/clothing/under/soviet,/obj/item/clothing/under/space,/obj/item/clothing/under/swimsuit/stripper/mankini,/obj/item/clothing/under/suit_jacket/female,/obj/item/clothing/under/rank/psych/turtleneck,/obj/item/clothing/under/syndicate/combat,/obj/item/clothing/under/syndicate/combat,/obj/item/clothing/under/syndicate/tacticool,/obj/item/clothing/under/syndicate/tacticool,/obj/item/clothing/under/dress/sailordress,/obj/item/clothing/under/dress/redeveninggown,/obj/item/clothing/under/dress/dress_saloon,/obj/item/clothing/under/dress/blacktango,/obj/item/clothing/under/dress/blacktango/alt,/obj/item/clothing/under/dress/dress_orange,/obj/item/clothing/under/dress/maid/janitor,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"LX" = (/obj/machinery/vending/foodfish,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Mc" = (/turf/template_noop,/area/template_noop)
-"Mk" = (/obj/effect/floor_decal/industrial/warning,/obj/structure/closet/crate/internals,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"MO" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/captain,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"MP" = (/obj/structure/table/steel_reinforced,/obj/item/clothing/accessory/holster/hip,/obj/item/clothing/accessory/holster/armpit,/obj/item/clothing/accessory/holster/armpit,/obj/item/clothing/accessory/holster/hip,/obj/item/clothing/accessory/storage/white_vest,/obj/item/clothing/accessory/storage/white_vest,/obj/item/clothing/accessory/storage/webbing,/obj/item/clothing/accessory/storage/webbing,/obj/item/clothing/accessory/storage/black_vest,/obj/item/clothing/accessory/storage/black_vest,/obj/item/clothing/accessory/storage/brown_vest,/obj/item/clothing/accessory/storage/brown_vest,/obj/item/clothing/accessory/scarf/white,/obj/item/clothing/accessory/scarf/lightblue,/obj/item/clothing/accessory/scarf/red,/obj/item/clothing/accessory/scarf/purple,/obj/item/clothing/accessory/armband/science,/obj/item/clothing/accessory/armband/med,/obj/item/clothing/accessory/armband/engine,/obj/item/clothing/accessory/armband/cargo,/obj/item/clothing/accessory/armband,/obj/item/clothing/accessory/medal/nobel_science,/obj/item/clothing/accessory/medal/silver,/obj/item/clothing/accessory/medal/gold,/obj/item/clothing/accessory/medal/bronze_heart,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"MT" = (/turf/simulated/shuttle/wall/dark,/area/survivalpod/superpose/TradingShip)
-"No" = (/obj/machinery/atmospherics/pipe/simple/visible{dir = 5},/obj/machinery/atm{pixel_x = -32},/obj/machinery/meter,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Nq" = (/obj/effect/floor_decal/industrial/warning{dir = 5},/obj/mecha/working/ripley/mining,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"NE" = (/obj/vehicle/train/trolley,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"NJ" = (/obj/structure/bed/chair{dir = 8},/obj/machinery/computer/security/telescreen/entertainment{icon_state = "frame"; pixel_x = 32},/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"NQ" = (/obj/machinery/sleeper{dir = 4},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Od" = (/obj/item/weapon/storage/firstaid/regular{pixel_x = -2; pixel_y = 4},/obj/item/weapon/storage/firstaid/regular{pixel_x = -2; pixel_y = 4},/obj/item/bodybag/cryobag{pixel_x = 5},/obj/item/bodybag/cryobag{pixel_x = 5},/obj/item/weapon/storage/firstaid/o2{layer = 2.8; pixel_x = 4; pixel_y = 6},/obj/item/weapon/storage/box/masks,/obj/item/weapon/storage/box/gloves{pixel_x = 3; pixel_y = 4},/obj/item/weapon/storage/firstaid/toxin,/obj/item/weapon/storage/firstaid/fire{layer = 2.9; pixel_x = 2; pixel_y = 3},/obj/item/weapon/storage/firstaid/adv{pixel_x = -2},/obj/item/weapon/reagent_containers/blood/empty,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/item/weapon/reagent_containers/blood/OMinus,/obj/structure/closet/medical_wall{pixel_y = 32},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"OE" = (/obj/structure/bed/chair/office/dark,/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"OK" = (/obj/structure/table/steel_reinforced,/obj/item/clothing/suit/hgpirate,/obj/item/clothing/suit/imperium_monk,/obj/item/clothing/suit/leathercoat,/obj/item/clothing/suit/justice,/obj/item/clothing/suit/justice,/obj/item/clothing/suit/justice,/obj/item/clothing/suit/justice,/obj/item/clothing/suit/justice,/obj/item/clothing/suit/pirate,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Pb" = (/obj/machinery/light{dir = 4},/obj/structure/sign/kiddieplaque{desc = "A plaque commemorating the construction of the cargo ship Beruang."; name = "Beruang"; pixel_x = 32},/mob/living/simple_mob/animal/passive/dog/tamaskan/Spice,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/TradingShip)
-"Pv" = (/obj/machinery/atm{pixel_x = -32},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"PW" = (/obj/structure/table/steel_reinforced,/obj/structure/flora/pottedplant{icon_state = "plant-09"; name = "Esteban"; pixel_y = 8},/obj/machinery/newscaster{pixel_x = 32},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Qm" = (/obj/structure/closet/wardrobe/captain,/obj/item/weapon/gun/projectile/revolver/mateba,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Qp" = (/obj/machinery/newscaster{pixel_y = 32},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"QB" = (/obj/machinery/sleep_console,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"QQ" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"Ry" = (/obj/structure/table/steel_reinforced,/obj/item/weapon/paper_bin{pixel_x = -3; pixel_y = 8},/obj/item/weapon/pen{pixel_y = 4},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Sp" = (/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Sy" = (/obj/machinery/atmospherics/pipe/tank/air{start_pressure = 740.5},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"SE" = (/turf/simulated/shuttle/wall/dark/hard_corner,/area/survivalpod/superpose/TradingShip)
-"SI" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/largecrate/hoverpod,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"SR" = (/obj/machinery/vending/tool{emagged = 1},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"SV" = (/obj/structure/closet/crate/secure/weapon,/obj/item/stack/material/phoron{material = 50},/obj/item/stack/material/phoron{material = 50},/obj/item/stack/material/phoron{material = 50},/obj/item/stack/material/phoron{material = 50},/obj/random/cash/huge,/obj/random/cash/huge,/obj/random/cash/huge,/obj/random/cash/huge,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Tb" = (/obj/structure/bed/chair{dir = 8},/turf/simulated/floor/carpet,/area/survivalpod/superpose/TradingShip)
-"TJ" = (/obj/structure/bed/padded,/obj/item/weapon/bedsheet/hos,/obj/structure/sign/poster{pixel_y = -32},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"TK" = (/obj/machinery/door/airlock/multi_tile/glass,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"TU" = (/obj/machinery/door/blast/shutters{density = 0; icon_state = "shutter0"; id = "tradebridgeshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/window/reinforced{dir = 4},/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"Uw" = (/obj/machinery/vending/coffee,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Uy" = (/obj/structure/closet{name = "custodial"},/obj/item/weapon/reagent_containers/spray/cleaner,/obj/item/weapon/reagent_containers/glass/bucket,/obj/item/weapon/mop,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Uz" = (/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "tradestarshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"VL" = (/obj/machinery/vending/engivend{emagged = 1},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"VP" = (/obj/machinery/door/airlock/glass_medical{name = "Medical Bay"; req_access = null; req_one_access = null},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"VX" = (/obj/structure/table/steel_reinforced,/obj/random/toolbox,/obj/random/toolbox,/obj/random/toolbox,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"VY" = (/obj/machinery/suit_cycler/syndicate,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Wy" = (/obj/structure/table/steel_reinforced,/obj/random/contraband,/obj/random/contraband,/obj/random/contraband,/obj/random/contraband,/obj/random/contraband,/obj/random/contraband,/obj/item/weapon/bikehorn,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"WG" = (/obj/machinery/door/blast/shutters{density = 0; dir = 2; icon_state = "shutter0"; id = "tradebridgeshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/window/reinforced{dir = 4},/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"WK" = (/obj/structure/table/steel_reinforced,/obj/item/stack/material/mhydrogen,/obj/item/stack/material/diamond,/obj/item/stack/material/sandstone,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"WL" = (/obj/machinery/door/window/westleft{name = "Storefront"; req_access = list(160)},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Xi" = (/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "tradebridgeshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"Xy" = (/obj/structure/noticeboard{pixel_y = 32},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"XH" = (/obj/machinery/door/airlock/multi_tile/glass{req_access = null},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/TradingShip)
-"XL" = (/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "tradeportshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced,/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
-"XO" = (/turf/simulated/shuttle/plating/airless/carry,/area/survivalpod/superpose/TradingShip)
-"Yc" = (/obj/structure/sign/poster{pixel_y = -32},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Yi" = (/obj/structure/table/steel_reinforced,/obj/random/plushie,/obj/random/plushie,/obj/random/plushie,/obj/random/plushie,/obj/random/plushie,/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"Zs" = (/obj/structure/bed/chair{dir = 8},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/TradingShip)
-"ZD" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/closet/crate/freezer/rations,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/TradingShip)
-"ZX" = (/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "tradebridgeshutters"; name = "Blast Shutters"; opacity = 0},/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced/full,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TradingShip)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/machinery/button/remote/blast_door{
+	id = "tradestarshutters";
+	name = "remote shutter control";
+	pixel_x = 30;
+	req_access = list(160)
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"aA" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "propulsion_l"
+	},
+/turf/simulated/shuttle/plating/airless/carry,
+/area/survivalpod/superpose/TradingShip)
+"aP" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/structure/largecrate/animal/corgi,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"bf" = (
+/obj/structure/table/standard,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"bk" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"bm" = (
+/obj/structure/table/standard,
+/obj/item/clothing/suit/space/void/merc,
+/obj/item/clothing/suit/space/void/merc,
+/obj/item/clothing/suit/space/void/merc,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/shoes/magboots,
+/obj/item/clothing/head/helmet/space/void/merc,
+/obj/item/clothing/head/helmet/space/void/merc,
+/obj/item/clothing/head/helmet/space/void/merc,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"ca" = (
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/phoron,
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "fridge_sci";
+	icon_contents = "chem";
+	icon_state = "fridge_sci";
+	name = "Phoron storage";
+	pixel_y = 0
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"cC" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 10
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"cM" = (
+/obj/machinery/vending/medical{
+	pixel_y = -32;
+	req_access = null
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"cV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"cX" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "tradeportshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"ds" = (
+/obj/machinery/atmospherics/unary/engine/bigger{
+	dir = 8
+	},
+/turf/simulated/shuttle/plating/airless/carry,
+/area/survivalpod/superpose/TradingShip)
+"dy" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"dP" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/closet/crate/secure/loot,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"dY" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"dZ" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/hyper,
+/obj/item/weapon/cell/potato,
+/obj/structure/window/reinforced,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"es" = (
+/obj/structure/table/standard,
+/obj/item/stack/material/steel{
+	amount = 2
+	},
+/obj/item/stack/material/steel{
+	amount = 2
+	},
+/obj/item/stack/material/glass{
+	amount = 15
+	},
+/obj/item/stack/material/glass{
+	amount = 15
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"eE" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	dir = 2;
+	req_access = null
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"eS" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/item/device/kit/paint/ripley/death,
+/obj/item/device/kit/paint/ripley/flames_blue,
+/obj/item/device/kit/paint/ripley/flames_red,
+/obj/item/device/kit/paint/ripley,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"fe" = (
+/obj/machinery/mineral/mint{
+	emagged = 1
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"fm" = (
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"fG" = (
+/obj/machinery/vending/cigarette{
+	name = "hacked cigarette machine";
+	prices = list();
+	products = list(/obj/item/weapon/storage/fancy/cigarettes=10,/obj/item/weapon/storage/box/matches=10,/obj/item/weapon/flame/lighter/zippo=4,/obj/item/clothing/mask/smokable/cigarette/cigar/havana=2)
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"fJ" = (
+/obj/machinery/door/airlock/silver{
+	name = "Restroom"
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/TradingShip)
+"fP" = (
+/obj/vehicle/train/engine,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"fU" = (
+/obj/machinery/door/window/northright{
+	name = "Cargo Hold";
+	req_access = list(160)
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"gq" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"gA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"gJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"hm" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/button/remote/blast_door{
+	id = "tradebridgeshutters";
+	name = "remote shutter control";
+	pixel_x = 30;
+	req_access = list(150)
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"hx" = (
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "trade";
+	name = "Shop Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"hI" = (
+/obj/structure/closet,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"hK" = (
+/obj/machinery/autolathe{
+	desc = "Your typical Autolathe. It appears to have much more options than your regular one, however...";
+	emagged = 1;
+	hacked = 1;
+	name = "Unlocked Autolathe"
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"ia" = (
+/obj/machinery/optable,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"jA" = (
+/obj/structure/fans/hardlight,
+/obj/machinery/door/airlock/multi_tile/metal/mait,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"jH" = (
+/obj/structure/table/standard,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"kd" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/meter,
+/obj/structure/largecrate/animal/cat,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"kw" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	dir = 4;
+	frequency = 1380;
+	id_tag = "trade_shuttle";
+	pixel_x = -25;
+	req_one_access = list(101);
+	tag_door = "trade_shuttle_hatch"
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"kx" = (
+/obj/structure/frame/computer,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"kB" = (
+/obj/machinery/button/remote/blast_door{
+	id = "tradeportshutters";
+	name = "remote shutter control";
+	pixel_x = 30;
+	req_access = list(160)
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"kD" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"kO" = (
+/obj/machinery/door/window/northleft{
+	name = "Cargo Hold";
+	req_access = list(160)
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"kU" = (
+/obj/machinery/access_button{
+	master_tag = null;
+	pixel_x = 27;
+	pixel_y = -7;
+	req_one_access = null
+	},
+/obj/machinery/door/airlock/external{
+	frequency = null;
+	icon_state = "door_locked";
+	id_tag = null;
+	locked = 1;
+	name = "Ship Hatch";
+	req_access = null
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"kV" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/card/id/external{
+	access = list(160)
+	},
+/obj/item/weapon/card/id/external{
+	access = list(160)
+	},
+/obj/item/weapon/card/id/external{
+	access = list(160)
+	},
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"lm" = (
+/obj/structure/closet/walllocker_double/north,
+/obj/item/device/gps,
+/obj/item/sticky_pad/random,
+/obj/item/device/starcaster_news,
+/obj/item/weapon/pen/blue,
+/obj/item/device/pda,
+/obj/item/weapon/card/id/external,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/gun/energy/locked/phasegun/pistol,
+/obj/item/weapon/material/knife/tacknife/survival,
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/device/camera,
+/obj/item/device/binoculars,
+/obj/item/device/threadneedle,
+/obj/random/soap,
+/obj/item/weapon/towel/random,
+/obj/item/bodybag/cryobag,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/color/yellow,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/weapon/flame/lighter/random,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/stack/nanopaste,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,
+/obj/item/weapon/storage/backpack/messenger,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/clothing/accessory/poncho/thermal,
+/obj/item/weapon/storage/box/survival/comp,
+/obj/item/weapon/storage/toolbox/brass,
+/obj/item/weapon/storage/box/khcrystal,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"lv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "tradeportshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"lQ" = (
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"lW" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"md" = (
+/obj/structure/salvageable/console_os{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"mi" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "tradestarshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"mF" = (
+/obj/structure/mirror{
+	pixel_y = 28
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/TradingShip)
+"mJ" = (
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/weapon/surgical/retractor{
+	pixel_y = 6
+	},
+/obj/item/weapon/surgical/scalpel,
+/obj/item/weapon/surgical/surgicaldrill,
+/obj/item/weapon/surgical/circular_saw,
+/obj/item/stack/nanopaste,
+/obj/item/weapon/surgical/hemostat{
+	pixel_y = 4
+	},
+/obj/item/weapon/surgical/cautery{
+	pixel_y = 4
+	},
+/obj/item/weapon/surgical/FixOVein{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/stack/medical/advanced/bruise_pack,
+/obj/item/weapon/surgical/bonesetter,
+/obj/item/weapon/surgical/bonegel{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"mK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bookcase,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"mR" = (
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/weapon/pen{
+	pixel_y = 4
+	},
+/obj/machinery/light,
+/obj/structure/table/glass,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"mY" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/coin/uranium,
+/obj/item/weapon/coin/silver,
+/obj/item/weapon/coin/platinum,
+/obj/item/weapon/coin/phoron,
+/obj/item/weapon/coin/iron,
+/obj/item/weapon/coin/gold,
+/obj/item/weapon/coin/diamond,
+/obj/structure/window/reinforced,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"nh" = (
+/obj/machinery/door/airlock/external{
+	frequency = null;
+	icon_state = "door_locked";
+	id_tag = null;
+	locked = 1;
+	name = "Ship Hatch";
+	req_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"nC" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/clothing/head/bearpelt,
+/obj/item/clothing/head/bowler,
+/obj/item/clothing/head/caphat/cap,
+/obj/item/clothing/head/beaverhat,
+/obj/item/clothing/head/beret/centcom,
+/obj/item/clothing/head/beret/sec,
+/obj/item/clothing/head/collectable/kitty,
+/obj/item/clothing/head/collectable/kitty,
+/obj/item/clothing/head/collectable/kitty,
+/obj/item/clothing/head/collectable/rabbitears,
+/obj/item/clothing/head/collectable/rabbitears,
+/obj/item/clothing/head/collectable/rabbitears,
+/obj/item/clothing/head/collectable/petehat,
+/obj/item/clothing/head/collectable/pirate,
+/obj/item/clothing/head/collectable/wizard,
+/obj/item/clothing/head/collectable/xenom,
+/obj/item/clothing/head/pin/flower/violet,
+/obj/item/clothing/head/pin/flower/blue,
+/obj/item/clothing/head/pin/flower/orange,
+/obj/item/clothing/head/pin/flower/pink,
+/obj/item/clothing/head/justice,
+/obj/item/clothing/head/justice/blue,
+/obj/item/clothing/head/justice/green,
+/obj/item/clothing/head/justice/pink,
+/obj/item/clothing/head/justice/yellow,
+/obj/item/clothing/head/philosopher_wig,
+/obj/item/clothing/head/plaguedoctorhat,
+/obj/item/clothing/head/xenos,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"nD" = (
+/obj/structure/table/steel_reinforced,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/obj/random/firstaid,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"nT" = (
+/obj/machinery/vending/sovietsoda,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"nW" = (
+/obj/machinery/vending/snack{
+	name = "hacked Getmore Chocolate Corp";
+	prices = list()
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"oi" = (
+/obj/structure/table/steel_reinforced,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/random/medical,
+/obj/structure/window/reinforced,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"pl" = (
+/obj/machinery/door/airlock/glass_engineering{
+	name = "Engineering";
+	req_access = null;
+	req_one_access = null
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"pr" = (
+/obj/machinery/door/airlock/silver{
+	name = "Toilet"
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/TradingShip)
+"pU" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "tradestarshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"qc" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/weapon/pen{
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"qo" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "tradebridgeshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"qz" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/largecrate/animal/corgi,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"qT" = (
+/obj/machinery/door/window/southright{
+	name = "Cargo Hold";
+	req_access = list(160)
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"qV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/structure/largecrate/animal/cat,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"rf" = (
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"rg" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-10"
+	},
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"ri" = (
+/obj/machinery/door/airlock/command{
+	name = "Captain's Quarters";
+	req_access = null;
+	req_one_access = null
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"rq" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "tradebridgeshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"rx" = (
+/obj/machinery/door/window/westright{
+	name = "Storefront";
+	req_access = list(160)
+	},
+/obj/structure/table/marble,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "trade";
+	name = "Shop Shutters";
+	opacity = 0
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/TradingShip)
+"rG" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "tradeportshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"se" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	pixel_y = 3
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/TradingShip)
+"sh" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/closet/crate/secure/loot,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"sj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"sT" = (
+/obj/machinery/bodyscanner{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"th" = (
+/obj/machinery/iv_drip,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"tu" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/light/small,
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/TradingShip)
+"tx" = (
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	req_access = null;
+	req_one_access = null
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"tN" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/TradingShip)
+"tQ" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"tX" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/largecrate/hoverpod,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"ua" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/glasses/square,
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"uo" = (
+/obj/structure/closet/crate,
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/fiftyspawner/blucarpet,
+/obj/fiftyspawner/oracarpet,
+/obj/fiftyspawner/purcarpet,
+/obj/fiftyspawner/sblucarpet,
+/obj/fiftyspawner/tealcarpet,
+/obj/fiftyspawner/turcarpet,
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/algae{
+	amount = 50
+	},
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/lead{
+	amount = 30
+	},
+/obj/item/stack/material/plasteel{
+	amount = 30;
+	pixel_y = 5
+	},
+/obj/item/stack/material/resin{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"uv" = (
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"uA" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/warning,
+/obj/item/device/kit/paint/gygax/darkgygax,
+/obj/item/device/kit/paint/gygax/recitence,
+/obj/item/device/kit/paint/durand,
+/obj/item/device/kit/paint/durand/phazon,
+/obj/item/device/kit/paint/durand/seraph,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"uL" = (
+/obj/machinery/light,
+/obj/structure/table/standard,
+/obj/item/weapon/soap,
+/obj/item/weapon/towel{
+	color = "#0000FF"
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"uR" = (
+/obj/structure/toilet,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/TradingShip)
+"vs" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"vC" = (
+/obj/machinery/vending/assist{
+	contraband = null;
+	name = "Old Vending Machine";
+	products = list(/obj/item/device/assembly/prox_sensor=5,/obj/item/device/assembly/signaler=4,/obj/item/device/assembly/infra=4,/obj/item/device/assembly/prox_sensor=4,/obj/item/weapon/handcuffs=8,/obj/item/device/flash=4,/obj/item/weapon/cartridge/signal=4,/obj/item/clothing/glasses/sunglasses=4)
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"vL" = (
+/obj/machinery/vending/boozeomat{
+	req_access = null
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"vM" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"wn" = (
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-22"
+	},
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"wz" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/airlock/external{
+	frequency = null;
+	icon_state = "door_locked";
+	id_tag = null;
+	locked = 1;
+	name = "Ship Hatch";
+	req_access = null
+	},
+/obj/machinery/access_button{
+	dir = 1;
+	master_tag = null;
+	pixel_x = -27;
+	pixel_y = 7;
+	req_one_access = null
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"wT" = (
+/obj/machinery/door/window/southleft{
+	name = "Cargo Hold";
+	req_access = list(160)
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"xd" = (
+/obj/structure/table/steel_reinforced,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/item/weapon/weldpack,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"xi" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/inflatable_duck,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/nofail,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"xz" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "tradestarshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"xF" = (
+/obj/structure/closet/wardrobe/pjs,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"xM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"xZ" = (
+/obj/structure/filingcabinet/filingcabinet,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"yw" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/rd,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"yx" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/rig/internalaffairs,
+/obj/item/clothing/head/helmet/space/void/wizard,
+/obj/item/clothing/suit/space/void/wizard,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"yN" = (
+/obj/machinery/photocopier,
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"yS" = (
+/obj/structure/closet/crate,
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/blue,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"zh" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"zN" = (
+/obj/machinery/button/remote/blast_door{
+	id = "trade";
+	name = "Shop Shutters";
+	pixel_y = -26
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/TradingShip)
+"Au" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 4;
+	icon_state = "propulsion_r"
+	},
+/turf/simulated/shuttle/plating/airless/carry,
+/area/survivalpod/superpose/TradingShip)
+"AL" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	id_tag = null
+	},
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	dir = 4;
+	frequency = 1331;
+	id_tag = "trade2_control";
+	pixel_x = -25;
+	req_access = list(150);
+	tag_airpump = null;
+	tag_chamber_sensor = null;
+	tag_exterior_door = null;
+	tag_interior_door = null
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"AR" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_y = -32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Be" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/survivalpod/superpose/TradingShip)
+"BH" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/clothing/gloves/black,
+/obj/item/clothing/gloves/blue,
+/obj/item/clothing/gloves/brown,
+/obj/item/clothing/gloves/captain,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/gloves/green,
+/obj/item/clothing/gloves/grey,
+/obj/item/clothing/gloves/light_brown,
+/obj/item/clothing/gloves/purple,
+/obj/item/clothing/gloves/rainbow,
+/obj/item/clothing/gloves/swat,
+/obj/item/clothing/gloves/white,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"BU" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"Cu" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"CV" = (
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/TradingShip)
+"DT" = (
+/obj/machinery/light,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"DX" = (
+/obj/structure/table/steel_reinforced,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/random/tool,
+/obj/item/slimepotion/stabilizer,
+/obj/item/slimepotion/steroid,
+/obj/item/slimepotion/unity,
+/obj/item/slimepotion/friendship,
+/obj/item/slimepotion/friendship,
+/obj/item/slimepotion/feeding,
+/obj/item/slimepotion/docility,
+/obj/item/slimepotion/enhancer,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"EK" = (
+/obj/machinery/door/airlock/silver{
+	name = "Sleeping"
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"ET" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Fy" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/card/id/casino{
+	desc = "An alien id card with strange glowing markings.";
+	icon_state = "changeling";
+	name = "Alien id"
+	},
+/obj/item/weapon/card/id/casino{
+	desc = "An alien id card with strange glowing markings.";
+	icon_state = "changeling";
+	name = "Alien id"
+	},
+/obj/item/weapon/card/id/casino{
+	desc = "An alien id card with strange glowing markings.";
+	icon_state = "changeling";
+	name = "Alien id"
+	},
+/obj/item/weapon/card/id/casino{
+	desc = "An alien id card with strange glowing markings.";
+	icon_state = "changeling";
+	name = "Alien id"
+	},
+/obj/item/weapon/card/id/casino{
+	desc = "An alien id card with strange glowing markings.";
+	icon_state = "changeling";
+	name = "Alien id"
+	},
+/obj/item/weapon/card/id/casino{
+	desc = "An alien id card with strange glowing markings.";
+	icon_state = "changeling";
+	name = "Alien id"
+	},
+/obj/item/weapon/card/id/casino{
+	desc = "An alien id card with strange glowing markings.";
+	icon_state = "changeling";
+	name = "Alien id"
+	},
+/obj/item/weapon/card/id/casino{
+	desc = "An alien id card with strange glowing markings.";
+	icon_state = "changeling";
+	name = "Alien id"
+	},
+/obj/item/weapon/card/id/casino{
+	desc = "An alien id card with strange glowing markings.";
+	icon_state = "changeling";
+	name = "Alien id"
+	},
+/obj/item/weapon/card/id/casino{
+	desc = "An alien id card with strange glowing markings.";
+	icon_state = "changeling";
+	name = "Alien id"
+	},
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"FL" = (
+/obj/machinery/door/window/westleft{
+	name = "Storefront";
+	req_access = list(160)
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "trade";
+	name = "Shop Shutters";
+	opacity = 0
+	},
+/obj/structure/table/marble,
+/obj/machinery/cash_register/civilian{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/TradingShip)
+"FW" = (
+/obj/machinery/door/airlock/external{
+	frequency = null;
+	icon_state = "door_locked";
+	id_tag = null;
+	locked = 1;
+	name = "Ship Hatch";
+	req_access = null
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"Gb" = (
+/obj/machinery/light,
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"Gk" = (
+/obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/bar_alc/full,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"GN" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	id_tag = null;
+	pixel_x = 27
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	id_tag = null
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"GS" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/mecha/working/ripley/firefighter,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"GU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/vending/foodstuffing,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Hh" = (
+/obj/structure/table/steel_reinforced,
+/obj/random/action_figure,
+/obj/random/action_figure,
+/obj/random/action_figure,
+/obj/random/action_figure,
+/obj/random/action_figure,
+/obj/random/action_figure,
+/obj/random/curseditem,
+/obj/random/curseditem,
+/obj/random/curseditem,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Hp" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/donkpockets,
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"HB" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/closet/crate/solar,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"HC" = (
+/obj/structure/table/standard,
+/obj/machinery/microwave,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"HP" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Ii" = (
+/obj/machinery/computer/arcade/battle,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"IL" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"Jg" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "tradestarshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"JF" = (
+/obj/machinery/vending/foodasian,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"JI" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "tradeportshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"JN" = (
+/obj/machinery/body_scanconsole,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Km" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/largecrate/animal/cow,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Ko" = (
+/obj/structure/table/glass,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Kv" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/lipstick/black,
+/obj/item/weapon/lipstick/jade,
+/obj/item/weapon/lipstick/purple,
+/obj/item/weapon/lipstick,
+/obj/item/weapon/lipstick/random,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Lp" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/steel_reinforced,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Lt" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/clothing/under/cheongsam,
+/obj/item/clothing/under/hosformalmale,
+/obj/item/clothing/under/hosformalfem,
+/obj/item/clothing/under/harness,
+/obj/item/clothing/under/gladiator,
+/obj/item/clothing/under/ert,
+/obj/item/clothing/under/schoolgirl,
+/obj/item/clothing/under/redcoat,
+/obj/item/clothing/under/sexymime,
+/obj/item/clothing/under/sexyclown,
+/obj/item/clothing/under/soviet,
+/obj/item/clothing/under/space,
+/obj/item/clothing/under/swimsuit/stripper/mankini,
+/obj/item/clothing/under/suit_jacket/female,
+/obj/item/clothing/under/rank/psych/turtleneck,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/syndicate/tacticool,
+/obj/item/clothing/under/syndicate/tacticool,
+/obj/item/clothing/under/dress/sailordress,
+/obj/item/clothing/under/dress/redeveninggown,
+/obj/item/clothing/under/dress/dress_saloon,
+/obj/item/clothing/under/dress/blacktango,
+/obj/item/clothing/under/dress/blacktango/alt,
+/obj/item/clothing/under/dress/dress_orange,
+/obj/item/clothing/under/dress/maid/janitor,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"LX" = (
+/obj/machinery/vending/foodfish,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Mc" = (
+/turf/template_noop,
+/area/template_noop)
+"Mk" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/closet/crate/internals,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"MO" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/captain,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"MP" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/clothing/accessory/holster/hip,
+/obj/item/clothing/accessory/holster/armpit,
+/obj/item/clothing/accessory/holster/armpit,
+/obj/item/clothing/accessory/holster/hip,
+/obj/item/clothing/accessory/storage/white_vest,
+/obj/item/clothing/accessory/storage/white_vest,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/webbing,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/accessory/storage/brown_vest,
+/obj/item/clothing/accessory/storage/brown_vest,
+/obj/item/clothing/accessory/scarf/white,
+/obj/item/clothing/accessory/scarf/lightblue,
+/obj/item/clothing/accessory/scarf/red,
+/obj/item/clothing/accessory/scarf/purple,
+/obj/item/clothing/accessory/armband/science,
+/obj/item/clothing/accessory/armband/med,
+/obj/item/clothing/accessory/armband/engine,
+/obj/item/clothing/accessory/armband/cargo,
+/obj/item/clothing/accessory/armband,
+/obj/item/clothing/accessory/medal/nobel_science,
+/obj/item/clothing/accessory/medal/silver,
+/obj/item/clothing/accessory/medal/gold,
+/obj/item/clothing/accessory/medal/bronze_heart,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"MT" = (
+/turf/simulated/shuttle/wall/dark,
+/area/survivalpod/superpose/TradingShip)
+"No" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
+	},
+/obj/machinery/atm{
+	pixel_x = -32
+	},
+/obj/machinery/meter,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Nq" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/mecha/working/ripley/mining,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"NE" = (
+/obj/vehicle/train/trolley,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"NJ" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	icon_state = "frame";
+	pixel_x = 32
+	},
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"NQ" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Od" = (
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = 5
+	},
+/obj/item/bodybag/cryobag{
+	pixel_x = 5
+	},
+/obj/item/weapon/storage/firstaid/o2{
+	layer = 2.8;
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/box/masks,
+/obj/item/weapon/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/fire{
+	layer = 2.9;
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/adv{
+	pixel_x = -2
+	},
+/obj/item/weapon/reagent_containers/blood/empty,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/structure/closet/medical_wall{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"OE" = (
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"OK" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/clothing/suit/hgpirate,
+/obj/item/clothing/suit/imperium_monk,
+/obj/item/clothing/suit/leathercoat,
+/obj/item/clothing/suit/justice,
+/obj/item/clothing/suit/justice,
+/obj/item/clothing/suit/justice,
+/obj/item/clothing/suit/justice,
+/obj/item/clothing/suit/justice,
+/obj/item/clothing/suit/pirate,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Pb" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/kiddieplaque{
+	desc = "A plaque commemorating the construction of the cargo ship Beruang.";
+	name = "Beruang";
+	pixel_x = 32
+	},
+/mob/living/simple_mob/animal/passive/dog/tamaskan/Spice,
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/TradingShip)
+"Pv" = (
+/obj/machinery/atm{
+	pixel_x = -32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"PW" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/flora/pottedplant{
+	icon_state = "plant-09";
+	name = "Esteban";
+	pixel_y = 8
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Qm" = (
+/obj/structure/closet/wardrobe/captain,
+/obj/item/weapon/gun/projectile/revolver/mateba,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Qp" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"QB" = (
+/obj/machinery/sleep_console,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"QQ" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"Ry" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/weapon/pen{
+	pixel_y = 4
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Sp" = (
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Sy" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	start_pressure = 740.5
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"SE" = (
+/turf/simulated/shuttle/wall/dark/hard_corner,
+/area/survivalpod/superpose/TradingShip)
+"SI" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/largecrate/hoverpod,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"SR" = (
+/obj/machinery/vending/tool{
+	emagged = 1
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"SV" = (
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/stack/material/phoron{
+	material = 50
+	},
+/obj/item/stack/material/phoron{
+	material = 50
+	},
+/obj/item/stack/material/phoron{
+	material = 50
+	},
+/obj/item/stack/material/phoron{
+	material = 50
+	},
+/obj/random/cash/huge,
+/obj/random/cash/huge,
+/obj/random/cash/huge,
+/obj/random/cash/huge,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Tb" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"TJ" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/hos,
+/obj/structure/sign/poster{
+	pixel_y = -32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"TK" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"TU" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "tradebridgeshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"Uw" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Uy" = (
+/obj/structure/closet{
+	name = "custodial"
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/mop,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Uz" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "tradestarshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"VL" = (
+/obj/machinery/vending/engivend{
+	emagged = 1
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"VP" = (
+/obj/machinery/door/airlock/glass_medical{
+	name = "Medical Bay";
+	req_access = null;
+	req_one_access = null
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"VX" = (
+/obj/structure/table/steel_reinforced,
+/obj/random/toolbox,
+/obj/random/toolbox,
+/obj/random/toolbox,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"VY" = (
+/obj/machinery/suit_cycler/syndicate,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Wy" = (
+/obj/structure/table/steel_reinforced,
+/obj/random/contraband,
+/obj/random/contraband,
+/obj/random/contraband,
+/obj/random/contraband,
+/obj/random/contraband,
+/obj/random/contraband,
+/obj/item/weapon/bikehorn,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"WG" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "tradebridgeshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"WK" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/stack/material/mhydrogen,
+/obj/item/stack/material/diamond,
+/obj/item/stack/material/sandstone,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"WL" = (
+/obj/machinery/door/window/westleft{
+	name = "Storefront";
+	req_access = list(160)
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Xi" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "tradebridgeshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"Xy" = (
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"XH" = (
+/obj/machinery/door/airlock/multi_tile/glass{
+	req_access = null
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"XL" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "tradeportshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"XO" = (
+/turf/simulated/shuttle/plating/airless/carry,
+/area/survivalpod/superpose/TradingShip)
+"Yc" = (
+/obj/structure/sign/poster{
+	pixel_y = -32
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Yi" = (
+/obj/structure/table/steel_reinforced,
+/obj/random/plushie,
+/obj/random/plushie,
+/obj/random/plushie,
+/obj/random/plushie,
+/obj/random/plushie,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Zs" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/TradingShip)
+"ZD" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/closet/crate/freezer/rations,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"ZX" = (
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 8;
+	icon_state = "shutter0";
+	id = "tradebridgeshutters";
+	name = "Blast Shutters";
+	opacity = 0
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced/full,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
 
 (1,1,1) = {"
-McMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMc
-McMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcSEjAlQSEMcMcMcMcMTMTMTMTMTMcMc
-McMcMcMcMcMcMcMcMcMTMTMTMTMTMTxzJgmiMTMcMcMcMcMcMTMTkwxMMTMTMcMcMTMTMTMTBeAuMcMc
-McMcMcMcMcMcMcMcMTSEhIywMTGkHCsjBUwnMTMTMcMcMcMTMTSEjAlQSEMTxzmiSEQBNQMTBeXOMcMc
-McMcMcMcMcMcMcMcUzQpSpSpEKSpSpuvHpTbMTMTxzJgmiMTMTPvSpSpVYMTsTJNOdSpdYMTBedsMcMc
-McMcMcMcMcMcMcMcpUxFmRTJMTSpSpvMuaNJMTxiWKyxDXVXILfPCVCVSpVPSpSpSpSpiaMTBeaAMcMc
-McMcMcMcMcMcMcMcMTMTMTMTMTMTARSpSpaaMTnDkDgJcVxdQQNECVCVSpVPSpDTcMSpSpMTMTMTMcMc
-McMcMcMcMcMcMcMcMcMcMcMcMTMTMTXHrfMTSEoiwTmYqTdZtQNECVSpARSEMTMTSEmJthMTMTMcMcMc
-McMcMcMTrqTUMTMTMTMTMTMTMTMTUwSpSpSpSpzhSpSpSpSpMTMTTKrfSEMTSVcaMTMTMTMTMcMcMcMc
-McMcMTMTIiPWMTuRMTtumFseSEMTnWSpCVCVCVCVCVCVCVCVCVSpCVSphxgACVCVfeMTBeAuMcMcMcMc
-McMcXikxCVPbMTprSEMTfJMTETMTfGCVCVqVKmZDeSshSINqCVCVCVCVrxtNCVCVLXMTBeXOMcMcMcMc
-McMcZXmdZsCVtxSpSpSpSpXySprfSpCVCVaPqzMkuAdPtXGSCVCVCVCVFLCVCVCVJFMTBedsMcMcMcMc
-McMcMTMTRyhmMTvCUynTuLYcSpeESpSpCVCVCVCVCVCVCVCVCVSpCVSpWLSpzNCVGUMTBeaAMcMcMcMc
-McMcMcMTqoWGMTMTMTMTMTMTMTSEvLSpSpSpSpDTSpSpSpSpMTMTTKrfSEMTjHlWMTMTMTMTMcMcMcMc
-McMcMcMcMcMcMcMcMcMcMcMcMTMTMTXHrfMTSELpkOYifUBHILSyCVSpHPSEMTMTMTVLSRMTMTMcMcMc
-McMcMcMcMcMcMcMcMTMTMTMTMTSpHPSpSpkBMTWyvsgqbknCQQkdCVCVSpplSpzhlmSpSpMTMTMTMcMc
-McMcMcMcMcMcMcMclvQmmKfmMTSpSpuvOEyNMTHhKvMPLtOKtQHBCVCVSpplSpSpSpSpuoMTBeAuMcMc
-McMcMcMcMcMcMcMcXLSpSpSpriSpSpqckVFyMTMTcXrGJIMTMTNodycCSpMTbmbfesSpdYMTBeXOMcMc
-McMcMcMcMcMcMcMcMTSEMOKoMTxZSpGbCurgMTMTMcMcMcMTMTSEwznhSEMTcXJIMTyShKMTBedsMcMc
-McMcMcMcMcMcMcMcMcMTMTMTMTMTMTcXrGJIMTMcMcMcMcMcMTMTALGNMTMTMcMcMTMTMTMTBeaAMcMc
-McMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcSEFWkUSEMcMcMcMcMTMTMTMTMTMcMc
-McMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMcMc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+"}
+(2,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+"}
+(3,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+MT
+Xi
+ZX
+MT
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+"}
+(4,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+MT
+MT
+kx
+md
+MT
+MT
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+"}
+(5,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+rq
+Ii
+CV
+Zs
+Ry
+qo
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+"}
+(6,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+TU
+PW
+Pb
+CV
+hm
+WG
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+"}
+(7,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+MT
+MT
+MT
+tx
+MT
+MT
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+"}
+(8,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+MT
+uR
+pr
+Sp
+vC
+MT
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+"}
+(9,1,1) = {"
+Mc
+Mc
+Mc
+MT
+Uz
+pU
+MT
+Mc
+MT
+MT
+SE
+Sp
+Uy
+MT
+Mc
+MT
+lv
+XL
+MT
+Mc
+Mc
+Mc
+"}
+(10,1,1) = {"
+Mc
+Mc
+MT
+SE
+Qp
+xF
+MT
+Mc
+MT
+tu
+MT
+Sp
+nT
+MT
+Mc
+MT
+Qm
+Sp
+SE
+MT
+Mc
+Mc
+"}
+(11,1,1) = {"
+Mc
+Mc
+MT
+hI
+Sp
+mR
+MT
+Mc
+MT
+mF
+fJ
+Sp
+uL
+MT
+Mc
+MT
+mK
+Sp
+MO
+MT
+Mc
+Mc
+"}
+(12,1,1) = {"
+Mc
+Mc
+MT
+yw
+Sp
+TJ
+MT
+Mc
+MT
+se
+MT
+Xy
+Yc
+MT
+Mc
+MT
+fm
+Sp
+Ko
+MT
+Mc
+Mc
+"}
+(13,1,1) = {"
+Mc
+Mc
+MT
+MT
+EK
+MT
+MT
+MT
+MT
+SE
+ET
+Sp
+Sp
+MT
+MT
+MT
+MT
+ri
+MT
+MT
+Mc
+Mc
+"}
+(14,1,1) = {"
+Mc
+Mc
+MT
+Gk
+Sp
+Sp
+MT
+MT
+MT
+MT
+MT
+rf
+eE
+SE
+MT
+Sp
+Sp
+Sp
+xZ
+MT
+Mc
+Mc
+"}
+(15,1,1) = {"
+Mc
+Mc
+MT
+HC
+Sp
+Sp
+AR
+MT
+Uw
+nW
+fG
+Sp
+Sp
+vL
+MT
+HP
+Sp
+Sp
+Sp
+MT
+Mc
+Mc
+"}
+(16,1,1) = {"
+Mc
+Mc
+xz
+sj
+uv
+vM
+Sp
+XH
+Sp
+Sp
+CV
+CV
+Sp
+Sp
+XH
+Sp
+uv
+qc
+Gb
+cX
+Mc
+Mc
+"}
+(17,1,1) = {"
+Mc
+Mc
+Jg
+BU
+Hp
+ua
+Sp
+rf
+Sp
+CV
+CV
+CV
+CV
+Sp
+rf
+Sp
+OE
+kV
+Cu
+rG
+Mc
+Mc
+"}
+(18,1,1) = {"
+Mc
+Mc
+mi
+wn
+Tb
+NJ
+aa
+MT
+Sp
+CV
+qV
+aP
+CV
+Sp
+MT
+kB
+yN
+Fy
+rg
+JI
+Mc
+Mc
+"}
+(19,1,1) = {"
+Mc
+Mc
+MT
+MT
+MT
+MT
+MT
+SE
+Sp
+CV
+Km
+qz
+CV
+Sp
+SE
+MT
+MT
+MT
+MT
+MT
+Mc
+Mc
+"}
+(20,1,1) = {"
+Mc
+Mc
+Mc
+MT
+MT
+xi
+nD
+oi
+zh
+CV
+ZD
+Mk
+CV
+DT
+Lp
+Wy
+Hh
+MT
+MT
+Mc
+Mc
+Mc
+"}
+(21,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+xz
+WK
+kD
+wT
+Sp
+CV
+eS
+uA
+CV
+Sp
+kO
+vs
+Kv
+cX
+Mc
+Mc
+Mc
+Mc
+"}
+(22,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+Jg
+yx
+gJ
+mY
+Sp
+CV
+sh
+dP
+CV
+Sp
+Yi
+gq
+MP
+rG
+Mc
+Mc
+Mc
+Mc
+"}
+(23,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+mi
+DX
+cV
+qT
+Sp
+CV
+SI
+tX
+CV
+Sp
+fU
+bk
+Lt
+JI
+Mc
+Mc
+Mc
+Mc
+"}
+(24,1,1) = {"
+Mc
+Mc
+Mc
+MT
+MT
+VX
+xd
+dZ
+Sp
+CV
+Nq
+GS
+CV
+Sp
+BH
+nC
+OK
+MT
+MT
+Mc
+Mc
+Mc
+"}
+(25,1,1) = {"
+Mc
+Mc
+MT
+MT
+MT
+IL
+QQ
+tQ
+MT
+CV
+CV
+CV
+CV
+MT
+IL
+QQ
+tQ
+MT
+MT
+MT
+Mc
+Mc
+"}
+(26,1,1) = {"
+Mc
+SE
+MT
+SE
+Pv
+fP
+NE
+NE
+MT
+Sp
+CV
+CV
+Sp
+MT
+Sy
+kd
+HB
+No
+SE
+MT
+SE
+Mc
+"}
+(27,1,1) = {"
+Mc
+jA
+kw
+jA
+Sp
+CV
+CV
+CV
+TK
+CV
+CV
+CV
+CV
+TK
+CV
+CV
+CV
+dy
+wz
+AL
+FW
+Mc
+"}
+(28,1,1) = {"
+Mc
+lQ
+xM
+lQ
+Sp
+CV
+CV
+Sp
+rf
+Sp
+CV
+CV
+Sp
+rf
+Sp
+CV
+CV
+cC
+nh
+GN
+kU
+Mc
+"}
+(29,1,1) = {"
+Mc
+SE
+MT
+SE
+VY
+Sp
+Sp
+AR
+SE
+hx
+rx
+FL
+WL
+SE
+HP
+Sp
+Sp
+Sp
+SE
+MT
+SE
+Mc
+"}
+(30,1,1) = {"
+Mc
+Mc
+MT
+MT
+MT
+VP
+VP
+SE
+MT
+gA
+tN
+CV
+Sp
+MT
+SE
+pl
+pl
+MT
+MT
+MT
+Mc
+Mc
+"}
+(31,1,1) = {"
+Mc
+Mc
+Mc
+xz
+sT
+Sp
+Sp
+MT
+SV
+CV
+CV
+CV
+zN
+jH
+MT
+Sp
+Sp
+bm
+cX
+Mc
+Mc
+Mc
+"}
+(32,1,1) = {"
+Mc
+Mc
+Mc
+mi
+JN
+Sp
+DT
+MT
+ca
+CV
+CV
+CV
+CV
+lW
+MT
+zh
+Sp
+bf
+JI
+Mc
+Mc
+Mc
+"}
+(33,1,1) = {"
+Mc
+Mc
+MT
+SE
+Od
+Sp
+cM
+SE
+MT
+fe
+LX
+JF
+GU
+MT
+MT
+lm
+Sp
+es
+MT
+MT
+Mc
+Mc
+"}
+(34,1,1) = {"
+Mc
+MT
+MT
+QB
+Sp
+Sp
+Sp
+mJ
+MT
+MT
+MT
+MT
+MT
+MT
+VL
+Sp
+Sp
+Sp
+yS
+MT
+MT
+Mc
+"}
+(35,1,1) = {"
+Mc
+MT
+MT
+NQ
+dY
+ia
+Sp
+th
+MT
+Be
+Be
+Be
+Be
+MT
+SR
+Sp
+uo
+dY
+hK
+MT
+MT
+Mc
+"}
+(36,1,1) = {"
+Mc
+MT
+MT
+MT
+MT
+MT
+MT
+MT
+MT
+Au
+XO
+ds
+aA
+MT
+MT
+MT
+MT
+MT
+MT
+MT
+MT
+Mc
+"}
+(37,1,1) = {"
+Mc
+MT
+Be
+Be
+Be
+Be
+MT
+MT
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+MT
+MT
+Be
+Be
+Be
+Be
+MT
+Mc
+"}
+(38,1,1) = {"
+Mc
+MT
+Au
+XO
+ds
+aA
+MT
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+MT
+Au
+XO
+ds
+aA
+MT
+Mc
+"}
+(39,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+"}
+(40,1,1) = {"
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
+Mc
 "}


### PR DESCRIPTION
-Made Demon Pool v2 less painful to use via changing doors. -Removed the mechas on the fab ship.
-Removed 2/3s of the mechas for mech storage fab
-Nerfed the trading ship by removing the extra pods, and the charged slime core

I want to make some more outsider pods, but unsure where area code is.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
remap: tweaked some outsider pods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
