### PR TITLE
Fixes Mailman uniform

### DIFF
--- a/modular_chomp/code/modules/clothing/under/jobs/civilian.dm
+++ b/modular_chomp/code/modules/clothing/under/jobs/civilian.dm
@@ -2,6 +2,7 @@
 	name = "mailman's suit"
 	desc = "A good looking suit for the delivery person!"
 	icon_state = "mailman2"
-	icon = 'icons/inventory/uniform/item_ch.dmi'
+	icon = 'icons/inventory/uniform/mob_ch.dmi'
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	rolled_sleeves = 0
+	icon_override = 'icons/inventory/uniform/mob_ch.dmi' //rollsleeves mechanics set by upstream overrides and breaks all clothing in \under\ otherwise.


### PR DESCRIPTION
Fixes the Mailman uniform added in https://github.com/CHOMPStation2/CHOMPStation2/pull/7286/files by pointing it to the correct 4 sided sprite .dmi instead of the 1 sided floor sprite. also bandaids the sprite from getting overridden into breaking by upstream rollsleeve mechanics even when coded correctly.