### PR TITLE
Putting the Behemoth in line

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/juggernaut.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/juggernaut.dm
@@ -50,7 +50,7 @@
 	..()
 
 /mob/living/simple_mob/construct/juggernaut/bullet_act(var/obj/item/projectile/P)
-	var/reflectchance = 100 - round(P.damage*2) //chompEDIT: We have lower damage vaules now
+	var/reflectchance = 100 - round(P.damage*2) //chompEDIT: We have lower damage values now
 	if(prob(reflectchance))
 		var/damage_mod = rand(2,4)
 		var/projectile_dam_type = P.damage_type
@@ -125,7 +125,7 @@
 							)
 
 /mob/living/simple_mob/construct/juggernaut/behemoth/bullet_act(var/obj/item/projectile/P)
-	var/reflectchance = 100 - round(P.damage*2) //chompEDIT: We have lower damage vaules now
+	var/reflectchance = 100 - round(P.damage*2) //chompEDIT: We have lower damage values now
 	if(prob(reflectchance))
 		visible_message("<span class='danger'>The [P.name] gets reflected by [src]'s shell!</span>", \
 						"<span class='userdanger'>The [P.name] gets reflected by [src]'s shell!</span>")

--- a/code/modules/mob/living/simple_mob/subtypes/occult/constructs/juggernaut.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/occult/constructs/juggernaut.dm
@@ -50,7 +50,7 @@
 	..()
 
 /mob/living/simple_mob/construct/juggernaut/bullet_act(var/obj/item/projectile/P)
-	var/reflectchance = 100 - round(P.damage)
+	var/reflectchance = 100 - round(P.damage*2) //chompEDIT: We have lower damage vaules now
 	if(prob(reflectchance))
 		var/damage_mod = rand(2,4)
 		var/projectile_dam_type = P.damage_type
@@ -125,7 +125,7 @@
 							)
 
 /mob/living/simple_mob/construct/juggernaut/behemoth/bullet_act(var/obj/item/projectile/P)
-	var/reflectchance = 100 - round(P.damage)
+	var/reflectchance = 100 - round(P.damage*2) //chompEDIT: We have lower damage vaules now
 	if(prob(reflectchance))
 		visible_message("<span class='danger'>The [P.name] gets reflected by [src]'s shell!</span>", \
 						"<span class='userdanger'>The [P.name] gets reflected by [src]'s shell!</span>")

--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/occult/constructs/juggernaut.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/occult/constructs/juggernaut.dm
@@ -15,14 +15,14 @@
 	melee_damage_lower = 22
 	melee_damage_upper = 33
 	ai_holder_type = /datum/ai_holder/simple_mob/intentional/adv_dark_gygax
-	projectiletype = /obj/item/projectile/energy/electrode/cult
+	projectiletype = /obj/item/projectile/energy/inversion
 	movement_cooldown = 1
 
 	loot_list = list(/obj/item/weapon/rig/ch/aegis = 100)
 
 
 /mob/living/simple_mob/construct/juggernaut/behemoth/unstoppable/bullet_act(var/obj/item/projectile/P)
-	var/reflectchance = 100 - round(P.damage)
+	var/reflectchance = 100 - round(P.damage*2)
 	if(prob(reflectchance))
 		visible_message("<span class='danger'>The [P.name] gets reflected by [src]'s shell!</span>", \
 						"<span class='userdanger'>The [P.name] gets reflected by [src]'s shell!</span>")


### PR DESCRIPTION
We had our damage  values nerfed.
The reflect chance was not.
Altered the reflect chance to respect this.
Also made the projectile one more inline with cult things instead of the relic of me figuring things out.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Juggernaught and Behemoth should respect our lower damage values now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
