### PR TITLE
Give devs and event managers freedom from job whitelists

### DIFF
--- a/code/game/jobs/whitelist_vr.dm
+++ b/code/game/jobs/whitelist_vr.dm
@@ -20,7 +20,7 @@ var/list/job_whitelist = list()
 		return 1
 	if(rank == USELESS_JOB) //VOREStation Edit - Visitor not Assistant
 		return 1
-	if(check_rights(R_ADMIN, 0))
+	if(check_rights(R_ADMIN, 0) || check_rights(R_DEBUG, 0) || check_rights(R_EVENT, 0))
 		return 1
 	if(!job_whitelist)
 		return 0

--- a/code/game/jobs/whitelist_vr.dm
+++ b/code/game/jobs/whitelist_vr.dm
@@ -20,7 +20,7 @@ var/list/job_whitelist = list()
 		return 1
 	if(rank == USELESS_JOB) //VOREStation Edit - Visitor not Assistant
 		return 1
-	if(check_rights(R_ADMIN, 0) || check_rights(R_DEBUG, 0) || check_rights(R_EVENT, 0))
+	if(check_rights(R_ADMIN, 0) || check_rights(R_DEBUG, 0) || check_rights(R_EVENT, 0)) // CHOMPedit
 		return 1
 	if(!job_whitelist)
 		return 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

So a while back devs and event managers were given job whitelisting as a perk of being staff. At some point this stopped working. This fixes that.

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: all staff should have job whitelists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
