### PR TITLE
Follow up fix for #7269, fixes tongue breaking

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -283,9 +283,9 @@
 		user.visible_message("<span class='filter_notice'>[user] begins to lap up water from [target.name].</span>", "<span class='notice'>You begin to lap up water from [target.name].</span>")
 		busy = 1
 		if(do_after(user, 50))
-			busy = 0
 			water.add_charge(50)
 			to_chat(src, "<span class='filter_notice'>You refill some of your water reserves.</span>")
+		busy = 0
 	else if(water.energy < 5)
 		to_chat(user, "<span class='notice'>Your mouth feels dry. You should drink up some water .</span>")
 	//CHOMPADD End
@@ -295,40 +295,41 @@
 		user.visible_message("<span class='filter_notice'>[user] begins to lick off \the [target.name].</span>", "<span class='notice'>You begin to lick off \the [target.name]...</span>")
 		busy = 1
 		if(do_after(user, 50))
-			busy = 0
 			to_chat(user, "<span class='notice'>You finish licking off \the [target.name].</span>")
 			water.use_charge(5)
 			qdel(target)
 			var/mob/living/silicon/robot/R = user
 			R.cell.charge += 50
+		busy = 0
 	//CHOMPADD End
 	else if(istype(target,/obj/item))
 		if(istype(target,/obj/item/trash))
 			user.visible_message("<span class='filter_notice'>[user] nibbles away at \the [target.name].</span>", "<span class='notice'>You begin to nibble away at \the [target.name]...</span>")
 			busy = 1 //CHOMPAdd prevents abuse
 			if(do_after (user, 50))
-				busy = 0 //CHOMPAdd prevents abuse
 				user.visible_message("<span class='filter_notice'>[user] finishes eating \the [target.name].</span>", "<span class='notice'>You finish eating \the [target.name].</span>")
 				to_chat(user, "<span class='notice'>You finish off \the [target.name].</span>")
 				qdel(target)
 				var/mob/living/silicon/robot/R = user
 				R.cell.charge += 250
 				water.use_charge(5)  //CHOMPAdd
+			busy = 0 //CHOMPAdd prevents abuse
 			return
 		if(istype(target,/obj/item/weapon/reagent_containers/food))
 			user.visible_message("[user] nibbles away at \the [target.name].", "<span class='notice'>You begin to nibble away at \the [target.name]...</span>")
+			busy = 1 //CHOMPAdd prevents abuse
 			if(do_after (user, 50))
 				user.visible_message("[user] finishes eating \the [target.name].", "<span class='notice'>You finish eating \the [target.name].</span>")
 				user << "<span class='notice'>You finish off \the [target.name].</span>"
 				del(target)
 				var/mob/living/silicon/robot/R = user
 				R.cell.charge = R.cell.charge + 250
+			busy = 0 //CHOMPAdd prevents abuse
 			return
 		if(istype(target,/obj/item/weapon/cell))
 			user.visible_message("<span class='filter_notice'>[user] begins cramming \the [target.name] down its throat.</span>", "<span class='notice'>You begin cramming \the [target.name] down your throat...</span>")
 			busy = 1 //CHOMPAdd prevents abuse
 			if(do_after (user, 50))
-				busy = 0 //CHOMPAdd prevents abuse
 				user.visible_message("<span class='filter_notice'>[user] finishes gulping down \the [target.name].</span>", "<span class='notice'>You finish swallowing \the [target.name].</span>")
 				to_chat(user, "<span class='notice'>You finish off \the [target.name], and gain some charge!</span>")
 				var/mob/living/silicon/robot/R = user
@@ -336,17 +337,18 @@
 				R.cell.charge += C.charge / 3
 				water.use_charge(5) //CHOMPAdd
 				qdel(target)
+			busy = 0 //CHOMPAdd prevents abuse
 			return
 		//CHOMPAdd Start
 		user.visible_message("<span class='filter_notice'>[user] begins to lick \the [target.name] clean...</span>", "<span class='notice'>You begin to lick \the [target.name] clean...</span>")
 		busy = 1
 		if(do_after(user, 50, exclusive = TRUE))
-			busy = 0
 			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
 			water.use_charge(5)
 			var/obj/effect/decal/cleanable/C = locate() in target
 			qdel(C)
 			target.clean_blood()
+		busy = 0
 		//CHOMPADD End
 	else if(ishuman(target))
 		if(src.emagged)
@@ -373,7 +375,6 @@
 		user.visible_message("<span class='filter_notice'>[user] begins to lick \the [target.name] clean...</span>", "<span class='notice'>You begin to lick \the [target.name] clean...</span>")
 		busy = 1
 		if(do_after(user, 50))
-			busy = 0
 			to_chat(user, "<span class='notice'>You clean \the [target.name].</span>")
 			var/obj/effect/decal/cleanable/C = locate() in target
 			qdel(C)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes the issue of the synth tongue breaking if an action is interrupted.
Added the busy check for another case where the tongue otherwise could throw runtimes.

Issue introduced in #7269

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: lickclean will no longer break the synthtongue
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
