### PR TITLE
Bun-Chaoscake Fix

### DIFF
--- a/code/modules/food/recipes_grill.dm
+++ b/code/modules/food/recipes_grill.dm
@@ -96,6 +96,7 @@
 
 /datum/recipe/bunbun
 	appliance = GRILL
+	reagents = list("sodiumchloride" = 1)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/bun,
 		/obj/item/weapon/reagent_containers/food/snacks/bun

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -522,6 +522,7 @@ I said no!
 	result = /obj/item/weapon/reagent_containers/food/snacks/soup/onion
 
 /datum/recipe/microwavebun
+	reagents = list("sodiumchloride" = 1)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/dough
 	)

--- a/code/modules/food/recipes_oven.dm
+++ b/code/modules/food/recipes_oven.dm
@@ -180,6 +180,7 @@
 
 /datum/recipe/bun
 	appliance = OVEN
+	reagents = list("sodiumchloride" = 1)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/dough
 	)


### PR DESCRIPTION
Adds 1u salt to the buns and bunbun cooking recipes as the dough in the recipes on their own interfere with making chaos cakes, by disregarding the rest of the components for chaos cakes in order to pop out all of the dough as buns.

:cl:
fix: fixes buns/bunbun cooking by fixing chaos cake interference
/:cl: