### PR TITLE
Solar grubs can now evolve

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/solargrub.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/solargrub.dm
@@ -16,7 +16,7 @@ List of things solar grubs should be able to do:
 	value = CATALOGUER_REWARD_EASY
 
 #define SINK_POWER 1
-var/global/list/moth_amount = 0 // Chompstation Addition, Rykka waz here. *pawstamp*
+var/global/moth_amount = 0 // Chompstation Addition, Rykka waz here. *pawstamp*
 
 /mob/living/simple_mob/vore/solargrub
 	name = "juvenile solargrub"
@@ -103,11 +103,12 @@ var/global/list/moth_amount = 0 // Chompstation Addition, Rykka waz here. *pawst
 			PN = null
 
 		// CHOMPEDIT Start, Rykka waz here. *pawstamp*
-		if(prob(1) && charge >= 32000 && can_evolve == 1 && moth_amount <= 1) //it's reading from the moth_amount global list to determine if it can evolve. There should only ever be a maxcap of 1 existing solar moth alive at any time. TODO: make the code decrease the list after 1 has spawned this shift.
+		if(prob(1) && charge >= 32000 && can_evolve == 1 && moth_amount < 1) //it's reading from the moth_amount global list to determine if it can evolve. There should only ever be a maxcap of 1 existing solar moth alive at any time. TODO: make the code decrease the list after 1 has spawned this shift.
 			anchored = 0
 			PN = attached.powernet
 			release_vore_contents()
-			prey_excludes.Cut()
+			if(prey_excludes)
+				prey_excludes.Cut()
 			moth_amount = moth_amount + 1
 			death_star()
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/solarmoth_ch.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/solarmoth_ch.dm
@@ -59,7 +59,7 @@
 	minbodytemp = 0
 	heat_damage_per_tick = 0 //Even if the atmos stuff doesn't work, at least it won't take any damage.
 
-	armor = list(			
+	armor = list(
 				"melee" = 0,
 				"bullet" = 90,
 				"laser" = 100,
@@ -67,12 +67,12 @@
 				"bomb" = 100,
 				"bio" = 100,
 				"rad" = 100)
-				
+
 	can_be_drop_prey = FALSE //CHOMP Add
 
 /datum/say_list/solarmoth
 	emote_see = list("flutters")
-	
+
 /mob/living/simple_mob/vore/solarmoth/apply_melee_effects(var/atom/A)
 	if(isliving(A))
 		var/mob/living/L = A
@@ -110,17 +110,17 @@
 			if(heat_transfer > 0 && env.temperature < T0C + 200)	//This should start heating the room at a moderate pace up to 200 degrees celsius.
 				heat_transfer = min(heat_transfer , heating_power) //limit by the power rating of the heater
 				removed.add_thermal_energy(heat_transfer)
-			
+
 			else if(heat_transfer > 0 && env.temperature < set_temperature) //Set temperature is 10,000 degrees celsius. So this thing will start cooking crazy hot between the temperatures of 200C and 10,000C.
 				heating_power = original_temp*100 //Changed to work variable -shark //FLAME ON! This will make the moth heat up the room at an incredible rate.
 				heat_transfer = min(heat_transfer , heating_power) //limit by the power rating of the heater. Except it's hot, so yeah.
 				removed.add_thermal_energy(heat_transfer)
-			
+
 			else
 				return
 
 			env.merge(removed)
-		
+
 
 
 	//Since I'm changing hyper mode to be variable we need to store old power
@@ -129,6 +129,7 @@
 /mob/living/simple_mob/vore/solarmoth/proc/explode()
 	src.anchored = 0
 	set_light(0)
+	moth_amount = clamp(moth_amount - 1, 0, 1)
 	if(empulse(src, emp_heavy, emp_med, emp_light, emp_long))
 		qdel(src)
 	return
@@ -136,11 +137,11 @@
 /mob/living/simple_mob/vore/solarmoth/death()
 	explode()
 	..()
-	
+
 /mob/living/simple_mob/vore/solarmoth/gib() //This baby will explode no matter what you do to it.
 	explode()
 	..()
-	
+
 
 
 /mob/living/simple_mob/vore/solarmoth/handle_light()
@@ -161,9 +162,9 @@
 /mob/living/simple_mob/vore/solarmoth/lunarmoth
 	name = "lunarmoth"
 	desc = "A majestic sparkling lunarmoth. Also a slight engineering hazard."
-	
+
 	var/nospampls = 0
-	
+
 	cold_damage_per_tick = 0
 	//ATMOS
 	set_temperature = T0C - 10000
@@ -176,7 +177,7 @@
 	if(prob(25))
 		for(var/obj/machinery/light/light in range(5, src))
 			if(prob(50))
-				light.broken() 
+				light.broken()
 	if(prob(10))
 		for(var/obj/structure/window/window in range(5, src))
 			if(prob(50))
@@ -187,7 +188,7 @@
 				visible_message("<span class='danger'>Emergency Shutter malfunction!</span>")
 				door.blocked = 0
 				door.open(1)
-	
+
 	spawn(100)
 		nospampls = 0
 
@@ -195,4 +196,3 @@
 	..()
 	if(!nospampls)
 		chilltheglass() //shatter and broken calls for glass and lights. Also some special thing.
-	

--- a/modular_chomp/maps/submaps/surface_submaps/valley/solarmoff.dmm
+++ b/modular_chomp/maps/submaps/surface_submaps/valley/solarmoff.dmm
@@ -155,7 +155,7 @@
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/submap/solarmoff)
 "U" = (
-/mob/living/simple_mob/vore/spacecritter/solarray/galaxyray,
+/mob/living/simple_mob/vore/solarmoth,
 /obj/item/rig_module/device/stamp,
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/submap/solarmoff)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
**It was not the solar moth in the valley after all.**
An evolving solargrub attempting to expel prey from an empty belly would throw an exception and wouldn't allow it to evolve, leaving them as solar grubs forever.

Additionally, killing a solar moth would not bring the solar moth count down, which only allowed a singular moth to ever exist per shift.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Solar grubs can now evolve
remap: Solar moth re-added to the valley
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
