### PR TITLE
Disposals Fix - Carrier

### DIFF
--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -443,6 +443,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "arV" = (
@@ -1144,9 +1148,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -2155,9 +2156,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
@@ -2179,12 +2177,13 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/expoutpost/uppersternhallway)
@@ -2340,6 +2339,9 @@
 	id = "aeg_bar_blastdoor";
 	name = "Bar Blast Doors";
 	pixel_y = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
@@ -4191,6 +4193,15 @@
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
+"dxV" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/expoutpost/gatewayeva)
 "dya" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -4293,24 +4304,21 @@
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/washroom)
 "dzZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/effect/catwalk_plated/techfloor,
-/obj/machinery/door/firedoor/multi_tile/glass,
-/obj/machinery/door/airlock/multi_tile/glass{
-	dir = 8;
-	name = "Breakroom"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
-/area/expoutpost/breakroom)
+/turf/simulated/floor/tiled/freezer,
+/area/expoutpost/washroom)
 "dBB" = (
 /obj/structure/shuttle/engine/heater,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/yellow,
@@ -5004,10 +5012,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
 /obj/effect/catwalk_plated/techfloor,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/expoutpost/slingcarrierdock)
 "ehd" = (
@@ -5088,7 +5097,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
@@ -6224,9 +6234,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/midsternhallway)
@@ -6338,9 +6345,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/techfloor,
@@ -6800,6 +6804,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -8531,12 +8538,6 @@
 /obj/structure/closet/secure_closet/freezer/meat{
 	pixel_x = 5
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/wall{
-	pixel_y = 35
-	},
 /obj/item/weapon/reagent_containers/food/drinks/milk,
 /obj/item/weapon/reagent_containers/food/drinks/milk,
 /obj/item/weapon/reagent_containers/food/drinks/milk,
@@ -9225,8 +9226,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction,
 /obj/effect/catwalk_plated/techfloor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/expoutpost/midsternhallway)
 "hrX" = (
@@ -9994,7 +9995,10 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/kitchen)
 "hXD" = (
@@ -10518,21 +10522,16 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/effect/catwalk_plated/techfloor,
+/obj/structure/disposalpipe/junction{
+	dir = 2
+	},
 /turf/simulated/floor,
 /area/expoutpost/portbowhallway)
 "isf" = (
 /obj/machinery/vending/dinnerware{
 	density = 0;
 	pixel_y = 24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/kitchen)
@@ -10798,11 +10797,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/expoutpost/uppersternhallway)
 "iDN" = (
@@ -13852,6 +13852,16 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/restrooms)
+"leR" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/green/border,
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/gatewayeva)
 "leU" = (
 /obj/machinery/door/airlock{
 	id_tag = "aeg_toilet1_bolt";
@@ -15708,6 +15718,9 @@
 	req_access = list(25)
 	},
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/bar)
 "mrc" = (
@@ -15739,11 +15752,12 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor,
 /area/expoutpost/lowersternhallway)
 "msz" = (
@@ -15817,6 +15831,13 @@
 	dir = 8;
 	pixel_x = 4;
 	pixel_y = 4
+	},
+/obj/machinery/disposal/wall{
+	dir = 8;
+	pixel_x = 35
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/kitchen)
@@ -16187,8 +16208,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j2"
+	dir = 2
 	},
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
@@ -16791,15 +16811,16 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/catwalk_plated/techfloor,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor,
 /area/expoutpost/civaccesshallway)
 "niM" = (
@@ -19738,6 +19759,9 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "pwY" = (
@@ -20604,18 +20628,17 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
 "qcz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/green/border,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/midsternhallway)
+/obj/machinery/disposal/wall{
+	dir = 1;
+	pixel_y = -35
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/gatewayeva)
 "qdh" = (
 /obj/structure/closet/jcloset,
 /obj/item/weapon/soap/nanotrasen,
@@ -21283,10 +21306,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/effect/catwalk_plated/techfloor,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor,
 /area/expoutpost/midsternhallway)
 "qCD" = (
@@ -21744,10 +21768,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/effect/catwalk_plated/techfloor,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor,
 /area/expoutpost/starbowhallway)
 "qVL" = (
@@ -22597,22 +22622,22 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/techstorage)
 "rwb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/midsternhallway)
+/turf/simulated/floor/tiled,
+/area/expoutpost/gatewayeva)
 "rwi" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -22626,11 +22651,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/effect/catwalk_plated/techfloor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/expoutpost/midsternhallway)
 "rwo" = (
@@ -22653,16 +22676,21 @@
 /area/expoutpost/hangarfive)
 "rxe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/portbowhallway)
+/area/expoutpost/uppersternhallway)
 "rxD" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/carpet,
@@ -22820,6 +22848,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
+"rHJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/expoutpost/washroom)
 "rIo" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -22855,11 +22889,12 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor,
 /area/expoutpost/uppersternhallway)
 "rIV" = (
@@ -23637,7 +23672,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/kitchen)
 "sjY" = (
@@ -23852,7 +23886,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -24641,6 +24674,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "taW" = (
@@ -25125,8 +25159,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/disposalpipe/junction{
+	dir = 2
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/breakroom)
 "tyw" = (
@@ -25313,10 +25349,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
 /obj/effect/catwalk_plated/techfloor,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/expoutpost/slingcarrierdock)
 "tEx" = (
@@ -25687,6 +25724,10 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
@@ -26450,7 +26491,6 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -26665,7 +26705,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/junction,
+/obj/structure/disposalpipe/junction{
+	dir = 2
+	},
 /obj/effect/catwalk_plated/techfloor,
 /turf/simulated/floor,
 /area/expoutpost/portbowhallway)
@@ -26989,11 +27031,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor,
 /area/expoutpost/lowersternhallway)
 "uOo" = (
@@ -27330,6 +27373,9 @@
 /obj/machinery/disposal/wall{
 	pixel_y = 35
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/washroom)
 "uYh" = (
@@ -27477,6 +27523,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "veB" = (
@@ -28797,18 +28846,23 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/lowersternhallway)
 "wbs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor/glass,
+/obj/effect/catwalk_plated/techfloor,
+/obj/machinery/door/airlock/silver{
+	name = "Washroom"
+	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/breakroom)
+/turf/simulated/floor,
+/area/expoutpost/washroom)
 "wbC" = (
 /obj/machinery/suit_cycler/engineering,
 /obj/structure/window/reinforced{
@@ -28916,6 +28970,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "wer" = (
@@ -30074,6 +30131,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/washroom)
 "xeN" = (
@@ -30828,12 +30886,13 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor,
 /area/expoutpost/lowersternhallway)
@@ -31314,12 +31373,15 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/junction,
 /obj/effect/catwalk_plated/techfloor,
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor,
 /area/expoutpost/lowersternhallway)
 "xTw" = (
@@ -31902,12 +31964,13 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor,
 /area/expoutpost/lowersternhallway)
@@ -62540,16 +62603,16 @@ gHs
 lIe
 xcU
 rwi
-qcz
-dzZ
-wbs
-wbs
-wbs
+xcU
+fGp
+jEv
+jEv
+jEv
 usz
-wbs
-wbs
+jEv
+jEv
 stI
-wbs
+jEv
 txi
 jEv
 fGp
@@ -62694,7 +62757,7 @@ kBn
 fVW
 vjn
 wpp
-fVW
+rHJ
 eqH
 kBn
 pgk
@@ -62797,7 +62860,7 @@ hMk
 pWz
 uJZ
 xab
-rwb
+tAp
 xab
 rEw
 bhm
@@ -62952,10 +63015,10 @@ sFB
 sFB
 sFB
 sFB
-sFB
+dzZ
 xeC
-jmh
-rxe
+wbs
+mpO
 irI
 mpO
 mpO
@@ -63055,7 +63118,7 @@ gqv
 gqv
 gqv
 bsK
-rwb
+tAp
 rqt
 jia
 jia
@@ -63313,7 +63376,7 @@ otU
 edQ
 gqv
 rcx
-rwb
+tAp
 juR
 jia
 svh
@@ -63571,7 +63634,7 @@ eNb
 ueT
 gqv
 iGn
-rwb
+tAp
 juR
 jia
 gFl
@@ -64087,7 +64150,7 @@ lzy
 pnJ
 gqv
 iGn
-rwb
+tAp
 juR
 jia
 oct
@@ -64282,7 +64345,7 @@ oGw
 bhq
 mpb
 jrB
-mYG
+aCC
 gyI
 sFu
 udW
@@ -64326,7 +64389,7 @@ koU
 tqQ
 nOu
 pWz
-jnK
+rxe
 tZF
 mAn
 jib
@@ -64345,7 +64408,7 @@ lon
 eOE
 gqv
 iGn
-rwb
+tAp
 emn
 jia
 cTf
@@ -64540,7 +64603,7 @@ oGw
 wlO
 mpb
 jrB
-mYG
+aCC
 tHc
 uvM
 tux
@@ -64584,7 +64647,7 @@ koU
 kvy
 nOu
 dBU
-jnK
+rxe
 tZF
 wPO
 jib
@@ -64603,7 +64666,7 @@ gqv
 jHs
 gqv
 iGn
-rwb
+tAp
 juR
 jia
 juu
@@ -64798,7 +64861,7 @@ itM
 ehn
 mpb
 jrB
-mYG
+aCC
 tHc
 eJv
 hfm
@@ -64842,7 +64905,7 @@ gNy
 kYS
 nOu
 oiU
-jnK
+rxe
 tHQ
 nTf
 aZU
@@ -64861,7 +64924,7 @@ eWM
 njT
 iNT
 kLD
-rwb
+tAp
 juR
 jia
 vXp
@@ -65056,7 +65119,7 @@ oGw
 rLq
 mpb
 jrB
-mYG
+aCC
 tHc
 eog
 gxB
@@ -65314,7 +65377,7 @@ oGw
 bhq
 mpb
 jrB
-mYG
+aCC
 gyI
 ojE
 nUL
@@ -65358,7 +65421,7 @@ koU
 hlV
 nOu
 dfj
-jnK
+rxe
 tZF
 wPO
 jib
@@ -65377,7 +65440,7 @@ iBp
 fkF
 iNT
 rcx
-rwb
+tAp
 juR
 jia
 xvZ
@@ -65635,7 +65698,7 @@ iBp
 fkF
 iNT
 uxa
-rwb
+tAp
 juR
 jia
 ebi
@@ -65893,7 +65956,7 @@ iBp
 glR
 iNT
 iGn
-rwb
+tAp
 juR
 jia
 jia
@@ -66409,7 +66472,7 @@ fgm
 naY
 iNT
 iGn
-rwb
+tAp
 emn
 jia
 pVF
@@ -66667,7 +66730,7 @@ iNT
 iNT
 iNT
 cYy
-rwb
+tAp
 hkb
 jia
 jia
@@ -66925,7 +66988,7 @@ kUb
 dfj
 uJZ
 xab
-rwb
+tAp
 xab
 fSU
 hkb
@@ -67965,7 +68028,7 @@ bLH
 dbd
 bie
 kaM
-bWJ
+rwb
 eFo
 uzg
 uzg
@@ -68481,7 +68544,7 @@ jfX
 jfJ
 bie
 eYr
-bWJ
+rwb
 gKD
 owV
 owV
@@ -68739,7 +68802,7 @@ jfX
 gei
 bie
 jsf
-bWJ
+rwb
 gKD
 ubS
 ect
@@ -69255,7 +69318,7 @@ xua
 jfX
 jjo
 owV
-bWJ
+rwb
 eXr
 mzc
 nDD
@@ -69513,11 +69576,11 @@ jfX
 ikj
 bie
 rPN
-bWJ
+rwb
 igu
 fwE
 tYF
-oKC
+qcz
 jSE
 qKs
 oRl
@@ -70030,10 +70093,10 @@ tRS
 bie
 vEr
 arK
-fEs
-fEs
+dxV
+dxV
 taQ
-tjn
+leR
 jSE
 oNO
 oRl


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes the various issues with the disposals loop on the exploration carrier. This should allow the disposals bins to all function correctly and send trash to the disposals section of the carrier (instead of ejecting it from other bins or through the floor).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
del: Removed some excessive pipework causing redundant loops and potential "stuck" trash
fix: Fixed some disposals junction's orientations so that the trash flows correctly towards the disposals sorting room
fix: Connected a couple of disposals bins to the loop that were previously not connected
remap: Added a disposals bin in the gateway prep room, and connected it to the dead end pipework that was heading in that direction
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
