### PR TITLE
Lost and Found Remap v2

### DIFF
--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -32,6 +32,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn/morphspawn,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "aae" = (
@@ -539,6 +540,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "acq" = (
@@ -742,6 +744,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "acN" = (
@@ -854,6 +859,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "adm" = (
@@ -1648,6 +1657,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "agD" = (
@@ -1934,6 +1944,7 @@
 	},
 /obj/random/mob/mouse,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "ahK" = (
@@ -2132,6 +2143,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/trash,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "ais" = (
@@ -2242,6 +2254,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "aiK" = (
@@ -2352,6 +2365,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "ajb" = (
@@ -2430,6 +2444,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
@@ -13959,6 +13977,7 @@
 /obj/effect/landmark{
 	name = "maint_pred"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "dXV" = (
@@ -14729,6 +14748,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "dZH" = (
@@ -15519,6 +15539,9 @@
 "elz" = (
 /obj/structure/sink{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/teleporter/firstdeck)
@@ -20509,6 +20532,9 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/teleporter/firstdeck)
 "jUv" = (
@@ -20770,6 +20796,12 @@
 	temperature = 80
 	},
 /area/tcomm/chamber)
+"kdp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/teleporter/firstdeck)
 "kdq" = (
 /obj/machinery/light{
 	dir = 4
@@ -24537,6 +24569,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "oET" = (
@@ -25299,6 +25334,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/teleporter/firstdeck)
 "pAY" = (
@@ -29048,6 +29086,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/starboard)
+"tEX" = (
+/obj/structure/disposalpipe/up,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/foreport)
 "tFZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29144,6 +29186,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/nuke_storage)
+"tMR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/foreport)
 "tNe" = (
 /obj/structure/sign/deck/first{
 	pixel_y = 32
@@ -30249,6 +30305,22 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/starboard)
+"uQd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	req_access = null;
+	req_one_access = null
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/firstdeck/foreport)
 "uRg" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -31979,6 +32051,14 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/machinery/disposal/wall/cleaner{
+	name = "Resleeving lost & found bin";
+	pixel_y = -35;
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/teleporter/firstdeck)
@@ -60846,7 +60926,7 @@ aiY
 aiY
 aiY
 aiY
-ajn
+tEX
 ajM
 adm
 aFf
@@ -61347,7 +61427,7 @@ aiY
 aiY
 aiY
 aiY
-aiY
+kdp
 aiY
 aiY
 aiY
@@ -61605,8 +61685,8 @@ aaa
 aCl
 aau
 aWv
-aiI
-ciy
+tMR
+uQd
 aiI
 aiI
 aiI

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -2068,6 +2068,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "aem" = (
@@ -5558,6 +5561,10 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "apB" = (
@@ -6778,8 +6785,19 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/meter,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
+"atn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/barrestroom)
 "atq" = (
 /turf/simulated/wall/r_wall,
 /area/ai_monitored/storage/eva)
@@ -7071,6 +7089,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "aue" = (
@@ -7090,6 +7111,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "auf" = (
@@ -7106,6 +7130,9 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -7134,6 +7161,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -7310,6 +7340,7 @@
 	dir = 6
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "avc" = (
@@ -7869,6 +7900,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "awI" = (
@@ -8242,6 +8274,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "aya" = (
@@ -9715,6 +9748,9 @@
 	icon_state = "1-2"
 	},
 /obj/random/trash,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "aDc" = (
@@ -9732,6 +9768,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -13269,6 +13308,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "aPc" = (
@@ -13704,6 +13747,9 @@
 "aQu" = (
 /obj/structure/lattice,
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/down{
+	dir = 1
+	},
 /turf/simulated/open,
 /area/maintenance/engineering)
 "aQv" = (
@@ -16689,6 +16735,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/ascenter)
 "aZJ" = (
@@ -17898,6 +17945,7 @@
 	req_access = null;
 	req_one_access = null
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bdA" = (
@@ -18243,6 +18291,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "beY" = (
@@ -18256,6 +18307,9 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = null;
 	req_one_access = null
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
@@ -18286,6 +18340,9 @@
 	req_access = null;
 	req_one_access = null
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "bfb" = (
@@ -18295,10 +18352,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "bfc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -18306,6 +18369,9 @@
 "bfh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
@@ -18941,6 +19007,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bgW" = (
@@ -19361,6 +19428,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "biv" = (
@@ -21933,6 +22001,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bpr" = (
@@ -24119,6 +24188,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bwo" = (
@@ -24838,6 +24911,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/ascenter)
 "byp" = (
@@ -26264,6 +26338,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/trash,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bBF" = (
@@ -27181,6 +27256,10 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bEJ" = (
@@ -27249,6 +27328,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bFj" = (
@@ -28216,6 +28296,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bIl" = (
@@ -29157,6 +29240,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bLV" = (
@@ -29525,6 +29609,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bNC" = (
@@ -30120,6 +30205,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/trash,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bPs" = (
@@ -30470,6 +30556,7 @@
 	req_access = null;
 	req_one_access = null
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bQN" = (
@@ -31271,6 +31358,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "bTv" = (
@@ -31301,6 +31389,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "bTx" = (
@@ -32432,6 +32521,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/trash,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "bXh" = (
@@ -34198,6 +34288,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "cdl" = (
@@ -34698,9 +34789,14 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
 "cel" = (
-/obj/machinery/alarm{
+/obj/machinery/disposal/wall/cleaner{
 	dir = 4;
-	pixel_x = -22
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/barrestroom)
@@ -34708,6 +34804,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/barrestroom)
@@ -34921,6 +35020,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "cfi" = (
@@ -35093,6 +35193,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "cfH" = (
@@ -35418,6 +35519,10 @@
 /obj/structure/cable/green,
 /obj/random/soap,
 /obj/random/soap,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/barrestroom)
 "cgD" = (
@@ -36069,6 +36174,9 @@
 "ciC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/maintenance/substation/civilian)
@@ -41345,6 +41453,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "cza" = (
@@ -41378,6 +41489,9 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/barrestroom)
 "czq" = (
@@ -41404,6 +41518,9 @@
 	dir = 4
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "czu" = (
@@ -41416,6 +41533,9 @@
 	dir = 4
 	},
 /obj/item/inflatable/door/torn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "czx" = (
@@ -41435,6 +41555,9 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "czJ" = (
@@ -41444,6 +41567,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -41458,6 +41584,10 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "czO" = (
@@ -42005,6 +42135,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "cCa" = (
@@ -42772,6 +42903,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cDY" = (
@@ -42786,6 +42920,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
@@ -42819,6 +42956,9 @@
 	dir = 4
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cEb" = (
@@ -42834,6 +42974,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cEc" = (
@@ -43215,6 +43359,10 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "cFb" = (
@@ -43244,6 +43392,9 @@
 	icon_state = "4-8"
 	},
 /obj/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "cFj" = (
@@ -43262,6 +43413,9 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = null;
 	req_one_access = null
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -43283,6 +43437,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
@@ -43326,6 +43483,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/seconddeck/fscenter)
 "cFN" = (
@@ -43343,6 +43503,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
@@ -43363,6 +43526,9 @@
 	req_access = null;
 	req_one_access = null
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cFP" = (
@@ -43379,6 +43545,9 @@
 	},
 /obj/machinery/light/small,
 /obj/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cFU" = (
@@ -43397,6 +43566,9 @@
 	icon_state = "4-8"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cFW" = (
@@ -43410,6 +43582,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
@@ -43427,6 +43602,9 @@
 	},
 /obj/random/junk,
 /obj/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "cFZ" = (
@@ -43440,6 +43618,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
@@ -44615,6 +44797,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "dlx" = (
@@ -44838,6 +45021,19 @@
 /obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
+"dsu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/storage/emergency_storage/seconddeck/fs_emergency)
 "dtw" = (
 /obj/item/weapon/cane{
 	pixel_x = -6;
@@ -44899,6 +45095,7 @@
 "duK" = (
 /obj/machinery/floodlight,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/fs_emergency)
 "duU" = (
@@ -45559,6 +45756,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
+"dOv" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "medbayquar";
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/seconddeck/starboard)
 "dOF" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
@@ -46190,6 +46402,24 @@
 /obj/machinery/power/thermoregulator,
 /turf/simulated/floor,
 /area/engineering/storage)
+"ehR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "eia" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -46388,6 +46618,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "emI" = (
@@ -46765,6 +46996,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/research)
+"exs" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/storage/emergency_storage/seconddeck/fs_emergency)
 "eyb" = (
 /obj/structure/table/woodentable,
 /obj/item/toy/plushie/therapy/blue,
@@ -46797,6 +47032,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "eBi" = (
@@ -47298,6 +47534,9 @@
 /area/crew_quarters/seconddeck/artsupplies)
 "eLa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/wall,
 /area/maintenance/substation/civilian)
 "eLe" = (
@@ -48100,6 +48339,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "fhn" = (
@@ -48237,20 +48477,16 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/fs_emergency)
 "fkF" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/structure/disposaloutlet{
-	dir = 8;
-	name = "Lost & found disposal outlet";
-	pixel_x = -7;
-	pixel_y = -2
-	},
-/turf/simulated/wall/r_wall,
-/area/medical/virology)
+/turf/simulated/wall,
+/area/chapel/office)
 "fld" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -50051,6 +50287,23 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
+"ggj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "ggA" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
 	dir = 8
@@ -51906,6 +52159,7 @@
 	icon_state = "2-4"
 	},
 /obj/random/trash,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "hff" = (
@@ -53735,6 +53989,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "hYU" = (
@@ -53812,6 +54067,13 @@
 "ich" = (
 /turf/simulated/wall,
 /area/rnd/lab)
+"icq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/storage/emergency_storage/seconddeck/fs_emergency)
 "icB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -54373,6 +54635,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/mixing)
+"ird" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/maintenance/chapel)
 "irj" = (
 /obj/effect/floor_decal/industrial/warning/cee{
 	dir = 4
@@ -54876,6 +55144,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/wall,
 /area/maintenance/substation/civilian)
 "iKa" = (
@@ -54887,6 +55158,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "iKg" = (
@@ -56965,6 +57237,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "jLI" = (
@@ -59081,6 +59354,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "kQG" = (
@@ -59529,6 +59803,13 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/storage/primary)
+"lgQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/storage/emergency_storage/seconddeck/fs_emergency)
 "lhc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -60252,6 +60533,18 @@
 /obj/structure/sign/department/cargo,
 /turf/simulated/wall/r_wall,
 /area/maintenance/cargo)
+"lEe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/medbay)
 "lEm" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -62038,17 +62331,11 @@
 /obj/structure/table/rack/shelf/steel{
 	pixel_y = -3
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/sign/department/cargo{
 	desc = "NT is not responsible for personal items left or lost on SouthernCross. Any lost and found inquiries can be made at the HoP front desk.";
 	name = "Resleeving lost & found bin";
 	pixel_y = -32
 	},
-/obj/random/maintenance/clean,
-/obj/random/maintenance/engineering,
-/obj/random/junk,
 /obj/structure/curtain/black,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/medical/cryo/autoresleeve)
@@ -62260,6 +62547,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "mNt" = (
@@ -62888,6 +63176,12 @@
 	temperature = 80
 	},
 /area/server)
+"ncC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/holodeck_control)
 "ncQ" = (
 /obj/item/toy/eight_ball,
 /obj/structure/table/bench/glass,
@@ -63975,6 +64269,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "nKR" = (
@@ -65613,6 +65908,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "oGx" = (
@@ -66890,6 +67186,9 @@
 	name = "Utility Down";
 	req_one_access = list(11,24)
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "pnz" = (
@@ -66980,6 +67279,7 @@
 	pixel_x = -22
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "poL" = (
@@ -67730,6 +68030,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "pLC" = (
@@ -68626,6 +68927,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "qkB" = (
@@ -68929,6 +69231,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "qqA" = (
@@ -70370,6 +70673,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "roS" = (
@@ -70568,6 +70872,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "rtT" = (
@@ -71079,6 +71384,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "rIm" = (
@@ -71097,9 +71405,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/patient_a)
 "rIU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/wall,
 /area/maintenance/research_medical)
@@ -71262,6 +71570,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/seconddeck/artsupplies)
+"rNC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "rOI" = (
 /obj/structure/table/glass,
 /obj/effect/floor_decal/borderfloor{
@@ -71432,16 +71746,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/cryo/autoresleeve)
 "rRD" = (
-/obj/structure/table/rack/shelf/steel{
-	pixel_y = -3
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/random/maintenance/clean,
-/obj/random/maintenance/engineering,
-/obj/random/thermalponcho,
 /obj/structure/curtain/black,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 4;
+	name = "Lost & found disposal outlet";
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/structure/plasticflaps/mining,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/medical/cryo/autoresleeve)
 "rRH" = (
@@ -72022,6 +72337,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "shD" = (
@@ -72163,6 +72479,17 @@
 "smA" = (
 /turf/simulated/floor/plating,
 /area/maintenance/locker)
+"smB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering)
 "snu" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_medical{
@@ -72822,6 +73149,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "sFN" = (
@@ -73049,6 +73377,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "sMp" = (
@@ -73091,6 +73423,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fpcenter)
+"sNz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/barrestroom)
 "sOC" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
@@ -73128,6 +73467,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/ascenter)
 "sPy" = (
@@ -73614,6 +73954,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "tfB" = (
@@ -75493,6 +75834,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "unr" = (
@@ -75589,6 +75933,10 @@
 	icon_state = "2-8"
 	},
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "uqg" = (
@@ -78273,6 +78621,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "vSR" = (
@@ -78356,6 +78705,7 @@
 	d2 = 0;
 	icon_state = "16-0"
 	},
+/obj/structure/disposalpipe/up,
 /turf/simulated/floor/plating,
 /area/storage/emergency_storage/seconddeck/as_emergency)
 "vVG" = (
@@ -78945,6 +79295,13 @@
 "wnB" = (
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry/D1)
+"wnK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/holodeck_control)
 "woi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -79871,6 +80228,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/chapel)
 "wSc" = (
@@ -79992,6 +80353,9 @@
 	regulate_mode = 0;
 	unlocked = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "wVu" = (
@@ -80022,6 +80386,9 @@
 	dir = 4;
 	name = "Medical automatic shutoff valve"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "wVM" = (
@@ -80047,6 +80414,9 @@
 	dir = 4
 	},
 /obj/machinery/meter,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "wWx" = (
@@ -80065,6 +80435,9 @@
 /area/hallway/secondary/entry/D2)
 "wWW" = (
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "wWX" = (
@@ -80135,6 +80508,9 @@
 	},
 /obj/structure/catwalk,
 /obj/random/junk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "wZh" = (
@@ -80226,6 +80602,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "xbq" = (
@@ -80256,6 +80635,9 @@
 	},
 /obj/structure/catwalk,
 /obj/random/trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
 "xch" = (
@@ -80268,6 +80650,9 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access = null;
 	req_one_access = null
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/medbay_fore)
@@ -80284,6 +80669,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/starboard)
@@ -80353,6 +80741,9 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
 "xeu" = (
@@ -80365,6 +80756,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
@@ -80381,6 +80775,10 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
@@ -80572,6 +80970,17 @@
 /obj/machinery/shield_diffuser,
 /turf/space,
 /area/space)
+"xkG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/meter,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/research)
 "xkS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -81859,6 +82268,9 @@
 	id = "medbayquar";
 	name = "Medbay Emergency Lockdown Shutters";
 	opacity = 0
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/seconddeck/starboard)
@@ -110246,7 +110658,7 @@ vxj
 atZ
 vxj
 aPc
-vxj
+rNC
 aqI
 vxj
 aTX
@@ -110502,8 +110914,8 @@ sFM
 sFM
 sFM
 sFM
-aNv
-aNv
+smB
+smB
 aPb
 pjT
 aNv
@@ -111004,7 +111416,7 @@ atq
 atq
 atq
 atq
-auh
+ggj
 aeK
 aBC
 awI
@@ -112294,7 +112706,7 @@ asw
 asw
 asw
 atq
-auh
+ggj
 cBN
 vxj
 cEZ
@@ -112552,7 +112964,7 @@ atq
 atq
 atq
 atq
-aem
+ehR
 syU
 afk
 awO
@@ -112810,7 +113222,7 @@ aqt
 ary
 asy
 atq
-auh
+ggj
 syU
 syU
 syU
@@ -113068,7 +113480,7 @@ csj
 ctS
 cvY
 atq
-auh
+ggj
 cBO
 afm
 awQ
@@ -116425,7 +116837,7 @@ cxA
 csw
 aWb
 cuE
-cDZ
+cEd
 aWb
 enG
 enG
@@ -117199,7 +117611,7 @@ crE
 crE
 crE
 cDR
-cDZ
+cEd
 iXZ
 aWb
 aaa
@@ -117457,7 +117869,7 @@ cxL
 czZ
 cCp
 cuE
-cDZ
+cEd
 gjV
 aWb
 aaa
@@ -117973,7 +118385,7 @@ cxN
 cAc
 crE
 cDW
-cDZ
+cEd
 cuE
 csa
 aaa
@@ -118286,10 +118698,10 @@ njG
 cFt
 cFt
 cFt
-cFt
-cFt
-cFt
-cFt
+sNz
+chG
+chG
+atn
 fFD
 xKO
 xKO
@@ -118489,7 +118901,7 @@ cxP
 cAv
 crE
 cDW
-cDZ
+cEd
 cDP
 csa
 aaa
@@ -118547,7 +118959,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+ncC
 voL
 voL
 kEz
@@ -118747,7 +119159,7 @@ crE
 crE
 crE
 cDW
-cDZ
+cEd
 aWb
 aWb
 aaa
@@ -118805,7 +119217,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+ncC
 git
 wOC
 uvS
@@ -119004,7 +119416,7 @@ cwt
 cxQ
 cAx
 crJ
-cAM
+xkG
 cFZ
 aWb
 aaa
@@ -119063,7 +119475,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+ncC
 gFD
 xip
 msv
@@ -119321,7 +119733,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+ncC
 gFO
 xHj
 emX
@@ -119579,7 +119991,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+ncC
 gKC
 xLN
 jvu
@@ -119778,7 +120190,7 @@ cui
 cui
 cAB
 crJ
-cDZ
+cEd
 cGd
 dtI
 euB
@@ -119837,7 +120249,7 @@ vMO
 vMO
 vMO
 vMO
-cFI
+ncC
 hiK
 kqH
 lLD
@@ -120095,8 +120507,8 @@ vMO
 vMO
 vMO
 vMO
-cFI
-voL
+wnK
+fkF
 voL
 voL
 voL
@@ -120295,7 +120707,7 @@ crJ
 crJ
 crJ
 cEb
-cGd
+icq
 duc
 evb
 fjy
@@ -120553,11 +120965,11 @@ cxU
 cAJ
 cCy
 cEc
-cGd
+lgQ
 duK
-evb
+dsu
 fjA
-cGd
+exs
 heB
 hYM
 iKa
@@ -120833,7 +121245,7 @@ sPZ
 ueZ
 xMr
 hIE
-aDc
+lEe
 aEi
 aPk
 aPk
@@ -121128,7 +121540,7 @@ njG
 njG
 njG
 cFI
-fnp
+ird
 rrB
 dWC
 bNr
@@ -126252,7 +126664,7 @@ ufl
 vxe
 wqq
 xeT
-xPX
+dOv
 wDy
 eMV
 nrg
@@ -133985,7 +134397,7 @@ opM
 opM
 opM
 opM
-fkF
+opM
 opM
 opM
 uEF

--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -880,6 +880,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "aHx" = (
@@ -1045,6 +1046,13 @@
 /area/maintenance/thirddeck/dormsaft{
 	name = "Third Deck Aft Maintenance"
 	})
+"aQw" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "aRa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1184,6 +1192,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
+"aYI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/toilet)
 "aYM" = (
 /obj/item/weapon/pen/multi,
 /turf/simulated/floor/wood,
@@ -1231,6 +1246,13 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/solars/foreportsolar)
+"bep" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_1)
 "beu" = (
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/sleep/vistor_room_2)
@@ -1821,6 +1843,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_3)
 "bHJ" = (
@@ -2039,6 +2065,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_12)
 "bTP" = (
@@ -2209,6 +2239,16 @@
 /area/maintenance/thirddeck/dormsport{
 	name = "Third Deck Aft Port Maintenance"
 	})
+"ccx" = (
+/obj/structure/mirror{
+	pixel_y = -28
+	},
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/toilet)
 "cdc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -2541,6 +2581,9 @@
 	},
 /obj/structure/mirror{
 	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_6)
@@ -3109,6 +3152,12 @@
 /area/maintenance/thirddeck/dormsport{
 	name = "Third Deck Aft Port Maintenance"
 	})
+"cOi" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_1)
 "cOx" = (
 /obj/structure/table/standard,
 /obj/item/weapon/aiModule/nanotrasen,
@@ -3587,6 +3636,14 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
 	},
+/obj/machinery/disposal/wall/cleaner{
+	name = "Resleeving lost & found bin";
+	pixel_y = -35;
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_9)
 "dpB" = (
@@ -3668,6 +3725,12 @@
 "dvD" = (
 /turf/simulated/wall/r_wall,
 /area/ai/ai_cyborg_station)
+"dwb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_1)
 "dwY" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -3968,6 +4031,16 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/ai/ai_cyborg_station)
+"dFQ" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "dGv" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorms9";
@@ -4534,6 +4607,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/vistor_room_1)
+"dYp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_4)
 "dYv" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -4583,6 +4663,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "dZQ" = (
@@ -5027,6 +5108,29 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/sc/hor/quarters)
+"eqE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "erh" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorms11";
@@ -5423,6 +5527,13 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/cmo/quarters)
+"eDv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_4)
 "eEi" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -5818,6 +5929,10 @@
 /area/maintenance/thirddeck/dormsport{
 	name = "Third Deck Aft Port Maintenance"
 	})
+"eSf" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_9)
 "eSu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -6218,6 +6333,11 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/thirddeck/starboard)
+"ffN" = (
+/obj/random/trash,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "ffQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -6421,6 +6541,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "flb" = (
@@ -6657,6 +6778,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/central)
+"fuO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_10)
 "fvh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -6724,6 +6851,11 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/starboard)
+"fxV" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "fyg" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
@@ -7142,6 +7274,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "fLv" = (
@@ -7827,6 +7960,7 @@
 	c_tag = "Third Deck - Aft Civ Dorms 5";
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "giJ" = (
@@ -7848,6 +7982,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/port)
+"gjP" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_4)
 "gjT" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8195,6 +8336,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/dorms)
+"gBw" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/toilet)
 "gDa" = (
 /obj/item/clothing/suit/space/vox/civ/chef,
 /obj/structure/sign/poster{
@@ -8224,6 +8375,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/particleaccelerator)
+"gEI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_11)
 "gEK" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8549,6 +8706,22 @@
 	can_open = 1
 	},
 /area/maintenance/thirddeck/hiddenkitchen)
+"gXM" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftstarboardcentral)
 "gXS" = (
 /turf/simulated/wall,
 /area/crew_quarters/heads/sc/hos/quarters)
@@ -8614,6 +8787,12 @@
 "hcP" = (
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/heads/sc/bs)
+"hcQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_7)
 "hdM" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -8627,6 +8806,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/starboard)
+"hex" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_9)
 "heB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8972,6 +9158,12 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/sleep/vistor_room_3)
+"huJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_3)
 "hvg" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -9108,6 +9300,13 @@
 /area/maintenance/thirddeck/dormsport{
 	name = "Third Deck Aft Port Maintenance"
 	})
+"hBe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_2)
 "hBG" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9433,6 +9632,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/thirddeck/hiddenkitchen)
+"hUR" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_5)
 "hVq" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -9572,6 +9777,22 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/sc/bs)
+"ibb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/station_map{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "ibq" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -9813,6 +10034,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/seconddeck/gym)
+"imm" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftstarboardcentral)
 "inP" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -10293,6 +10529,10 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/central)
+"iPZ" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "iQh" = (
 /obj/structure/closet,
 /obj/item/weapon/storage/backpack,
@@ -10589,6 +10829,13 @@
 /area/maintenance/thirddeck/dormsaft{
 	name = "Third Deck Aft Maintenance"
 	})
+"jhb" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_5)
 "jhg" = (
 /turf/simulated/floor/reinforced/airless,
 /area/thirddeck/roof)
@@ -10950,6 +11197,7 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "jEj" = (
@@ -11579,6 +11827,15 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 8;
+	name = "Resleeving lost & found bin";
+	pixel_x = 35;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_1)
@@ -12526,6 +12783,10 @@
 /obj/item/clothing/under/swimsuit/stripper,
 /turf/simulated/floor/tiled,
 /area/maintenance/thirddeck/aftport)
+"lhh" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_5)
 "lht" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -13419,6 +13680,10 @@
 /obj/structure/sign/directions/gym{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/wall,
 /area/crew_quarters/toilet)
 "mcQ" = (
@@ -14023,6 +14288,12 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsatmos)
+"mAu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/hallway/primary/thirddeck/aftdoorm)
 "mAS" = (
 /obj/machinery/atmospherics/valve,
 /obj/effect/floor_decal/industrial/warning{
@@ -14698,6 +14969,13 @@
 /obj/random/junk,
 /turf/simulated/floor/wood,
 /area/maintenance/thirddeck/dormsatmos)
+"nhx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_11)
 "nhz" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -15148,6 +15426,7 @@
 	icon_state = "32-2"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/down,
 /turf/simulated/open,
 /area/maintenance/thirddeck/aftstarboard)
 "nBd" = (
@@ -15741,6 +16020,12 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/bridge)
+"nYW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_4)
 "nZp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15921,6 +16206,12 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/sc/sd)
+"off" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/brown/bordercorner,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "ofh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15952,6 +16243,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
 "ojq" = (
@@ -16446,6 +16738,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/solars/aftstarboardsolar)
+"ozZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_7)
 "oBP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -16533,6 +16832,7 @@
 /area/crew_quarters/seconddeck/gym)
 "oIl" = (
 /obj/machinery/floodlight,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
 "oIF" = (
@@ -16616,6 +16916,7 @@
 /obj/random/soap,
 /obj/item/weapon/towel/random,
 /obj/item/weapon/towel/random,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_9)
 "oMy" = (
@@ -16800,6 +17101,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftstarboardcentral)
 "oTP" = (
@@ -16982,6 +17284,10 @@
 	layer = 3.3;
 	pixel_y = 26
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftstarboardcentral)
 "pbI" = (
@@ -16992,6 +17298,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftstarboardcentral)
 "pcr" = (
@@ -17034,6 +17343,9 @@
 	dir = 1;
 	pixel_y = 26
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftstarboardcentral)
 "pef" = (
@@ -17045,6 +17357,9 @@
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftstarboardcentral)
@@ -17836,6 +18151,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftstarboardcentral)
+"pLY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_7)
 "pMo" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/crew_quarters/sleep/vistor_room_8)
@@ -17980,6 +18302,9 @@
 /obj/structure/toilet{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_6)
 "pWI" = (
@@ -18067,6 +18392,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "qbV" = (
@@ -18607,6 +18936,7 @@
 "qwG" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "qyx" = (
@@ -18773,6 +19103,7 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/multi_tile/glass,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/aftdoorm)
 "qEY" = (
@@ -19122,6 +19453,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/crew_quarters/cafeteria)
+"qYw" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_4)
 "qYQ" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -19225,6 +19560,7 @@
 "rcR" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/brown/bordercorner,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/aftdoorm)
 "rcT" = (
@@ -19425,6 +19761,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/particleaccelerator)
 "rjS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "rlC" = (
@@ -19527,6 +19867,19 @@
 /obj/effect/floor_decal/corner/orange/diagonal,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cafeteria)
+"rpi" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "rpp" = (
 /obj/random/junk,
 /turf/simulated/floor/carpet/bcarpet,
@@ -20268,6 +20621,7 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "rZO" = (
@@ -20303,6 +20657,10 @@
 	},
 /turf/simulated/open,
 /area/crew_quarters/seconddeck/gym)
+"sbs" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/monotile,
+/area/hallway/primary/thirddeck/aftstarboardcentral)
 "sbH" = (
 /turf/simulated/open,
 /area/crew_quarters/seconddeck/gym)
@@ -20333,6 +20691,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/vistor_room_3)
+"sdP" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/brown/bordercorner,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "sdS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -20852,6 +21219,7 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "sDu" = (
@@ -20859,6 +21227,13 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
+"sEc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_5)
 "sEf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -21067,6 +21442,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "sMl" = (
@@ -21646,6 +22022,13 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/wall/cleaner{
+	name = "Resleeving lost & found bin";
+	pixel_y = 35
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_6)
 "thN" = (
@@ -21797,6 +22180,15 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 8;
+	name = "Resleeving lost & found bin";
+	pixel_x = 35;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_12)
@@ -22264,6 +22656,7 @@
 /area/crew_quarters/toilet)
 "tPm" = (
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "tQk" = (
@@ -22826,6 +23219,7 @@
 /area/crew_quarters/sleep/vistor_room_2)
 "umm" = (
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "umq" = (
@@ -22986,6 +23380,15 @@
 	},
 /turf/simulated/open,
 /area/hallway/primary/thirddeck/aft)
+"uuD" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = null;
+	req_one_access = null
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "uwA" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/white/bordercorner,
@@ -23298,6 +23701,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "uKq" = (
@@ -23315,6 +23719,15 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_3)
@@ -23438,6 +23851,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "uQK" = (
@@ -23460,6 +23874,13 @@
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/wood/alt/panel,
 /area/maintenance/thirddeck/hiddenkitchen)
+"uRm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/hallway/primary/thirddeck/aftdoorm)
 "uRz" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/alarm{
@@ -23534,8 +23955,13 @@
 /area/hallway/primary/thirddeck/aftdoorm)
 "uSU" = (
 /obj/random/junk,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
+"uTc" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/maintenance/thirddeck/aftstarboard)
 "uTK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -24248,6 +24674,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vum" = (
@@ -24298,6 +24725,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vvI" = (
@@ -24314,6 +24744,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vvN" = (
@@ -24324,6 +24757,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vwy" = (
@@ -24333,6 +24769,9 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -24352,6 +24791,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
@@ -24385,6 +24827,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vyl" = (
@@ -24393,6 +24838,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
@@ -24407,6 +24855,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vyE" = (
@@ -24418,6 +24869,9 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "vzh" = (
@@ -24444,6 +24898,9 @@
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
@@ -24521,6 +24978,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vEG" = (
@@ -24539,6 +24999,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vFj" = (
@@ -24558,8 +25021,17 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
+"vFA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_12)
 "vGZ" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/brown{
@@ -24569,6 +25041,25 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
+"vHc" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vHp" = (
@@ -24608,6 +25099,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vIQ" = (
@@ -24621,6 +25115,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vJc" = (
@@ -24639,6 +25136,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vJf" = (
@@ -24653,6 +25153,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vJX" = (
@@ -24667,6 +25170,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vKr" = (
@@ -24682,6 +25188,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vLA" = (
@@ -24707,6 +25216,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vMA" = (
@@ -24720,6 +25232,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vMB" = (
@@ -24737,6 +25252,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "vNs" = (
@@ -24760,6 +25278,9 @@
 	},
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
@@ -24937,6 +25458,13 @@
 /obj/machinery/door/firedoor/multi_tile/glass,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/aftdoorm)
+"vUr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_10)
 "vWX" = (
 /turf/simulated/wall,
 /area/crew_quarters/sleep/vistor_room_4)
@@ -25008,6 +25536,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/solars/aftportsolar)
+"vYL" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/beige/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/aftdoorm)
 "vZb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -25248,6 +25791,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/sleep/vistor_room_4)
 "whE" = (
@@ -25752,6 +26296,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/aftdoorm)
 "wCi" = (
@@ -25971,6 +26516,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "wLB" = (
@@ -26269,6 +26815,10 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "wTp" = (
@@ -26287,6 +26837,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/brown/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -26434,6 +26987,13 @@
 /obj/structure/coatrack,
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/vistor_room_7)
+"xbY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall,
+/area/crew_quarters/sleep/vistor_room_9)
 "xco" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -26574,6 +27134,9 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "xhm" = (
@@ -26661,6 +27224,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "xlk" = (
@@ -26723,6 +27287,10 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_7)
 "xoK" = (
@@ -26755,6 +27323,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_10)
 "xpu" = (
@@ -26835,6 +27407,7 @@
 /obj/random/soap,
 /obj/item/weapon/towel/random,
 /obj/item/weapon/towel/random,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_2)
 "xti" = (
@@ -26918,6 +27491,15 @@
 /obj/item/weapon/towel/random,
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle/wataur,
 /obj/item/weapon/towel/random,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 8;
+	name = "Resleeving lost & found bin";
+	pixel_x = 35;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_4)
 "xvY" = (
@@ -26980,6 +27562,15 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_7)
 "xzs" = (
@@ -27064,6 +27655,15 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 8;
+	name = "Resleeving lost & found bin";
+	pixel_x = 35;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_10)
@@ -27239,6 +27839,15 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_2)
 "xJn" = (
@@ -27305,6 +27914,10 @@
 	},
 /obj/structure/mirror{
 	pixel_x = -24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_8)
@@ -27401,6 +28014,15 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_11)
@@ -27546,6 +28168,7 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "xUy" = (
@@ -27630,6 +28253,15 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 4;
+	name = "Resleeving lost & found bin";
+	pixel_x = -35;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_5)
 "xVW" = (
@@ -27641,6 +28273,9 @@
 /obj/structure/table/rack/shelf,
 /obj/item/weapon/towel/random,
 /obj/item/weapon/towel/random,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_5)
 "xVX" = (
@@ -27656,6 +28291,10 @@
 /obj/random/soap,
 /obj/item/weapon/towel/random,
 /obj/item/weapon/towel/random,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_8)
 "xWY" = (
@@ -27668,6 +28307,15 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/wall/cleaner{
+	dir = 8;
+	name = "Resleeving lost & found bin";
+	pixel_x = 35;
+	pixel_y = 0
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_8)
@@ -27728,6 +28376,9 @@
 	},
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
@@ -57954,8 +58605,8 @@ xGv
 agg
 pFO
 sMO
-xGv
-xSX
+bep
+hBe
 xSX
 xSX
 yis
@@ -58212,7 +58863,7 @@ xGv
 rMA
 uZX
 qwD
-xGv
+cOi
 xsQ
 xIR
 lVD
@@ -58470,7 +59121,7 @@ xGv
 dYo
 gSd
 gSd
-xGv
+dwb
 tRd
 xJn
 xSX
@@ -58481,7 +59132,7 @@ xSX
 qVX
 qVX
 aEt
-tKC
+huJ
 jjB
 fCn
 xzy
@@ -58728,7 +59379,7 @@ xGv
 wbX
 xnf
 dFk
-xGv
+dwb
 uSF
 xJQ
 xSX
@@ -58739,7 +59390,7 @@ xSX
 jwk
 dUm
 orc
-tKC
+huJ
 vFj
 woS
 xzy
@@ -58986,7 +59637,7 @@ xGv
 wdC
 xGv
 xGv
-xGv
+dwb
 xSX
 xSX
 xSX
@@ -58997,7 +59648,7 @@ xSX
 tKC
 tKC
 qAy
-tKC
+huJ
 tKC
 tKC
 xzy
@@ -59244,7 +59895,7 @@ vUd
 wgb
 nxY
 wSU
-xld
+eqE
 xld
 xld
 xTz
@@ -59755,11 +60406,11 @@ wzy
 wxU
 fQw
 vkN
-wxU
-vWX
+uRm
+qYw
 wgy
-vWX
-vWX
+qYw
+dYp
 vWX
 vWX
 vWX
@@ -60792,8 +61443,8 @@ vWX
 wiR
 wFq
 wYO
-vWX
-vWX
+eDv
+dYp
 vWX
 vWX
 xxD
@@ -61050,7 +61701,7 @@ vWX
 wjf
 wjf
 xam
-vWX
+nYW
 xvY
 xLd
 xVw
@@ -61308,7 +61959,7 @@ vWX
 wle
 wGX
 wle
-vWX
+nYW
 xwQ
 xLL
 xVW
@@ -61562,19 +62213,19 @@ uSd
 uZK
 voP
 vJc
-vWX
-vWX
-vWX
-vWX
-vWX
-xxD
-xxD
-xxD
-xxD
-xxD
-xxD
-xxD
-xxD
+qYw
+qYw
+qYw
+qYw
+gjP
+lhh
+hUR
+jhb
+lhh
+lhh
+lhh
+lhh
+sEc
 pWc
 wSi
 fKF
@@ -61832,10 +62483,10 @@ ylw
 ayz
 sjD
 gYN
-oEO
-oEO
-oEO
-oEO
+xbY
+hex
+eSf
+eSf
 oLL
 doL
 eeU
@@ -62856,7 +63507,7 @@ vXe
 wpU
 wJl
 xdo
-vXe
+hcQ
 xzs
 xMh
 xXs
@@ -63114,7 +63765,7 @@ vXe
 wqg
 wJY
 xeN
-vXe
+hcQ
 xzO
 xNr
 xXQ
@@ -63367,12 +64018,12 @@ tnz
 wxU
 rQm
 vum
-wxU
+mAu
 vXe
 wtR
 vXe
-vXe
-vXe
+ozZ
+pLY
 vXe
 vXe
 vXe
@@ -63620,9 +64271,9 @@ tad
 tpf
 tMI
 udn
-uee
-uMG
-tpf
+gBw
+ccx
+aYI
 vbK
 vvy
 vNs
@@ -63883,23 +64534,23 @@ gkA
 mbQ
 fLj
 vvH
-vPu
+sdP
 wCh
-aaM
+dFQ
 wKP
-vPu
-tKo
-tKo
-tKo
+sdP
+vYL
+rpi
+rpi
 yaQ
 gig
 wKP
 rcR
-tKo
+rpi
 rZr
 wKP
-vPu
-tKo
+off
+vHc
 xtq
 qSC
 tmZ
@@ -64140,16 +64791,16 @@ qvB
 uMG
 tpf
 tnF
-vik
+ibb
 wxU
 vXU
 vXU
 wLB
 vXU
+fuO
 vXU
 vXU
-vXU
-ybj
+gEI
 ybj
 erh
 ybj
@@ -64157,7 +64808,7 @@ ybj
 aGg
 hiy
 aGg
-aGg
+vFA
 aGg
 aGg
 dxT
@@ -64404,10 +65055,10 @@ vXU
 wuJ
 wMb
 xhm
-vXU
+fuO
 xAo
 xNt
-ybj
+gEI
 vqf
 vxE
 ehe
@@ -64415,7 +65066,7 @@ ybj
 uBu
 jMK
 dDx
-aGg
+vFA
 wbY
 tZq
 dxT
@@ -64662,10 +65313,10 @@ vXU
 wvZ
 wMi
 xht
-vXU
+fuO
 xAy
 xNU
-ybj
+gEI
 uoG
 iWc
 vRi
@@ -64673,7 +65324,7 @@ ybj
 tZd
 fjD
 euk
-aGg
+vFA
 wjE
 fwz
 dxT
@@ -64923,7 +65574,7 @@ xiT
 xpl
 xDf
 xOJ
-ybj
+gEI
 abm
 cXs
 fjE
@@ -65180,8 +65831,8 @@ wNN
 xjF
 vXU
 vXU
-vXU
-ybj
+vUr
+nhx
 tfl
 dUe
 eUq
@@ -65922,9 +66573,9 @@ mRd
 iDw
 nAZ
 oif
-kfL
+qLM
 oIl
-sEn
+uTc
 pbl
 prP
 pPL
@@ -66699,7 +67350,7 @@ ojY
 owX
 oIQ
 sEn
-oYt
+imm
 psu
 pUj
 qaU
@@ -66978,7 +67629,7 @@ qbV
 qaU
 qaU
 vhe
-qwl
+aQw
 rQK
 qTC
 qaU
@@ -67215,27 +67866,27 @@ okt
 oxB
 njY
 oGh
-oYt
-psu
+gXM
+sbs
 oTG
-qbV
+uuD
 qwG
-qwl
-qwl
-rQK
-rjS
-rjS
-rQK
+fxV
+fxV
+ffN
+iPZ
+iPZ
+ffN
 sLV
-qwl
-qwl
-qwl
+fxV
+fxV
+fxV
 tPm
 umm
 uJg
 uQF
 uSU
-rjS
+iPZ
 rjS
 qRa
 xpu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Remaps the lost and found system, hopefully adding some QoL changes and some more lost and found bins in public bathrooms for easier and more discreet return of prey's items. The new lost and found bins can be found in the public bathroom areas near common scene locations (bar, gym, dorms and near the qpad - for those returning from Sif).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: New lost and found bins added to dorms bathrooms, the bathroom near the qpad, the bathroom near the bar and the bathroom near the gym, to allow for easier and more discreet item returns. These connect to the lost and found loop and also clean prey items.
del: Removed the junk on the shelves in Autoresleeving so you don't have to go digging through random junk to get your stuff. Removed one shelf to make room for chute.
remap: Moved the lost and found exit out of the wall, so any players summarily "tossed" into a bin don't get wall-stuck. Aimed the chute at a wall so that there's no risk of any window breaking if hit excessively.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
