### PR TITLE
Lost and Found Remap

### DIFF
--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -32,6 +32,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn/morphspawn,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "aae" = (
@@ -539,6 +540,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "acq" = (
@@ -742,6 +744,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "acN" = (
@@ -854,6 +859,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "adm" = (
@@ -1648,6 +1657,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "agD" = (
@@ -1934,6 +1944,7 @@
 	},
 /obj/random/mob/mouse,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "ahK" = (
@@ -2132,6 +2143,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/trash,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "ais" = (
@@ -2242,6 +2254,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "aiK" = (
@@ -2352,6 +2365,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "ajb" = (
@@ -2430,6 +2444,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
@@ -13959,6 +13977,7 @@
 /obj/effect/landmark{
 	name = "maint_pred"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "dXV" = (
@@ -14729,6 +14748,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "dZH" = (
@@ -15519,6 +15539,9 @@
 "elz" = (
 /obj/structure/sink{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/teleporter/firstdeck)
@@ -16990,14 +17013,14 @@
 /turf/simulated/shuttle/plating/airless/carry,
 /area/shuttle/large_escape_pod2/station)
 "fQn" = (
+/obj/machinery/seed_storage/xenobotany{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
 	},
 /obj/machinery/camera/network/research{
 	c_tag = "SCI - Xenoflora Starboard";
-	dir = 1
-	},
-/obj/machinery/seed_storage/xenobotany{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -17376,6 +17399,12 @@
 /obj/structure/shuttle/window,
 /turf/simulated/shuttle/plating,
 /area/shuttle/large_escape_pod1/station)
+"ghY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/teleporter/firstdeck)
 "gia" = (
 /obj/structure/bed/chair,
 /turf/simulated/shuttle/floor/white,
@@ -19938,6 +19967,10 @@
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plating,
 /area/storage/tech)
+"jty" = (
+/obj/structure/disposalpipe/up,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/foreport)
 "jtM" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/airlock/glass_external{
@@ -20508,6 +20541,9 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/teleporter/firstdeck)
@@ -24537,6 +24573,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "oET" = (
@@ -24931,6 +24970,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/tcomm/computer)
+"pia" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/foreport)
 "pil" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -25299,6 +25352,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/teleporter/firstdeck)
 "pAY" = (
@@ -29064,6 +29120,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/escape/firstdeck/ep_starboard)
+"tGQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	req_access = null;
+	req_one_access = null
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/foreport)
 "tHc" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
@@ -31979,6 +32051,14 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/machinery/disposal/wall/cleaner{
+	name = "Resleeving lost & found bin";
+	pixel_y = -35;
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/teleporter/firstdeck)
@@ -60846,7 +60926,7 @@ aiY
 aiY
 aiY
 aiY
-ajn
+jty
 ajM
 adm
 aFf
@@ -61347,7 +61427,7 @@ aiY
 aiY
 aiY
 aiY
-aiY
+ghY
 aiY
 aiY
 aiY
@@ -61605,8 +61685,8 @@ aaa
 aCl
 aau
 aWv
-aiI
-ciy
+pia
+tGQ
 aiI
 aiI
 aiI

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -2068,6 +2068,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "aem" = (
@@ -3684,6 +3687,7 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/sc/chief)
 "aiT" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -3693,7 +3697,6 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
-/obj/machinery/vending/wardrobe/engidrobe,
 /turf/simulated/floor/tiled/yellow,
 /area/engineering/locker_room)
 "aiU" = (
@@ -4075,6 +4078,7 @@
 /turf/simulated/floor/tiled,
 /area/engineering/break_room)
 "ajZ" = (
+/obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
@@ -4082,7 +4086,6 @@
 	layer = 4;
 	pixel_x = -32
 	},
-/obj/machinery/vending/wardrobe/atmosdrobe,
 /turf/simulated/floor/tiled/yellow,
 /area/engineering/locker_room)
 "aka" = (
@@ -5558,6 +5561,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "apB" = (
@@ -6778,6 +6785,10 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/meter,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "atq" = (
@@ -7071,6 +7082,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "aue" = (
@@ -7090,6 +7104,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "auf" = (
@@ -7106,6 +7123,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -7134,6 +7154,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -7310,6 +7333,7 @@
 	dir = 6
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "avc" = (
@@ -7869,6 +7893,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "awI" = (
@@ -8242,6 +8267,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "aya" = (
@@ -8733,7 +8759,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/vending/wardrobe/secdrobe,
 /turf/simulated/floor/tiled,
 /area/security/security_lockerroom)
 "azD" = (
@@ -9560,10 +9585,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/ascenter)
 "aCw" = (
+/obj/machinery/seed_storage/garden,
 /obj/effect/floor_decal/spline/plain{
 	dir = 8
 	},
-/obj/machinery/seed_storage/garden,
 /turf/simulated/floor/tiled/hydro,
 /area/hallway/primary/seconddeck/ascenter)
 "aCx" = (
@@ -9715,6 +9740,9 @@
 	icon_state = "1-2"
 	},
 /obj/random/trash,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "aDc" = (
@@ -9732,6 +9760,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -13269,6 +13300,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "aPc" = (
@@ -13704,6 +13739,9 @@
 "aQu" = (
 /obj/structure/lattice,
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/down{
+	dir = 1
+	},
 /turf/simulated/open,
 /area/maintenance/engineering)
 "aQv" = (
@@ -14521,7 +14559,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/vending/wardrobe/cargodrobe,
 /turf/simulated/floor/tiled,
 /area/quartermaster/lockerroom)
 "aSU" = (
@@ -16689,6 +16726,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/ascenter)
 "aZJ" = (
@@ -17898,6 +17936,7 @@
 	req_access = null;
 	req_one_access = null
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bdA" = (
@@ -18243,6 +18282,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "beY" = (
@@ -18256,6 +18298,9 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = null;
 	req_one_access = null
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
@@ -18286,6 +18331,9 @@
 	req_access = null;
 	req_one_access = null
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "bfb" = (
@@ -18295,10 +18343,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "bfc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -18306,6 +18360,9 @@
 "bfh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
@@ -18762,8 +18819,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/ai_monitored/storage/emergency/eva)
 "bgp" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/techmaint,
 /area/ai_monitored/storage/emergency/eva)
 "bgq" = (
@@ -18941,6 +18997,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bgW" = (
@@ -19361,6 +19418,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "biv" = (
@@ -21933,6 +21991,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bpr" = (
@@ -24119,6 +24178,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bwo" = (
@@ -24838,6 +24901,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/ascenter)
 "byp" = (
@@ -26264,6 +26328,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/trash,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bBF" = (
@@ -26412,10 +26477,12 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
 "bCi" = (
+/obj/machinery/vending/coffee{
+	dir = 1
+	},
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/vending/wardrobe/bardrobe,
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
 "bCj" = (
@@ -27181,6 +27248,10 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bEJ" = (
@@ -27249,6 +27320,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bFj" = (
@@ -27590,11 +27662,11 @@
 /turf/simulated/floor/tiled,
 /area/engineering/atmos)
 "bFW" = (
+/obj/structure/kitchenspike,
 /obj/machinery/alarm/freezer{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/vending/wardrobe/chefdrobe,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/kitchen)
 "bFX" = (
@@ -28216,6 +28288,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bIl" = (
@@ -29157,6 +29232,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bLV" = (
@@ -29210,9 +29286,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bMb" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
+/obj/structure/curtain/open/privacy,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
 	},
@@ -29222,7 +29301,6 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "bMc" = (
@@ -29241,16 +29319,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "bMf" = (
+/obj/structure/closet/wardrobe/medic_white,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/extraction_pack,
-/obj/item/extraction_pack,
-/obj/item/extraction_pack,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "bMh" = (
@@ -29525,6 +29600,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bNC" = (
@@ -29615,8 +29691,6 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 10
 	},
-/obj/structure/table/glass,
-/obj/structure/bedsheetbin,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "bNM" = (
@@ -29708,8 +29782,7 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner2{
 	dir = 5
 	},
-/obj/structure/table/glass,
-/obj/item/fulton_core,
+/obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "bNV" = (
@@ -29999,6 +30072,7 @@
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
 "bOD" = (
+/obj/structure/closet/wardrobe/detective,
 /obj/item/device/radio/intercom/department/security{
 	dir = 4;
 	icon_override = "secintercom";
@@ -30007,7 +30081,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
-/obj/machinery/vending/wardrobe/detdrobe,
 /turf/simulated/floor/lino,
 /area/security/detectives_office)
 "bOE" = (
@@ -30120,6 +30193,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/trash,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bPs" = (
@@ -30470,6 +30544,7 @@
 	req_access = null;
 	req_one_access = null
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bQN" = (
@@ -31271,6 +31346,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bTv" = (
@@ -31301,6 +31377,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "bTx" = (
@@ -32432,6 +32509,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/trash,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "bXh" = (
@@ -34198,6 +34276,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "cdl" = (
@@ -34698,9 +34777,14 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
 "cel" = (
-/obj/machinery/alarm{
+/obj/machinery/disposal/wall/cleaner{
 	dir = 4;
-	pixel_x = -22
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/barrestroom)
@@ -34708,6 +34792,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/barrestroom)
@@ -34921,6 +35008,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "cfi" = (
@@ -35093,6 +35181,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "cfH" = (
@@ -35418,6 +35507,10 @@
 /obj/structure/cable/green,
 /obj/random/soap,
 /obj/random/soap,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/barrestroom)
 "cgD" = (
@@ -36069,6 +36162,9 @@
 "ciC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/maintenance/substation/civilian)
@@ -41345,6 +41441,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "cza" = (
@@ -41378,6 +41477,9 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/barrestroom)
 "czq" = (
@@ -41404,6 +41506,9 @@
 	dir = 4
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "czu" = (
@@ -41416,6 +41521,9 @@
 	dir = 4
 	},
 /obj/item/inflatable/door/torn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "czx" = (
@@ -41435,6 +41543,9 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "czJ" = (
@@ -41444,6 +41555,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -41458,6 +41572,10 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "czO" = (
@@ -42005,6 +42123,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "cCa" = (
@@ -42772,6 +42891,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cDY" = (
@@ -42786,6 +42909,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
@@ -42819,6 +42945,9 @@
 	dir = 4
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cEb" = (
@@ -42834,6 +42963,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cEc" = (
@@ -43215,6 +43348,10 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "cFb" = (
@@ -43244,6 +43381,9 @@
 	icon_state = "4-8"
 	},
 /obj/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "cFj" = (
@@ -43262,6 +43402,9 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = null;
 	req_one_access = null
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -43283,6 +43426,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
@@ -43326,6 +43472,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/fscenter)
 "cFN" = (
@@ -43343,6 +43492,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
@@ -43363,6 +43515,9 @@
 	req_access = null;
 	req_one_access = null
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cFP" = (
@@ -43379,6 +43534,9 @@
 	},
 /obj/machinery/light/small,
 /obj/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cFU" = (
@@ -43397,6 +43555,9 @@
 	icon_state = "4-8"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cFW" = (
@@ -43410,6 +43571,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
@@ -43427,6 +43591,9 @@
 	},
 /obj/random/junk,
 /obj/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cFZ" = (
@@ -43440,6 +43607,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
@@ -43457,6 +43627,10 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cGd" = (
@@ -44615,6 +44789,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "dlx" = (
@@ -44700,6 +44875,10 @@
 /obj/structure/bed/chair/comfy/purp,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"dmQ" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/storage/emergency_storage/seconddeck/fs_emergency)
 "doj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
@@ -44899,6 +45078,7 @@
 "duK" = (
 /obj/machinery/floodlight,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/fs_emergency)
 "duU" = (
@@ -45284,7 +45464,6 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
-/obj/machinery/vending/wardrobe/scidrobe,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_lockerroom)
 "dEU" = (
@@ -45350,7 +45529,6 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
-/obj/machinery/vending/wardrobe/robodrobe,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_lockerroom)
 "dGE" = (
@@ -46296,22 +46474,6 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
-"ekr" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/machinery/vending/wardrobe/genedrobe,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "ekL" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -46388,6 +46550,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "emI" = (
@@ -46797,6 +46960,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "eBi" = (
@@ -47298,6 +47462,9 @@
 /area/crew_quarters/seconddeck/artsupplies)
 "eLa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/wall,
 /area/maintenance/substation/civilian)
 "eLe" = (
@@ -48100,6 +48267,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "fhn" = (
@@ -48237,20 +48405,16 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/fs_emergency)
 "fkF" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/structure/disposaloutlet{
-	dir = 8;
-	name = "Lost & found disposal outlet";
-	pixel_x = -7;
-	pixel_y = -2
-	},
-/turf/simulated/wall/r_wall,
-/area/medical/virology)
+/turf/simulated/wall,
+/area/storage/emergency_storage/seconddeck/fs_emergency)
 "fld" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -48331,6 +48495,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
+"fmX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/barrestroom)
 "fno" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -49621,6 +49792,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medical_lockerroom)
+"fXn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/storage/emergency_storage/seconddeck/fs_emergency)
 "fXq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -51719,6 +51903,13 @@
 /obj/random/soap,
 /turf/simulated/floor/tiled/freezer,
 /area/medical/medical_restroom)
+"hav" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/barrestroom)
 "hax" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -51906,6 +52097,7 @@
 	icon_state = "2-4"
 	},
 /obj/random/trash,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "hff" = (
@@ -51989,20 +52181,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/ai_monitored/storage/emergency/eva)
-"hhC" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = 21
-	},
-/obj/machinery/vending/wardrobe/medidrobe,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "hhQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -52032,7 +52210,7 @@
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
 "hiK" = (
-/obj/machinery/vending/wardrobe/chapdrobe,
+/obj/structure/closet/wardrobe/chaplain_black,
 /turf/simulated/floor/lino,
 /area/chapel/office)
 "hjA" = (
@@ -53735,6 +53913,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "hYU" = (
@@ -54510,6 +54689,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/drone_fabrication)
+"ivA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
 "ivF" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/seconddeck/dockhallway)
@@ -54876,6 +55067,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/wall,
 /area/maintenance/substation/civilian)
 "iKa" = (
@@ -54887,6 +55081,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "iKg" = (
@@ -54938,7 +55133,6 @@
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/eastright,
 /obj/item/clothing/suit/space,
-/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space,
 /turf/simulated/floor/tiled/techmaint,
@@ -55524,6 +55718,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics)
+"iZd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "iZh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -56965,6 +57177,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "jLI" = (
@@ -59081,6 +59294,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "kQG" = (
@@ -60034,13 +60248,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
-"lwg" = (
-/obj/structure/table/steel,
-/obj/item/weapon/circuitboard/transhuman_clonepod,
-/obj/item/weapon/circuitboard/transhuman_resleever,
-/obj/item/weapon/circuitboard/resleeving_control,
-/turf/simulated/floor/tiled/dark,
-/area/medical/surgery_storage)
 "lwA" = (
 /obj/structure/closet/wardrobe/chemistry_white,
 /obj/item/device/radio/headset/headset_med,
@@ -60453,6 +60660,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
+"lKp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "lKy" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -60895,6 +61113,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
 "lUX" = (
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/obj/structure/curtain/open/privacy,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
 	},
@@ -60904,7 +61125,6 @@
 /obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
-/obj/machinery/vending/wardrobe/virodrobe,
 /turf/simulated/floor/tiled/white,
 /area/medical/ward)
 "lUZ" = (
@@ -61066,6 +61286,21 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/robotics)
+"lYZ" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "medbayquar";
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/seconddeck/starboard)
 "lZV" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -62038,17 +62273,11 @@
 /obj/structure/table/rack/shelf/steel{
 	pixel_y = -3
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/sign/department/cargo{
 	desc = "NT is not responsible for personal items left or lost on SouthernCross. Any lost and found inquiries can be made at the HoP front desk.";
 	name = "Resleeving lost & found bin";
 	pixel_y = -32
 	},
-/obj/random/maintenance/clean,
-/obj/random/maintenance/engineering,
-/obj/random/junk,
 /obj/structure/curtain/black,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/medical/cryo/autoresleeve)
@@ -62260,6 +62489,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "mNt" = (
@@ -63640,6 +63870,13 @@
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/kitchen)
+"nBP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/holodeck_control)
 "nCC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -63873,6 +64110,23 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/morgue)
+"nIq" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "nIS" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box,
@@ -63928,9 +64182,6 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/obj/machinery/chemical_dispenser/bar_coffee/full{
-	dir = 8
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/bar)
 "nJh" = (
@@ -63975,6 +64226,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "nKR" = (
@@ -65613,6 +65865,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "oGx" = (
@@ -65841,17 +66094,25 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research_foyer)
 "oPy" = (
-/obj/structure/closet/crate/medical{
-	name = "surgery crate"
-	},
+/obj/structure/closet/crate/medical,
+/obj/item/weapon/surgical/surgicaldrill,
+/obj/item/weapon/surgical/FixOVein,
+/obj/item/weapon/surgical/circular_saw,
+/obj/item/weapon/surgical/scalpel,
+/obj/item/stack/medical/advanced/bruise_pack,
+/obj/item/weapon/surgical/retractor,
+/obj/item/weapon/surgical/hemostat,
+/obj/item/weapon/surgical/cautery,
+/obj/item/weapon/surgical/bonesetter,
+/obj/item/weapon/surgical/bonegel,
+/obj/item/stack/nanopaste,
+/obj/item/weapon/autopsy_scanner,
 /obj/item/weapon/reagent_containers/spray/cleaner{
 	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
 	name = "Surgery Cleaner";
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/obj/item/weapon/storage/firstaid/surgery,
-/obj/item/weapon/storage/firstaid/surgery,
 /turf/simulated/floor/tiled/dark,
 /area/medical/surgery_storage)
 "oPJ" = (
@@ -66890,6 +67151,9 @@
 	name = "Utility Down";
 	req_one_access = list(11,24)
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "pnz" = (
@@ -66980,6 +67244,7 @@
 	pixel_x = -22
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "poL" = (
@@ -67115,6 +67380,12 @@
 	},
 /turf/simulated/floor,
 /area/engineering/engine_waste)
+"puP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/holodeck_control)
 "puY" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -67730,6 +68001,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "pLC" = (
@@ -67754,7 +68026,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/vending/wardrobe/hydrobe,
 /turf/simulated/floor/tiled/hydro,
 /area/hydroponics)
 "pMu" = (
@@ -67962,6 +68233,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
+"pPa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/maintenance/chapel)
 "pPc" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -68577,6 +68854,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
+"qhy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/chapel/office)
 "qim" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -68626,6 +68910,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "qkB" = (
@@ -68929,6 +69214,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "qqA" = (
@@ -70370,6 +70656,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "roS" = (
@@ -70568,6 +70855,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "rtT" = (
@@ -71079,6 +71367,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "rIm" = (
@@ -71097,9 +71388,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
 "rIU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/wall,
 /area/maintenance/research_medical)
@@ -71353,15 +71644,6 @@
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/green/border,
-/obj/structure/table/steel,
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/device/multitool,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/workshop)
 "rQF" = (
@@ -71432,16 +71714,16 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/cryo/autoresleeve)
 "rRD" = (
-/obj/structure/table/rack/shelf/steel{
-	pixel_y = -3
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/random/maintenance/clean,
-/obj/random/maintenance/engineering,
-/obj/random/thermalponcho,
 /obj/structure/curtain/black,
+/obj/structure/disposaloutlet{
+	dir = 4;
+	name = "Lost & found disposal outlet";
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/medical/cryo/autoresleeve)
 "rRH" = (
@@ -72022,6 +72304,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "shD" = (
@@ -72822,6 +73105,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "sFN" = (
@@ -72914,10 +73198,6 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/distillery)
@@ -73049,6 +73329,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "sMp" = (
@@ -73128,6 +73412,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/ascenter)
 "sPy" = (
@@ -73614,6 +73899,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "tfB" = (
@@ -75493,6 +75779,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "unr" = (
@@ -75589,6 +75878,10 @@
 	icon_state = "2-8"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "uqg" = (
@@ -77660,10 +77953,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/seconddeck/research_medical)
-"vDt" = (
-/obj/machinery/gear_dispenser/suit_fancy/autolok,
-/turf/simulated/floor/tiled/techmaint,
-/area/ai_monitored/storage/emergency/eva)
 "vDJ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -78273,6 +78562,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "vSR" = (
@@ -78356,6 +78646,7 @@
 	d2 = 0;
 	icon_state = "16-0"
 	},
+/obj/structure/disposalpipe/up,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/as_emergency)
 "vVG" = (
@@ -78865,6 +79156,7 @@
 	},
 /obj/item/weapon/tool/crowbar/red,
 /obj/item/weapon/tool/crowbar/red,
+/obj/item/weapon/storage/firstaid/surgery,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket,
 /turf/simulated/floor/tiled/dark,
@@ -79095,6 +79387,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
+"wrC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/storage/emergency_storage/seconddeck/fs_emergency)
 "wrK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79871,6 +80170,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "wSc" = (
@@ -79992,6 +80295,9 @@
 	regulate_mode = 0;
 	unlocked = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "wVu" = (
@@ -80022,6 +80328,9 @@
 	dir = 4;
 	name = "Medical automatic shutoff valve"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "wVM" = (
@@ -80047,6 +80356,9 @@
 	dir = 4
 	},
 /obj/machinery/meter,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "wWx" = (
@@ -80065,6 +80377,9 @@
 /area/hallway/secondary/entry/D2)
 "wWW" = (
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "wWX" = (
@@ -80135,6 +80450,9 @@
 	},
 /obj/structure/catwalk,
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "wZh" = (
@@ -80226,6 +80544,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "xbq" = (
@@ -80256,6 +80577,9 @@
 	},
 /obj/structure/catwalk,
 /obj/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "xch" = (
@@ -80268,6 +80592,9 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = null;
 	req_one_access = null
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
@@ -80284,6 +80611,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/starboard)
@@ -80353,6 +80683,9 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
 "xeu" = (
@@ -80365,6 +80698,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
@@ -80381,6 +80717,10 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
@@ -81350,7 +81690,6 @@
 	},
 /obj/machinery/door/window/eastleft,
 /obj/item/clothing/suit/space,
-/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space,
 /turf/simulated/floor/tiled/techmaint,
@@ -81554,21 +81893,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/starboard)
-"xLY" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/obj/machinery/vending/wardrobe/chemdrobe,
-/turf/simulated/floor/tiled/white,
-/area/medical/ward)
 "xMr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81859,6 +82183,9 @@
 	id = "medbayquar";
 	name = "Medbay Emergency Lockdown Shutters";
 	opacity = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/starboard)
@@ -82205,6 +82532,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
+"yid" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "yij" = (
 /obj/structure/table/rack,
 /obj/item/device/suit_cooling_unit,
@@ -108968,7 +109301,7 @@ bzy
 aCo
 bgp
 bzy
-vDt
+rVs
 rVs
 bzy
 nGq
@@ -110246,7 +110579,7 @@ vxj
 atZ
 vxj
 aPc
-vxj
+yid
 aqI
 vxj
 aTX
@@ -110502,8 +110835,8 @@ sFM
 sFM
 sFM
 sFM
-aNv
-aNv
+lKp
+lKp
 aPb
 pjT
 aNv
@@ -111004,7 +111337,7 @@ atq
 atq
 atq
 atq
-auh
+nIq
 aeK
 aBC
 awI
@@ -112294,7 +112627,7 @@ asw
 asw
 asw
 atq
-auh
+nIq
 cBN
 vxj
 cEZ
@@ -112552,7 +112885,7 @@ atq
 atq
 atq
 atq
-aem
+iZd
 syU
 afk
 awO
@@ -112810,7 +113143,7 @@ aqt
 ary
 asy
 atq
-auh
+nIq
 syU
 syU
 syU
@@ -113068,7 +113401,7 @@ csj
 ctS
 cvY
 atq
-auh
+nIq
 cBO
 afm
 awQ
@@ -116425,7 +116758,7 @@ cxA
 csw
 aWb
 cuE
-cDZ
+cEd
 aWb
 enG
 enG
@@ -117199,7 +117532,7 @@ crE
 crE
 crE
 cDR
-cDZ
+cEd
 iXZ
 aWb
 aaa
@@ -117457,7 +117790,7 @@ cxL
 czZ
 cCp
 cuE
-cDZ
+cEd
 gjV
 aWb
 aaa
@@ -117973,7 +118306,7 @@ cxN
 cAc
 crE
 cDW
-cDZ
+cEd
 cuE
 csa
 aaa
@@ -118286,10 +118619,10 @@ njG
 cFt
 cFt
 cFt
-cFt
-cFt
-cFt
-cFt
+hav
+chG
+chG
+fmX
 fFD
 xKO
 xKO
@@ -118489,7 +118822,7 @@ cxP
 cAv
 crE
 cDW
-cDZ
+cEd
 cDP
 csa
 aaa
@@ -118547,7 +118880,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+puP
 voL
 voL
 kEz
@@ -118747,7 +119080,7 @@ crE
 crE
 crE
 cDW
-cDZ
+cEd
 aWb
 aWb
 aaa
@@ -118805,7 +119138,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+puP
 git
 wOC
 uvS
@@ -119063,7 +119396,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+puP
 gFD
 xip
 msv
@@ -119321,7 +119654,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+puP
 gFO
 xHj
 emX
@@ -119579,7 +119912,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+puP
 gKC
 xLN
 jvu
@@ -119778,7 +120111,7 @@ cui
 cui
 cAB
 crJ
-cDZ
+cEd
 cGd
 dtI
 euB
@@ -119837,7 +120170,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+puP
 hiK
 kqH
 lLD
@@ -120095,8 +120428,8 @@ vMO
 vMO
 vMO
 vMO
-cFI
-voL
+nBP
+qhy
 voL
 voL
 voL
@@ -120295,7 +120628,7 @@ crJ
 crJ
 crJ
 cEb
-cGd
+fkF
 duc
 evb
 fjy
@@ -120553,11 +120886,11 @@ cxU
 cAJ
 cCy
 cEc
-cGd
+wrC
 duK
-evb
+fXn
 fjA
-cGd
+dmQ
 heB
 hYM
 iKa
@@ -120833,7 +121166,7 @@ sPZ
 ueZ
 xMr
 hIE
-aDc
+ivA
 aEi
 aPk
 aPk
@@ -121128,7 +121461,7 @@ njG
 njG
 njG
 cFI
-fnp
+pPa
 rrB
 dWC
 bNr
@@ -124206,7 +124539,7 @@ wXZ
 pMH
 bcR
 bKu
-xLY
+btU
 bNM
 bCM
 bHC
@@ -124464,8 +124797,8 @@ hHj
 bHo
 oew
 bKu
-ekr
-bNM
+btH
+bNY
 bDd
 jQo
 bSo
@@ -124722,7 +125055,7 @@ bIP
 mOZ
 xaD
 bKu
-hhC
+bPG
 bNX
 bPA
 qvr
@@ -126252,7 +126585,7 @@ ufl
 vxe
 wqq
 xeT
-xPX
+lYZ
 wDy
 eMV
 nrg
@@ -128857,7 +129190,7 @@ rYP
 jyb
 okt
 rSH
-lwg
+xDM
 dPW
 qws
 vNi
@@ -133985,7 +134318,7 @@ opM
 opM
 opM
 opM
-fkF
+opM
 opM
 opM
 uEF

--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -195,6 +195,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/ai)
+"aeg" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_1)
 "aeh" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -806,6 +812,10 @@
 /area/maintenance/thirddeck/dormsport{
 	name = "Third Deck Aft Port Maintenance"
 	})
+"aFc" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/thirddeck/aftstarboardcentral)
 "aFn" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
@@ -880,6 +890,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "aHx" = (
@@ -1821,6 +1832,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_3)
 "bHJ" = (
@@ -2013,9 +2028,23 @@
 /area/maintenance/thirddeck/foreport)
 "bRW" = (
 /obj/item/weapon/stool/padded,
-/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
+"bSk" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftstarboardcentral)
 "bSv" = (
 /obj/machinery/vending/loadout/gadget,
 /obj/effect/floor_decal/corner_steel_grid{
@@ -2039,6 +2068,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_12)
 "bTP" = (
@@ -2532,6 +2565,12 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/maintenance/solars/foreportsolar)
+"cog" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/hallway/primary/thirddeck/aftdoorm)
 "cpl" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -2541,6 +2580,9 @@
 	},
 /obj/structure/mirror{
 	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_6)
@@ -3498,6 +3540,13 @@
 /area/maintenance/thirddeck/dormsaft{
 	name = "Third Deck Aft Maintenance"
 	})
+"dlB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_4)
 "dmb" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -3586,6 +3635,14 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
+	},
+/obj/machinery/disposal/wall/cleaner{
+	name = "Resleeving lost & found bin";
+	pixel_y = -35;
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_9)
@@ -4127,6 +4184,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai/ai_server_room)
+"dMT" = (
+/obj/random/trash,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "dNq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4583,6 +4645,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "dZQ" = (
@@ -4719,6 +4782,23 @@
 	},
 /turf/simulated/wall,
 /area/crew_quarters/cafeteria)
+"edl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/toilet)
+"edP" = (
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/toilet)
 "eeA" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -5566,7 +5646,6 @@
 	id = "hopquarters";
 	name = "Bolt Control";
 	pixel_y = -30;
-	req_access = list(57);
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
@@ -5757,7 +5836,6 @@
 	id = "cmoquarters";
 	name = "Bolt Control";
 	pixel_y = -30;
-	req_access = list(40);
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet/blue,
@@ -5773,7 +5851,6 @@
 	id = "rdquarters";
 	name = "Bolt Control";
 	pixel_y = -30;
-	req_access = list(30);
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
@@ -6421,6 +6498,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "flb" = (
@@ -6506,6 +6584,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/port)
+"fnl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_11)
 "fnn" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -7142,6 +7227,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "fLv" = (
@@ -7607,8 +7693,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/cafeteria)
 "fZP" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/weapon/implant/dud,
+/obj/structure/loot_pile/maint/technical,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "fZT" = (
@@ -7827,6 +7912,7 @@
 	c_tag = "Third Deck - Aft Civ Dorms 5";
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "giJ" = (
@@ -8256,6 +8342,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/starboard)
+"gGs" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = null;
+	req_one_access = null
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "gGw" = (
 /obj/structure/sign/deck/third,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -8279,6 +8374,12 @@
 /obj/structure/barricade,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
+"gIX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_10)
 "gJe" = (
 /turf/simulated/floor/carpet,
 /area/bridge/meeting_room)
@@ -8737,6 +8838,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cafeteria)
+"hiS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_1)
 "hjc" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1380;
@@ -8833,6 +8941,12 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/sc/restroom)
+"hmW" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_5)
 "hnK" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8895,7 +9009,6 @@
 	id = "cequarters";
 	name = "Bolt Control";
 	pixel_y = 30;
-	req_access = list(56);
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
@@ -9081,7 +9194,6 @@
 	id = "hosquarters";
 	name = "Bolt Control";
 	pixel_y = 30;
-	req_access = list(58);
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
@@ -9097,7 +9209,6 @@
 	id = "comsecquarters";
 	name = "Bolt Control";
 	pixel_y = 30;
-	req_access = list(19);
 	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet/blue,
@@ -9606,6 +9717,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/starboard)
+"ibX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_4)
 "icv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10133,6 +10251,21 @@
 /area/maintenance/thirddeck/dormsaft{
 	name = "Third Deck Aft Maintenance"
 	})
+"iHJ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "iHL" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 8
@@ -10285,6 +10418,12 @@
 /area/maintenance/thirddeck/dormsaft{
 	name = "Third Deck Aft Maintenance"
 	})
+"iPn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_11)
 "iPV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -10862,6 +11001,16 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/heads/sc/sd)
+"juw" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "jux" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -10950,6 +11099,7 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "jEj" = (
@@ -11467,6 +11617,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
+"jXc" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_4)
 "jXl" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -11578,6 +11735,15 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 8;
+	name = "Resleeving lost & found bin";
+	pixel_x = 35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -11879,6 +12045,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
+"ktT" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_5)
 "kuz" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -12643,8 +12813,6 @@
 /area/bridge)
 "lrr" = (
 /obj/machinery/clonepod,
-/obj/item/weapon/reagent_containers/glass/bottle/biomass,
-/obj/item/weapon/reagent_containers/glass/bottle/biomass,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "lsm" = (
@@ -12654,6 +12822,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
+"lsn" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "lsr" = (
 /obj/random/trash,
 /turf/simulated/floor/tiled/techmaint,
@@ -12907,16 +13082,14 @@
 	id = "sbridgedoor";
 	name = "Starboard Bridge Door Control";
 	pixel_x = 30;
-	pixel_y = -6;
-	req_access = list(20)
+	pixel_y = -6
 	},
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control switch for the captain's office.";
 	id = "captaindoor";
 	name = "Office Door Control";
 	pixel_x = 30;
-	pixel_y = 6;
-	req_access = list(20)
+	pixel_y = 6
 	},
 /obj/effect/landmark/start/captain,
 /turf/simulated/floor/wood,
@@ -13419,6 +13592,10 @@
 /obj/structure/sign/directions/gym{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/wall,
 /area/crew_quarters/toilet)
 "mcQ" = (
@@ -13536,7 +13713,13 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "mhi" = (
-/obj/machinery/transhuman/resleever,
+/obj/item/weapon/implant/dud,
+/obj/structure/table/steel,
+/obj/item/weapon/implant/sizecontrol,
+/obj/item/weapon/implant/dud,
+/obj/item/clothing/under/rank/geneticist,
+/obj/item/weapon/handcuffs/cable/white,
+/obj/item/clothing/suit/storage/toggle/labcoat,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "mhm" = (
@@ -14296,6 +14479,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/sc/sd)
+"mPN" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftstarboardcentral)
 "mQo" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
@@ -14383,13 +14582,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
+"mVx" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "mVO" = (
 /obj/machinery/photocopier,
 /obj/machinery/button/remote/blast_door{
 	id = "csblast";
 	name = "Blastdoors";
-	pixel_y = -24;
-	req_access = list(19)
+	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
@@ -14634,14 +14845,12 @@
 /obj/machinery/button/remote/blast_door{
 	id = "bridge blast";
 	name = "Bridge Blastdoors";
-	pixel_y = -36;
-	req_access = list(19)
+	pixel_y = -36
 	},
 /obj/machinery/button/windowtint{
 	id = "bridge_center";
 	pixel_x = -11;
-	pixel_y = -24;
-	req_access = null
+	pixel_y = -24
 	},
 /obj/machinery/keycard_auth{
 	pixel_y = -24
@@ -14805,6 +15014,29 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/solars/aftstarboardsolar)
+"nkx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "nkF" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -15104,8 +15336,7 @@
 /obj/machinery/button/remote/blast_door{
 	id = "directorblast";
 	name = "Security Shutters";
-	pixel_x = -26;
-	req_access = list(20)
+	pixel_x = -26
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/heads/sc/sd)
@@ -15148,6 +15379,7 @@
 	icon_state = "32-2"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/down,
 /turf/simulated/open,
 /area/maintenance/thirddeck/aftstarboard)
 "nBd" = (
@@ -15952,6 +16184,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
 "ojq" = (
@@ -15999,6 +16232,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
+"oka" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/station_map{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "okd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -16533,6 +16782,7 @@
 /area/crew_quarters/seconddeck/gym)
 "oIl" = (
 /obj/machinery/floodlight,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
 "oIF" = (
@@ -16616,6 +16866,7 @@
 /obj/random/soap,
 /obj/item/weapon/towel/random,
 /obj/item/weapon/towel/random,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_9)
 "oMy" = (
@@ -16793,6 +17044,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/primary/thirddeck/stationgateway)
+"oTv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_1)
 "oTG" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
@@ -16800,6 +17057,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftstarboardcentral)
 "oTP" = (
@@ -16982,6 +17240,10 @@
 	layer = 3.3;
 	pixel_y = 26
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftstarboardcentral)
 "pbI" = (
@@ -16992,6 +17254,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftstarboardcentral)
 "pcr" = (
@@ -17034,6 +17299,9 @@
 	dir = 1;
 	pixel_y = 26
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftstarboardcentral)
 "pef" = (
@@ -17045,6 +17313,9 @@
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftstarboardcentral)
@@ -17925,6 +18196,13 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space)
+"pSf" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_5)
 "pTi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -17979,6 +18257,9 @@
 "pWc" = (
 /obj/structure/toilet{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_6)
@@ -18067,6 +18348,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "qbV" = (
@@ -18133,8 +18418,7 @@
 /obj/machinery/button/remote/blast_door{
 	id = "heads_meeting";
 	name = "Security Shutters";
-	pixel_x = -26;
-	req_access = list(19)
+	pixel_x = -26
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
@@ -18142,6 +18426,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/maintenance/thirddeck/hiddenkitchen)
+"qgo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_10)
 "qhw" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/grey/border,
@@ -18274,6 +18565,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/aft)
+"qkn" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_9)
 "qkA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18607,6 +18905,7 @@
 "qwG" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "qyx" = (
@@ -18773,6 +19072,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/multi_tile/glass,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/aftdoorm)
 "qEY" = (
@@ -19147,6 +19447,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
+"ram" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_10)
 "rbj" = (
 /obj/structure/railing{
 	dir = 4
@@ -19225,6 +19534,7 @@
 "rcR" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/brown/bordercorner,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/aftdoorm)
 "rcT" = (
@@ -19425,6 +19735,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/particleaccelerator)
 "rjS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "rlC" = (
@@ -19635,6 +19949,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
+"rrX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_9)
 "rth" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19758,6 +20079,12 @@
 	name = "yoga mat"
 	},
 /area/crew_quarters/seconddeck/gym)
+"rxQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_7)
 "ryq" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7{
 	dir = 9
@@ -19808,6 +20135,13 @@
 /area/maintenance/thirddeck/dormsaft{
 	name = "Third Deck Aft Maintenance"
 	})
+"rCe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_7)
 "rCL" = (
 /obj/structure/cryofeed{
 	dir = 4;
@@ -19816,6 +20150,12 @@
 /obj/machinery/vr_sleeper,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/crew_quarters/thirddeck/vrroom)
+"rDv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_3)
 "rDw" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -20077,6 +20417,10 @@
 /area/maintenance/thirddeck/dormsaft{
 	name = "Third Deck Aft Maintenance"
 	})
+"rRs" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_9)
 "rSg" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -20268,6 +20612,7 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "rZO" = (
@@ -20456,6 +20801,12 @@
 	},
 /turf/simulated/open,
 /area/crew_quarters/cafeteria)
+"sjk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_4)
 "sjD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -20852,11 +21203,11 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "sDu" = (
-/obj/random/junk,
-/obj/random/trash,
+/obj/random/obstruction,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "sEf" = (
@@ -21067,6 +21418,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "sMl" = (
@@ -21089,6 +21441,13 @@
 /obj/structure/dogbed,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/vistor_room_1)
+"sNm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_5)
 "sNB" = (
 /obj/machinery/vending/snack{
 	dir = 1
@@ -21646,6 +22005,13 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
 	},
+/obj/machinery/disposal/wall/cleaner{
+	name = "Resleeving lost & found bin";
+	pixel_y = 35
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_6)
 "thN" = (
@@ -21797,6 +22163,15 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 8;
+	name = "Resleeving lost & found bin";
+	pixel_x = 35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_12)
@@ -22036,6 +22411,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/first_aid_station/thirddeck)
+"tCX" = (
+/obj/structure/mirror{
+	pixel_y = -28
+	},
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/toilet)
 "tDd" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -22264,6 +22649,7 @@
 /area/crew_quarters/toilet)
 "tPm" = (
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "tQk" = (
@@ -22703,6 +23089,10 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
+"ueL" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "ueN" = (
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/central)
@@ -22799,6 +23189,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
+"ukJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/hallway/primary/thirddeck/aftdoorm)
 "ukQ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -22826,6 +23223,7 @@
 /area/crew_quarters/sleep/vistor_room_2)
 "umm" = (
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "umq" = (
@@ -23145,12 +23543,6 @@
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/sleep/vistor_room_9)
-"uDZ" = (
-/obj/structure/loot_pile/maint/technical,
-/turf/simulated/floor/plating,
-/area/maintenance/thirddeck/dormsaft{
-	name = "Third Deck Aft Maintenance"
-	})
 "uEb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -23174,6 +23566,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/first_aid_station/thirddeck)
+"uEs" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_4)
 "uEI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/purple{
 	dir = 8
@@ -23298,6 +23694,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "uKq" = (
@@ -23315,6 +23712,15 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_3)
@@ -23438,6 +23844,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "uQK" = (
@@ -23534,6 +23941,7 @@
 /area/hallway/primary/thirddeck/aftdoorm)
 "uSU" = (
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "uTK" = (
@@ -23932,6 +24340,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
+"vjd" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "vjg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23958,6 +24371,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/vistor_room_6)
+"vkv" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "vkH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24150,6 +24579,13 @@
 /obj/item/weapon/pen,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
+"vrk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_7)
 "vsu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24248,6 +24684,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vum" = (
@@ -24298,6 +24735,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vvI" = (
@@ -24314,6 +24754,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vvN" = (
@@ -24324,6 +24767,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vwy" = (
@@ -24333,6 +24779,9 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -24352,6 +24801,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
@@ -24385,6 +24837,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vyl" = (
@@ -24393,6 +24848,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
@@ -24407,6 +24865,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vyE" = (
@@ -24418,6 +24879,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "vzh" = (
@@ -24444,6 +24908,9 @@
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
@@ -24521,6 +24988,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vEG" = (
@@ -24539,6 +25009,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vFj" = (
@@ -24558,6 +25031,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vGZ" = (
@@ -24569,6 +25045,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vHp" = (
@@ -24608,6 +25087,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vIQ" = (
@@ -24621,6 +25103,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vJc" = (
@@ -24639,6 +25124,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vJf" = (
@@ -24653,6 +25141,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vJX" = (
@@ -24667,6 +25158,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vKr" = (
@@ -24682,6 +25176,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vLA" = (
@@ -24707,6 +25204,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vMA" = (
@@ -24720,6 +25220,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vMB" = (
@@ -24737,6 +25240,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vNs" = (
@@ -24760,6 +25266,9 @@
 	},
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
@@ -25248,6 +25757,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/sleep/vistor_room_4)
 "whE" = (
@@ -25752,6 +26262,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/aftdoorm)
 "wCi" = (
@@ -25971,6 +26482,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "wLB" = (
@@ -26269,6 +26781,10 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "wTp" = (
@@ -26287,6 +26803,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -26574,6 +27093,9 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "xhm" = (
@@ -26661,6 +27183,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "xlk" = (
@@ -26711,9 +27234,10 @@
 	name = "Third Deck Aft Maintenance"
 	})
 "xnt" = (
-/obj/machinery/computer/transhuman{
-	dir = 1
-	},
+/obj/effect/decal/cleanable/generic,
+/obj/item/weapon/implanter,
+/obj/structure/table/steel,
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "xob" = (
@@ -26723,6 +27247,10 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_7)
 "xoK" = (
@@ -26755,6 +27283,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_10)
 "xpu" = (
@@ -26835,6 +27367,7 @@
 /obj/random/soap,
 /obj/item/weapon/towel/random,
 /obj/item/weapon/towel/random,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_2)
 "xti" = (
@@ -26895,6 +27428,22 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_4)
+"xtW" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/brown/bordercorner,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
+"xuK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_2)
 "xvg" = (
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
@@ -26918,6 +27467,15 @@
 /obj/item/weapon/towel/random,
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle/wataur,
 /obj/item/weapon/towel/random,
+/obj/machinery/disposal/wall/cleaner{
+	dir = 8;
+	name = "Resleeving lost & found bin";
+	pixel_x = 35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_4)
 "xvY" = (
@@ -26980,6 +27538,15 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_7)
 "xzs" = (
@@ -27064,6 +27631,15 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 8;
+	name = "Resleeving lost & found bin";
+	pixel_x = 35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_10)
@@ -27239,6 +27815,15 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_2)
 "xJn" = (
@@ -27306,6 +27891,10 @@
 /obj/structure/mirror{
 	pixel_x = -24
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_8)
 "xLV" = (
@@ -27329,6 +27918,12 @@
 "xMh" = (
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_7)
+"xMu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_12)
 "xMw" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
@@ -27400,6 +27995,15 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -27546,6 +28150,7 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "xUy" = (
@@ -27565,6 +28170,12 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 4
 	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
+"xUF" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/brown/bordercorner,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "xUK" = (
@@ -27630,6 +28241,15 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_5)
 "xVW" = (
@@ -27641,6 +28261,9 @@
 /obj/structure/table/rack/shelf,
 /obj/item/weapon/towel/random,
 /obj/item/weapon/towel/random,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_5)
 "xVX" = (
@@ -27656,6 +28279,10 @@
 /obj/random/soap,
 /obj/item/weapon/towel/random,
 /obj/item/weapon/towel/random,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_8)
 "xWY" = (
@@ -27667,6 +28294,15 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 8;
+	name = "Resleeving lost & found bin";
+	pixel_x = 35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -27694,6 +28330,10 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_7)
+"xZb" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/maintenance/thirddeck/aftstarboard)
 "xZM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -27728,6 +28368,9 @@
 	},
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
@@ -27774,7 +28417,6 @@
 /area/crew_quarters/cafeteria)
 "ydk" = (
 /obj/effect/decal/cleanable/greenglow,
-/obj/item/weapon/implant/sizecontrol,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "ydV" = (
@@ -27817,7 +28459,6 @@
 /obj/item/weapon/photo,
 /obj/item/weapon/photo,
 /obj/item/weapon/disk/nifsoft/compliance,
-/obj/item/weapon/implanter,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "yfh" = (
@@ -57954,8 +58595,8 @@ xGv
 agg
 pFO
 sMO
-xGv
-xSX
+hiS
+xuK
 xSX
 xSX
 yis
@@ -58212,7 +58853,7 @@ xGv
 rMA
 uZX
 qwD
-xGv
+aeg
 xsQ
 xIR
 lVD
@@ -58470,7 +59111,7 @@ xGv
 dYo
 gSd
 gSd
-xGv
+oTv
 tRd
 xJn
 xSX
@@ -58481,7 +59122,7 @@ xSX
 qVX
 qVX
 aEt
-tKC
+rDv
 jjB
 fCn
 xzy
@@ -58728,7 +59369,7 @@ xGv
 wbX
 xnf
 dFk
-xGv
+oTv
 uSF
 xJQ
 xSX
@@ -58739,7 +59380,7 @@ xSX
 jwk
 dUm
 orc
-tKC
+rDv
 vFj
 woS
 xzy
@@ -58986,7 +59627,7 @@ xGv
 wdC
 xGv
 xGv
-xGv
+oTv
 xSX
 xSX
 xSX
@@ -58997,7 +59638,7 @@ xSX
 tKC
 tKC
 qAy
-tKC
+rDv
 tKC
 tKC
 xzy
@@ -59244,7 +59885,7 @@ vUd
 wgb
 nxY
 wSU
-xld
+nkx
 xld
 xld
 xTz
@@ -59755,11 +60396,11 @@ wzy
 wxU
 fQw
 vkN
-wxU
-vWX
+ukJ
+uEs
 wgy
-vWX
-vWX
+uEs
+ibX
 vWX
 vWX
 vWX
@@ -60792,8 +61433,8 @@ vWX
 wiR
 wFq
 wYO
-vWX
-vWX
+dlB
+ibX
 vWX
 vWX
 xxD
@@ -61050,7 +61691,7 @@ vWX
 wjf
 wjf
 xam
-vWX
+sjk
 xvY
 xLd
 xVw
@@ -61308,7 +61949,7 @@ vWX
 wle
 wGX
 wle
-vWX
+sjk
 xwQ
 xLL
 xVW
@@ -61562,19 +62203,19 @@ uSd
 uZK
 voP
 vJc
-vWX
-vWX
-vWX
-vWX
-vWX
-xxD
-xxD
-xxD
-xxD
-xxD
-xxD
-xxD
-xxD
+uEs
+uEs
+uEs
+uEs
+jXc
+ktT
+hmW
+pSf
+ktT
+ktT
+ktT
+ktT
+sNm
 pWc
 wSi
 fKF
@@ -61832,10 +62473,10 @@ ylw
 ayz
 sjD
 gYN
-oEO
-oEO
-oEO
-oEO
+rrX
+qkn
+rRs
+rRs
 oLL
 doL
 eeU
@@ -62856,7 +63497,7 @@ vXe
 wpU
 wJl
 xdo
-vXe
+rxQ
 xzs
 xMh
 xXs
@@ -63114,7 +63755,7 @@ vXe
 wqg
 wJY
 xeN
-vXe
+rxQ
 xzO
 xNr
 xXQ
@@ -63367,12 +64008,12 @@ tnz
 wxU
 rQm
 vum
-wxU
+cog
 vXe
 wtR
 vXe
-vXe
-vXe
+rCe
+vrk
 vXe
 vXe
 vXe
@@ -63620,9 +64261,9 @@ tad
 tpf
 tMI
 udn
-uee
-uMG
-tpf
+edP
+tCX
+edl
 vbK
 vvy
 vNs
@@ -63883,23 +64524,23 @@ gkA
 mbQ
 fLj
 vvH
-vPu
+xtW
 wCh
-aaM
+juw
 wKP
-vPu
-tKo
-tKo
-tKo
+xtW
+iHJ
+mVx
+mVx
 yaQ
 gig
 wKP
 rcR
-tKo
+mVx
 rZr
 wKP
-vPu
-tKo
+xUF
+vkv
 xtq
 qSC
 tmZ
@@ -64140,16 +64781,16 @@ qvB
 uMG
 tpf
 tnF
-vik
+oka
 wxU
 vXU
 vXU
 wLB
 vXU
+ram
 vXU
 vXU
-vXU
-ybj
+iPn
 ybj
 erh
 ybj
@@ -64157,7 +64798,7 @@ ybj
 aGg
 hiy
 aGg
-aGg
+xMu
 aGg
 aGg
 dxT
@@ -64404,10 +65045,10 @@ vXU
 wuJ
 wMb
 xhm
-vXU
+gIX
 xAo
 xNt
-ybj
+iPn
 vqf
 vxE
 ehe
@@ -64415,7 +65056,7 @@ ybj
 uBu
 jMK
 dDx
-aGg
+xMu
 wbY
 tZq
 dxT
@@ -64662,10 +65303,10 @@ vXU
 wvZ
 wMi
 xht
-vXU
+gIX
 xAy
 xNU
-ybj
+iPn
 uoG
 iWc
 vRi
@@ -64673,7 +65314,7 @@ ybj
 tZd
 fjD
 euk
-aGg
+xMu
 wjE
 fwz
 dxT
@@ -64923,7 +65564,7 @@ xiT
 xpl
 xDf
 xOJ
-ybj
+iPn
 abm
 cXs
 fjE
@@ -65180,8 +65821,8 @@ wNN
 xjF
 vXU
 vXU
-vXU
-ybj
+qgo
+fnl
 tfl
 dUe
 eUq
@@ -65922,9 +66563,9 @@ mRd
 iDw
 nAZ
 oif
-kfL
+qLM
 oIl
-sEn
+xZb
 pbl
 prP
 pPL
@@ -66699,7 +67340,7 @@ ojY
 owX
 oIQ
 sEn
-oYt
+bSk
 psu
 pUj
 qaU
@@ -66978,7 +67619,7 @@ qbV
 qaU
 qaU
 vhe
-qwl
+lsn
 rQK
 qTC
 qaU
@@ -66987,7 +67628,7 @@ shV
 qaU
 qaU
 xRu
-fZP
+ydk
 sVv
 sDu
 xnt
@@ -66996,7 +67637,7 @@ qRF
 sIj
 miC
 eyp
-uDZ
+uge
 wzA
 xfF
 iHm
@@ -67215,27 +67856,27 @@ okt
 oxB
 njY
 oGh
-oYt
-psu
+mPN
+aFc
 oTG
-qbV
+gGs
 qwG
-qwl
-qwl
-rQK
-rjS
-rjS
-rQK
+vjd
+vjd
+dMT
+ueL
+ueL
+dMT
 sLV
-qwl
-qwl
-qwl
+vjd
+vjd
+vjd
 tPm
 umm
 uJg
 uQF
 uSU
-rjS
+ueL
 rjS
 qRa
 xpu
@@ -67505,7 +68146,7 @@ qaU
 tfU
 yeL
 fFk
-rQK
+fZP
 lrr
 wzA
 gqL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Remaps the lost and found system, hopefully adding some QoL changes and some more lost and found bins in public bathrooms for easier and more discreet return of prey's items. The new lost and found bins can be found in the public bathroom areas near common scene locations (bar, gym, dorms and near the qpad - for those returning from Sif).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: New lost and found bins added to dorms bathrooms, the bathroom near the qpad, the bathroom near the bar and the bathroom near the gym, to allow for easier and more discreet item returns. These connect to the lost and found loop and also clean prey items.
del: Removed the junk on the shelves in Autoresleeving so you don't have to go digging through random junk to get your stuff. Removed one shelf to make room for chute.
remap: Moved the lost and found exit out of the wall, so any players summarily "tossed" into a bin don't get wall-stuck. Aimed the chute at a wall so that there's no risk of any window breaking if hit excessively.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
