### PR TITLE
fixes 2 runtimes in the liquid system

### DIFF
--- a/code/modules/reagents/holder/holder.dm
+++ b/code/modules/reagents/holder/holder.dm
@@ -268,9 +268,13 @@
 //If for some reason touch effects are bypassed (e.g. injecting stuff directly into a reagent container or person),
 //call the appropriate trans_to_*() proc.
 /datum/reagents/proc/trans_to(var/atom/target, var/amount = 1, var/multiplier = 1, var/copy = 0)
-	if(ismob(target))  //CHOMPEdit
-		return splash_mob(target, amount * multiplier, copy) //Touch effects handled by splash_mob
+	//CHOMPEdit Start, we only can do the splashing first on carbon (Runtime reasons)
+	if(iscarbon(target))
+		return splash_mob(target, amount * multiplier, copy)
+	//CHOMPEdit End
 	touch(target, amount * multiplier) //First, handle mere touch effects
+	if(ismob(target))
+		return splash_mob(target, amount * multiplier, copy) //Touch effects handled by splash_mob
 	if(isturf(target))
 		return trans_to_turf(target, amount, multiplier, copy)
 	if(isobj(target) && target.is_open_container() && !isbelly(target.loc)) //CHOMPEdit

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -437,16 +437,17 @@
 			M.take_organ_damage(0, removed * power * 0.1) // Balance. The damage is instant, so it's weaker. 10 units -> 5 damage, double for pacid. 120 units beaker could deal 60, but a) it's burn, which is not as dangerous, b) it's a one-use weapon, c) missing with it will splash it over the ground and d) clothes give some protection, so not everything will hit
 
 /datum/reagent/acid/touch_obj(var/obj/O, var/amount) //CHOMPEdit Start
-	if(isbelly(O.loc) || isbelly(O.loc.loc))
-		var/obj/belly/B = O.loc
-		if(B.item_digest_mode == IM_HOLD)
+	if(istype(O, /obj/item) && O.loc)
+		if(isbelly(O.loc) || isbelly(O.loc.loc))
+			var/obj/belly/B = O.loc
+			if(B.item_digest_mode == IM_HOLD)
+				return
+			var/obj/item/I = O
+			var/spent_amt = I.digest_act(I.loc, 1, amount / (meltdose / 3))
+			remove_self(spent_amt) //10u stomacid per w_class, less if stronger acid.
+			if(B.owner)
+				B.owner_adjust_nutrition((B.nutrition_percent / 100) * 5 * spent_amt)
 			return
-		var/obj/item/I = O
-		var/spent_amt = I.digest_act(I.loc, 1, amount / (meltdose / 3))
-		remove_self(spent_amt) //10u stomacid per w_class, less if stronger acid.
-		if(B.owner)
-			B.owner_adjust_nutrition((B.nutrition_percent / 100) * 5 * spent_amt)
-		return
 	..()
 	if(O.unacidable || is_type_in_list(O,item_digestion_blacklist)) //CHOMPEdit End
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Firstly, the change that splashing is preferred over touching led to runtimes on robots which are not able to hold the variable. So the proc as been restored into its original state and the preferred splashing action moved towards carbons which support it.

Secondly, the reagent application calls itself during the atom check until destruction. With the object moved into null space before deletion, this led to loc.loc ending up as null.loc. We only ever should have this lookup when the object is not already on its deletion path.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: runtime during belly acid reagent applications on robot robot noms
fix: runtime during acid reagent application on destructible objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
