### PR TITLE
nerfs heart damage

### DIFF
--- a/code/game/objects/items/devices/defib.dm
+++ b/code/game/objects/items/devices/defib.dm
@@ -346,8 +346,8 @@
 		blood_volume *= 0.3
 	else if(heart.is_bruised())
 		blood_volume *= 0.7
-	else if(heart.damage > 1)
-		blood_volume *= 0.8
+	else if(heart.damage > 5) //CHOMPedit, so ONE heart damage isnt 20% of blood missing, now its 5
+		blood_volume *= 0.9 //chompedit, 90% instead of 80%
 	return blood_volume < H.species.blood_volume*H.species.blood_level_fatal
 
 /obj/item/weapon/shockpaddles/proc/check_charge(var/charge_amt)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -94,9 +94,11 @@ var/const/CE_STABLE_THRESHOLD = 0.5
 			else if(heart.is_bruised())
 				blood_volume_raw *= 0.7
 				blood_volume *= 0.7
+			else if(heart.damage > 5) //CHOMPedit, //CHOMPedit, so 0.00005 heart damage isnt 20% of blood missing, now its 5
+				blood_volume_raw *= 0.9 //chompedit from 0.8 to 0.9
+				blood_volume *= 0.9 //chompedit from 0.8 to 0.9
 			else if(heart.damage)
-				blood_volume_raw *= 0.8
-				blood_volume *= 0.8
+				return
 
 		//Effects of bloodloss
 		var/dmg_coef = 1				//Lower means less damage taken


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
SO TURNS OUT, HAVING EVEN 0.01 HEART DAMAGE LOWERS YOUR BLOOD VOLUME TO 80%
Who thought this was a good idea?
Now heart damage effects start minor at 5 damage, where ~95% blood will start the oxyloss damage. Unchanged values at 10 and beyond 

![dreamseeker_xd19Rz887m](https://github.com/CHOMPStation2/CHOMPStation2/assets/10555869/2f3c1d30-20b4-4b94-87c6-f52edf640e2c)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Heart Damage is no longer debilitating at decimal values.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
