### PR TITLE
Fixes raw nutrition not digesting on food mode

### DIFF
--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -412,11 +412,11 @@
 			return
 		if(B.owner)
 			if(B.reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && B.reagents.total_volume < B.custom_max_volume)
-				B.owner.adjust_nutrition(removed * (B.nutrition_percent / 100) * power)
+				B.owner_adjust_nutrition(removed * (B.nutrition_percent / 100) * power)
 				B.digest_nutri_gain += removed * (B.nutrition_percent / 100) + 0.5
 				B.GenerateBellyReagents_digesting()
 			else
-				B.owner.adjust_nutrition(removed * (B.nutrition_percent / 100) * power) //CHOMPEdit End
+				B.owner_adjust_nutrition(removed * (B.nutrition_percent / 100) * power) //CHOMPEdit End
 
 	if(volume < meltdose) // Not enough to melt anything
 		M.take_organ_damage(0, removed * power * 0.2) //burn damage, since it causes chemical burns. Acid doesn't make bones shatter, like brute trauma would.
@@ -444,7 +444,7 @@
 		var/spent_amt = I.digest_act(I.loc, 1, amount / (meltdose / 3))
 		remove_self(spent_amt) //10u stomacid per w_class, less if stronger acid.
 		if(B.owner)
-			B.owner.adjust_nutrition((B.nutrition_percent / 100) * 5 * spent_amt)
+			B.owner_adjust_nutrition((B.nutrition_percent / 100) * 5 * spent_amt)
 		return
 	..()
 	if(O.unacidable || is_type_in_list(O,item_digestion_blacklist)) //CHOMPEdit End
@@ -465,11 +465,11 @@
 			return
 		if(B.owner)
 			if(B.reagent_mode_flags & DM_FLAG_REAGENTSDIGEST && B.reagents.total_volume < B.custom_max_volume)
-				B.owner.adjust_nutrition(volume * (B.nutrition_percent / 100) * power)
+				B.owner_adjust_nutrition(volume * (B.nutrition_percent / 100) * power)
 				B.digest_nutri_gain += volume * (B.nutrition_percent / 100) + 0.5
 				B.GenerateBellyReagents_digesting()
 			else
-				B.owner.adjust_nutrition(volume * (B.nutrition_percent / 100) * power)
+				B.owner_adjust_nutrition(volume * (B.nutrition_percent / 100) * power)
 	L.adjustFireLoss(volume * power * 0.2)
 	remove_self(volume) //CHOMPAdd End
 

--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -602,9 +602,7 @@
 	w_class = ITEMSIZE_SMALL
 	var/stored_nutrition = 0
 
-/obj/item/weapon/reagent_containers/food/rawnutrition/afterattack(atom/target, mob/living/user, proximity)
-	if(!proximity)
-		return
+/obj/item/weapon/reagent_containers/food/rawnutrition/standard_feed_mob(var/mob/user, var/mob/target)
 	if(isliving(target))
 		var/mob/living/L = target
 		L.nutrition += stored_nutrition

--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -583,17 +583,17 @@
 
 /obj/belly/proc/owner_adjust_nutrition(var/amount = 0)
 	if(storing_nutrition && amount > 0)
-		for(var/obj/item/trash/rawnutrition/R in contents)
+		for(var/obj/item/weapon/reagent_containers/food/rawnutrition/R in contents)
 			if(istype(R))
 				R.stored_nutrition += amount
 				return
-		var/obj/item/trash/rawnutrition/NR = new /obj/item/trash/rawnutrition(src)
+		var/obj/item/weapon/reagent_containers/food/rawnutrition/NR = new /obj/item/weapon/reagent_containers/food/rawnutrition(src)
 		NR.stored_nutrition += amount
 		return
 	else
 		owner.adjust_nutrition(amount)
 
-/obj/item/trash/rawnutrition
+/obj/item/weapon/reagent_containers/food/rawnutrition
 	name = "raw nutrition"
 	desc = "A nutritious pile of converted mass ready for consumption."
 	icon = 'icons/obj/recycling.dmi'
@@ -602,7 +602,7 @@
 	w_class = ITEMSIZE_SMALL
 	var/stored_nutrition = 0
 
-/obj/item/trash/rawnutrition/afterattack(atom/target, mob/living/user, proximity)
+/obj/item/weapon/reagent_containers/food/rawnutrition/afterattack(atom/target, mob/living/user, proximity)
 	if(!proximity)
 		return
 	if(isliving(target))

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -288,7 +288,7 @@
 		if(IM_HOLD)
 			items_preserved |= I
 		if(IM_DIGEST_FOOD)
-			if(istype(I,/obj/item/weapon/reagent_containers/food) || istype(I, /obj/item/organ))
+			if(istype(I,/obj/item/weapon/reagent_containers/food) || istype(I, /obj/item/organ) || istype(I, /obj/item/trash/rawnutrition)) //CHOMPEdit
 				did_an_item = digest_item(I, touchable_amount) //CHOMPEdit
 			else
 				items_preserved |= I

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -288,7 +288,7 @@
 		if(IM_HOLD)
 			items_preserved |= I
 		if(IM_DIGEST_FOOD)
-			if(istype(I,/obj/item/weapon/reagent_containers/food) || istype(I, /obj/item/organ) || istype(I, /obj/item/trash/rawnutrition)) //CHOMPEdit
+			if(istype(I,/obj/item/weapon/reagent_containers/food) || istype(I, /obj/item/organ)))
 				did_an_item = digest_item(I, touchable_amount) //CHOMPEdit
 			else
 				items_preserved |= I

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -288,7 +288,7 @@
 		if(IM_HOLD)
 			items_preserved |= I
 		if(IM_DIGEST_FOOD)
-			if(istype(I,/obj/item/weapon/reagent_containers/food) || istype(I, /obj/item/organ)))
+			if(istype(I,/obj/item/weapon/reagent_containers/food) || istype(I, /obj/item/organ))
 				did_an_item = digest_item(I, touchable_amount) //CHOMPEdit
 			else
 				items_preserved |= I

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -217,7 +217,7 @@
 			return FALSE
 	. = ..()
 
-/obj/item/trash/rawnutrition/digest_act(atom/movable/item_storage = null) //CHOMPAdd
+/obj/item/weapon/reagent_containers/food/rawnutrition/digest_act(atom/movable/item_storage = null) //CHOMPAdd
 	if(isbelly(item_storage))
 		var/obj/belly/B = item_storage
 		if(istype(B) && B.storing_nutrition)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes food only item digest mode not being able to digest the raw nutrition piles.
Also fixes acid reagent gurgles not producing raw nutrition.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed food only mode not digesting raw nutrition piles.
fix: Fixed acid reagent digestion not producing raw nutrition in store mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
