### PR TITLE
adds inaprovaline to explo hound

### DIFF
--- a/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper.dm
@@ -2,7 +2,7 @@
 	name = "Store-Belly"
 	desc = "Equipment for a ExploreHound unit. A mounted portable-storage device that holds supplies/person."
 	icon_state = "sleeperlost"
-	injection_chems = null
+	injection_chems = list("inaprovaline") // Only to stabilize during extractions
 	compactor = TRUE
 	max_item_count = 4
 	medsensor = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
To allow extractions and keeping patients alive, the explohound can now inject inaprovaline. This drug is a slight painkiller with stabilizes patients.

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: adds inaprovaline to the explohound sleeper
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
