### PR TITLE
fixes explo multi repair proc exploit

### DIFF
--- a/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
@@ -66,7 +66,7 @@
 	var/disabled_icon = "armor"
 	var/active_icon = "armor_broken"
 	var/target_component = "armour"
-	var/repairing = 0
+	var/repairing = FALSE
 
 /obj/item/device/self_repair_system/New()
 	..()
@@ -74,7 +74,7 @@
 
 /obj/item/device/self_repair_system/attack_self(mob/user)
 	if(repairing)
-		return;
+		return
 	var/mob/living/silicon/robot/R = user
 	var/datum/robot_component/C = R.components[target_component]
 	if(C && !istype(C.wrapped, /obj/item/broken_device))
@@ -84,9 +84,9 @@
 		to_chat(R, "<span class='notice'>Repair system initializated. Repairing plating and wiring.</span>")
 		icon_state = active_icon
 		update_icon()
-		repairing = 1
+		repairing = TRUE
 		src.self_repair(R, C, 25, 2.5)
-		repairing = 0
+		repairing = FALSE
 		icon_state = disabled_icon
 		update_icon()
 	else

--- a/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
@@ -66,12 +66,15 @@
 	var/disabled_icon = "armor"
 	var/active_icon = "armor_broken"
 	var/target_component = "armour"
+	var/repairing = 0
 
 /obj/item/device/self_repair_system/New()
 	..()
 	flags |= NOBLUDGEON
 
 /obj/item/device/self_repair_system/attack_self(mob/user)
+	if(repairing)
+		return;
 	var/mob/living/silicon/robot/R = user
 	var/datum/robot_component/C = R.components[target_component]
 	if(C && !istype(C.wrapped, /obj/item/broken_device))
@@ -81,7 +84,9 @@
 		to_chat(R, "<span class='notice'>Repair system initializated. Repairing plating and wiring.</span>")
 		icon_state = active_icon
 		update_icon()
+		repairing = 1
 		src.self_repair(R, C, 25, 2.5)
+		repairing = 0
 		icon_state = disabled_icon
 		update_icon()
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Seems I've forgotten to lock the proc down not to be multi procable
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Explohound repair multiproc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
