### PR TITLE
Removes scene-disrupting transcore autonotification

### DIFF
--- a/code/controllers/subsystems/transcore_vr.dm
+++ b/code/controllers/subsystems/transcore_vr.dm
@@ -116,11 +116,11 @@ SUBSYSTEM_DEF(transcore)
 		if(since_backup < overdue_time)
 			curr_MR.dead_state = MR_NORMAL
 		else
-			if(curr_MR.dead_state != MR_DEAD) //First time switching to dead	//Remove auto notification! Ghosts have a button to notify, so no more false flags. CHOMPEdit: Revert removal
+/*			if(curr_MR.dead_state != MR_DEAD) //First time switching to dead	//Remove auto notification! Ghosts have a button to notify, so no more false flags. CHOMPEdit: Readded removal.
 				if(curr_MR.do_notify)
 					db.notify(curr_MR)
 					curr_MR.last_notification = world.time
-
+*/
 			curr_MR.dead_state = MR_DEAD
 
 		if(MC_TICK_CHECK)


### PR DESCRIPTION
:cl:
qol: Removed transcore automatic notifications for deceased crew. You can still manually ping transcore for a resleeve from the OOC tab or use the autoresleever as needed.
/:cl: