### PR TITLE
Small Adjustments

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_xeno_ch.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno_ch.dm
@@ -19,7 +19,7 @@
 	sort_category = "Xenowear"
 
 /datum/gear/double_tank_phoron
-	display_name = "Pocket sized double phoron tank (Vox, Customs)"
+	display_name = "Pocket sized double phoron tank (Customs)"
 	path = /obj/item/weapon/tank/emergency/phoron/double
-	whitelisted = list(SPECIES_VOX, SPECIES_CUSTOM)
+	whitelisted = SPECIES_CUSTOM //CHOMPedit: voxes don't need phoron here, not full whitelist removal because I am unsure of what use non-customs get
 	sort_category = "Xenowear"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/neutral.dm
@@ -55,6 +55,7 @@
 			"x" = list("ks", "kss", "ksss")
 		),
 	autohiss_exempt = list(LANGUAGE_UNATHI))
+	custom_only = FALSE //CHOMPedit: Normal folks of species can't take their autohiss for some reason. Also ascents.
 	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_vassilian, /datum/trait/neutral/autohiss_zaddat) // CHOMPEdit: exclude vassillian hiss
 
 /datum/trait/neutral/autohiss_tajaran
@@ -67,6 +68,7 @@
 		),
 	autohiss_exempt = list(LANGUAGE_SIIK,LANGUAGE_AKHANI,LANGUAGE_ALAI))
 	excludes = list(/datum/trait/neutral/autohiss_unathi, /datum/trait/neutral/autohiss_zaddat, /datum/trait/neutral/autohiss_vassilian) // CHOMPEdit: exclude vassillian hiss
+	custom_only = FALSE //CHOMPedit: Normal folks of species can't take their autohiss for some reason. Also ascents.
 
 /datum/trait/neutral/autohiss_zaddat
 	name = "Autohiss (Zaddat)"
@@ -85,6 +87,7 @@
 		),
 	autohiss_exempt = list(LANGUAGE_ZADDAT,LANGUAGE_VESPINAE))
 	excludes = list(/datum/trait/neutral/autohiss_tajaran, /datum/trait/neutral/autohiss_unathi)
+	custom_only = FALSE //CHOMPedit: Normal folks of species can't take their autohiss for some reason. Also ascents.
 
 /datum/trait/neutral/bloodsucker
 	name = "Bloodsucker, Obligate"
@@ -530,6 +533,7 @@
 	name = "Colorblindness (Monochromancy)"
 	desc = "You simply can't see colors at all, period. You are 100% colorblind."
 	cost = 0
+	custom_only = FALSE //CHOMPedit: Some of this are named with species, and there is a descent number of reasons to have this.
 
 /datum/trait/neutral/colorblind/mono/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
@@ -539,6 +543,7 @@
 	name = "Colorblindness (Para Vulp)"
 	desc = "You have a severe issue with green colors and have difficulty recognizing them from red colors."
 	cost = 0
+	custom_only = FALSE //CHOMPedit: Some of this are named with species, and there is a descent number of reasons to have this.
 
 /datum/trait/neutral/colorblind/para_vulp/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
@@ -548,6 +553,7 @@
 	name = "Colorblindness (Para Taj)"
 	desc = "You have a minor issue with blue colors and have difficulty recognizing them from red colors."
 	cost = 0
+	custom_only = FALSE //CHOMPedit: Some of this are named with species, and there is a descent number of reasons to have this.
 
 /datum/trait/neutral/colorblind/para_taj/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()

--- a/modular_chomp/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/modular_chomp/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -19,7 +19,7 @@
 
 /datum/gear/suit/winterhood
 	display_name = "Winter Hood"
-	path = /obj/item/clothing/head/hood/cloak/winter
+	path = /obj/item/clothing/head/hood/winter
 	cost = 0
 
 /datum/gear/suit/martianminer

--- a/modular_chomp/code/modules/exploration/lootsafe.dm
+++ b/modular_chomp/code/modules/exploration/lootsafe.dm
@@ -110,6 +110,8 @@
 		code += pick(digits)
 		digits -= code[code.len]
 
+	generate_loot()
+
 
 /obj/structure/closet/crate/secure/lootsafe/numberlock/togglelock(mob/user as mob)
 	if(!locked)
@@ -208,6 +210,9 @@
 	for(var/i in 1 to codelen)
 		code += pick(digits)
 		digits -= code[code.len]
+
+	generate_loot()
+
 
 
 /obj/structure/closet/crate/secure/lootsafe/devillock/togglelock(mob/user as mob)


### PR DESCRIPTION
-Winter coat hood has proper pathing
-Added custom species = false to autohisses, and colorblindness 
-Phoron double tank lost the vox whitelist requirement, but uhhh, wasn't really useful to vox. Soo custom species should be able to take it?
-Holler at me in the morning if something is wrong

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
qol: Everyone can be colorblind now, and have auto-hisses. 
qol: Removed vox requirement from Double Phoron tank
fix: improper pathing on winter coat hood loadout
fix: Loot safes not having loot in them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
