### PR TITLE
Cyborgs can navigate space again

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -14,6 +14,7 @@
 	if(module && module.no_slip)
 		return 0
 	..(prob_slip)
+*/// CHOMPedit end.
 
 /mob/living/silicon/robot/Process_Spacemove(var/check_drift = 0)
 	if(..())//Can move due to other reasons, don't use jetpack fuel
@@ -25,7 +26,6 @@
 		return 1
 
 	return 0
-*/// CHOMPedit end.
 
  //No longer needed, but I'll leave it here incase we plan to re-use it.
 /mob/living/silicon/robot/movement_delay()


### PR DESCRIPTION
:cl:
fix: Corrected a misplaced chompedit that removed code necessary for cyborgs to navigate in space.
/:cl: