### PR TITLE
Buffs the speed of all surgeries plus minor change.

### DIFF
--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -18,8 +18,8 @@
 	can_infect = 1
 	blood_level = 1
 
-	min_duration = 50
-	max_duration = 60
+	min_duration = 30 //CHOMPedit
+	max_duration = 40 //CHOMPedit
 
 /datum/surgery_step/glue_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -60,8 +60,8 @@
 
 	allowed_procs = list(IS_WRENCH = 75)
 
-	min_duration = 60
-	max_duration = 70
+	min_duration = 30 //CHOMPedit
+	max_duration = 45 //CHOMPedit
 
 /datum/surgery_step/set_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -107,8 +107,8 @@
 
 	allowed_procs = list(IS_WRENCH = 75)
 
-	min_duration = 60
-	max_duration = 70
+	min_duration = 40 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/mend_skull/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -152,8 +152,8 @@
 	can_infect = 1
 	blood_level = 1
 
-	min_duration = 50
-	max_duration = 60
+	min_duration = 30 //CHOMPedit
+	max_duration = 30 //CHOMPedit
 
 /datum/surgery_step/finish_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -194,8 +194,8 @@
 	can_infect = 1
 	blood_level = 1
 
-	min_duration = 70
-	max_duration = 90
+	min_duration = 45 //CHOMPedit
+	max_duration = 55 //CHOMPedit
 
 /datum/surgery_step/clamp_bone/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -28,8 +28,8 @@
 		/obj/item/weapon/material/knife/machete/hatchet = 75
 	)
 
-	min_duration = 50
-	max_duration = 70
+	min_duration = 50 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/open_encased/saw/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -79,8 +79,8 @@
 
 	allowed_procs = list(IS_CROWBAR = 75)
 
-	min_duration = 30
-	max_duration = 40
+	min_duration = 30 //CHOMPedit
+	max_duration = 30 //CHOMPedit
 
 /datum/surgery_step/open_encased/retract/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -134,7 +134,7 @@
 	allowed_procs = list(IS_CROWBAR = 75)
 
 	min_duration = 20
-	max_duration = 40
+	max_duration = 30 //CHOMPedit
 
 /datum/surgery_step/open_encased/close/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -193,7 +193,7 @@
 	allowed_procs = list(IS_SCREWDRIVER = 75)
 
 	min_duration = 20
-	max_duration = 40
+	max_duration = 20 //CHOMPedit
 
 /datum/surgery_step/open_encased/mend/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -234,8 +234,8 @@
 
 	priority = 3
 
-	min_duration = 60
-	max_duration = 90
+	min_duration = 30 //CHOMPedit
+	max_duration = 35 //CHOMPedit
 	excludes_steps = list(/datum/surgery_step/open_encased/saw)
 
 /datum/surgery_step/open_encased/advancedsaw_open/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -285,8 +285,8 @@
 
 	priority = 3
 
-	min_duration = 30
-	max_duration = 60
+	min_duration = 30 //CHOMPedit
+	max_duration = 30 //CHOMPedit
 
 /datum/surgery_step/open_encased/advancedsaw_mend/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))

--- a/code/modules/surgery/external_repair.dm
+++ b/code/modules/surgery/external_repair.dm
@@ -48,7 +48,7 @@
 	can_infect = 0 //The only exception here. Sweeping a scanner probably won't transfer many germs.
 
 	min_duration = 20
-	max_duration = 40
+	max_duration = 20 //CHOMPedit
 
 /datum/surgery_step/repairflesh/scan_injury/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -98,8 +98,8 @@
 
 	priority = 3
 
-	min_duration = 90
-	max_duration = 120
+	min_duration = 40 //CHOMPedit
+	max_duration = 40 //CHOMPedit
 
 /datum/surgery_step/repairflesh/repair_burns/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -163,8 +163,8 @@
 
 	priority = 3
 
-	min_duration = 90
-	max_duration = 120
+	min_duration = 40 //CHOMPedit
+	max_duration = 40 //CHOMPedit
 
 /datum/surgery_step/repairflesh/repair_brute/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -31,8 +31,8 @@
 	/obj/item/weapon/material/shard = 50, 		\
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 50 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/generic/cut_face/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target_zone == O_MOUTH && target.op_stage.face == 0
@@ -66,8 +66,8 @@
 	/obj/item/device/assembly/mousetrap = 10	//I don't know. Don't ask me. But I'm leaving it because hilarity.
 	)
 
-	min_duration = 70
-	max_duration = 90
+	min_duration = 50 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/face/mend_vocal/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target.op_stage.face == 1
@@ -100,8 +100,8 @@
 
 	allowed_procs = list(IS_CROWBAR = 55)
 
-	min_duration = 80
-	max_duration = 100
+	min_duration = 50 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/face/fix_face/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target.op_stage.face == 2
@@ -135,8 +135,8 @@
 	/obj/item/weapon/weldingtool = 25
 	)
 
-	min_duration = 70
-	max_duration = 100
+	min_duration = 50 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/face/cauterize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target.op_stage.face > 0

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -37,8 +37,8 @@
 	)
 	req_open = 0
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 40 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/generic/cut_open/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -83,8 +83,8 @@
 	)
 	priority = 2
 	req_open = 0
-	min_duration = 90
-	max_duration = 110
+	min_duration = 40 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 	excludes_steps = list(/datum/surgery_step/generic/cut_open)
 
 /datum/surgery_step/generic/cut_with_laser/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -141,8 +141,8 @@
 
 	priority = 2
 	req_open = 0
-	min_duration = 80
-	max_duration = 120
+	min_duration = 60 //Chompedit
+	max_duration = 70 //CHOMPedit
 	excludes_steps = list(/datum/surgery_step/generic/cut_open)
 
 /datum/surgery_step/generic/incision_manager/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -189,8 +189,8 @@
 		/obj/item/device/assembly/mousetrap = 20
 	)
 
-	min_duration = 40
-	max_duration = 60
+	min_duration = 30 //CHOMPedit
+	max_duration = 30 //CHOMPedit
 
 /datum/surgery_step/generic/clamp_bleeders/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -231,7 +231,7 @@
 	allowed_procs = list(IS_CROWBAR = 75)
 
 	min_duration = 30
-	max_duration = 40
+	max_duration = 30 //CHOMPedit
 
 /datum/surgery_step/generic/retract_skin/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -291,8 +291,8 @@
 		/obj/item/weapon/weldingtool = 25
 	)
 
-	min_duration = 70
-	max_duration = 100
+	min_duration = 30 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/generic/cauterize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -332,8 +332,8 @@
 	)
 	req_open = 0
 
-	min_duration = 110
-	max_duration = 160
+	min_duration = 100 //CHOMPedit
+	max_duration = 120 //CHOMPedit
 
 /datum/surgery_step/generic/amputate/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (target_zone == O_EYES)	//there are specific steps for eye surgery

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -55,7 +55,7 @@
 	)
 
 	min_duration = 60
-	max_duration = 80
+	max_duration = 60  //CHOMPedit
 
 /datum/surgery_step/cavity/make_space/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -89,8 +89,8 @@
 		/obj/item/weapon/weldingtool = 25
 	)
 
-	min_duration = 60
-	max_duration = 80
+	min_duration = 30 //CHOMPedit
+	max_duration = 30 //CHOMPedit
 
 /datum/surgery_step/cavity/close_space/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -120,7 +120,7 @@
 	allowed_tools = list(/obj/item = 100)
 
 	min_duration = 80
-	max_duration = 100
+	max_duration = 80 //CHOMPedit
 
 /datum/surgery_step/cavity/place_item/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!istype(tool))
@@ -187,8 +187,8 @@
 
 	allowed_procs = list(IS_WIRECUTTER = 75)
 
-	min_duration = 80
-	max_duration = 100
+	min_duration = 50 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/cavity/implant_removal/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -27,7 +27,7 @@
 	allowed_tools = list(/obj/item/organ/external = 100)
 
 	min_duration = 50
-	max_duration = 70
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/limb/attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!istype(tool))
@@ -91,8 +91,8 @@
 	)
 	can_infect = 1
 
-	min_duration = 100
-	max_duration = 120
+	min_duration = 70 //CHOMPedit Keeping this one on the longer side
+	max_duration = 70 //CHOMPedit
 
 /datum/surgery_step/limb/connect/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)

--- a/code/modules/surgery/neck.dm
+++ b/code/modules/surgery/neck.dm
@@ -70,7 +70,7 @@
 	allowed_procs = list(IS_SCREWDRIVER = 75)
 
 	min_duration = 200 //Very. Very. Carefully.
-	max_duration = 300
+	max_duration = 200 //CHOMPedit
 
 /datum/surgery_step/brainstem/drill_vertebrae/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target_zone == BP_HEAD && target.op_stage.brainstem == 1
@@ -152,7 +152,7 @@
 		/obj/item/device/assembly/mousetrap = 5)
 
 	min_duration = 100
-	max_duration = 200
+	max_duration = 100 //CHOMPedit
 
 /datum/surgery_step/brainstem/mend_cord/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target_zone == BP_HEAD && target.op_stage.brainstem == 3
@@ -192,7 +192,7 @@
 		/obj/item/weapon/tape_roll = 5)
 
 	min_duration = 100
-	max_duration = 160
+	max_duration = 100 //CHOMPedit
 
 /datum/surgery_step/brainstem/mend_vertebrae/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target_zone == BP_HEAD && target.op_stage.brainstem == 4

--- a/code/modules/surgery/organ_ripper_vr.dm
+++ b/code/modules/surgery/organ_ripper_vr.dm
@@ -8,8 +8,8 @@
 
 	blood_level = 99 //Ripper sugery gets you super bloody.
 
-	min_duration = 60
-	max_duration = 80
+	min_duration = 40 //CHOMPedit
+	max_duration = 40 //CHOMPedit
 	excludes_steps = list(/datum/surgery_step/generic/cut_open) //These things can already do the first step!
 
 /datum/surgery_step/generic/ripper/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/weapon/surgical/scalpel/ripper/tool)
@@ -169,8 +169,8 @@
 
 	blood_level = 3
 
-	min_duration = 60
-	max_duration = 80
+	min_duration = 40 //CHOMPedit
+	max_duration = 40 //CHOMPedit
 	excludes_steps = list(/datum/surgery_step/generic/cut_open)
 
 /datum/surgery_step/generic/ripper/rip_organ/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -27,8 +27,8 @@
 	/obj/item/stack/medical/bruise_pack = 20
 	)
 
-	min_duration = 70
-	max_duration = 90
+	min_duration = 60 //CHOMPedit
+	max_duration = 60 //CHOMPedit
 
 /datum/surgery_step/internal/fix_organ/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -125,8 +125,8 @@
 	/obj/item/weapon/storage/toolbox = 10 	//Percussive Maintenance
 	)
 
-	min_duration = 70
-	max_duration = 90
+	min_duration = 60 //CHOMPedit
+	max_duration = 60 //CHOMPedit
 
 /datum/surgery_step/fix_organic_organ_robotic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))
@@ -199,8 +199,8 @@
 	/obj/item/weapon/material/shard = 50, 		\
 	)
 
-	min_duration = 90
-	max_duration = 110
+	min_duration = 60 //CHOMPedit
+	max_duration = 60 //CHOMPedit
 
 /datum/surgery_step/internal/detatch_organ/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!..())
@@ -267,7 +267,7 @@
 	allowed_procs = list(IS_WIRECUTTER = 100) //FBP code also uses this, so let's be nice. Roboticists won't know to use hemostats.
 
 	min_duration = 60
-	max_duration = 80
+	max_duration = 60 //CHOMPedit
 
 /datum/surgery_step/internal/remove_organ/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!..())
@@ -339,8 +339,8 @@
 	/obj/item/organ = 100
 	)
 
-	min_duration = 60
-	max_duration = 80
+	min_duration = 40 //CHOMPedit
+	max_duration = 40 //CHOMPedit
 
 /datum/surgery_step/internal/replace_organ/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/internal/O = tool
@@ -363,14 +363,15 @@
 		to_chat(user, "<span class='danger'>You have no idea what species this person is. Report this on the bug tracker.</span>")
 		return SURGERY_FAILURE
 
-	var/o_is = (O.gender == PLURAL) ? "are" : "is"
+	//var/o_is = (O.gender == PLURAL) ? "are" : "is"
 	var/o_a =  (O.gender == PLURAL) ? "" : "a "
 	var/o_do = (O.gender == PLURAL) ? "don't" : "doesn't"
 
+/* CHOMPedit begin, allow rotten/damaged organs to be inserted again to allow for organ repair in the case of worst-case-scenerio gib situation. Also to make a funny if lets say, a doctor didnt examine a damaged organ and inserted it anyway.
 	if(O.damage > (O.max_damage * 0.75))
 		to_chat(user, "<span class='warning'>\The [O.organ_tag] [o_is] in no state to be transplanted.</span>")
 		return SURGERY_FAILURE
-
+*/
 	if(!target.internal_organs_by_name[O.organ_tag])
 		organ_missing = 1
 	else
@@ -420,8 +421,8 @@
 	/obj/item/stack/cable_coil = 75
 	)
 
-	min_duration = 100
-	max_duration = 120
+	min_duration = 40 //CHOMPedit
+	max_duration = 40 //CHOMPedit
 
 /datum/surgery_step/internal/attach_organ/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!..())

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -17,8 +17,8 @@
 	can_infect = 1
 	blood_level = 1
 
-	min_duration = 70
-	max_duration = 90
+	min_duration = 50 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/fix_vein/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!hasorgans(target))
@@ -73,8 +73,8 @@
 	can_infect = 1
 	blood_level = 1
 
-	min_duration = 110
-	max_duration = 160
+	min_duration = 50 //CHOMPedit
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/fix_dead_tissue/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!hasorgans(target))
@@ -125,8 +125,8 @@
 	can_infect = 0
 	blood_level = 0
 
-	min_duration = 50
-	max_duration = 60
+	min_duration = 40 //CHOMPedit
+	max_duration = 40 //CHOMPedit
 
 /datum/surgery_step/treat_necrosis/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!istype(tool, /obj/item/weapon/reagent_containers))
@@ -265,8 +265,8 @@
 	allowed_tools = list(
 		/obj/item/weapon/surgical/bioregen = 100
 	)
-	min_duration = 90
-	max_duration = 120
+	min_duration = 60 //CHOMPedit
+	max_duration = 60 //CHOMPedit
 
 /datum/surgery_step/dehusk/structinitial/can_use(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target.op_stage.dehusk == 0
@@ -297,8 +297,8 @@
 		/obj/item/stack/cable_coil = 75, 	\
 		/obj/item/device/assembly/mousetrap = 20
 	)
-	min_duration = 90
-	max_duration = 120
+	min_duration = 60 //CHOMPedit
+	max_duration = 60 //CHOMPedit
 
 /datum/surgery_step/dehusk/relocateflesh/can_use(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target.op_stage.dehusk == 1
@@ -328,8 +328,8 @@
 		/obj/item/weapon/surgical/bioregen = 100, \
 		/obj/item/weapon/surgical/FixOVein = 30
 	)
-	min_duration = 90
-	max_duration = 120
+	min_duration = 60 //CHOMPedit
+	max_duration = 60 //CHOMPedit
 
 /datum/surgery_step/dehusk/structfinish/can_use(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target.op_stage.dehusk == 2
@@ -368,8 +368,8 @@
 	surgery_name = "Detoxify"
 	blood_level = 1
 	allowed_tools = list(/obj/item/weapon/surgical/bioregen=100)
-	min_duration = 90
-	max_duration = 120
+	min_duration = 40 //CHOMPedit
+	max_duration = 40 //CHOMPedit
 
 /datum/surgery_step/internal/detoxify/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target_zone == BP_TORSO && (target.toxloss > 25 || target.oxyloss > 25)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -199,7 +199,7 @@
 	)
 
 	min_duration = 50
-	max_duration = 60
+	max_duration = 50 //CHOMPedit
 
 /datum/surgery_step/robotics/repair_burn/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -251,7 +251,7 @@
 	allowed_procs = list(IS_SCREWDRIVER = 100)
 
 	min_duration = 70
-	max_duration = 90
+	max_duration = 70 //CHOMPedit
 
 /datum/surgery_step/robotics/fix_organ_robotic/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if (!hasorgans(target))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
This PR will reduce the speed of most surgeries to 5-6ish seconds with a couple exceptions while also significantly lowering the RNG time between each step, (Some steps can take up to 10 seconds longer or shorter just because). Hopefully this makes surgery just feel less unnecessarily time-sinky

This was originally just a ATK surgery buff but decided to go all the way. Synth surgeries are not touched because power tools are easy to get and very powerful.

Also damaged organs are now able to be re-inserted into bodies if some of you crazys want to completely re-brain someone if they get gibbed.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Surgery speed has been massively buffed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
