### PR TITLE
Upgrades Sif grass, fixes wingrilles

### DIFF
--- a/code/game/objects/structures/window_spawner.dm
+++ b/code/game/objects/structures/window_spawner.dm
@@ -7,6 +7,7 @@
 	name = "window grille spawner"
 	icon = 'icons/obj/structures.dmi'
 	icon_state = "wingrille"
+	layer = 1.9 // CHOMPedit: more visible for mappers
 	density = TRUE
 	anchored = TRUE
 	pressure_resistance = 4*ONE_ATMOSPHERE
@@ -27,7 +28,7 @@
 	return FALSE
 
 /obj/effect/wingrille_spawn/Initialize()
-	if(win_path && ticker && ticker.current_state < GAME_STATE_PLAYING)
+	if(win_path && ticker && ticker.current_state < GAME_STATE_FINISHED) // CHOMPedit: let's make these work after round start
 		activate()
 	..()
 	return INITIALIZE_HINT_QDEL

--- a/code/game/turfs/simulated/outdoors/grass.dm
+++ b/code/game/turfs/simulated/outdoors/grass.dm
@@ -39,7 +39,7 @@ var/list/grass_types = list(
 	name = "growth"
 	icon_state = "grass_sif0"
 	initial_flooring = /decl/flooring/grass/sif
-	edge_blending_priority = 2
+	edge_blending_priority = 3 // CHOMPedit
 	grass_chance = 5
 	var/tree_chance = 0.7 //CHOMPedit
 

--- a/code/game/turfs/simulated/outdoors/outdoors.dm
+++ b/code/game/turfs/simulated/outdoors/outdoors.dm
@@ -114,7 +114,7 @@ var/list/turf_edge_cache = list()
 /turf/simulated/floor/outdoors/mud
 	name = "mud"
 	icon_state = "mud_dark"
-	edge_blending_priority = 3
+	edge_blending_priority = 4 // CHOMPedit
 	initial_flooring = /decl/flooring/mud
 	can_dig = TRUE
 


### PR DESCRIPTION
-Tweaks turf edges so normal Sif grass can grow onto dirt paths.
-Makes wingrilles spawners able to function after round start. Why were these disabled when specific code exists to trigger an inactivate spawner?
-Tweaks wingrille spawner layer for mappers.

:cl:
qol: Adjust turf edges priority
qol: Tweaks windgrille spawner layer
fix: Makes wingrille spawners work after roundstart
/:cl:
