### PR TITLE
Removes the pulse rifle from explo loot spawns (Plus dark fix)

### DIFF
--- a/code/game/objects/random/mob_vr.dm
+++ b/code/game/objects/random/mob_vr.dm
@@ -65,7 +65,7 @@
 				prob(3);/obj/item/weapon/gun/energy/lasercannon,\
 				prob(3);/obj/item/weapon/gun/projectile/shotgun/pump/rifle/lever,\
 				prob(3);/obj/item/weapon/gun/projectile/automatic/bullpup,\
-				prob(2);/obj/item/weapon/gun/energy/pulse_rifle,\
+				/*prob(2);/obj/item/weapon/gun/energy/pulse_rifle,\ */ //CHOMPEDIT Players should absolutely not have this
 				prob(2);/obj/item/weapon/gun/energy/gun/nuclear,\
 				prob(2);/obj/item/weapon/gun/projectile/automatic/l6_saw,\
 				prob(2);/obj/item/weapon/gun/energy/gun/burst,\

--- a/maps/southern_cross/southern_cross-8.dmm
+++ b/maps/southern_cross/southern_cross-8.dmm
@@ -12598,6 +12598,7 @@
 /obj/random/miniature,
 /obj/random/miniature,
 /obj/random/miniature,
+/obj/item/device/pda,
 /turf/simulated/floor/tiled/techmaint,
 /area/shadekin)
 "kSi" = (
@@ -17366,6 +17367,7 @@
 /obj/random/maintenance/cargo,
 /obj/random/maintenance/cargo,
 /obj/random/maintenance/cargo,
+/obj/item/device/pda,
 /turf/simulated/floor/tiled/techmaint,
 /area/shadekin)
 "pMy" = (
@@ -23201,6 +23203,7 @@
 /obj/effect/floor_decal/milspec/cargo,
 /obj/random/tetheraid,
 /obj/random/tetheraid,
+/obj/item/device/pda,
 /turf/simulated/floor/tiled/techmaint,
 /area/shadekin)
 "vpZ" = (

--- a/maps/southern_cross/southern_cross-8.dmm
+++ b/maps/southern_cross/southern_cross-8.dmm
@@ -1795,7 +1795,8 @@
 /area/centcom/bar)
 "bfZ" = (
 /obj/machinery/vending/boozeomat{
-	pixel_y = 16
+	pixel_y = 16;
+	req_log_access = null
 	},
 /obj/effect/floor_decal/milspec/color/silver,
 /turf/simulated/floor/tiled/techmaint,
@@ -2413,9 +2414,7 @@
 /turf/unsimulated/beach/sand,
 /area/beach)
 "bIF" = (
-/obj/machinery/vending/cart{
-	req_access = null
-	},
+/obj/machinery/vending/hydroseeds,
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 8
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Players should not have access to pulse rifles, no matter the situation

Also removes access in one Dark vendor, and replaces the PDA vendor with something else due to shadekin having access to station altering ValuePAKs. PDAs were put in the shelves above the portal.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
del: Removed spawn of a pulse rifle
remap: Minor fixes in The Dark
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
