### PR TITLE
self recolour for simple mob / robot

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -187,3 +187,10 @@ if (!(DATUM.datum_flags & DF_ISPROCESSING)) {\
 //#define  PART_AI  		/obj/item/weapon/computer_hardware/ai_slot						// AI slot, an intellicard housing that allows modifications of AIs.
 #define  PART_TESLA  	/obj/item/weapon/computer_hardware/tesla_link					// Tesla Link, Allows remote charging from nearest APC.
 //#define  PART_SCANNER  	/obj/item/weapon/computer_hardware/scanner						// One of several optional scanner attachments.
+
+//CHOMPAdd Start
+// ColorMate states
+#define COLORMATE_TINT 1
+#define COLORMATE_HSV 2
+#define COLORMATE_MATRIX 3
+//CHOMPAdd End

--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -187,10 +187,3 @@ if (!(DATUM.datum_flags & DF_ISPROCESSING)) {\
 //#define  PART_AI  		/obj/item/weapon/computer_hardware/ai_slot						// AI slot, an intellicard housing that allows modifications of AIs.
 #define  PART_TESLA  	/obj/item/weapon/computer_hardware/tesla_link					// Tesla Link, Allows remote charging from nearest APC.
 //#define  PART_SCANNER  	/obj/item/weapon/computer_hardware/scanner						// One of several optional scanner attachments.
-
-//CHOMPAdd Start
-// ColorMate states
-#define COLORMATE_TINT 1
-#define COLORMATE_HSV 2
-#define COLORMATE_MATRIX 3
-//CHOMPAdd End

--- a/code/__defines/misc_ch.dm
+++ b/code/__defines/misc_ch.dm
@@ -32,3 +32,8 @@
 #define VANTAG_VORE_DE	"vantag_vore_de"
 #define VANTAG_VORE_DD	"vantag_vore_dd"
 #define VANTAG_VORE_DA	"vantag_vore_da"
+
+// ColorMate states
+#define COLORMATE_TINT 1
+#define COLORMATE_HSV 2
+#define COLORMATE_MATRIX 3

--- a/modular_chomp/code/datums/colormate/colormate.dm
+++ b/modular_chomp/code/datums/colormate/colormate.dm
@@ -1,7 +1,3 @@
-#define COLORMATE_TINT 1
-#define COLORMATE_HSV 2
-#define COLORMATE_MATRIX 3
-
 /datum/ColorMate
 	var/name = "colouring"
 	var/atom/movable/inserted

--- a/modular_chomp/code/datums/colormate/colormate.dm
+++ b/modular_chomp/code/datums/colormate/colormate.dm
@@ -1,0 +1,223 @@
+#define COLORMATE_TINT 1
+#define COLORMATE_HSV 2
+#define COLORMATE_MATRIX 3
+
+/datum/ColorMate
+	var/name = "colouring"
+	var/atom/movable/inserted
+	var/activecolor = "#FFFFFF"
+	var/list/color_matrix_last
+	var/active_mode = COLORMATE_HSV
+
+	var/build_hue = 0
+	var/build_sat = 1
+	var/build_val = 1
+
+	/// Minimum lightness for normal mode
+	var/minimum_normal_lightness = 50
+	/// Minimum lightness for matrix mode, tested using 4 test colors of full red, green, blue, white.
+	var/minimum_matrix_lightness = 75
+	/// Minimum matrix tests that must pass for something to be considered a valid color (see above)
+	var/minimum_matrix_tests = 2
+	/// Temporary messages
+	var/temp
+
+/datum/ColorMate/New(mob/user)
+	color_matrix_last = list(
+		1, 0, 0,
+		0, 1, 0,
+		0, 0, 1,
+		0, 0, 0,
+	)
+	if(istype(user))
+		inserted = user
+	. = ..()
+
+/datum/ColorMate/Destroy()
+	inserted = null
+	. = ..()
+
+/datum/ColorMate/tgui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "ColorMate", name)
+		ui.open()
+
+/datum/ColorMate/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "ColorMate", src.name)
+		ui.set_autoupdate(FALSE) //This might be a bit intensive, better to not update it every few ticks
+		ui.open()
+
+/datum/ColorMate/tgui_state(mob/user)
+	return GLOB.tgui_conscious_state
+
+/datum/ColorMate/tgui_data()
+	. = list()
+	.["activemode"] = active_mode
+	.["matrixcolors"] = list(
+		"rr" = color_matrix_last[1],
+		"rg" = color_matrix_last[2],
+		"rb" = color_matrix_last[3],
+		"gr" = color_matrix_last[4],
+		"gg" = color_matrix_last[5],
+		"gb" = color_matrix_last[6],
+		"br" = color_matrix_last[7],
+		"bg" = color_matrix_last[8],
+		"bb" = color_matrix_last[9],
+		"cr" = color_matrix_last[10],
+		"cg" = color_matrix_last[11],
+		"cb" = color_matrix_last[12],
+	)
+	.["buildhue"] = build_hue
+	.["buildsat"] = build_sat
+	.["buildval"] = build_val
+	if(temp)
+		.["temp"] = temp
+	if(inserted)
+		.["item"] = list()
+		.["item"]["name"] = inserted.name
+		.["item"]["sprite"] = icon2base64(get_flat_icon(inserted,dir=SOUTH,no_anim=TRUE))
+		.["item"]["preview"] = icon2base64(build_preview())
+	else
+		.["item"] = null
+
+/datum/ColorMate/tgui_act(action, params)
+	. = ..()
+	if(.)
+		return
+	if(inserted)
+		switch(action)
+			if("switch_modes")
+				active_mode = text2num(params["mode"])
+				return TRUE
+			if("choose_color")
+				var/chosen_color = input(inserted, "Choose a color: ", "ColorMate colour picking", activecolor) as color|null
+				if(chosen_color)
+					activecolor = chosen_color
+				return TRUE
+			if("paint")
+				do_paint(inserted)
+				temp = "Painted Successfully!"
+				if(istype(inserted, /mob/living/simple_mob))
+					var/mob/living/simple_mob/M = inserted
+					M.has_recoloured = TRUE
+				if(istype(inserted, /mob/living/silicon/robot))
+					var/mob/living/silicon/robot/R = inserted
+					R.has_recoloured = TRUE
+				Destroy()
+			if("drop")
+				temp = ""
+				Destroy()
+			if("clear")
+				inserted.remove_atom_colour(FIXED_COLOUR_PRIORITY)
+				playsound(src, 'sound/effects/spray3.ogg', 50, 1)
+				temp = "Cleared Successfully!"
+				return TRUE
+			if("set_matrix_color")
+				color_matrix_last[params["color"]] = params["value"]
+				return TRUE
+			if("set_hue")
+				build_hue = clamp(text2num(params["buildhue"]), 0, 360)
+				return TRUE
+			if("set_sat")
+				build_sat = clamp(text2num(params["buildsat"]), -10, 10)
+				return TRUE
+			if("set_val")
+				build_val = clamp(text2num(params["buildval"]), -10, 10)
+				return TRUE
+
+/datum/ColorMate/proc/do_paint(mob/user)
+	var/color_to_use
+	switch(active_mode)
+		if(COLORMATE_TINT)
+			color_to_use = activecolor
+		if(COLORMATE_MATRIX)
+			color_to_use = rgb_construct_color_matrix(
+				text2num(color_matrix_last[1]),
+				text2num(color_matrix_last[2]),
+				text2num(color_matrix_last[3]),
+				text2num(color_matrix_last[4]),
+				text2num(color_matrix_last[5]),
+				text2num(color_matrix_last[6]),
+				text2num(color_matrix_last[7]),
+				text2num(color_matrix_last[8]),
+				text2num(color_matrix_last[9]),
+				text2num(color_matrix_last[10]),
+				text2num(color_matrix_last[11]),
+				text2num(color_matrix_last[12]),
+			)
+		if(COLORMATE_HSV)
+			color_to_use = color_matrix_hsv(build_hue, build_sat, build_val)
+			color_matrix_last = color_to_use
+	if(!color_to_use || !check_valid_color(color_to_use, user))
+		to_chat(user, SPAN_NOTICE("Invalid color."))
+		return FALSE
+	inserted.add_atom_colour(color_to_use, FIXED_COLOUR_PRIORITY)
+	playsound(src, 'sound/effects/spray3.ogg', 50, 1)
+	return TRUE
+
+/// Produces the preview image of the item, used in the UI, the way the color is not stacking is a sin.
+/datum/ColorMate/proc/build_preview()
+	if(inserted) //sanity
+		var/list/cm
+		switch(active_mode)
+			if(COLORMATE_MATRIX)
+				cm = rgb_construct_color_matrix(
+					text2num(color_matrix_last[1]),
+					text2num(color_matrix_last[2]),
+					text2num(color_matrix_last[3]),
+					text2num(color_matrix_last[4]),
+					text2num(color_matrix_last[5]),
+					text2num(color_matrix_last[6]),
+					text2num(color_matrix_last[7]),
+					text2num(color_matrix_last[8]),
+					text2num(color_matrix_last[9]),
+					text2num(color_matrix_last[10]),
+					text2num(color_matrix_last[11]),
+					text2num(color_matrix_last[12]),
+				)
+				if(!check_valid_color(cm, usr))
+					return get_flat_icon(inserted, dir=SOUTH, no_anim=TRUE)
+
+			if(COLORMATE_TINT)
+				if(!check_valid_color(activecolor, usr))
+					return get_flat_icon(inserted, dir=SOUTH, no_anim=TRUE)
+
+			if(COLORMATE_HSV)
+				cm = color_matrix_hsv(build_hue, build_sat, build_val)
+				color_matrix_last = cm
+				if(!check_valid_color(cm, usr))
+					return get_flat_icon(inserted, dir=SOUTH, no_anim=TRUE)
+
+		var/cur_color = inserted.color
+		inserted.color = null
+		inserted.color = (active_mode == COLORMATE_TINT ? activecolor : cm)
+		var/icon/preview = get_flat_icon(inserted, dir=SOUTH, no_anim=TRUE)
+		inserted.color = cur_color
+		temp = ""
+
+		. = preview
+
+/datum/ColorMate/proc/check_valid_color(list/cm, mob/user)
+	if(!islist(cm))		// normal
+		var/list/HSV = ReadHSV(RGBtoHSV(cm))
+		if(HSV[3] < minimum_normal_lightness)
+			temp = "[cm] is too dark (Minimum lightness: [minimum_normal_lightness])"
+			return FALSE
+		return TRUE
+	else	// matrix
+		// We test using full red, green, blue, and white
+		// A predefined number of them must pass to be considered valid
+		var/passed = 0
+#define COLORTEST(thestring, thematrix) passed += (ReadHSV(RGBtoHSV(RGBMatrixTransform(thestring, thematrix)))[3] >= minimum_matrix_lightness)
+		COLORTEST("FF0000", cm)
+		COLORTEST("00FF00", cm)
+		COLORTEST("0000FF", cm)
+		COLORTEST("FFFFFF", cm)
+#undef COLORTEST
+		if(passed < minimum_matrix_tests)
+			temp = "Matrix is too dark. (passed [passed] out of [minimum_matrix_tests] required tests. Minimum lightness: [minimum_matrix_lightness])."
+			return FALSE
+		return TRUE

--- a/modular_chomp/code/game/machinery/colormate.dm
+++ b/modular_chomp/code/game/machinery/colormate.dm
@@ -1,7 +1,3 @@
-#define COLORMATE_TINT 1
-#define COLORMATE_HSV 2
-#define COLORMATE_MATRIX 3
-
 /obj/machinery/gear_painter
 	name = "Color Mate"
 	desc = "A machine to give your apparel a fresh new color!"

--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot.dm
@@ -40,7 +40,7 @@
 	set desc = "Allows to recolour once."
 
 	if(!has_recoloured)
-		var/datum/ColorMate/recolour = new(usr)
+		var/datum/ColorMate/recolour = new /datum/ColorMate(usr)
 		recolour.tgui_interact(usr)
 		return
 	to_chat(usr, "You've already recoloured yourself once. Ask for a module reset for another.")

--- a/modular_chomp/code/modules/mob/living/silicon/robot/robot.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/robot.dm
@@ -1,6 +1,7 @@
 /mob/living/silicon/robot
 	var/sleeper_resting = FALSE //Enable resting belly sprites for dogborgs that have the sprites
 	var/datum/matter_synth/water_res = null //Enable water for lick clean
+	var/has_recoloured = FALSE
 
 /mob/living/silicon/robot/verb/purge_nutrition()
 	set name = "Purge Nutrition"
@@ -28,3 +29,18 @@
 				to_chat(src, "<span class='filter_notice'>You refill the extinguisher using your water reserves.</span>")
 			else
 				to_chat(src, "<span class='filter_notice'>Insufficient water reserves.</span>")
+
+/mob/living/silicon/robot/module_reset()
+	..()
+	has_recoloured = FALSE
+
+/mob/living/silicon/robot/verb/ColorMate()
+	set name = "Recolour Module"
+	set category = "Robot Commands"
+	set desc = "Allows to recolour once."
+
+	if(!has_recoloured)
+		var/datum/ColorMate/recolour = new(usr)
+		recolour.tgui_interact(usr)
+		return
+	to_chat(usr, "You've already recoloured yourself once. Ask for a module reset for another.")

--- a/modular_chomp/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -140,7 +140,7 @@
 	set desc = "Allows to recolour once."
 
 	if(!has_recoloured)
-		var/datum/ColorMate/recolour = new(usr)
+		var/datum/ColorMate/recolour = new /datum/ColorMate(usr)
 		recolour.tgui_interact(usr)
 		return
 	to_chat(usr, "You've already recoloured yourself once. You are only allowed to recolour yourself once during a around.")

--- a/modular_chomp/code/modules/mob/living/simple_mob/simple_mob.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/simple_mob.dm
@@ -3,6 +3,7 @@
 	var/list/speech_sounds = list()
 	var/speech_chance = 75 //mobs can be a bit more emotive than carbon/humans
 	var/speech_sound_enabled = TRUE
+	var/has_recoloured = FALSE
 
 	//vars for vore_icons toggle control
 	var/vore_icons_cache = null // null by default. Going from ON to OFF should store vore_icons val here, OFF to ON reset as null
@@ -132,3 +133,14 @@
 
 /mob/living/simple_mob/proc/character_directory_species()
 	return "simplemob"
+
+/mob/living/simple_mob/verb/ColorMate()
+	set name = "Recolour"
+	set category = "Abilities"
+	set desc = "Allows to recolour once."
+
+	if(!has_recoloured)
+		var/datum/ColorMate/recolour = new(usr)
+		recolour.tgui_interact(usr)
+		return
+	to_chat(usr, "You've already recoloured yourself once. You are only allowed to recolour yourself once during a around.")

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4607,7 +4607,7 @@
 #include "modular_chomp\code\datums\autolathe\general_ch.dm"
 #include "modular_chomp\code\datums\browser\color_matrix_picker.dm"
 #include "modular_chomp\code\datums\changelog\changelog.dm"
-#include "modular_chomp\code\datums\colormate\ColourMate.dm"
+#include "modular_chomp\code\datums\colormate\colormate.dm"
 #include "modular_chomp\code\datums\components\gargoyle.dm"
 #include "modular_chomp\code\datums\components\squeak.dm"
 #include "modular_chomp\code\datums\components\xenoqueen.dm"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4607,6 +4607,7 @@
 #include "modular_chomp\code\datums\autolathe\general_ch.dm"
 #include "modular_chomp\code\datums\browser\color_matrix_picker.dm"
 #include "modular_chomp\code\datums\changelog\changelog.dm"
+#include "modular_chomp\code\datums\colormate\ColourMate.dm"
 #include "modular_chomp\code\datums\components\gargoyle.dm"
 #include "modular_chomp\code\datums\components\squeak.dm"
 #include "modular_chomp\code\datums\components\xenoqueen.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
It's finally done... not the best implementation, but due to the differences between the object handling in the machine compared to a self recolour, it's mostly duplications for now and no fully datum migration. So this is a stripped down version of BM's matrix colour code for self use.

-> Simple Mobs can use it once per round
-> Robots can use a module reset board to use it again

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: self recolour verb for simple mobs and robots
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
