### PR TITLE
Virusfix

### DIFF
--- a/code/modules/gamemaster/event2/events/medical/virus.dm
+++ b/code/modules/gamemaster/event2/events/medical/virus.dm
@@ -44,7 +44,7 @@
 
 /datum/event2/event/virus/set_up()
 	for(var/mob/living/carbon/human/H in player_list)
-		if(H.client && !H.isSynthetic() && H.stat != DEAD && !player_is_antag(H.mind) && !isbelly(H.loc))
+		if(H.client && !H.isSynthetic() && H.stat != DEAD && !player_is_antag(H.mind) && !isbelly(H.loc) && !H.species.get_virus_immune(H)) // CHOMPEdit - Make sure they're not immune
 			candidates += H
 	candidates = shuffle(candidates)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Virus event won't pick immune species when rolled. Should include shadekins, xenochimeras and prometheans.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Virus event will no longer pick immune species
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
