### PR TITLE
Black Sapbean Fix

### DIFF
--- a/code/modules/reagents/reactions/instant/instant_ch.dm
+++ b/code/modules/reagents/reactions/instant/instant_ch.dm
@@ -91,6 +91,7 @@
 	id = "nutriment"
 	result = "nutriment"
 	required_reagents = list("purplesap" = 1, "orangesap" = 1, "bluesap" = 1)
+	catalysts = list("water" = 5) //CHOMPedit: Catalyst added to prevent conflict with reagents reacting and nixxing each other in black sapbeans
 	result_amount = 3
 
 /////SERAZINE RECIPES//////


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Fixes the black sapbean plant so it no longer nixes all its reagents into nutriment upon harvest

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Added water as a catalyst to the "nutriment from sap" reaction as a workaround to prevent black sapbeans from losing their reagents on harvest. Recipe now requires 5u water before the three saps react.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
