### PR TITLE
Binder fixes

### DIFF
--- a/code/game/objects/items/toys/toys.dm
+++ b/code/game/objects/items/toys/toys.dm
@@ -847,6 +847,10 @@
 
 	if(src && input && !M.stat && in_range(M,src))
 		name = input
+		//CHOMPAdd Start - Rename possessed voices too
+		for(var/mob/living/voice/V in possessed_voice)
+			V.name = input
+		//CHOMPAdd End
 		to_chat(M, "You name the plushie [input], giving it a hug for good luck.")
 		return 1
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -46,6 +46,7 @@
 			for(var/mob/living/voice/V in I.possessed_voice)
 				if(!V.tf_mob_holder)
 					V.ghostize(0)
+					V.stat = DEAD //CHOMPAdd - Helps with autosleeving
 					V.Destroy()
 	//CHOMPAdd End
 

--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -14,6 +14,8 @@
 
 		for(var/mob/living/voice/V in possessed_voice) // Delete voices.
 			V.ghostize(0) //CHOMPAdd - Prevent Reenter Corpse sending observers to the shadow realm
+			V.stat = DEAD //CHOMPAdd - Helps with autosleeving
+			if(V.mind) V.mind.vore_death = 1 //CHOMPAdd - Digested item TFs get vore_death timer
 			V.Destroy() //Destroy the voice.
 		for(var/mob/living/M in contents)//Drop mobs from objects(shoes) before deletion
 			M.forceMove(item_storage)
@@ -115,6 +117,8 @@
 		if(!recycled)
 			for(var/mob/living/voice/V in possessed_voice) // Delete voices.
 				V.ghostize(0) //CHOMPAdd - Prevent Reenter Corpse sending observers to the shadow realm
+				V.stat = DEAD //CHOMPAdd - Helps with autosleeving
+				if(V.mind) V.mind.vore_death = 1 //CHOMPAdd - Digested item TFs get vore_death timer
 				V.Destroy() //Destroy the voice.
 		if(istype(B) && recycled)
 		//CHOMPEdit End

--- a/modular_chomp/code/game/objects/items/devices/mind_binder.dm
+++ b/modular_chomp/code/game/objects/items/devices/mind_binder.dm
@@ -35,6 +35,9 @@
 	update_icon()
 
 /obj/item/device/mindbinder/pre_attack(atom/A)
+	if(istype(A, /obj/structure/gargoyle))
+		var/obj/structure/gargoyle/G = A
+		A = G.gargoyle
 	if(istype(A, /mob/living))
 		var/mob/living/M = A
 		if(usr == M)

--- a/modular_chomp/code/game/objects/items/devices/mind_binder.dm
+++ b/modular_chomp/code/game/objects/items/devices/mind_binder.dm
@@ -38,6 +38,9 @@
 	if(istype(A, /obj/structure/gargoyle))
 		var/obj/structure/gargoyle/G = A
 		A = G.gargoyle
+	if(istype(A, /obj/item/weapon/holder))
+		var/obj/item/weapon/holder/H = A
+		A = H.held_mob
 	if(istype(A, /mob/living))
 		var/mob/living/M = A
 		if(usr == M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Small tweaks relating to Item TF and the Mind Binder. The automatic resleever can be used now after perishing as an item, and being digested as an item also gives the 5 minute timer instead of 30 minutes. Gargoyles are now able to be targeted in their statue form. Especially important for returning a mind to someone's original body after it hardens automatically with the gargoyle trait. Using the Mind Binder on a scooped mob now targets the mob in the holder, not the holder item. Renaming a plushie also updates the name of the one turned into it.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Mind Binder can now target gargoyles in their stone form
add: Renaming a plushie also updates the name of the one turned into it
fix: Auto resleever can now properly be used after being destroyed as an item
fix: Using the Mind Binder on a scooped mob now targets the mob in the holder, not the holder item
qol: Digesting as an item now lets you use the belly digested respawn timer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
