### PR TITLE
Patient Ward Tweak

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -23414,11 +23414,6 @@
 	},
 /turf/simulated/open,
 /area/quartermaster/lockerroom)
-"bup" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/patient_b)
 "buq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -34259,11 +34254,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/barrestroom)
-"cda" = (
-/obj/machinery/door/firedoor,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/medical/patient_a)
 "cde" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -69613,7 +69603,9 @@
 /area/medical/cryo)
 "qAJ" = (
 /obj/machinery/door/firedoor/glass,
-/obj/effect/wingrille_spawn/reinforced,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "pr1_window_tint"
+	},
 /turf/simulated/floor/plating,
 /area/medical/patient_a)
 "qAW" = (
@@ -78177,7 +78169,9 @@
 /area/maintenance/bar)
 "vGS" = (
 /obj/machinery/door/firedoor/glass,
-/obj/effect/wingrille_spawn/reinforced,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "pr2_window_tint"
+	},
 /turf/simulated/floor/plating,
 /area/medical/patient_b)
 "vHd" = (
@@ -130302,7 +130296,7 @@ drJ
 wls
 lUA
 vda
-cda
+drJ
 aaa
 aaa
 aaa
@@ -130818,7 +130812,7 @@ drJ
 wUp
 ojP
 qtn
-cda
+drJ
 aaa
 aaa
 aaa
@@ -131334,7 +131328,7 @@ rEb
 pOQ
 vxF
 rKn
-bup
+rEb
 aaa
 aaa
 aaa
@@ -131850,7 +131844,7 @@ rEb
 mre
 kzs
 sUz
-bup
+rEb
 aaa
 aaa
 aaa


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Adds electrochromatic windows to the isolation ward exterior windows for more privacy from space critters and nosy astronauts

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
remap: Isolation ward exterior windows made electrochromatic
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
