### PR TITLE
Remove EVA Slipping, Make gravity 'thunk' less impactful

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -455,11 +455,11 @@ var/list/mob/living/forced_ambiance_list = new
 			return
 
 		if(H.m_intent == "run")
-			H.AdjustStunned(6)
-			H.AdjustWeakened(6)
+			H.AdjustStunned(1) // CHOMPedit: No longer a supermassive long stun.
+//			H.AdjustWeakened(6) // CHOMPedit: No longer weakens.
 		else
-			H.AdjustStunned(3)
-			H.AdjustWeakened(3)
+			H.AdjustStunned(1) // CHOMPedit: No longer a supermassive long stun.
+//			H.AdjustWeakened(3) // CHOMPedit: No longer weakens.
 		to_chat(mob, "<span class='notice'>The sudden appearance of gravity makes you fall to the floor!</span>")
 		playsound(mob, "bodyfall", 50, 1)
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -225,6 +225,7 @@
 	return FALSE
 
 
+/* CHOMPedit: Nuking slipping.
 /mob/living/carbon/human/Process_Spaceslipping(var/prob_slip = 5)
 	//If knocked out we might just hit it and stop.  This makes it possible to get dead bodies and such.
 
@@ -253,6 +254,7 @@
 
 	prob_slip = round(prob_slip)
 	return(prob_slip)
+*/// CHOMPedit end.
 
 // Handle footstep sounds
 /mob/living/carbon/human/handle_footstep(var/turf/T)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -325,9 +325,10 @@ var/list/mob_hat_cache = list()
 		return
 	..()
 
-//DRONE MOVEMENT.
+/* DRONE MOVEMENT. // CHOMPedit: Nuking slipping.
 /mob/living/silicon/robot/drone/Process_Spaceslipping(var/prob_slip)
 	return 0
+*/// CHOMPedit end.
 
 //CONSOLE PROCS
 /mob/living/silicon/robot/drone/proc/law_resync()

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -6,6 +6,7 @@
 /mob/living/silicon/robot/Check_Shoegrip()
 	return module && module.no_slip
 
+/* CHOMPedit: Nuking slipping.
 /mob/living/silicon/robot/Process_Spaceslipping(var/prob_slip)
 	var/obj/item/weapon/tank/jetpack/thrust = get_jetpack()
 	if(thrust?.can_thrust(0.01))
@@ -24,6 +25,7 @@
 		return 1
 
 	return 0
+*/// CHOMPedit end.
 
  //No longer needed, but I'll leave it here incase we plan to re-use it.
 /mob/living/silicon/robot/movement_delay()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -433,7 +433,10 @@
 
 	if(restrained()) //Check to see if we can do things
 		return 0
+	inertia_dir = 0
+	return 1
 
+/* CHOMPedit: Nuking slipping.
 	//Check to see if we slipped
 	if(prob(Process_Spaceslipping(5)) && !buckled)
 		to_chat(src, "<span class='notice'><B>You slipped!</B></span>")
@@ -441,8 +444,7 @@
 		step(src, src.inertia_dir) // Not using Move for smooth glide here because this is a 'slip' so should be sudden.
 		return 0
 	//If not then we can reset inertia and move
-	inertia_dir = 0
-	return 1
+*/// CHOMPedit end.
 
 /mob/proc/Check_Dense_Object() //checks for anything to push off in the vicinity. also handles magboots on gravity-less floors tiles
 
@@ -485,6 +487,7 @@
 /mob/proc/Check_Shoegrip()
 	return 0
 
+/* CHOMPedit: Nuking slipping.
 /mob/proc/Process_Spaceslipping(var/prob_slip = 5)
 	//Setup slipage
 	//If knocked out we might just hit it and stop.  This makes it possible to get dead bodies and such.
@@ -493,6 +496,7 @@
 
 	prob_slip = round(prob_slip)
 	return(prob_slip)
+*/// CHOMPedit end.
 
 /mob/proc/mob_has_gravity(turf/T)
 	return has_gravity(src, T)


### PR DESCRIPTION
:cl:
balance: Removed the random EVA 'slipping' chance. This contributed nothing besides making spacewalks without magboots incredibly annoying.
balance: The 'thunk' proc (walking onto a gravity tile from zero gravity) now only stuns you for 1 tick (around one second or less) and no longer weakens you. This'll cause you to drop what you're holding but otherwise it's only a brief, mild disruption for not using magboots or walk intenting onto a tile with gravity.
/:cl: