### PR TITLE
Buffing the Chompers

### DIFF
--- a/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
@@ -109,3 +109,60 @@
 		R.updatehealth()
 		R.cell.use(50)
 		src.self_repair(R, C, tick_delay, heal_per_tick)
+
+/obj/item/weapon/melee/dogborg/jaws/big
+	name = "combat jaws"
+	icon = 'icons/mob/dogborg_vr.dmi'
+	icon_state = "jaws"
+	desc = "The jaws of the law."
+	force = 25
+	armor_penetration = 25 //30 to try and make it not useless against armored mobs but not fully nullify it.
+	defend_chance = 15
+	throwforce = 0
+	hitsound = 'sound/weapons/bite.ogg'
+	attack_verb = list("chomped", "bit", "ripped", "mauled", "enforced")
+	w_class = ITEMSIZE_NORMAL
+
+/obj/item/weapon/melee/dogborg/jaws/small
+	name = "puppy jaws"
+	icon = 'icons/mob/dogborg_vr.dmi'
+	icon_state = "smalljaws"
+	desc = "The jaws of a small dog."
+	force = 10
+	armor_penetration = 0 //30 to try and make it not useless against armored mobs but not fully nullify it.
+	defend_chance = 5
+	throwforce = 0
+	hitsound = 'sound/weapons/bite.ogg'
+	attack_verb = list("nibbled", "bit", "gnawed", "chomped", "nommed")
+	w_class = ITEMSIZE_NORMAL
+	var/emagged = 0
+
+/obj/item/weapon/melee/dogborg/jaws/small/attack_self(mob/user)
+	var/mob/living/silicon/robot/R = user
+	if(R.emagged || R.emag_items)
+		emagged = !emagged
+		if(emagged)
+			name = "combat jaws"
+			icon = 'icons/mob/dogborg_vr.dmi'
+			icon_state = "jaws"
+			desc = "The jaws of the law."
+			force = 25
+			armor_penetration = 25 //30 to try and make it not useless against armored mobs but not fully nullify it.
+			defend_chance = 15
+			throwforce = 0
+			hitsound = 'sound/weapons/bite.ogg'
+			attack_verb = list("chomped", "bit", "ripped", "mauled", "enforced")
+			w_class = ITEMSIZE_NORMAL
+		else
+			name = "puppy jaws"
+			icon = 'icons/mob/dogborg_vr.dmi'
+			icon_state = "smalljaws"
+			desc = "The jaws of a small dog."
+			force = 10
+			armor_penetration = 0 //30 to try and make it not useless against armored mobs but not fully nullify it.
+			defend_chance = 5
+			throwforce = 0
+			hitsound = 'sound/weapons/bite.ogg'
+			attack_verb = list("nibbled", "bit", "gnawed", "chomped", "nommed")
+			w_class = ITEMSIZE_NORMAL
+		update_icon()

--- a/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
@@ -135,7 +135,7 @@
 	hitsound = 'sound/weapons/bite.ogg'
 	attack_verb = list("nibbled", "bit", "gnawed", "chomped", "nommed")
 	w_class = ITEMSIZE_NORMAL
-	var/emagged = 0
+	emagged = 0
 
 /obj/item/weapon/melee/dogborg/jaws/small/attack_self(mob/user)
 	var/mob/living/silicon/robot/R = user


### PR DESCRIPTION
Puppy jaws now deal 10 force.

Combat jaws now deal 25 force, ignore 25% armor, and have a 15% chance to defend against melee attacks while active.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Title

## Changelog

:cl:
balance: Buffed Dogborg jaws on all non-explo models. Puppy jaws now deal damage comparable to a moderately heavy blunt object. Combat jaws are a viable lethal option with armor penetration and melee deflection chance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
