### PR TITLE
Properly fixes swoopie neck speed and turbomode inits

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -468,7 +468,7 @@
 		owner = loc
 		owner.vore_organs |= src
 		if(isliving(loc))
-			if(speedy_mob_processing) //CHOMPEdit Start
+			if(mode_flags & DM_FLAG_TURBOMODE) //CHOMPEdit Start
 				START_PROCESSING(SSobj, src)
 			else
 				START_PROCESSING(SSbellies, src)
@@ -477,7 +477,7 @@
 	flags |= NOREACT		// We dont want bellies to start bubling nonstop due to people mixing when transfering and making different reagents
 
 /obj/belly/Destroy()
-	if(speedy_mob_processing)
+	if(mode_flags & DM_FLAG_TURBOMODE)
 		STOP_PROCESSING(SSobj, src)
 	else
 		STOP_PROCESSING(SSbellies, src)

--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
@@ -92,45 +92,6 @@
 	B.count_items_for_sprite = TRUE
 
 	B = new /obj/belly/longneck(src)
-	B.affects_vore_sprites = TRUE
-	B.belly_sprite_to_affect = "neck4"
-	B.name = "vacuum hose 4"
-	B.autotransferlocation = "Churno-Vac"
-	B.desc = "Thank you for your biofuel contribution~"
-	B.fancy_vore = 1
-	B.vore_sound = "Stomach Move"
-	B.sound_volume = 20
-
-	B = new /obj/belly/longneck(src)
-	B.affects_vore_sprites = TRUE
-	B.belly_sprite_to_affect = "neck3"
-	B.name = "vacuum hose 3"
-	B.autotransferlocation = "vacuum hose 4"
-	B.desc = "Looks like it's gonna be all downhill from here..."
-	B.fancy_vore = 1
-	B.vore_sound = "Stomach Move"
-	B.sound_volume = 40
-
-	B = new /obj/belly/longneck(src)
-	B.affects_vore_sprites = TRUE
-	B.belly_sprite_to_affect = "neck2"
-	B.name = "vacuum hose 2"
-	B.autotransferlocation = "vacuum hose 3"
-	B.desc = "It feels very tight in here..."
-	B.fancy_vore = 1
-	B.vore_sound = "Stomach Move"
-	B.sound_volume = 80
-
-	B = new /obj/belly/longneck(src)
-	B.affects_vore_sprites = TRUE
-	B.belly_sprite_to_affect = "neck1"
-	B.name = "vacuum hose"
-	B.autotransferlocation = "vacuum hose 2"
-	B.fancy_vore = 1
-	B.vore_sound = "Stomach Move"
-	B.sound_volume = 100
-
-	B = new /obj/belly/longneck(src)
 	B.affects_vore_sprites = FALSE
 	B.name = "Vac-Beak"
 	B.desc = "SNAP! You have been sucked up into the big synthbird's beak, the powerful vacuum within the bird roaring somewhere beyond the abyssal deep gullet hungrily gaping before you, eagerly sucking you deeper inside towards a long bulgy ride down the bird's vacuum hose of a neck!"
@@ -144,6 +105,45 @@
 	B.belly_fullscreen = "VBO_maw8" //Swoopies have beaks!!
 
 	vore_selected = B
+
+	B = new /obj/belly/longneck(src)
+	B.affects_vore_sprites = TRUE
+	B.belly_sprite_to_affect = "neck1"
+	B.name = "vacuum hose"
+	B.autotransferlocation = "vacuum hose 2"
+	B.fancy_vore = 1
+	B.vore_sound = "Stomach Move"
+	B.sound_volume = 100
+
+	B = new /obj/belly/longneck(src)
+	B.affects_vore_sprites = TRUE
+	B.belly_sprite_to_affect = "neck2"
+	B.name = "vacuum hose 2"
+	B.autotransferlocation = "vacuum hose 3"
+	B.desc = "It feels very tight in here..."
+	B.fancy_vore = 1
+	B.vore_sound = "Stomach Move"
+	B.sound_volume = 80
+
+	B = new /obj/belly/longneck(src)
+	B.affects_vore_sprites = TRUE
+	B.belly_sprite_to_affect = "neck3"
+	B.name = "vacuum hose 3"
+	B.autotransferlocation = "vacuum hose 4"
+	B.desc = "Looks like it's gonna be all downhill from here..."
+	B.fancy_vore = 1
+	B.vore_sound = "Stomach Move"
+	B.sound_volume = 40
+
+	B = new /obj/belly/longneck(src)
+	B.affects_vore_sprites = TRUE
+	B.belly_sprite_to_affect = "neck4"
+	B.name = "vacuum hose 4"
+	B.autotransferlocation = "Churno-Vac"
+	B.desc = "Thank you for your biofuel contribution~"
+	B.fancy_vore = 1
+	B.vore_sound = "Stomach Move"
+	B.sound_volume = 20
 
 /obj/belly/longneck
 	affects_vore_sprites = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Swaps the init order of the neck sections to prevent the autotransfer skip bug.
Also fixes turbo mode processing not getting initialized from the mode addon.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Fixed turbo mode initialization and swoopie neck speed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
