### PR TITLE
Fixes fatal heartburns involving custom liquid bellies digesting synthetics.

### DIFF
--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -354,6 +354,7 @@
 	touch_met = 50 // It's acid!
 	var/power = 5
 	var/meltdose = 10 // How much is needed to melt
+	affects_robots = TRUE //CHOMPedit, it's acid! Still eats metal!
 
 /datum/reagent/acid/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(alien == IS_GREY) //ywedit

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -1494,6 +1494,8 @@
 			Prey.ingested.trans_to_holder(Pred.ingested, Prey.ingested.total_volume, 0.5, TRUE) // Therefore don't bother spending cpu
 			Prey.touching.del_reagent("stomacid") //Don't need this stuff in our bloodstream.
 			Prey.touching.del_reagent("diet_stomacid") //Don't need this stuff in our bloodstream.
+			Prey.touching.del_reagent("pacid") //Don't need this stuff in our bloodstream.
+			Prey.touching.del_reagent("sacid") //Don't need this stuff in our bloodstream.
 			Prey.touching.del_reagent("cleaner") //Don't need this stuff in our bloodstream.
 			Prey.touching.trans_to_holder(Pred.ingested, Prey.touching.total_volume, 0.5, TRUE) // On updating the prey's reagents
 		else if(M.reagents)
@@ -1585,6 +1587,8 @@
 		Prey.ingested.trans_to_holder(Pred.ingested, Prey.ingested.total_volume, copy = TRUE)
 		Prey.touching.del_reagent("stomacid") //CHOMPEdit Don't need this stuff in our bloodstream.
 		Prey.touching.del_reagent("diet_stomacid") //CHOMPEdit Don't need this stuff in our bloodstream.
+		Prey.touching.del_reagent("pacid") //Don't need this stuff in our bloodstream.
+		Prey.touching.del_reagent("sacid") //Don't need this stuff in our bloodstream.
 		Prey.touching.del_reagent("cleaner") //CHOMPEdit Don't need this stuff in our bloodstream.
 		Prey.touching.trans_to_holder(Pred.ingested, Prey.touching.total_volume, copy = TRUE)
 		// TODO - Find a way to make the absorbed prey share the effects with the pred.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
So if someone had a Polyacid gut digesting a synthcrew, the acids will not affect the synth and build up on the synth, and the second they did get digested, you'd get full of your own acid and die. 
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: No more fatal heartburn to organic crew with stronger acids.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
