### PR TITLE
Change global projectile speed

### DIFF
--- a/modular_chomp/code/modules/projectiles/projectile.dm
+++ b/modular_chomp/code/modules/projectiles/projectile.dm
@@ -1,2 +1,2 @@
 /obj/item/projectile
-	speed = 3.0
+	speed = 1.5 // Movespeed is in Deciseconds per movement. Lower is faster. default was 0.8, but we had it at 3.0 for a while.


### PR DESCRIPTION
Tweaks the projectile speed (Deciseconds per movement, lower is faster)
Original was 0.8
We've had it on 3.0 for a while and things feel a touch too easy
Can change this easily to try different balances.

:cl:
balance: global projectile speed increased from 3.0 to 1.5 (Lower is faster)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
