### PR TITLE
fix runtime, increase sm explosion damage

### DIFF
--- a/code/game/machinery/air_alarm.dm
+++ b/code/game/machinery/air_alarm.dm
@@ -845,6 +845,8 @@
 	spawn(rand(0,15))
 		update_icon()
 		// CHOMPEdit Start: Looping Alarms
+		if(!soundloop)
+			return
 		if(stat & (NOPOWER | BROKEN))
 			soundloop.stop()
 		else if(atmoswarn)

--- a/code/game/machinery/fire_alarm.dm
+++ b/code/game/machinery/fire_alarm.dm
@@ -67,11 +67,11 @@ FIRE ALARM
 	causality = new(list(src), FALSE) // CHOMPEdit: Create soundloop
 
 /obj/machinery/firealarm/Destroy()
+	reset()		//CHOMPEdit alarm needs to go when destroyed
 	QDEL_NULL(soundloop) // CHOMPEdit: Just clearing the loop here
 	QDEL_NULL(engalarm) // CHOMPEdit: Clearing the loop here too
 	QDEL_NULL(critalarm) // CHOMPEdit: Clearing the loop here too
 	QDEL_NULL(causality) // CHOMPEdit: Clearing the loop here too
-	reset()		//CHOMPEdit alarm needs to go when destroyed
 	return ..()
 
 /obj/machinery/firealarm/proc/offset_alarm()
@@ -183,6 +183,8 @@ FIRE ALARM
 	spawn(rand(0,15))
 		update_icon()
 		// CHOMPEdit Start: Looping Red/Violet/Orange Alarms
+		if(!soundloop)
+			return
 		if(stat & (NOPOWER | BROKEN)) // Are we broken or out of power?
 			soundloop.stop() // Stop the loop once we're out of power
 			engalarm.stop() // Stop these bc we're out of power

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -85,8 +85,8 @@
 	var/pull_radius = 14
 	// Time in ticks between delamination ('exploding') and exploding (as in the actual boom)
 	var/pull_time = 100
-	var/min_explosion_power = 12 // CHOMPEdit some more dmage was 8
-	var/max_explosion_power = 24 // CHOMPEdit some more dmage was 16
+	var/min_explosion_power = 12 // CHOMPEdit some more damage was 8
+	var/max_explosion_power = 24 // CHOMPEdit some more damage was 16
 
 	var/emergency_issued = 0
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -85,8 +85,8 @@
 	var/pull_radius = 14
 	// Time in ticks between delamination ('exploding') and exploding (as in the actual boom)
 	var/pull_time = 100
-	var/min_explosion_power = 8
-	var/max_explosion_power = 16
+	var/min_explosion_power = 12 // CHOMPEdit some more dmage was 8
+	var/max_explosion_power = 24 // CHOMPEdit some more dmage was 16
 
 	var/emergency_issued = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
Increasing the damage of a delam. The maximum range now reaches up to the tech storage. Minimum range is also less forgiving, messing up the engine room.

We really shouldn't call procs on objects we have QDEL_NULL deleted. Therefore, we now first reset the alarms and prevent all changes on power change on nulled objects.

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: increased SM delam explosion range by 50 % (MIN 8 -> 12. MAX 16 -> 24)
fix: fixed a runtime in the alarm system.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
