### PR TITLE
removes 2 loose walls in carrier shuttle

### DIFF
--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -128,14 +128,15 @@
 	base_area = /area/expoutpost/hangarfive;
 	base_turf = /turf/simulated/floor/reinforced;
 	landmark_tag = "needle_dock";
-	name = "Needle Dock"
+	name = "Needle Dock";
+	docking_controller = "needle_dock"
 	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "afR" = (
 /turf/simulated/floor,
@@ -166,7 +167,7 @@
 	pixel_x = -25;
 	pixel_y = 32
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "ahX" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -376,7 +377,7 @@
 /area/expoutpost/hangarfour)
 "apk" = (
 /obj/structure/sign/nanotrasen,
-/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/turf/simulated/wall/thull,
 /area/shuttle/ursula)
 "apr" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -552,9 +553,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/slingcarrierdock)
-"axJ" = (
-/turf/simulated/shuttle/wall/voidcraft/no_join,
-/area/shuttle/needle)
 "aym" = (
 /obj/effect/mist,
 /obj/machinery/light/small{
@@ -729,7 +727,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "aFH" = (
 /obj/machinery/power/apc{
@@ -815,7 +813,7 @@
 /area/expoutpost/starfuelstorage)
 "aHq" = (
 /obj/structure/sign/nanotrasen,
-/turf/simulated/shuttle/wall/voidcraft/no_join,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "aHw" = (
 /obj/machinery/power/smes/buildable{
@@ -950,7 +948,7 @@
 	},
 /obj/item/weapon/gun/energy/locked/phasegun/rifle,
 /obj/item/weapon/gun/energy/locked/phasegun/rifle,
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor/tiled/red,
 /area/shuttle/stargazer)
 "aMn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1058,7 +1056,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "aRW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1073,7 +1071,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "aSF" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -1231,7 +1229,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "aZm" = (
 /obj/structure/closet/emcloset,
@@ -1299,7 +1297,7 @@
 /obj/structure/sign/poster/nanotrasen{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "bbO" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
@@ -1477,7 +1475,7 @@
 /area/expoutpost/engstorage)
 "bjP" = (
 /obj/structure/sign/nanotrasen,
-/turf/simulated/shuttle/wall/voidcraft/no_join,
+/turf/simulated/wall/thull,
 /area/shuttle/needle)
 "bjT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1541,12 +1539,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
-/turf/simulated/shuttle/wall/voidcraft/no_join,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "blO" = (
 /obj/structure/ore_box,
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/echidna)
 "bmu" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1587,7 +1585,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal,
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/needle)
 "bnN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1805,7 +1803,7 @@
 "bwn" = (
 /obj/structure/shuttle/engine/heater,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/yellow,
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "bwJ" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -2035,7 +2033,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/baby_mammoth)
 "bKJ" = (
 /obj/machinery/power/smes/buildable{
@@ -2127,7 +2125,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "bOb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -2304,7 +2302,7 @@
 /obj/machinery/door/airlock/glass_centcom{
 	req_one_access = list(67)
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "bTg" = (
 /obj/structure/shuttle/engine/heater,
@@ -2325,7 +2323,7 @@
 /obj/machinery/computer/shuttle_control/explore/ursula{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "bVv" = (
 /obj/effect/floor_decal/techfloor{
@@ -2393,7 +2391,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "bYa" = (
 /turf/simulated/floor/reinforced,
@@ -2468,7 +2466,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "cbF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2523,7 +2521,7 @@
 	layer = 2.5;
 	name = "window blast shield"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "ccE" = (
 /obj/structure/closet/walllocker/emerglocker{
@@ -2534,7 +2532,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "ccN" = (
 /turf/simulated/floor/tiled/white,
@@ -2581,7 +2579,7 @@
 /obj/structure/bed/chair/bay/comfy/captain{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "cev" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -2591,7 +2589,7 @@
 /obj/structure/sign/poster/nanotrasen{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/stargazer)
 "ceN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2870,7 +2868,7 @@
 	pixel_x = -32;
 	pixel_y = 32
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "cpa" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -2902,7 +2900,7 @@
 	dir = 4
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "cqN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2987,7 +2985,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "ctL" = (
 /obj/item/trash,
@@ -3024,7 +3022,7 @@
 	dir = 2;
 	req_one_access = list(67)
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "cuH" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -3160,7 +3158,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "czY" = (
 /obj/machinery/light{
@@ -3264,7 +3262,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "cEh" = (
 /obj/effect/floor_decal/techfloor{
@@ -3353,7 +3351,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/stargazer)
 "cJB" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -3408,7 +3406,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/ursula)
 "cMj" = (
 /turf/simulated/wall/r_wall,
@@ -3440,7 +3438,7 @@
 	health = 25;
 	name = "reinforced grille"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "cNv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -3499,7 +3497,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "cQy" = (
 /obj/effect/floor_decal/techfloor{
@@ -3614,7 +3612,7 @@
 	frequency = 1380;
 	id_tag = "echidna_pump"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "cTW" = (
 /obj/structure/catwalk,
@@ -3876,7 +3874,7 @@
 	health = 25;
 	name = "reinforced grille"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "dhb" = (
 /obj/structure/window/plastitanium/full,
@@ -3900,7 +3898,7 @@
 	name = "window blast shield"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "dhO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4000,7 +3998,7 @@
 	health = 25;
 	name = "reinforced grille"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "dnG" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -4126,7 +4124,7 @@
 /obj/machinery/sleeper{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/white,
 /area/shuttle/baby_mammoth)
 "dvg" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -4143,7 +4141,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "dwh" = (
 /obj/structure/extinguisher_cabinet{
@@ -4191,7 +4189,7 @@
 /obj/structure/sign/poster/nanotrasen{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "dya" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -4316,7 +4314,7 @@
 "dBB" = (
 /obj/structure/shuttle/engine/heater,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/yellow,
-/turf/simulated/shuttle/wall/voidcraft/red,
+/turf/simulated/wall/thull,
 /area/shuttle/needle)
 "dBU" = (
 /obj/effect/floor_decal/techfloor{
@@ -4324,9 +4322,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/uppersternhallway)
-"dCk" = (
-/turf/simulated/shuttle/wall/voidcraft/no_join,
-/area/shuttle/echidna)
 "dDf" = (
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/purple/bordercorner,
@@ -4375,7 +4370,7 @@
 	frequency = 1380;
 	id_tag = "echidna_pump"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "dEY" = (
 /obj/effect/floor_decal/borderfloorblack/corner,
@@ -4403,7 +4398,7 @@
 	dir = 1;
 	req_one_access = list(67)
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "dGt" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -4475,7 +4470,7 @@
 /obj/machinery/computer/ship/engines{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "dHI" = (
 /obj/structure/table/rack/shelf,
@@ -4632,7 +4627,7 @@
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
 "dMm" = (
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "dMs" = (
 /obj/effect/wingrille_spawn/reinforced_phoron,
@@ -4756,7 +4751,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "dTw" = (
 /obj/structure/closet/secure_closet/miner{
@@ -4765,7 +4760,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "dTM" = (
 /obj/effect/floor_decal/techfloor{
@@ -4797,7 +4792,7 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "dVz" = (
 /turf/simulated/floor/carpet,
@@ -5160,7 +5155,7 @@
 "emW" = (
 /obj/machinery/shipsensors,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "enc" = (
 /obj/structure/window/reinforced{
@@ -5253,7 +5248,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 1
 	},
-/turf/simulated/shuttle/wall/voidcraft/orange,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "eqH" = (
 /obj/structure/table/standard,
@@ -5281,7 +5276,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "erv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5344,7 +5339,8 @@
 /area/expoutpost/midsternhallway)
 "etp" = (
 /obj/machinery/chem_master,
-/turf/simulated/shuttle/floor/purple,
+/obj/effect/floor_decal/milspec/color/purple,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "ets" = (
 /obj/machinery/cell_charger,
@@ -5383,7 +5379,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "euW" = (
 /obj/machinery/light{
@@ -5637,7 +5633,7 @@
 /area/expoutpost/breakroom)
 "eCl" = (
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "eCw" = (
 /obj/structure/table/marble,
@@ -5796,9 +5792,6 @@
 	},
 /turf/simulated/floor,
 /area/expoutpost/starfuelstorage)
-"eKg" = (
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/shuttle/ursula)
 "eKi" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
@@ -5878,7 +5871,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "eMf" = (
 /obj/machinery/power/quantumpad{
@@ -6010,7 +6003,7 @@
 /obj/machinery/shuttle_sensor{
 	id_tag = "shuttle4sens_exp_psg"
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "eQM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6131,7 +6124,7 @@
 	dir = 8;
 	pixel_x = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "eTu" = (
 /turf/simulated/floor/tiled,
@@ -6170,7 +6163,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "eVg" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -6436,7 +6429,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "ffb" = (
 /obj/machinery/washing_machine,
@@ -6550,7 +6543,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "fkd" = (
 /obj/structure/table/wooden_reinforced,
@@ -6561,7 +6554,8 @@
 /area/expoutpost/suite2)
 "fkh" = (
 /obj/machinery/mineral/equipment_vendor/survey,
-/turf/simulated/shuttle/floor/purple,
+/obj/effect/floor_decal/milspec/color/purple,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "fkD" = (
 /obj/structure/catwalk,
@@ -6607,7 +6601,7 @@
 /obj/machinery/recharger{
 	pixel_x = -6
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "flu" = (
 /obj/structure/cable/green{
@@ -6615,7 +6609,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "fmp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6835,7 +6829,7 @@
 	pixel_x = 4;
 	pixel_y = 25
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "ftT" = (
 /obj/random/trash,
@@ -6885,7 +6879,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "fwE" = (
 /obj/structure/table/steel_reinforced,
@@ -6894,7 +6888,8 @@
 /area/expoutpost/gatewayeva)
 "fwG" = (
 /obj/machinery/autolathe,
-/turf/simulated/shuttle/floor/purple,
+/obj/effect/floor_decal/milspec/color/purple,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "fwT" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -6961,7 +6956,7 @@
 	id_tag = "baby_mammoth_sensor";
 	pixel_y = 28
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "fzr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -7114,7 +7109,7 @@
 	health = 25;
 	name = "reinforced grille"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "fEU" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -7134,7 +7129,7 @@
 	pixel_x = 32;
 	pixel_y = 3
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "fGm" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
@@ -7223,7 +7218,7 @@
 	health = 25;
 	name = "reinforced grille"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "fLd" = (
 /obj/structure/sign/directions/bridge,
@@ -7243,7 +7238,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "fMI" = (
 /obj/machinery/door/firedoor/multi_tile/glass{
@@ -7359,7 +7354,8 @@
 	pixel_x = 24;
 	pixel_y = 32
 	},
-/turf/simulated/shuttle/floor/purple,
+/obj/effect/floor_decal/milspec/color/purple,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "fRS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -7390,7 +7386,7 @@
 	id = "stargazer_blast";
 	name = "window blast shield"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "fSU" = (
 /obj/machinery/door/firedoor/glass,
@@ -7400,7 +7396,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/midsternhallway)
 "fVa" = (
-/turf/simulated/shuttle/wall/voidcraft,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "fVd" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -7419,7 +7415,7 @@
 	opacity = 1;
 	req_one_access = list(67)
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "fVW" = (
 /turf/simulated/floor/tiled/freezer,
@@ -7546,7 +7542,7 @@
 	dir = 5;
 	id_tag = "shuttle4sens_exp"
 	},
-/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "gcz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
@@ -7719,7 +7715,7 @@
 	id_tag = "baby_mammoth_pump"
 	},
 /obj/structure/closet/emcloset,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "ggX" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -7741,7 +7737,7 @@
 /obj/structure/bed/chair/bay/comfy/red{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "ghC" = (
 /obj/structure/grille,
@@ -7780,7 +7776,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/shuttle/plating,
 /area/shuttle/shuttle3/start)
 "giX" = (
 /obj/structure/catwalk,
@@ -7967,7 +7963,7 @@
 /area/expoutpost/telecomms)
 "gtk" = (
 /obj/machinery/computer/ship/sensors,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "gui" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -8050,7 +8046,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "gxB" = (
 /obj/effect/floor_decal/grass_edge/corner{
@@ -8097,7 +8093,7 @@
 	id = "stargazer_blast";
 	name = "window blast shield"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "gzy" = (
 /turf/simulated/wall/r_wall,
@@ -8121,7 +8117,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/thull,
 /area/shuttle/ursula)
 "gAd" = (
 /obj/structure/railing/grey{
@@ -8178,14 +8174,14 @@
 /obj/structure/bed/chair/bay/comfy/green{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "gBv" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
 /obj/structure/sign/nanotrasen,
-/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "gBy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -8251,7 +8247,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/thull,
 /area/shuttle/ursula)
 "gEi" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -8327,7 +8323,7 @@
 /area/expoutpost/hangarfive)
 "gKs" = (
 /obj/structure/sign/mining,
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "gKu" = (
 /obj/effect/floor_decal/grass_edge{
@@ -8457,7 +8453,7 @@
 /area/expoutpost/staginghangar)
 "gNG" = (
 /obj/structure/bed/chair/bay/shuttle,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "gNV" = (
 /obj/structure/cable/green{
@@ -8505,7 +8501,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "gPH" = (
 /obj/structure/shuttle/engine/heater,
@@ -8668,7 +8664,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/ursula)
 "gYa" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
@@ -8960,7 +8956,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "hju" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9035,7 +9031,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "hlF" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -9083,7 +9079,12 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/shuttle/plating,
+/obj/machinery/door/airlock/voidcraft/vertical{
+	frequency = 1380;
+	id_tag = "echidna_inner";
+	name = "External Access"
+	},
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "hmz" = (
 /obj/structure/cable/green{
@@ -9203,13 +9204,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/baby_mammoth)
 "hrn" = (
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "hrw" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -9261,7 +9262,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "hsO" = (
 /obj/structure/cable/green{
@@ -9467,7 +9468,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/ursula)
 "hCj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -9748,7 +9749,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "hKH" = (
 /obj/machinery/computer/gyrotron_control{
@@ -9920,12 +9921,6 @@
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/janitorial)
-"hSD" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/turf/simulated/shuttle/wall/voidcraft/no_join,
-/area/shuttle/baby_mammoth)
 "hTs" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -9976,7 +9971,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "hVm" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
@@ -10025,7 +10020,7 @@
 	layer = 2.5;
 	name = "window blast shield"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "hZq" = (
 /obj/structure/window/plastitanium/full,
@@ -10040,7 +10035,7 @@
 	health = 25;
 	name = "reinforced grille"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "hZv" = (
 /obj/machinery/smartfridge/sheets{
@@ -10117,7 +10112,7 @@
 /turf/simulated/floor/grass2,
 /area/expoutpost/botany)
 "idy" = (
-/turf/simulated/shuttle/wall/voidcraft/no_join,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "idW" = (
 /obj/machinery/computer/ship/navigation/telescreen{
@@ -10128,7 +10123,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "iel" = (
 /obj/machinery/light{
@@ -10244,7 +10239,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
-/turf/simulated/shuttle/wall/voidcraft/no_join,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "ihP" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -10359,7 +10354,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 1
 	},
-/turf/simulated/shuttle/wall/voidcraft/no_join,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "imf" = (
 /obj/effect/catwalk_plated/techfloor,
@@ -10383,7 +10378,7 @@
 /obj/machinery/door/window/survival_pod{
 	dir = 2
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "imX" = (
 /obj/structure/disposalpipe/segment{
@@ -10444,7 +10439,7 @@
 	pixel_x = 24;
 	pixel_y = 32
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "ipN" = (
 /obj/structure/disposalpipe/trunk{
@@ -10504,7 +10499,7 @@
 "iry" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/shipsensors,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "irI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -10550,7 +10545,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "isv" = (
 /obj/structure/table/steel_reinforced,
@@ -10618,7 +10613,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
-/turf/simulated/shuttle/wall/voidcraft/no_join,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "iuL" = (
 /obj/effect/floor_decal/techfloor{
@@ -10671,6 +10666,12 @@
 	},
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "echidna_dock";
+	name = "shuttle bay controller";
+	pixel_x = -29
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
@@ -10736,7 +10737,7 @@
 /area/expoutpost/civaccesshallway)
 "iBn" = (
 /obj/structure/bed/chair/bay/shuttle,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "iBp" = (
 /turf/simulated/floor/tiled/white,
@@ -10851,7 +10852,7 @@
 "iFY" = (
 /obj/structure/shuttle/engine/router,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
-/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/turf/simulated/wall/thull,
 /area/shuttle/ursula)
 "iGn" = (
 /obj/effect/floor_decal/techfloor{
@@ -10918,7 +10919,7 @@
 /area/expoutpost/hangartwo)
 "iKh" = (
 /obj/machinery/sleep_console,
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/white,
 /area/shuttle/stargazer)
 "iKm" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -11091,7 +11092,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
-/turf/simulated/shuttle/wall/voidcraft/no_join,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "iSg" = (
 /obj/structure/cable/blue{
@@ -11167,7 +11168,7 @@
 /area/expoutpost/staginghangar)
 "iUF" = (
 /obj/structure/sign/nanotrasen,
-/turf/simulated/shuttle/wall/voidcraft/green,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "iUL" = (
 /obj/structure/table/rack/shelf,
@@ -11185,9 +11186,6 @@
 /obj/item/clothing/head/helmet/space/void/security,
 /turf/simulated/floor/tiled,
 /area/expoutpost/secoffice)
-"iUS" = (
-/turf/simulated/shuttle/wall/voidcraft/green,
-/area/shuttle/stargazer)
 "iVw" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11390,10 +11388,7 @@
 /area/shuttle/shuttle3/start)
 "jeH" = (
 /obj/structure/sign/nanotrasen,
-/turf/simulated/shuttle/wall/voidcraft/lightblue,
-/area/shuttle/baby_mammoth)
-"jfl" = (
-/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "jfr" = (
 /obj/structure/cable/green{
@@ -11564,7 +11559,7 @@
 	name = "Fuel Into Main"
 	},
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/shuttle3/start)
 "jlK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11581,7 +11576,7 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/stationqpad)
 "jlO" = (
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/thull,
 /area/shuttle/needle)
 "jmh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11610,7 +11605,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "jnf" = (
 /obj/structure/window/plastitanium/full,
@@ -11629,7 +11624,7 @@
 	id = "stargazer_blast";
 	name = "window blast shield"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "jng" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -11717,7 +11712,7 @@
 	dir = 6
 	},
 /obj/structure/shuttle/engine/router,
-/turf/simulated/shuttle/wall/voidcraft/red,
+/turf/simulated/wall/thull,
 /area/shuttle/needle)
 "jqu" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -11804,7 +11799,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "jtd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11891,7 +11886,7 @@
 /area/expoutpost/miningfoyer)
 "jwP" = (
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "jwU" = (
 /obj/machinery/light/small{
@@ -12144,7 +12139,7 @@
 	pixel_x = 4;
 	pixel_y = -32
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "jHs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -12190,7 +12185,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "jIb" = (
 /obj/machinery/power/quantumpad{
@@ -12556,7 +12551,7 @@
 	frequency = 1380;
 	id_tag = "stargazer_pump"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "jWv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
@@ -12571,9 +12566,6 @@
 "jWP" = (
 /turf/simulated/wall/r_wall,
 /area/expoutpost/secarmory)
-"jWS" = (
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/shuttle/baby_mammoth)
 "jWV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12646,7 +12638,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "kbl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12808,7 +12800,7 @@
 	frequency = 1380;
 	id_tag = "ursula_pump"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "kkt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -13018,7 +13010,7 @@
 "ksy" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/machinery/atmospherics/portables_connector,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "ktu" = (
 /turf/simulated/wall/r_wall,
@@ -13078,7 +13070,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "kwM" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -13115,14 +13107,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/stargazer)
 "kxZ" = (
 /obj/structure/shuttle/engine/heater,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
-/turf/simulated/shuttle/wall/voidcraft/orange,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "kye" = (
 /obj/structure/cable/green{
@@ -13253,7 +13245,7 @@
 /area/expoutpost/staginghangar)
 "kDE" = (
 /obj/structure/window/reinforced/survival_pod,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "kDU" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -13298,7 +13290,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "kHY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13509,7 +13501,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/baby_mammoth)
 "kQr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
@@ -13556,7 +13548,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/wall/rpshull,
 /area/expoutpost/uppersternhallway)
 "kSB" = (
 /obj/structure/catwalk,
@@ -13580,7 +13572,7 @@
 /obj/machinery/computer/ship/sensors{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "kTo" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
@@ -13666,7 +13658,7 @@
 	health = 25;
 	name = "reinforced grille"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "kXt" = (
 /obj/machinery/atmospherics/binary/pump,
@@ -13744,7 +13736,7 @@
 /area/expoutpost/rnd)
 "kZQ" = (
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "lae" = (
 /obj/structure/closet/crate,
@@ -13820,7 +13812,7 @@
 	req_access = list(67);
 	specialfunctions = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "lcN" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -13829,7 +13821,7 @@
 	name = "Fuel Into Main"
 	},
 /obj/machinery/light,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "ldk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13957,7 +13949,7 @@
 /obj/machinery/door/airlock/centcom{
 	req_one_access = newlist()
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/shuttle3/start)
 "liP" = (
 /turf/simulated/floor/tiled,
@@ -13976,7 +13968,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/exploarmory)
 "ljI" = (
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "ljK" = (
 /obj/machinery/body_scanconsole,
@@ -14475,7 +14467,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/ursula)
 "lDn" = (
 /obj/machinery/light{
@@ -14484,7 +14476,7 @@
 /obj/machinery/computer/shuttle_control/explore/baby_mammoth{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "lDp" = (
 /obj/random/soap,
@@ -14516,7 +14508,7 @@
 	frequency = 1380;
 	id_tag = "stargazer_pump"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "lEc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14599,7 +14591,7 @@
 	name = "remote blast shielding control";
 	pixel_x = 27
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "lGu" = (
 /obj/machinery/door/firedoor/glass,
@@ -14812,7 +14804,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "lMZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14843,7 +14835,7 @@
 	pixel_x = -28;
 	pixel_y = -1
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "lOd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14857,9 +14849,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/eva)
-"lOl" = (
-/turf/simulated/shuttle/wall/voidcraft/no_join,
-/area/shuttle/stargazer)
 "lOK" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/machinery/atmospherics/portables_connector{
@@ -14869,7 +14858,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "lOU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14960,14 +14949,14 @@
 	pixel_x = -25;
 	pixel_y = 32
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "lRD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
 /obj/structure/shuttle/engine/router,
-/turf/simulated/shuttle/wall/voidcraft/red,
+/turf/simulated/wall/thull,
 /area/shuttle/needle)
 "lRH" = (
 /obj/structure/table/wooden_reinforced,
@@ -15125,7 +15114,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/white,
 /area/shuttle/baby_mammoth)
 "lVZ" = (
 /obj/structure/cable/green{
@@ -15168,7 +15157,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/thull,
 /area/shuttle/ursula)
 "lXD" = (
 /obj/structure/toilet{
@@ -15242,7 +15231,7 @@
 "lZG" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/shipsensors,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "lZN" = (
 /obj/structure/closet/secure_closet/guncabinet/phase{
@@ -15273,7 +15262,7 @@
 /obj/structure/panic_button{
 	pixel_x = -32
 	},
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor/tiled/red,
 /area/shuttle/baby_mammoth)
 "mbg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -15384,7 +15373,7 @@
 	id = "stargazer_blast";
 	name = "window blast shield"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "mef" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -15459,7 +15448,7 @@
 	inputting = 1
 	},
 /obj/structure/cable/green,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "miL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15536,7 +15525,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "mld" = (
 /obj/machinery/vending/tool{
@@ -15578,7 +15567,8 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medbaylobby)
 "mmL" = (
-/turf/simulated/shuttle/floor/purple,
+/obj/effect/floor_decal/milspec/color/purple,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "mmN" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -15606,7 +15596,7 @@
 /area/space)
 "mnn" = (
 /obj/machinery/computer/ship/navigation,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "mnp" = (
 /obj/machinery/atmospherics/unary/engine/biggest{
@@ -15994,7 +15984,7 @@
 	pixel_y = 5
 	},
 /obj/structure/closet/walllocker_double/hydrant/east,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "mFX" = (
 /obj/effect/floor_decal/techfloor{
@@ -16057,7 +16047,7 @@
 /turf/simulated/floor,
 /area/expoutpost/atmospherics)
 "mGP" = (
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/white,
 /area/shuttle/baby_mammoth)
 "mHR" = (
 /obj/structure/cable/green{
@@ -16127,7 +16117,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/shuttle/plating,
 /area/shuttle/shuttle3/start)
 "mJA" = (
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -16304,7 +16294,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "mPx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16344,7 +16334,7 @@
 /area/expoutpost/eva)
 "mRH" = (
 /obj/machinery/computer/ship/helm,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "mTc" = (
 /obj/machinery/light{
@@ -16575,13 +16565,13 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/thull,
 /area/shuttle/needle)
 "nas" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
-/turf/simulated/shuttle/wall/voidcraft/orange,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "naY" = (
 /obj/structure/table/standard,
@@ -16631,7 +16621,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/secbowcheckpoint)
 "ncz" = (
-/turf/simulated/shuttle/wall/voidcraft/orange,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "ncM" = (
 /turf/simulated/wall/r_wall,
@@ -16757,7 +16747,7 @@
 /area/expoutpost/atmospherics)
 "nhn" = (
 /obj/machinery/computer/ship/helm,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "nhZ" = (
 /obj/structure/railing{
@@ -16834,13 +16824,13 @@
 	pixel_y = -26;
 	specialfunctions = 4
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "njd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
-/turf/simulated/shuttle/wall/voidcraft/no_join,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "njk" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
@@ -16900,9 +16890,10 @@
 	base_area = /area/expoutpost/hangarsix;
 	base_turf = /turf/simulated/floor/reinforced;
 	landmark_tag = "echidna_dock";
-	name = "Echidna Dock"
+	name = "Echidna Dock";
+	docking_controller = "echidna_dock"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "nlk" = (
 /obj/structure/cable/green{
@@ -16931,7 +16922,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/needle)
 "nlT" = (
 /obj/machinery/door/airlock/voidcraft/vertical{
@@ -16944,7 +16935,7 @@
 	pixel_y = -26;
 	specialfunctions = 4
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "nmj" = (
 /obj/effect/floor_decal/techfloor,
@@ -16977,7 +16968,7 @@
 	health = 25;
 	name = "reinforced grille"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "nmZ" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -17002,7 +16993,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "nnn" = (
 /obj/machinery/recharger/wallcharger{
@@ -17142,6 +17133,12 @@
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 1
 	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "stargazer_dock";
+	name = "shuttle bay controller";
+	pixel_x = -29
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
 "nsG" = (
@@ -17164,7 +17161,7 @@
 	dir = 1
 	},
 /obj/machinery/computer/shuttle_control/explore/echidna,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "ntb" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -17172,7 +17169,7 @@
 	dir = 4;
 	name = "Phoron to Connector"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/stargazer)
 "nte" = (
 /obj/structure/table/steel_reinforced,
@@ -17233,12 +17230,6 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
 "nuF" = (
-/obj/machinery/door/airlock/multi_tile/metal/mait{
-	dir = 1;
-	icon_state = "door_locked";
-	id_tag = "echidna_inner";
-	locked = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
@@ -17247,7 +17238,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "nuL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17304,7 +17295,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "nwM" = (
 /obj/machinery/door/firedoor/multi_tile/glass,
@@ -17340,7 +17331,12 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/shuttle/plating,
+/obj/machinery/door/airlock/voidcraft/vertical{
+	frequency = 1380;
+	id_tag = "echidna_outer";
+	name = "External Access"
+	},
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "nyb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -17429,7 +17425,7 @@
 /area/expoutpost/lowersternhallway)
 "nBb" = (
 /obj/machinery/computer/ship/sensors,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "nBd" = (
 /obj/machinery/power/apc{
@@ -17502,7 +17498,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "nCG" = (
 /obj/effect/floor_decal/techfloor/corner{
@@ -17686,7 +17682,7 @@
 /obj/item/device/t_scanner,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/gloves/yellow,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "nHj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17738,7 +17734,7 @@
 /area/shuttle/shuttle3/start)
 "nIp" = (
 /obj/machinery/recharge_station,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "nIv" = (
 /obj/structure/cable/green{
@@ -17812,7 +17808,7 @@
 /area/expoutpost/staruppermaint)
 "nKT" = (
 /obj/machinery/computer/ship/helm,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "nLe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17865,7 +17861,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "nMy" = (
 /obj/machinery/light{
@@ -17943,7 +17939,7 @@
 /obj/structure/bed/chair/bay/comfy/blue{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "nTf" = (
 /turf/simulated/wall/r_wall,
@@ -17971,7 +17967,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/thull,
 /area/shuttle/ursula)
 "nVw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -18122,7 +18118,8 @@
 	base_area = /area/expoutpost/hangartwo;
 	base_turf = /turf/simulated/floor/reinforced;
 	landmark_tag = "baby_mammoth_dock";
-	name = "Baby Mammoth Dock"
+	name = "Baby Mammoth Dock";
+	docking_controller = "baby_mammoth_dock"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -18132,7 +18129,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "obN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18149,6 +18146,24 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/washroom)
+"obS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "ursula_dock";
+	name = "shuttle bay controller";
+	pixel_x = 29
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarthree)
 "oct" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -18272,7 +18287,7 @@
 /obj/machinery/computer/shuttle_control/explore/stargazer{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "ofo" = (
 /obj/machinery/suit_cycler/pilot,
@@ -18324,7 +18339,7 @@
 	pixel_x = -25;
 	pixel_y = 32
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "oiA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18375,7 +18390,7 @@
 /area/expoutpost/hangarone)
 "ojA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/shuttle/wall/voidcraft/green,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "ojE" = (
 /obj/structure/railing/grey{
@@ -18406,7 +18421,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
-/turf/simulated/shuttle/wall/voidcraft/no_join,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "olw" = (
 /obj/machinery/alarm{
@@ -18600,7 +18615,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "ovS" = (
 /obj/structure/cable/green{
@@ -18848,7 +18863,7 @@
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "oFn" = (
 /obj/structure/window/reinforced,
@@ -19379,7 +19394,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "peF" = (
 /obj/effect/floor_decal/techfloor{
@@ -19427,7 +19442,8 @@
 /obj/structure/closet/walllocker_double/hydrant/south,
 /obj/item/weapon/storage/firstaid/o2,
 /obj/item/weapon/storage/firstaid/regular,
-/turf/simulated/shuttle/floor/purple,
+/obj/effect/floor_decal/milspec/color/purple,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "phG" = (
 /obj/machinery/gateway/centerstation,
@@ -19504,7 +19520,8 @@
 	},
 /obj/item/weapon/tank/phoron,
 /obj/item/weapon/tank/phoron,
-/turf/simulated/shuttle/floor/purple,
+/obj/effect/floor_decal/milspec/color/purple,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "pko" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19537,11 +19554,11 @@
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_y = 32
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/stargazer)
 "pmr" = (
 /obj/effect/overmap/visitable/ship/landable/baby_mammoth,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "pmD" = (
 /turf/simulated/floor/reinforced,
@@ -19565,7 +19582,7 @@
 /obj/item/device/gps,
 /obj/item/weapon/tank/phoron,
 /obj/item/weapon/tank/phoron,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "pnG" = (
 /obj/effect/floor_decal/grass_edge{
@@ -19642,7 +19659,7 @@
 /obj/machinery/computer/ship/engines{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "psU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19787,7 +19804,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "pzJ" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -19860,7 +19877,7 @@
 /area/expoutpost/breakroom)
 "pBa" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "pBY" = (
 /obj/structure/catwalk,
@@ -19893,7 +19910,7 @@
 	health = 25;
 	name = "reinforced grille"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "pDu" = (
 /obj/structure/railing/overhang/waterless/grey,
@@ -19949,7 +19966,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "pEN" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -20045,7 +20062,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "pKJ" = (
 /obj/structure/railing/grey{
@@ -20162,8 +20179,12 @@
 /turf/simulated/floor,
 /area/expoutpost/starsciencemaint)
 "pNA" = (
-/turf/simulated/shuttle/wall/voidcraft/red,
-/area/shuttle/needle)
+/obj/structure/shuttle/engine/heater,
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 1
+	},
+/turf/simulated/wall/thull,
+/area/shuttle/ursula)
 "pNT" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -20295,7 +20316,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "pVg" = (
 /obj/machinery/door/firedoor/multi_tile/glass,
@@ -20617,10 +20638,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /turf/simulated/floor/wood,
 /area/expoutpost/washroom)
-"qei" = (
-/obj/structure/sign/mining,
-/turf/simulated/shuttle/wall/voidcraft/orange,
-/area/shuttle/echidna)
 "qes" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -20637,7 +20654,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "qgo" = (
 /obj/effect/floor_decal/techfloor/corner{
@@ -20854,7 +20871,7 @@
 	id = "stargazer_blast";
 	name = "window blast shield"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "qpa" = (
 /obj/structure/cable/green{
@@ -20915,7 +20932,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/turf/simulated/wall/thull,
 /area/shuttle/ursula)
 "qrC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -20971,7 +20988,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "qse" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -20992,7 +21009,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/needle)
 "qtv" = (
 /obj/structure/closet/walllocker_double/hydrant/north,
@@ -21000,7 +21017,7 @@
 	pixel_x = -27;
 	pixel_y = -4
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/stargazer)
 "qtA" = (
 /obj/machinery/door/airlock/voidcraft/vertical{
@@ -21016,7 +21033,7 @@
 	pixel_y = 26;
 	req_access = null
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/shuttle/plating,
 /area/shuttle/shuttle3/start)
 "qtK" = (
 /obj/machinery/door/firedoor/glass,
@@ -21141,7 +21158,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "qwc" = (
 /obj/structure/table/wooden_reinforced,
@@ -21294,7 +21311,7 @@
 /area/expoutpost/slingcarrierdock)
 "qDn" = (
 /obj/machinery/computer/ship/navigation,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "qDv" = (
 /obj/effect/floor_decal/techfloor{
@@ -21372,7 +21389,7 @@
 /area/expoutpost/reactorroom)
 "qGj" = (
 /obj/structure/sign/redcross,
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "qGW" = (
 /obj/structure/cable/green{
@@ -21451,7 +21468,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "qKs" = (
 /obj/effect/floor_decal/techfloor{
@@ -21475,7 +21492,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "qLk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -21519,7 +21536,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "qLD" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -21538,7 +21555,7 @@
 	frequency = 1380;
 	id_tag = "ursula_pump"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "qMu" = (
 /obj/structure/sign/directions/cargo,
@@ -21561,7 +21578,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/ursula)
 "qMV" = (
 /obj/random/maintenance/clean,
@@ -21745,7 +21762,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/stargazer)
 "qWQ" = (
 /turf/simulated/wall/r_wall,
@@ -21911,19 +21928,13 @@
 /turf/simulated/floor,
 /area/expoutpost/lowersternhallway)
 "rdi" = (
-/obj/machinery/door/airlock/multi_tile/metal/mait{
-	dir = 1;
-	icon_state = "door_locked";
-	id_tag = "echidna_outer";
-	locked = 1
-	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/shuttle/plating,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "rdq" = (
 /obj/machinery/light/small{
@@ -22077,7 +22088,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor/tiled/red,
 /area/shuttle/stargazer)
 "rij" = (
 /obj/structure/cable/green{
@@ -22140,7 +22151,7 @@
 	pixel_x = -26;
 	pixel_y = -1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "rkg" = (
 /obj/machinery/light/small{
@@ -22162,7 +22173,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/turf/simulated/shuttle/wall/voidcraft/orange,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "rku" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22414,7 +22425,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "rrQ" = (
 /obj/structure/cable/green{
@@ -22431,7 +22442,7 @@
 /obj/item/weapon/storage/firstaid/toxin,
 /obj/item/weapon/storage/firstaid/o2,
 /obj/item/roller,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "rsv" = (
 /obj/structure/cable/green{
@@ -22442,7 +22453,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "rsG" = (
 /obj/effect/floor_decal/techfloor/corner{
@@ -22702,7 +22713,7 @@
 /obj/item/clothing/accessory/holster/hip,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/device/gps/mining,
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/echidna)
 "rAJ" = (
 /obj/effect/floor_decal/techfloor{
@@ -22884,7 +22895,7 @@
 /area/expoutpost/staginghangar)
 "rKb" = (
 /obj/machinery/computer/ship/navigation,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "rKf" = (
 /obj/effect/floor_decal/industrial/warning/cee{
@@ -23024,14 +23035,15 @@
 	base_area = /area/expoutpost/hangarfour;
 	base_turf = /turf/simulated/floor/reinforced;
 	landmark_tag = "stargazer_dock";
-	name = "Stargazer Dock"
+	name = "Stargazer Dock";
+	docking_controller = "stargazer_dock"
 	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "rNo" = (
 /obj/machinery/autolathe,
@@ -23090,7 +23102,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "rOJ" = (
 /obj/effect/floor_decal/techfloor/corner{
@@ -23208,7 +23220,7 @@
 /obj/structure/sign/poster/nanotrasen{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/white,
 /area/shuttle/stargazer)
 "rQS" = (
 /obj/structure/plasticflaps/mining,
@@ -23400,14 +23412,15 @@
 	base_area = /area/expoutpost/hangarthree;
 	base_turf = /turf/simulated/floor/reinforced;
 	landmark_tag = "ursula_dock";
-	name = "Ursula Dock"
+	name = "Ursula Dock";
+	docking_controller = "ursula_dock"
 	},
 /obj/structure/cable/blue{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "rXD" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -23547,9 +23560,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
-"sgt" = (
-/turf/simulated/shuttle/wall/voidcraft/no_join,
-/area/shuttle/ursula)
 "sgz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23578,14 +23588,14 @@
 	dir = 4;
 	name = "Fuel Into Main"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "sii" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
 /obj/structure/sign/nanotrasen,
-/turf/simulated/shuttle/wall/voidcraft/green,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "sim" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23869,7 +23879,7 @@
 	id = "stargazer_blast";
 	name = "window blast shield"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "suq" = (
 /obj/structure/table/wooden_reinforced,
@@ -24039,7 +24049,7 @@
 /obj/item/weapon/storage/firstaid/toxin,
 /obj/item/weapon/storage/firstaid/regular,
 /obj/item/roller,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "sCn" = (
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -24079,7 +24089,7 @@
 /area/expoutpost/botany)
 "sEi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/thull,
 /area/shuttle/ursula)
 "sEA" = (
 /obj/structure/grille,
@@ -24135,7 +24145,7 @@
 	frequency = 1380;
 	id_tag = "stargazer_pump"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "sHQ" = (
 /obj/structure/cable/green{
@@ -24143,7 +24153,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "sIv" = (
 /obj/structure/bed/chair/sofa/corner/brown{
@@ -24435,13 +24445,13 @@
 	dir = 1
 	},
 /obj/structure/bed/chair/bay/shuttle,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "sTY" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/shuttle/plating,
 /area/shuttle/shuttle3/start)
 "sUH" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -24451,7 +24461,7 @@
 /area/expoutpost/rnd)
 "sUJ" = (
 /obj/effect/overmap/visitable/ship/landable/needle,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "sUK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -24506,7 +24516,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "sXC" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -24805,14 +24815,14 @@
 /area/expoutpost/suite2)
 "thw" = (
 /obj/effect/overmap/visitable/ship/landable/stargazer,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "thD" = (
 /obj/machinery/sleep_console,
 /obj/structure/sign/nosmoking_1{
 	pixel_y = 32
 	},
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/white,
 /area/shuttle/baby_mammoth)
 "thG" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -24832,7 +24842,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/needle)
 "tis" = (
 /obj/item/weapon/folder/yellow,
@@ -24961,7 +24971,7 @@
 	pixel_x = -32;
 	pixel_y = -4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "tpm" = (
 /obj/structure/cable/blue{
@@ -24974,7 +24984,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/stargazer)
 "tpv" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -25171,7 +25181,7 @@
 	id = "stargazer_blast";
 	name = "window blast shield"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "tzB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -25415,7 +25425,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "tHC" = (
 /obj/random/trash_pile,
@@ -25423,7 +25433,7 @@
 /area/expoutpost/portuppermaint)
 "tHG" = (
 /obj/effect/overmap/visitable/ship/landable/echidna,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "tHQ" = (
 /obj/structure/sign/department/medbay{
@@ -25612,7 +25622,7 @@
 /obj/structure/panic_button{
 	pixel_x = 32
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "tNr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25660,7 +25670,7 @@
 	},
 /obj/machinery/light,
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "tOE" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -25720,7 +25730,7 @@
 	pixel_x = -25;
 	pixel_y = -1
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "tTX" = (
 /obj/structure/flora/pottedplant/aquatic,
@@ -25750,7 +25760,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "tUp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -25868,7 +25878,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "tYc" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -25895,7 +25905,8 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
-/turf/simulated/shuttle/floor/purple,
+/obj/effect/floor_decal/milspec/color/purple,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "tYC" = (
 /obj/random/trash_pile,
@@ -26127,7 +26138,7 @@
 /obj/machinery/computer/ship/helm{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "ugO" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -26186,9 +26197,6 @@
 	},
 /turf/simulated/floor,
 /area/expoutpost/lowersternhallway)
-"ujC" = (
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/shuttle/stargazer)
 "ujJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26263,7 +26271,7 @@
 /turf/simulated/floor,
 /area/expoutpost/reactoraccess)
 "ulX" = (
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "umd" = (
 /obj/machinery/door/airlock/glass_external{
@@ -26284,7 +26292,7 @@
 /area/expoutpost/civaccesshallway)
 "unl" = (
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "unp" = (
 /obj/structure/railing/grey,
@@ -26360,7 +26368,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "upU" = (
 /obj/structure/cable/green{
@@ -26473,7 +26481,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/echidna)
 "usS" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -26546,7 +26554,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/techstorage)
 "uwQ" = (
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "uwX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -26616,7 +26624,7 @@
 /obj/structure/bed/chair/bay/comfy/red{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "uzg" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -26640,7 +26648,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
 "uzI" = (
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/stargazer)
 "uzN" = (
 /obj/machinery/alarm{
@@ -26690,7 +26698,7 @@
 /obj/structure/sign/poster/nanotrasen{
 	dir = 8
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "uBe" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -26800,7 +26808,7 @@
 /obj/machinery/computer/shuttle_control/explore/needle{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "uEZ" = (
 /turf/simulated/wall/r_wall,
@@ -26838,7 +26846,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
-/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "uIT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27193,7 +27201,7 @@
 /obj/structure/sign/poster/nanotrasen{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "uTc" = (
 /obj/structure/window/reinforced{
@@ -27312,7 +27320,7 @@
 	frequency = 1380;
 	id_tag = "stargazer_pump"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "uWW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27354,6 +27362,12 @@
 	},
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	id_tag = "baby_mammoth_dock";
+	name = "shuttle bay controller";
+	pixel_x = -29
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
@@ -27536,7 +27550,7 @@
 	health = 25;
 	name = "reinforced grille"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "vfD" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -27636,7 +27650,7 @@
 "vmL" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/shipsensors/weak,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/needle)
 "vmY" = (
 /obj/structure/closet/crate/radiation,
@@ -27651,7 +27665,7 @@
 /area/expoutpost/engstorage)
 "vnd" = (
 /obj/machinery/optable,
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/white,
 /area/shuttle/baby_mammoth)
 "vnD" = (
 /obj/vehicle/train/rover/engine{
@@ -27717,7 +27731,7 @@
 	pixel_x = 24;
 	pixel_y = 32
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "voN" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -27827,6 +27841,12 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 4
 	},
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1380;
+	name = "shuttle bay controller";
+	pixel_x = 29;
+	id_tag = "needle_dock"
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
 "vsC" = (
@@ -27844,7 +27864,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
 "vsW" = (
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "vtK" = (
 /obj/machinery/power/shield_generator/charged{
@@ -27864,7 +27884,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "vub" = (
 /obj/structure/bed/chair/bay/shuttle{
@@ -27910,7 +27930,7 @@
 /obj/item/weapon/storage/firstaid/o2,
 /obj/item/weapon/storage/firstaid/surgery,
 /obj/item/weapon/storage/firstaid/adv,
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/white,
 /area/shuttle/baby_mammoth)
 "vvK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27978,7 +27998,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "vxd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27992,7 +28012,7 @@
 	pixel_x = 32
 	},
 /obj/structure/bed/chair/bay/shuttle,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "vxS" = (
 /obj/structure/extinguisher_cabinet{
@@ -28133,7 +28153,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "vEk" = (
 /turf/simulated/floor,
@@ -28173,7 +28193,7 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/expoutpost/botany)
 "vGF" = (
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "vGM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28262,7 +28282,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
-/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "vKd" = (
 /obj/structure/window/plastitanium/full,
@@ -28281,7 +28301,7 @@
 	id = "stargazer_blast";
 	name = "window blast shield"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "vKk" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -28374,7 +28394,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/stargazer)
 "vMv" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -28423,7 +28443,7 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
 "vOu" = (
-/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/turf/simulated/wall/thull,
 /area/shuttle/ursula)
 "vOM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28432,7 +28452,7 @@
 /area/expoutpost/rndlobby)
 "vPp" = (
 /obj/machinery/door/airlock/glass_centcom,
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/white,
 /area/shuttle/baby_mammoth)
 "vPw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -28490,7 +28510,7 @@
 	dir = 1
 	},
 /obj/machinery/recharge_station,
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor/tiled/red,
 /area/shuttle/stargazer)
 "vQy" = (
 /obj/machinery/door/firedoor/glass,
@@ -28656,7 +28676,7 @@
 	req_one_access = null;
 	specialfunctions = 4
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/shuttle3/start)
 "vWD" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -28896,7 +28916,7 @@
 	id_tag = "baby_mammoth_pump"
 	},
 /obj/machinery/light,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "wed" = (
 /obj/structure/cable/green{
@@ -28941,7 +28961,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "weH" = (
 /obj/effect/floor_decal/techfloor{
@@ -29632,7 +29652,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "wLS" = (
 /obj/item/device/radio/intercom{
@@ -29803,7 +29823,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/echidna)
 "wSp" = (
 /obj/structure/closet/crate,
@@ -30178,7 +30198,7 @@
 /obj/item/weapon/storage/mre/random,
 /obj/item/weapon/storage/mre/random,
 /obj/item/weapon/storage/mre/random,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "xii" = (
 /obj/structure/cable/blue{
@@ -30374,8 +30394,21 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
 "xnV" = (
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
-/area/shuttle/echidna)
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor,
+/area/shuttle/shuttle3/start)
 "xoH" = (
 /obj/structure/railing{
 	dir = 4
@@ -30469,7 +30502,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/wall/rpshull,
 /area/expoutpost/uppersternhallway)
 "xsc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -30624,7 +30657,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "xxd" = (
 /obj/machinery/alarm{
@@ -30738,7 +30771,7 @@
 "xzH" = (
 /obj/machinery/shipsensors,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/ursula)
 "xzP" = (
 /obj/machinery/atmospherics/binary/algae_farm/filled{
@@ -30854,7 +30887,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
-/turf/simulated/shuttle/wall/voidcraft/orange,
+/turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "xFz" = (
 /obj/machinery/vending/cola{
@@ -30870,7 +30903,7 @@
 /area/expoutpost/explobriefroom)
 "xFR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "xGP" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -30889,7 +30922,7 @@
 /obj/structure/panic_button{
 	pixel_x = 32
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/shuttle/echidna)
 "xIx" = (
 /obj/effect/floor_decal/techfloor{
@@ -31102,7 +31135,7 @@
 	health = 25;
 	name = "reinforced grille"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/echidna)
 "xOk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -31165,7 +31198,7 @@
 	id_tag = "expshuttle4_door_cargo";
 	locked = 1
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "xPS" = (
 /obj/structure/toilet{
@@ -31211,7 +31244,7 @@
 	dir = 8
 	},
 /obj/structure/shuttle/engine/heater,
-/turf/simulated/shuttle/wall/voidcraft/hard_corner,
+/turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "xQK" = (
 /obj/structure/cable/green{
@@ -31306,7 +31339,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/black,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "xTO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -31494,7 +31527,8 @@
 	pixel_y = 5
 	},
 /obj/structure/table/darkglass,
-/turf/simulated/shuttle/floor/purple,
+/obj/effect/floor_decal/milspec/color/purple,
+/turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "yad" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31765,7 +31799,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
 	},
-/turf/simulated/shuttle/wall/voidcraft,
+/turf/simulated/wall/rshull,
 /area/shuttle/stargazer)
 "yiB" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -59664,7 +59698,7 @@ bFX
 ghC
 qzM
 lEK
-oUi
+xnV
 rIq
 ajQ
 rEv
@@ -60146,12 +60180,12 @@ xwl
 xwl
 xwl
 xwl
-pNA
+jlO
 niW
-pNA
+jlO
 bjP
 jlO
-pNA
+jlO
 xwl
 hcY
 lGy
@@ -60165,7 +60199,7 @@ vOu
 vOu
 vOu
 nlT
-sgt
+vOu
 qrm
 apk
 vOu
@@ -60180,7 +60214,7 @@ bFX
 sEA
 oGt
 lEK
-oUi
+xnV
 rIq
 ajQ
 wNc
@@ -60400,15 +60434,15 @@ jcG
 xwl
 xwl
 xwl
-pNA
+jlO
 pCz
-pNA
+jlO
 xwl
-pNA
+jlO
 ljI
 lcN
 jlO
-pNA
+jlO
 xwl
 xwl
 hcY
@@ -60418,7 +60452,7 @@ sPX
 mzd
 bYa
 vOu
-eKg
+vOu
 ugc
 bUY
 dxN
@@ -60657,15 +60691,15 @@ kXV
 jcG
 xwl
 xwl
-pNA
+jlO
 jlO
 uEr
 jlO
-axJ
+jlO
 jlO
 ccE
 rOE
-pNA
+jlO
 vmL
 xwl
 xwl
@@ -60914,7 +60948,7 @@ tMo
 kXV
 jcG
 xwl
-pNA
+jlO
 jlO
 mRH
 ghb
@@ -60934,7 +60968,7 @@ sPX
 mzd
 bYa
 vOu
-eKg
+vOu
 kTe
 fVj
 voF
@@ -61194,7 +61228,7 @@ bYa
 bYa
 vOu
 vOu
-eKg
+vOu
 pjI
 mmL
 aRW
@@ -61430,7 +61464,7 @@ tMo
 kXV
 jcG
 xwl
-pNA
+jlO
 jlO
 nBb
 uyH
@@ -61457,8 +61491,8 @@ mmL
 tYt
 gDR
 mPc
-eKg
-xkY
+vOu
+pNA
 nRS
 xuz
 bYa
@@ -61689,15 +61723,15 @@ kXV
 jcG
 xwl
 xwl
-pNA
+jlO
 jlO
 pqJ
 jlO
-axJ
+jlO
 jlO
 qrZ
 jlO
-pNA
+jlO
 kZQ
 xwl
 xwl
@@ -61948,15 +61982,15 @@ jcG
 xwl
 xwl
 xwl
-pNA
+jlO
 pCz
-pNA
+jlO
 xwl
-pNA
+jlO
 afh
 lNh
 jlO
-pNA
+jlO
 xwl
 xwl
 hcY
@@ -61968,7 +62002,7 @@ bYa
 bYa
 bYa
 vOu
-eKg
+vOu
 fwG
 fkh
 gzN
@@ -62210,12 +62244,12 @@ xwl
 xwl
 xwl
 xwl
-pNA
+jlO
 upT
-pNA
+jlO
 bjP
 jlO
-pNA
+jlO
 xwl
 hcY
 lGy
@@ -62229,7 +62263,7 @@ bYa
 vOu
 dgK
 dnE
-sgt
+vOu
 cts
 apk
 vOu
@@ -63006,7 +63040,7 @@ gnO
 gnO
 yfE
 gnO
-bZy
+obS
 ezJ
 ibm
 wFp
@@ -67389,10 +67423,10 @@ cJN
 cJN
 cJN
 cJN
-iUS
-iUS
-iUS
-iUS
+fVa
+fVa
+fVa
+fVa
 iUF
 ihN
 tMh
@@ -67623,7 +67657,7 @@ arV
 fil
 lvT
 ncz
-xnV
+ncz
 qLe
 pnw
 lOK
@@ -67641,13 +67675,13 @@ kKd
 sem
 cyD
 cJN
-iUS
+fVa
 stN
-iUS
+fVa
 stN
-lOl
-iUS
-iUS
+fVa
+fVa
+fVa
 qtv
 vQn
 cev
@@ -67880,7 +67914,7 @@ kKd
 arV
 fil
 lvT
-qei
+gKs
 nta
 ahD
 kDE
@@ -67898,8 +67932,8 @@ wxi
 kKd
 sem
 cyD
-iUS
-ujC
+fVa
+fVa
 ofh
 fVa
 vEd
@@ -68437,16 +68471,16 @@ pmD
 pmD
 pmD
 pmD
-jfl
+idy
 tzn
 idy
 tzn
 jeH
-jfl
+idy
 ccq
-jfl
-jfl
-jfl
+idy
+idy
+idy
 aIg
 gUm
 adT
@@ -68679,7 +68713,7 @@ fEH
 iBn
 iBn
 hsz
-lOl
+fVa
 fEH
 vMu
 fVa
@@ -68694,8 +68728,8 @@ sNH
 pmD
 pmD
 pmD
-jfl
-jWS
+idy
+idy
 dus
 lUK
 vvJ
@@ -68912,7 +68946,7 @@ kKd
 arV
 fil
 lvT
-qei
+gKs
 cDX
 ipz
 kDE
@@ -68930,8 +68964,8 @@ wxi
 kKd
 sem
 cyD
-iUS
-ujC
+fVa
+fVa
 dHD
 fVa
 sCg
@@ -68950,14 +68984,14 @@ gXs
 vQf
 sNH
 pmD
-jfl
+idy
 tzn
-jWS
-jWS
+idy
+idy
 thD
 mGP
 vnd
-jWS
+idy
 cbA
 hrh
 vtK
@@ -69171,7 +69205,7 @@ emt
 fil
 lvT
 ncz
-xnV
+ncz
 dTw
 flk
 eTt
@@ -69189,13 +69223,13 @@ kKd
 sem
 cyD
 cJN
-iUS
+fVa
 stN
-iUS
+fVa
 stN
-lOl
-iUS
-iUS
+fVa
+fVa
+fVa
 uWT
 rNe
 jWh
@@ -69207,15 +69241,15 @@ kLn
 gXs
 vQf
 sNH
-jfl
-jWS
+idy
+idy
 lDn
 lZN
-jWS
+idy
 qGj
 vPp
-jWS
-jWS
+idy
+idy
 tHB
 bKr
 nCe
@@ -69436,8 +69470,8 @@ aHq
 ncz
 ncz
 ncz
-dCk
-qei
+ncz
+gKs
 ncz
 ncz
 lvT
@@ -69453,8 +69487,8 @@ cJN
 cJN
 cJN
 cJN
-iUS
-iUS
+fVa
+fVa
 gPg
 ojA
 sii
@@ -69469,11 +69503,11 @@ mdR
 rjE
 nSv
 jmy
-jWS
+idy
 nIp
 vsW
 idW
-jWS
+idy
 dTq
 czV
 aRI
@@ -70239,8 +70273,8 @@ akr
 gXs
 vQf
 sNH
-jfl
-jWS
+idy
+idy
 feH
 xic
 ePO
@@ -70498,10 +70532,10 @@ gXs
 vQf
 sNH
 pmD
-jfl
+idy
 tzn
-jWS
-jWS
+idy
+idy
 uSR
 pzF
 tXS
@@ -70758,12 +70792,12 @@ sNH
 pmD
 pmD
 pmD
-jfl
-jWS
+idy
+idy
 ftL
 mDz
 jHm
-hSD
+ouM
 fzd
 oba
 ggU
@@ -71017,16 +71051,16 @@ pmD
 pmD
 pmD
 pmD
-jfl
+idy
 tzn
 iRY
 dhb
 gBv
-jfl
+idy
 nwH
 gbV
-jfl
-jfl
+idy
+idy
 aIg
 sgO
 hVa

--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -24495,18 +24495,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/expoutpost/portsternairlock)
-"sWr" = (
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
-	id_tag = "shuttle4_shuttle";
-	pixel_y = 26;
-	tag_airpump = "shuttle4_pump";
-	tag_chamber_sensor = "shuttle4_sensor";
-	tag_exterior_door = "shuttle4_outer";
-	tag_interior_door = "shuttle4_inner"
-	},
-/turf/simulated/wall/r_wall,
-/area/expoutpost/staruppermaint)
 "sWF" = (
 /obj/machinery/door/airlock/glass_centcom{
 	req_one_access = list(67)
@@ -74418,7 +74406,7 @@ cwA
 xEV
 xEV
 xEV
-sWr
+qWQ
 qWQ
 qWQ
 qWQ

--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -13548,7 +13548,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/wall/rpshull,
+/turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/uppersternhallway)
 "kSB" = (
 /obj/structure/catwalk,
@@ -30502,7 +30502,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/wall/rpshull,
+/turf/simulated/floor/tiled/dark,
 /area/expoutpost/uppersternhallway)
 "xsc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{

--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -1475,7 +1475,7 @@
 /area/expoutpost/engstorage)
 "bjP" = (
 /obj/structure/sign/nanotrasen,
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rplastihull,
 /area/shuttle/needle)
 "bjT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1585,7 +1585,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal,
-/turf/simulated/floor/tiled/yellow,
+/turf/simulated/floor/tiled/red,
 /area/shuttle/needle)
 "bnN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4314,7 +4314,7 @@
 "dBB" = (
 /obj/structure/shuttle/engine/heater,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/yellow,
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rplastihull,
 /area/shuttle/needle)
 "dBU" = (
 /obj/effect/floor_decal/techfloor{
@@ -11576,7 +11576,7 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/stationqpad)
 "jlO" = (
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rplastihull,
 /area/shuttle/needle)
 "jmh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11712,7 +11712,7 @@
 	dir = 6
 	},
 /obj/structure/shuttle/engine/router,
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rplastihull,
 /area/shuttle/needle)
 "jqu" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -12958,7 +12958,7 @@
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_y = -4
 	},
-/turf/simulated/shuttle/wall/voidcraft/no_join,
+/turf/simulated/wall/rplastihull,
 /area/shuttle/needle)
 "kra" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14956,7 +14956,7 @@
 	dir = 10
 	},
 /obj/structure/shuttle/engine/router,
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rplastihull,
 /area/shuttle/needle)
 "lRH" = (
 /obj/structure/table/wooden_reinforced,
@@ -16565,7 +16565,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/turf/simulated/wall/thull,
+/turf/simulated/wall/rplastihull,
 /area/shuttle/needle)
 "nas" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
@@ -21009,7 +21009,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/yellow,
+/turf/simulated/floor/tiled/red,
 /area/shuttle/needle)
 "qtv" = (
 /obj/structure/closet/walllocker_double/hydrant/north,
@@ -24842,7 +24842,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/yellow,
+/turf/simulated/floor/tiled/red,
 /area/shuttle/needle)
 "tis" = (
 /obj/item/weapon/folder/yellow,

--- a/modular_chomp/maps/overmap/space_pois/abandonedtele_13x12.dmm
+++ b/modular_chomp/maps/overmap/space_pois/abandonedtele_13x12.dmm
@@ -92,6 +92,7 @@
 	amount = 10
 	},
 /obj/item/weapon/circuitboard/teleporter,
+/obj/item/frame/apc,
 /turf/simulated/floor/plating/external,
 /area/submap/abandonedtele)
 "x" = (
@@ -120,6 +121,10 @@
 /area/submap/abandonedtele)
 "N" = (
 /turf/simulated/wall/r_wall,
+/area/submap/abandonedtele)
+"O" = (
+/obj/item/weapon/module/power_control,
+/turf/simulated/floor/plating/external,
 /area/submap/abandonedtele)
 "P" = (
 /obj/item/weapon/material/shard{
@@ -227,7 +232,7 @@ g
 k
 p
 u
-k
+O
 N
 N
 c

--- a/modular_chomp/maps/overmap/space_pois/turretedoutpost_23x19.dmm
+++ b/modular_chomp/maps/overmap/space_pois/turretedoutpost_23x19.dmm
@@ -43,6 +43,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/submap/turretedoutpost)
+"dL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/turretedoutpost)
 "eb" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -70,6 +78,14 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/turretedoutpost)
+"gL" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/smes/buildable/point_of_interest,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/turretedoutpost)
 "gQ" = (
@@ -236,6 +252,26 @@
 /mob/living/simple_mob/humanoid/merc/melee/sword/space,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/turretedoutpost)
+"up" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/turretedoutpost)
+"wu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/turretedoutpost)
 "wx" = (
 /obj/item/weapon/grenade/chem_grenade/teargas,
 /obj/structure/table/rack/shelf/steel,
@@ -266,7 +302,7 @@
 "xx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
-/obj/item/weapon/camera_bug,
+/obj/item/weapon/storage/box/syndie_kit/spy,
 /turf/simulated/floor/tiled/asteroid_steel{
 	icon_state = "dark"
 	},
@@ -338,6 +374,15 @@
 /obj/item/weapon/gun/energy/lasershotgun,
 /turf/simulated/floor/tiled/techfloor,
 /area/submap/turretedoutpost)
+"GJ" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/airless,
+/area/submap/turretedoutpost)
 "IG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -377,7 +422,7 @@
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/turretedoutpost)
 "Ne" = (
-/obj/item/weapon/reagent_containers/food/snacks/rawcutlet,
+/obj/item/weapon/reagent_containers/food/snacks/beetsoup,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -399,6 +444,14 @@
 /area/submap/turretedoutpost)
 "Qt" = (
 /obj/structure/salvageable/server,
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/submap/turretedoutpost)
+"QG" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/turretedoutpost)
 "Rj" = (
@@ -448,6 +501,14 @@
 "WY" = (
 /obj/structure/largecrate/animal/corgi,
 /turf/simulated/floor/tiled/techfloor,
+/area/submap/turretedoutpost)
+"Yg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
 /area/submap/turretedoutpost)
 "Yo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -793,12 +854,12 @@ id
 id
 eb
 Em
-sb
-sb
-sb
-mf
-sb
-sb
+up
+dL
+dL
+GJ
+dL
+Yg
 tS
 bT
 Ne
@@ -819,10 +880,10 @@ IG
 gq
 iG
 jX
-sb
-sb
-sb
-sb
+QG
+dL
+dL
+Yg
 Em
 eb
 id
@@ -843,7 +904,7 @@ zz
 sb
 Lc
 sb
-sb
+wu
 Em
 eb
 id
@@ -864,7 +925,7 @@ qE
 Ff
 gQ
 gQ
-gQ
+gL
 Em
 eb
 id


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Oops, mapping error hotfix
In an effort to enhance the overall experience within the carrier shuttle, we have decided to make a strategic adjustment. Specifically, we've chosen to remove two walls from the hallway. This modification aims to eliminate unnecessary engineering gameplay that was inadvertently discouraging roleplay. Our primary goal is to create a more immersive and enjoyable environment for all participants. We appreciate your understanding and look forward to fostering a vibrant roleplaying atmosphere aboard the carrier shuttle.
