### PR TITLE
Fixes mapping error in carrier shuttle

### DIFF
--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -13548,7 +13548,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/wall/rpshull,
+/turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/uppersternhallway)
 "kSB" = (
 /obj/structure/catwalk,
@@ -30490,7 +30490,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/wall/rpshull,
+/turf/simulated/floor/tiled/dark,
 /area/expoutpost/uppersternhallway)
 "xsc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{

--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -2521,7 +2521,7 @@
 	layer = 2.5;
 	name = "window blast shield"
 	},
-/turf/simulated/wall/rpshull,
+/turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "ccE" = (
 /obj/structure/closet/walllocker/emerglocker{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
In an effort to enhance the overall experience within the carrier shuttle, we have decided to make a strategic adjustment. Specifically, we've chosen to remove two walls from the hallway. This modification aims to eliminate unnecessary engineering gameplay that was inadvertently discouraging roleplay. Our primary goal is to create a more immersive and enjoyable environment for all participants. We appreciate your understanding and look forward to fostering a vibrant roleplaying atmosphere aboard the carrier shuttle.

TLDR: Fixes a mapping error
<!-- Describe The Pull Request. -->

