### PR TITLE
Nutrition purge balance

### DIFF
--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot.dm
@@ -1,10 +1,10 @@
 /mob/living/silicon/robot/verb/purge_nutrition()
 	set name = "Purge Nutrition"
 	set category = "IC"
-	set desc = "Allows you to clear out your nutrition if needed."
+	set desc = "Allows you to clear out most of your nutrition if needed."
 
-	if (stat != CONSCIOUS)
+	if (stat != CONSCIOUS || nutrition <= 1000)
 		return
-	nutrition = 0
-	to_chat(src, "<span class='warning'>You have purged the nutrition lingering in your systems.</span>")
+	nutrition = 1000
+	to_chat(src, "<span class='warning'>You have purged most of the nutrition lingering in your systems.</span>")
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Changed the nutrition purge to only purge down to 1000 nutrition instead of wiping all nutrition upon use. This prevents to end with absolutely no nutrition after having to purge a massive amount to avoid an unbearable slowdown due to some circumstances. Could be discussed if 500 as minimum might be better as 1000 is just below the threshold of the slowdown.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: changed borg nutrition purge to only reduce nutrition to 1000 instead of 0
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
