### PR TITLE
Adjustment to "Brings back pref ignoring micro stomps"

### DIFF
--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -319,7 +319,7 @@
 	now_pushing = 0
 	forceMove(tmob.loc)
 	if(a_intent != I_HELP)
-		if(tmob.size_multiplier > 0.75 && nofetish) //So we can stun micros with step mechanics off, but prevent macros from stunning regular heights
+		if(tmob.size_multiplier > 0.50 && nofetish) //So we can stun micros with step mechanics off, but prevent macros from stunning regular heights
 			to_chat(pred, "<span class='danger'>You pass over [tmob.name].</span>")
 			to_chat(prey, "<span class='danger'>[src.name] passes over you.</span>")
 			return FALSE


### PR DESCRIPTION
## About The Pull Request

Currently, if a player is 75% or below in size, they have 'step mechanics' disabled, are in harm/grab/disarm intent, and are bumped into by another player in harm/grab/disarm intent, they will be knocked to the ground and briefly inflicted with weaken.

What this basically means is that a character below 75% cannot turn off step mechanics, regardless of prefs. All they can do is disable the fetishy description of the act.

This is also inconsistent with the 'micro' debuffs that I'm aware of, which all have a cutoff of 50%.

As such, I've lowered the threshold for this feature to activate from 75% to 50%.

## Changelog

qol: Reduced the threshold where other players get knocked down to 50% size.


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
