### PR TITLE
Item TF device: Mind Binder

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -269,7 +269,7 @@
 			ghost.assumeform(src)
 			ghost.animate_towards(user)
 	//VORESTATION EDIT START. This handles possessed items.
-	if(src.possessed_voice && src.possessed_voice.len && !(user.ckey in warned_of_possession)) //Is this item possessed?
+	if(src.possessed_voice && src.possessed_voice.len > 1 && !(user.ckey in warned_of_possession)) //Is this item possessed?
 		warned_of_possession |= user.ckey
 		tgui_alert_async(user,{"
 		THIS ITEM IS POSSESSED BY A PLAYER CURRENTLY IN THE ROUND. This could be by anomalous means or otherwise.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -269,7 +269,7 @@
 			ghost.assumeform(src)
 			ghost.animate_towards(user)
 	//VORESTATION EDIT START. This handles possessed items.
-	if(src.possessed_voice && src.possessed_voice.len > 1 && !(user.ckey in warned_of_possession)) //Is this item possessed?
+	if(src.possessed_voice && src.possessed_voice.len > 1 && !(user.ckey in warned_of_possession)) // CHOMPEdit Is this item possessed?
 		warned_of_possession |= user.ckey
 		tgui_alert_async(user,{"
 		THIS ITEM IS POSSESSED BY A PLAYER CURRENTLY IN THE ROUND. This could be by anomalous means or otherwise.

--- a/code/game/objects/items/contraband_vr.dm
+++ b/code/game/objects/items/contraband_vr.dm
@@ -46,6 +46,7 @@
 						/obj/item/weapon/circuitboard/mecha/phazon/peripherals,
 						/obj/item/weapon/circuitboard/mecha/phazon/main,
 						/obj/item/device/bodysnatcher,
+						/obj/item/device/mindbinder,	//CHOMPAdd
 						/obj/item/weapon/bluespace_harpoon,
 						/obj/item/clothing/accessory/permit/gun,
 						/obj/item/device/perfect_tele,

--- a/code/game/objects/items/devices/scanners/sleevemate.dm
+++ b/code/game/objects/items/devices/scanners/sleevemate.dm
@@ -311,6 +311,11 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 		icon_state = initial(icon_state)
 
 /obj/item/device/sleevemate/emag_act(var/remaining_charges, var/mob/user)
+	//CHOMPEdit Start
+	var/list/choices = list("Body Snatcher","Mind Binder")
+	var/choice = tgui_input_list(user, "How would you like to modify the [src]?", "", choices)
+	if(!choice || !(choice in choices)) return
+	//CHOMPEdit End
 	to_chat(user,"<span class='danger'>You hack [src]!</span>")
 	var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
 	spark_system.set_up(5, 0, src.loc)
@@ -320,6 +325,11 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 		var/mob/living/L = src.loc
 		L.unEquip(src)
 	src.forceMove(get_turf(src))
-	new /obj/item/device/bodysnatcher(src.loc)
+	//CHOMPEdit Start
+	if(choice == "Body Snatcher")
+		new /obj/item/device/bodysnatcher(src.loc)
+	if(choice == "Mind Binder")
+		new /obj/item/device/mindbinder(src.loc)
+	//CHOMPEdit End
 	qdel(src)
 	return 1

--- a/code/game/objects/items_vr.dm
+++ b/code/game/objects/items_vr.dm
@@ -26,6 +26,12 @@
 	new_voice.verbs -= /mob/living/voice/verb/change_name //No changing your name! Bad!
 	new_voice.verbs -= /mob/living/voice/verb/hang_up //Also you can't hang up. You are the item!
 	src.item_tf_spawnpoint_used() //CHOMPEdit - Item TF spawnpoints
+	//CHOMPEdit Start - Let the inhabitor know what happened to them
+	if(istype(src, /obj/item/device/mindbinder))
+		to_chat(new_voice,"<span class='notice'>Your mind has been stored in [src]!</span>")
+	else
+		to_chat(new_voice,"<span class='notice'>You have become [src]!</span>")
+	//CHOMPEdit End
 
 // Chomp edit
 /obj/item/proc/muffled_by_belly(var/mob/user)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -39,6 +39,16 @@
 			m.visible_message("<span class = 'notice'>\The [m] tumbles out of \the [src]!</span>")
 	//VOREStation Add End
 
+	//CHOMPAdd Start possessed item cleanup
+	if(istype(src, /obj/item))
+		var/obj/item/I = src
+		if(I.possessed_voice && I.possessed_voice.len)
+			for(var/mob/living/voice/V in I.possessed_voice)
+				if(!V.tf_mob_holder)
+					V.ghostize(0)
+					V.Destroy()
+	//CHOMPAdd End
+
 	return ..()
 
 /obj/Topic(href, href_list, var/datum/tgui_state/state = GLOB.tgui_default_state)

--- a/code/game/objects/structures/trash_pile_vr.dm
+++ b/code/game/objects/structures/trash_pile_vr.dm
@@ -310,6 +310,7 @@
 					prob(1);/obj/item/device/radio_jammer,
 					prob(1);/obj/item/device/sleevemate,
 					prob(1);/obj/item/device/bodysnatcher,
+					prob(1);/obj/item/device/mindbinder,	//CHOMPAdd
 					prob(1);/obj/item/weapon/beartrap,
 					prob(1);/obj/item/weapon/cell/hyper/empty,
 					prob(1);/obj/item/weapon/disk/nifsoft/compliance,

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -139,7 +139,7 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 
 	var/obj/item/organ/internal/brain/B = src
 	if(istype(B) && owner)
-		if(istype(owner, /mob/living/carbon))
+		if(istype(owner, /mob/living/carbon) && owner.ckey) //CHOMPEdit - Make sure owner's mind isn't elsewhere otherwise on brain removal brings them back
 			B.transfer_identity(owner)
 
 	..()

--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -577,8 +577,22 @@
 					D.matter[mat] += modified_mats[mat]
 				if(O.w_class > D.w_class)
 					D.w_class = O.w_class
+				//CHOMPAdd Start
+				if(O.possessed_voice && O.possessed_voice.len)
+					for(var/mob/living/voice/V in O.possessed_voice)
+						D.inhabit_item(V, null, V.tf_mob_holder)
+						V.Destroy()
+					O.possessed_voice = list()
+				//CHOMPAdd End
 				return TRUE
-		new /obj/item/debris_pack/digested(src, modified_mats)
+		var/obj/item/debris_pack/digested/D = new /obj/item/debris_pack/digested(src, modified_mats) //CHOMPEdit
+		//CHOMPAdd Start
+		if(O.possessed_voice && O.possessed_voice.len)
+			for(var/mob/living/voice/V in O.possessed_voice)
+				D.inhabit_item(V, null, V.tf_mob_holder)
+				V.Destroy()
+			O.possessed_voice = list()
+		//CHOMPAdd End
 	return TRUE
 
 /obj/belly/proc/owner_adjust_nutrition(var/amount = 0)

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -13,6 +13,7 @@
 				P.id = null
 
 		for(var/mob/living/voice/V in possessed_voice) // Delete voices.
+			V.ghostize(0) //CHOMPAdd - Prevent Reenter Corpse sending observers to the shadow realm
 			V.Destroy() //Destroy the voice.
 		for(var/mob/living/M in contents)//Drop mobs from objects(shoes) before deletion
 			M.forceMove(item_storage)
@@ -76,8 +77,6 @@
 			var/obj/item/device/pda/P = src
 			if(P.id)
 				P.id = null
-		for(var/mob/living/voice/V in possessed_voice) // Delete voices.
-			V.Destroy() //Destroy the voice.
 		for(var/mob/living/M in contents)//Drop mobs from objects(shoes) before deletion
 			if(item_storage)
 				M.forceMove(item_storage)
@@ -107,7 +106,14 @@
 		else
 			soundfile = pick('sound/vore/shortgurgles/gurgle_S1.ogg', 'sound/vore/shortgurgles/gurgle_S2.ogg', 'sound/vore/shortgurgles/gurgle_S3.ogg')
 		playsound(src, soundfile, vol = g_sound_volume, vary = 1, falloff = VORE_SOUND_FALLOFF, frequency = noise_freq, preference = /datum/client_preference/eating_noises, volume_channel = VOLUME_CHANNEL_VORE) //CHOMPEdit
-		if(istype(B) && B.recycle(src))
+		//CHOMPEdit Start - Allow those turned into items to become the recycled item
+		var/recycled = B.recycle(src)
+		if(!recycled)
+			for(var/mob/living/voice/V in possessed_voice) // Delete voices.
+				V.ghostize(0) //CHOMPAdd - Prevent Reenter Corpse sending observers to the shadow realm
+				V.Destroy() //Destroy the voice.
+		if(istype(B) && recycled)
+		//CHOMPEdit End
 			g_damage = w_class / 2
 			if(B.item_digest_logs)
 				to_chat(B.owner,"<span class='notice'>[src] was digested inside your [lowertext(B.name)].</span>")

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -77,6 +77,10 @@
 			var/obj/item/device/pda/P = src
 			if(P.id)
 				P.id = null
+		/* CHOMPEdit Start - This is handled lower down now
+		for(var/mob/living/voice/V in possessed_voice) // Delete voices.
+			V.Destroy() //Destroy the voice.
+		CHOMPEdit End */
 		for(var/mob/living/M in contents)//Drop mobs from objects(shoes) before deletion
 			if(item_storage)
 				M.forceMove(item_storage)

--- a/code/modules/vore/resizing/holder_vr.dm
+++ b/code/modules/vore/resizing/holder_vr.dm
@@ -48,7 +48,7 @@
 		dropInto(user.drop_location())
 		dropped(user)
 	//VORESTATION EDIT START. This handles possessed items.
-	if(src.possessed_voice && src.possessed_voice.len > 1 && !(user.ckey in warned_of_possession)) //Is this item possessed?
+	if(src.possessed_voice && src.possessed_voice.len > 1 && !(user.ckey in warned_of_possession)) // CHOMPEdit Is this item possessed?
 		warned_of_possession |= user.ckey
 		tgui_alert_async(user,{"
 		THIS ITEM IS POSSESSED BY A PLAYER CURRENTLY IN THE ROUND. This could be by anomalous means or otherwise.

--- a/code/modules/vore/resizing/holder_vr.dm
+++ b/code/modules/vore/resizing/holder_vr.dm
@@ -48,7 +48,7 @@
 		dropInto(user.drop_location())
 		dropped(user)
 	//VORESTATION EDIT START. This handles possessed items.
-	if(src.possessed_voice && src.possessed_voice.len && !(user.ckey in warned_of_possession)) //Is this item possessed?
+	if(src.possessed_voice && src.possessed_voice.len > 1 && !(user.ckey in warned_of_possession)) //Is this item possessed?
 		warned_of_possession |= user.ckey
 		tgui_alert_async(user,{"
 		THIS ITEM IS POSSESSED BY A PLAYER CURRENTLY IN THE ROUND. This could be by anomalous means or otherwise.

--- a/modular_chomp/code/game/objects/items/devices/mind_binder.dm
+++ b/modular_chomp/code/game/objects/items/devices/mind_binder.dm
@@ -1,0 +1,176 @@
+// Another illegal hack of the sleevemate similar to the Body Snatcher. This one lets you store and bind minds to items.
+/obj/item/device/mindbinder
+	name = "\improper Mind Binder"
+	desc = "An extremely illegal tool modified from a SleeveMate. It allows the storing and transfer of minds, but can bind them to objects instead of just humanoids."
+	icon = 'icons/obj/device_alt.dmi'
+	icon_state = "sleevemate"
+	item_state = "healthanalyzer"
+	slot_flags = SLOT_BELT
+	w_class = ITEMSIZE_SMALL
+	matter = list(MAT_STEEL = 200)
+	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 2, TECH_ILLEGAL = 1)
+	possessed_voice = list()
+	var/self_bind = FALSE
+
+/obj/item/device/mindbinder/New()
+	..()
+	flags |= NOBLUDGEON //So borgs don't spark.
+
+/obj/item/device/mindbinder/attack(mob/living/M, mob/living/user)
+	usr.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	return
+
+/obj/item/device/mindbinder/attack_self(mob/living/user)
+	return
+
+/obj/item/device/mindbinder/proc/toggle_self_bind()
+	if(possessed_voice.len == 1)
+		to_chat(usr,"<span class='warning'>The device beeps a warning that there is already a mind loaded!</span>")
+		return
+	self_bind = !self_bind
+	if(self_bind)
+		to_chat(usr,"<span class='notice'>You prepare the device to use your own mind!</span>")
+	else
+		to_chat(usr,"<span class='notice'>You disable the device from using your mind.</span>")
+	update_icon()
+
+/obj/item/device/mindbinder/pre_attack(atom/A)
+	if(istype(A, /mob/living))
+		var/mob/living/M = A
+		if(usr == M)
+			toggle_self_bind()
+			return
+		if(possessed_voice.len == 1 || self_bind)
+			bind_mob(M)
+		else
+			store_mob(M)
+		return
+	if(istype(A, /obj/item))
+		var/obj/item/I = A
+		if(istype(I, /obj/item/weapon/holder/micro))
+			var/obj/item/weapon/holder/micro/H = I
+			if(possessed_voice.len == 1 || self_bind)
+				bind_mob(H.held_mob)
+			else
+				store_mob(H.held_mob)
+			return
+		if(possessed_voice.len == 1 || self_bind)
+			bind_item(I)
+		else
+			store_item(I)
+		return
+	return
+
+// Handle placing a mind into a mob
+/obj/item/device/mindbinder/proc/bind_mob(mob/living/target)
+	if(possessed_voice.len == 0 && !self_bind)
+		to_chat(usr,"<span class='warning'>The device beeps a warning that it doesn't contain a mind to bind!</span>")
+		return
+
+	if(target.ckey)
+		to_chat(usr,"<span class='warning'>The device beeps a warning that the target is already sentient!</span>")
+		return
+
+	if(self_bind)
+		var/choice = tgui_alert(usr,"This will bind YOUR mind to the target! You may not be able to go back without help. Continue?","Confirmation",list("Continue","Cancel"))
+		if(choice == "Cancel") return
+		choice = tgui_alert(usr,"No really. You cannot OOC Escape this. Are you sure?","Confirmation",list("Yes I'm sure","Cancel"))
+		if(choice == "Yes I'm sure" && usr.get_active_hand() == src && usr.Adjacent(target))
+			usr.visible_message("<span class='warning'>[usr] presses [src] against [target]. The device beginning to let out a series of beeps!</span>","<span class='notice'>You begin to bind yourself into [target]!</span>")
+			if(do_after(usr,30 SECONDS,target))
+				if(!target.ckey)
+					usr.mind.transfer_to(target)
+				self_bind = !self_bind
+				update_icon()
+				to_chat(usr,"<span class='notice'>Your mind as been bound to [target].</span>")
+		return
+
+	usr.visible_message("<span class='warning'>[usr] presses [src] against [target]. The device beginning to let out a series of beeps!</span>","<span class='notice'>You begin to bind someone's mind into [target]!</span>")
+	if(do_after(usr,5 SECONDS,target))
+		if(possessed_voice.len == 1 && !target.ckey)
+			possessed_voice[1].mind.transfer_to(target)
+			possessed_voice[1].Destroy()
+			possessed_voice = list()
+			to_chat(usr,"<span class='notice'>Mind bound to [target].</span>")
+
+	update_icon()
+
+// Handle placing a mind into an item
+/obj/item/device/mindbinder/proc/bind_item(obj/item/item)
+	if(possessed_voice.len == 0 && !self_bind)
+		to_chat(usr,"<span class='warning'>The device beeps a warning that it doesn't contain a mind to bind!</span>")
+		return
+
+	if(item.possessed_voice && item.possessed_voice.len)
+		to_chat(usr,"<span class='warning'>The device beeps a warning that the target is already sentient!</span>")
+		return
+
+	if(self_bind)
+		var/choice = tgui_alert(usr,"This will bind YOUR mind to the target! You will not be able to go back without help. Continue?","Confirmation",list("Continue","Cancel"))
+		if(choice == "Cancel") return
+		choice = tgui_alert(usr,"No really. You cannot OOC Escape this. Are you sure?","Confirmation",list("Yes I'm sure","Cancel"))
+		if(choice == "Yes I'm sure" && usr.get_active_hand() == src && usr.Adjacent(item))
+			usr.visible_message("<span class='warning'>[usr] presses [src] against [item]. The device beginning to let out a series of beeps!</span>","<span class='notice'>You begin to bind yourself into [item]!</span>")
+			if(do_after(usr,30 SECONDS,item))
+				item.inhabit_item(usr, null, null)
+				self_bind = !self_bind
+				update_icon()
+				to_chat(usr,"<span class='notice'>Your mind as been bound to [item].</span>")
+		return
+
+	usr.visible_message("<span class='warning'>[usr] presses [src] against [item]. The device beginning to let out a series of beeps!</span>","<span class='notice'>You begin to bind someone's mind into [item]!</span>")
+	if(do_after(usr,5 SECONDS,item))
+		if(possessed_voice.len == 1)
+			item.inhabit_item(possessed_voice[1], null, possessed_voice[1].tf_mob_holder)
+			possessed_voice[1].Destroy()
+			possessed_voice = list()
+			to_chat(usr,"<span class='notice'>Mind bound to [item].</span>")
+
+	update_icon()
+
+// Handle taking a mind out of a mob
+/obj/item/device/mindbinder/proc/store_mob(mob/living/target)
+	if(possessed_voice.len != 0)
+		to_chat(usr,"<span class='warning'>The device beeps a warning that there is already a mind loaded!</span>")
+		return
+
+	if(!target.mind || (target.mind.name in prevent_respawns))
+		to_chat(usr,"<span class='warning'>The device beeps a warning that the target isn't sentient.</span>")
+		return
+
+	var/choice = tgui_alert(usr,"This will download the target's mind into the device. Once their mind is loaded you can then bind it into an item. This will result in the target being stuck until you put them back in their original body. Please make sure OOC prefs align! Continue?","Confirmation",list("Continue","Cancel"))
+	if(choice == "Continue" && usr.get_active_hand() == src && usr.Adjacent(target))
+		usr.visible_message("<span class='warning'>[usr] presses [src] against [target]'s head. The device beginning to let out a series of beeps!</span>","<span class='notice'>You begin to download [target]'s mind!</span>")
+		if(do_after(usr,30 SECONDS,target))
+			if(possessed_voice.len == 0 && target.mind)
+				inhabit_item(target, target.real_name, null)
+				to_chat(usr,"<span class='notice'>Mind successfully stored!</span>")
+
+	update_icon()
+
+// Handle taking a mind out of an item
+/obj/item/device/mindbinder/proc/store_item(obj/item/item)
+	if(possessed_voice.len != 0)
+		to_chat(usr,"<span class='warning'>The device beeps a warning that there is already a mind loaded!</span>")
+		return
+
+	if(!(item.possessed_voice && item.possessed_voice.len))
+		return
+
+	var/mob/living/voice/target = item.possessed_voice[1]
+
+	usr.visible_message("<span class='warning'>[usr] presses [src] against [item]. The device beginning to let out a series of beeps!</span>","<span class='notice'>You begin to download someone's mind from [item]!</span>")
+	if(do_after(usr,5 SECONDS,item))
+		if(possessed_voice.len == 0 && item.possessed_voice.Find(target))
+			inhabit_item(target, target.real_name, target.tf_mob_holder)
+			target.Destroy()
+			item.possessed_voice.Remove(target)
+			to_chat(usr,"<span class='notice'>Mind successfully stored!</span>")
+
+	update_icon()
+
+/obj/item/device/mindbinder/update_icon()
+	if((possessed_voice && possessed_voice.len > 0) || self_bind)
+		icon_state = "[initial(icon_state)]_on"
+	else
+		icon_state = initial(icon_state)

--- a/modular_chomp/code/game/objects/items/devices/mind_binder.dm
+++ b/modular_chomp/code/game/objects/items/devices/mind_binder.dm
@@ -88,8 +88,9 @@
 	usr.visible_message("<span class='warning'>[usr] presses [src] against [target]. The device beginning to let out a series of beeps!</span>","<span class='notice'>You begin to bind someone's mind into [target]!</span>")
 	if(do_after(usr,5 SECONDS,target))
 		if(possessed_voice.len == 1 && !target.ckey)
-			possessed_voice[1].mind.transfer_to(target)
-			possessed_voice[1].Destroy()
+			var/mob/living/voice/V = possessed_voice[1]
+			V.mind.transfer_to(target)
+			V.Destroy()
 			possessed_voice = list()
 			to_chat(usr,"<span class='notice'>Mind bound to [target].</span>")
 
@@ -121,8 +122,9 @@
 	usr.visible_message("<span class='warning'>[usr] presses [src] against [item]. The device beginning to let out a series of beeps!</span>","<span class='notice'>You begin to bind someone's mind into [item]!</span>")
 	if(do_after(usr,5 SECONDS,item))
 		if(possessed_voice.len == 1)
-			item.inhabit_item(possessed_voice[1], null, possessed_voice[1].tf_mob_holder)
-			possessed_voice[1].Destroy()
+			var/mob/living/voice/V = possessed_voice[1]
+			item.inhabit_item(V, null, V.tf_mob_holder)
+			V.Destroy()
 			possessed_voice = list()
 			to_chat(usr,"<span class='notice'>Mind bound to [item].</span>")
 

--- a/modular_chomp/code/modules/research/designs/misc.dm
+++ b/modular_chomp/code/modules/research/designs/misc.dm
@@ -6,3 +6,11 @@
 	materials = list(MAT_STEEL = 5000)
 	build_path = /obj/item/trash/rkibble
 	sort_string = "KIBBB"
+
+/datum/design/item/general/mindbinder
+	name = "Mind Binder"
+	id = "mindbinder"
+	req_tech = list(TECH_MAGNET = 3, TECH_BIO = 3, TECH_ILLEGAL = 2)
+	materials = list(MAT_STEEL = 4000, MAT_GLASS = 4000, MAT_URANIUM = 2000)
+	build_path = /obj/item/device/mindbinder
+	sort_string = "TBVAB"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4651,6 +4651,7 @@
 #include "modular_chomp\code\game\objects\items\petrifier.dm"
 #include "modular_chomp\code\game\objects\items\clockwork\ratvarian_spear.dm"
 #include "modular_chomp\code\game\objects\items\devices\flipper.dm"
+#include "modular_chomp\code\game\objects\items\devices\mind_binder.dm"
 #include "modular_chomp\code\game\objects\items\devices\vacpack.dm"
 #include "modular_chomp\code\game\objects\items\devices\radio\headset.dm"
 #include "modular_chomp\code\game\objects\items\weapons\capture_crystal.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds a new illegal hack of the SleeveMate which enables binding minds to any item. Does not have all the functionality of a SleeveMate. It simply stores a mind within itself while leaving the body behind, and if it contains a mind it can place it within any item or back into a mob. Also has a mode to bind your own mind, along with plenty of warnings of how bad of an idea that might be unless you have help around you. Can be obtained through trash, contraband, the protolathe, and by emag'ing a SleeveMate.

Misc changes along with this is allowing those who are turned into objects, and being digested inside a belly with recycling, to transfer into becoming the digested material object which builds up with recycling enabled. Also found that the brain organ would teleport carbon's back into it on gib even if they no longer inhabited their body. So fixed that, and now you can turn your friends into items and dispose of the evidence without them teleporting back into their brain.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added new illegal item for handheld Item TF: Mind Binder
add: Sentient items digested in a belly with recycling now become the recycled matter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
