### PR TITLE
Buff gentlephasing

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -121,7 +121,7 @@
 	var/energy_light = 0.25
 	var/energy_dark = 0.75
 	var/nutrition_conversion_scaling = 0.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
-	var/phase_gentle = FALSE //CHOMPEdit - Add gentle phasing
+	var/phase_gentle = TRUE //CHOMPEdit - Add gentle phasing, defaults to on.
 	var/doing_phase = FALSE //CHOMPEdit - Prevent bugs when spamming phase button
 	var/manual_respite = FALSE //CHOMPEdit - Dark Respite
 	var/respite_activating = FALSE //CHOMPEdit - Dark Respite

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -204,6 +204,7 @@
 				if(L.z != z || get_dist(src,L) > 4)
 					continue
 				L.flicker(1)
+			src.Stun(1)
 		else
 			//CHOMPEdit end
 			for(var/obj/machinery/light/L in machines)

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -199,12 +199,11 @@
 		//CHOMPEdit end
 
 		//CHOMPEdit start - Add gentle phasing
-		if(SK.phase_gentle) // gentle case: No light destruction. Flicker in 4 tile radius once. Weaken for 3sec after
+		if(SK.phase_gentle) // gentle case: No light destruction. Flicker in 4 tile radius once.
 			for(var/obj/machinery/light/L in machines)
 				if(L.z != z || get_dist(src,L) > 4)
 					continue
 				L.flicker(1)
-			src.Stun(3)
 		else
 			//CHOMPEdit end
 			for(var/obj/machinery/light/L in machines)

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -199,11 +199,11 @@
 		//CHOMPEdit end
 
 		//CHOMPEdit start - Add gentle phasing
-		if(SK.phase_gentle) // gentle case: No light destruction. Flicker in 4 tile radius for 3s. Weaken for 3sec after
+		if(SK.phase_gentle) // gentle case: No light destruction. Flicker in 4 tile radius once. Weaken for 3sec after
 			for(var/obj/machinery/light/L in machines)
 				if(L.z != z || get_dist(src,L) > 4)
 					continue
-				L.flicker(3)
+				L.flicker(1)
 			src.Stun(3)
 		else
 			//CHOMPEdit end


### PR DESCRIPTION
The light flicker is a little annoying but it's important to keep phasing from stealth usage, so this changes 'gentle phasing's flicker to just a single one instead of for 3s.

Gentlephasing is now on by default.

:cl:
refactor: Gentle phasing flicker duration from 3s to 1s
refactor: Gentle phasing defaults on.
refactor: Gentle phasing stun reduced from 3s to 1s
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
