### PR TITLE
Metamorphosis Ray design for RnD

### DIFF
--- a/code/modules/research/designs/weapons_vr.dm
+++ b/code/modules/research/designs/weapons_vr.dm
@@ -33,16 +33,6 @@
 	build_path = /obj/item/weapon/gun/energy/netgun
 	sort_string = "MAAVC"
 
-//CHOMPAdd Start
-/datum/design/item/weapon/energy/metamorphosisray
-	name = "metamorphosis ray"
-	id = "metamorphosisray"
-	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_POWER = 4, TECH_BIO = 5, TECH_BLUESPACE = 4, TECH_ILLEGAL = 5)
-	materials = list(MAT_STEEL = 1000, MAT_GLASS = 2000, MAT_URANIUM = 500, MAT_PHORON = 1500)
-	build_path = /obj/item/weapon/gun/energy/mouseray/metamorphosis
-	sort_string = "MAAVD"
-//CHOMPAdd End
-
 // Misc weapons
 
 /datum/design/item/weapon/pummeler

--- a/code/modules/research/designs/weapons_vr.dm
+++ b/code/modules/research/designs/weapons_vr.dm
@@ -33,6 +33,16 @@
 	build_path = /obj/item/weapon/gun/energy/netgun
 	sort_string = "MAAVC"
 
+//CHOMPAdd Start
+/datum/design/item/weapon/energy/metamorphosisray
+	name = "metamorphosis ray"
+	id = "metamorphosisray"
+	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_POWER = 4, TECH_BIO = 5, TECH_BLUESPACE = 4, TECH_ILLEGAL = 5)
+	materials = list(MAT_STEEL = 1000, MAT_GLASS = 2000, MAT_URANIUM = 500, MAT_PHORON = 1500)
+	build_path = /obj/item/weapon/gun/energy/mouseray/metamorphosis
+	sort_string = "MAAVD"
+//CHOMPAdd End
+
 // Misc weapons
 
 /datum/design/item/weapon/pummeler

--- a/modular_chomp/code/modules/research/designs/weapons.dm
+++ b/modular_chomp/code/modules/research/designs/weapons.dm
@@ -7,6 +7,14 @@
 	build_path = /obj/item/weapon/gun/launcher/confetti_cannon
 	sort_string = "MAAVD"
 
+/datum/design/item/weapon/energy/metamorphosisray
+	name = "metamorphosis ray"
+	id = "metamorphosisray"
+	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_POWER = 4, TECH_BIO = 5, TECH_BLUESPACE = 4, TECH_ILLEGAL = 5)
+	materials = list(MAT_STEEL = 1000, MAT_GLASS = 2000, MAT_URANIUM = 500, MAT_PHORON = 1500)
+	build_path = /obj/item/weapon/gun/energy/mouseray/metamorphosis
+	sort_string = "MAAVE"
+
 //Phase weapon with lock safeties.
 /datum/design/item/weapon/phase/phase_pistol
 	id = "phasepistol"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
A fun scene tool now more available, similar to how RnD can print others like the Body Snatcher. Tech and Material costs based off the Recombobulation Ray design which is effectively the same gun but only reverts. Added requirement for Illegal level 5 and placed under the energy weapon category.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added the Metamorphosis Ray to science's protolathe designs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
