### PR TITLE
Shadekin rebalance tweaks

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -125,7 +125,7 @@
 	var/doing_phase = FALSE //CHOMPEdit - Prevent bugs when spamming phase button
 	var/manual_respite = FALSE //CHOMPEdit - Dark Respite
 	var/respite_activating = FALSE //CHOMPEdit - Dark Respite
-	var/nutrition_energy_conversion = FALSE //CHOMPEdit - Add toggle to nutrition and energy conversions. FALSE for now for rebalance
+	var/nutrition_energy_conversion = TRUE //CHOMPEdit - Add toggle to nutrition and energy conversions.
 
 /datum/species/shadekin/New()
 	..()
@@ -339,9 +339,9 @@
 		else
 			dark_gains = energy_light
 		//CHOMPEdit begin - Energy <-> nutrition conversion
-		if(nutrition_energy_conversion && get_energy(H) == 100 && dark_gains > 0)
+		if(nutrition_energy_conversion && get_energy(H) == 100 && dark_gains > 0 && nutrition_conversion_scaling > 0)
 			H.nutrition += dark_gains * 5 * nutrition_conversion_scaling
-		else if(nutrition_energy_conversion && get_energy(H) < 50 && H.nutrition > 500)
+		else if(nutrition_energy_conversion && get_energy(H) < 50 && H.nutrition > 500 && nutrition_conversion_scaling > 0)
 			H.nutrition -= nutrition_conversion_scaling * 50
 			dark_gains += nutrition_conversion_scaling
 		//CHOMPEdit end
@@ -477,37 +477,37 @@
 			energy_light = 0.5
 			energy_dark = 0.5
 			H.shadekin_set_max_energy(125)
-			nutrition_conversion_scaling = 0.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(RED_EYES)
 			total_health = 150
 			energy_light = 0
 			energy_dark = 0.5
 			H.shadekin_set_max_energy(150)
-			nutrition_conversion_scaling = 2 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(PURPLE_EYES)
 			total_health = 100
 			energy_light = 0
 			energy_dark = 2
 			H.shadekin_set_max_energy(100)
-			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(YELLOW_EYES)
 			total_health = 50
 			energy_light = 0
 			energy_dark = 3
 			H.shadekin_set_max_energy(150)
-			nutrition_conversion_scaling = 0.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(GREEN_EYES)
 			total_health = 100
 			energy_light = 0.125
 			energy_dark = 1
 			H.shadekin_set_max_energy(125)
-			nutrition_conversion_scaling = 0.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(ORANGE_EYES)
 			total_health = 125
 			energy_light = 0
 			energy_dark = 0.25
 			H.shadekin_set_max_energy(175)
-			nutrition_conversion_scaling = 1.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
 
 	//ChompEDIT END - Shadekin rebalance
 

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -125,7 +125,7 @@
 	var/doing_phase = FALSE //CHOMPEdit - Prevent bugs when spamming phase button
 	var/manual_respite = FALSE //CHOMPEdit - Dark Respite
 	var/respite_activating = FALSE //CHOMPEdit - Dark Respite
-	var/nutrition_energy_conversion = TRUE //CHOMPEdit - Add toggle to nutrition and energy conversions
+	var/nutrition_energy_conversion = FALSE //CHOMPEdit - Add toggle to nutrition and energy conversions. FALSE for now for rebalance
 
 /datum/species/shadekin/New()
 	..()
@@ -470,37 +470,46 @@
 
 	var/eyecolor_type = get_shadekin_eyecolor(H)
 
+	//ChompEDIT START - Shadekin rebalance
 	switch(eyecolor_type)
 		if(BLUE_EYES)
-			total_health = 100
+			total_health = 75 
 			energy_light = 0.5
 			energy_dark = 0.5
+			shadekin_set_max_energy(H, 125)
 			nutrition_conversion_scaling = 0.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(RED_EYES)
-			total_health = 200
-			energy_light = -1
-			energy_dark = 0.1
+			total_health = 150
+			energy_light = 0
+			energy_dark = 0.5
+			shadekin_set_max_energy(H, 150)
 			nutrition_conversion_scaling = 2 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(PURPLE_EYES)
-			total_health = 150
-			energy_light = -0.5
-			energy_dark = 1
+			total_health = 100
+			energy_light = 0
+			energy_dark = 2
+			shadekin_set_max_energy(H, 100)
 			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(YELLOW_EYES)
-			total_health = 100
-			energy_light = -2
+			total_health = 75
+			energy_light = 0
 			energy_dark = 3
+			shadekin_set_max_energy(H, 150)
 			nutrition_conversion_scaling = 0.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(GREEN_EYES)
 			total_health = 100
 			energy_light = 0.125
-			energy_dark = 2
+			energy_dark = 1
+			shadekin_set_max_energy(H, 125)
 			nutrition_conversion_scaling = 0.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(ORANGE_EYES)
-			total_health = 175
-			energy_light = -0.5
+			total_health = 125
+			energy_light = 0
 			energy_dark = 0.25
+			shadekin_set_max_energy(H, 175)
 			nutrition_conversion_scaling = 1.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
+
+	//ChompEDIT END - Shadekin rebalance
 
 	H.maxHealth = total_health
 

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -125,7 +125,7 @@
 	var/doing_phase = FALSE //CHOMPEdit - Prevent bugs when spamming phase button
 	var/manual_respite = FALSE //CHOMPEdit - Dark Respite
 	var/respite_activating = FALSE //CHOMPEdit - Dark Respite
-	var/nutrition_energy_conversion = TRUE //CHOMPEdit - Add toggle to nutrition and energy conversions.
+	var/nutrition_energy_conversion = TRUE //CHOMPEdit - Add toggle to nutrition and energy conversions
 
 /datum/species/shadekin/New()
 	..()
@@ -338,10 +338,10 @@
 			dark_gains = energy_dark
 		else
 			dark_gains = energy_light
-		//CHOMPEdit begin - Energy <-> nutrition conversion
-		if(nutrition_energy_conversion && get_energy(H) == 100 && dark_gains > 0 && nutrition_conversion_scaling > 0)
+		//CHOMPEdit begin - Darkness --> Nutrition
+		if(nutrition_energy_conversion && get_energy(H) == get_energy_max(H) && dark_gains > 0 && nutrition_conversion_scaling > 0)
 			H.nutrition = min(300, H.nutrition + (dark_gains * 5 * nutrition_conversion_scaling)) // Nutrition gain via darkness is capped at 300. 
-		//The lower part allows nutrition to go back into energy if you have above 500. 
+		//The lower part allows nutrition to go back into energy if you have above 500. This is commented out for now.
 		//else if(nutrition_energy_conversion && get_energy(H) < 50 && H.nutrition > 500 && nutrition_conversion_scaling > 0)
 		//	H.nutrition -= nutrition_conversion_scaling * 50
 		//	dark_gains += nutrition_conversion_scaling
@@ -478,37 +478,37 @@
 			energy_light = 0.5
 			energy_dark = 0.5
 			H.shadekin_set_max_energy(125)
-			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 		if(RED_EYES)
 			total_health = 150
 			energy_light = 0
 			energy_dark = 0.5
 			H.shadekin_set_max_energy(150)
-			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 		if(PURPLE_EYES)
 			total_health = 100
 			energy_light = 0
 			energy_dark = 2
 			H.shadekin_set_max_energy(100)
-			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 		if(YELLOW_EYES)
 			total_health = 50
 			energy_light = 0
 			energy_dark = 3
 			H.shadekin_set_max_energy(150)
-			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 		if(GREEN_EYES)
 			total_health = 100
 			energy_light = 0.125
 			energy_dark = 1
 			H.shadekin_set_max_energy(125)
-			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 		if(ORANGE_EYES)
 			total_health = 125
 			energy_light = 0
 			energy_dark = 0.25
 			H.shadekin_set_max_energy(175)
-			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 
 	//ChompEDIT END - Shadekin rebalance
 

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -340,10 +340,11 @@
 			dark_gains = energy_light
 		//CHOMPEdit begin - Energy <-> nutrition conversion
 		if(nutrition_energy_conversion && get_energy(H) == 100 && dark_gains > 0 && nutrition_conversion_scaling > 0)
-			H.nutrition += dark_gains * 5 * nutrition_conversion_scaling
-		else if(nutrition_energy_conversion && get_energy(H) < 50 && H.nutrition > 500 && nutrition_conversion_scaling > 0)
-			H.nutrition -= nutrition_conversion_scaling * 50
-			dark_gains += nutrition_conversion_scaling
+			H.nutrition = min(300, H.nutrition + (dark_gains * 5 * nutrition_conversion_scaling)) // Nutrition gain via darkness is capped at 300. 
+		//The lower part allows nutrition to go back into energy if you have above 500. 
+		//else if(nutrition_energy_conversion && get_energy(H) < 50 && H.nutrition > 500 && nutrition_conversion_scaling > 0)
+		//	H.nutrition -= nutrition_conversion_scaling * 50
+		//	dark_gains += nutrition_conversion_scaling
 		//CHOMPEdit end
 
 	set_energy(H, get_energy(H) + dark_gains)
@@ -477,37 +478,37 @@
 			energy_light = 0.5
 			energy_dark = 0.5
 			H.shadekin_set_max_energy(125)
-			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(RED_EYES)
 			total_health = 150
 			energy_light = 0
 			energy_dark = 0.5
 			H.shadekin_set_max_energy(150)
-			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(PURPLE_EYES)
 			total_health = 100
 			energy_light = 0
 			energy_dark = 2
 			H.shadekin_set_max_energy(100)
-			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(YELLOW_EYES)
 			total_health = 50
 			energy_light = 0
 			energy_dark = 3
 			H.shadekin_set_max_energy(150)
-			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(GREEN_EYES)
 			total_health = 100
 			energy_light = 0.125
 			energy_dark = 1
 			H.shadekin_set_max_energy(125)
-			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(ORANGE_EYES)
 			total_health = 125
 			energy_light = 0
 			energy_dark = 0.25
 			H.shadekin_set_max_energy(175)
-			nutrition_conversion_scaling = 0 //CHOMPEdit - Add nutrition <-> dark energy conversion
+			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
 
 	//ChompEDIT END - Shadekin rebalance
 

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -339,10 +339,10 @@
 		else
 			dark_gains = energy_light
 		//CHOMPEdit begin - Darkness --> Nutrition
-		if(nutrition_energy_conversion && get_energy(H) == get_energy_max(H) && dark_gains > 0 && nutrition_conversion_scaling > 0)
+		if(nutrition_energy_conversion && get_energy(H) == get_max_energy(H) && dark_gains > 0 && nutrition_conversion_scaling > 0)
 			H.nutrition = min(300, H.nutrition + (dark_gains * 5 * nutrition_conversion_scaling)) // Nutrition gain via darkness is capped at 300. 
 		//The lower part allows nutrition to go back into energy if you have above 500. This is commented out for now.
-		//else if(nutrition_energy_conversion && get_energy(H) < 50 && H.nutrition > 500 && nutrition_conversion_scaling > 0)
+		//else if(nutrition_energy_conversion && get_energy(H) < (get_max_energy(H)/2) && H.nutrition > 500 && nutrition_conversion_scaling > 0)
 		//	H.nutrition -= nutrition_conversion_scaling * 50
 		//	dark_gains += nutrition_conversion_scaling
 		//CHOMPEdit end
@@ -477,37 +477,37 @@
 			total_health = 75 
 			energy_light = 0.5
 			energy_dark = 0.5
-			H.shadekin_set_max_energy(125)
+			set_max_energy(H, 125)
 			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 		if(RED_EYES)
 			total_health = 150
 			energy_light = 0
 			energy_dark = 0.5
-			H.shadekin_set_max_energy(150)
+			set_max_energy(H, 150)
 			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 		if(PURPLE_EYES)
 			total_health = 100
 			energy_light = 0
 			energy_dark = 2
-			H.shadekin_set_max_energy(100)
+			set_max_energy(H, 100)
 			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 		if(YELLOW_EYES)
 			total_health = 50
 			energy_light = 0
 			energy_dark = 3
-			H.shadekin_set_max_energy(150)
+			set_max_energy(H, 150)
 			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 		if(GREEN_EYES)
 			total_health = 100
 			energy_light = 0.125
 			energy_dark = 1
-			H.shadekin_set_max_energy(125)
+			set_max_energy(H, 125)
 			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 		if(ORANGE_EYES)
 			total_health = 125
 			energy_light = 0
 			energy_dark = 0.25
-			H.shadekin_set_max_energy(175)
+			set_max_energy(H, 175)
 			nutrition_conversion_scaling = 1 //CHOMPEdit - Darkness --> Nutrition
 
 	//ChompEDIT END - Shadekin rebalance

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -476,37 +476,37 @@
 			total_health = 75 
 			energy_light = 0.5
 			energy_dark = 0.5
-			shadekin_set_max_energy(H, 125)
+			H.shadekin_set_max_energy(125)
 			nutrition_conversion_scaling = 0.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(RED_EYES)
 			total_health = 150
 			energy_light = 0
 			energy_dark = 0.5
-			shadekin_set_max_energy(H, 150)
+			H.shadekin_set_max_energy(150)
 			nutrition_conversion_scaling = 2 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(PURPLE_EYES)
 			total_health = 100
 			energy_light = 0
 			energy_dark = 2
-			shadekin_set_max_energy(H, 100)
+			H.shadekin_set_max_energy(100)
 			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(YELLOW_EYES)
 			total_health = 75
 			energy_light = 0
 			energy_dark = 3
-			shadekin_set_max_energy(H, 150)
+			H.shadekin_set_max_energy(150)
 			nutrition_conversion_scaling = 0.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(GREEN_EYES)
 			total_health = 100
 			energy_light = 0.125
 			energy_dark = 1
-			shadekin_set_max_energy(H, 125)
+			H.shadekin_set_max_energy(125)
 			nutrition_conversion_scaling = 0.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(ORANGE_EYES)
 			total_health = 125
 			energy_light = 0
 			energy_dark = 0.25
-			shadekin_set_max_energy(H, 175)
+			H.shadekin_set_max_energy(175)
 			nutrition_conversion_scaling = 1.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
 
 	//ChompEDIT END - Shadekin rebalance

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -338,9 +338,9 @@
 			dark_gains = energy_dark
 		else
 			dark_gains = energy_light
-		//CHOMPEdit begin - Darkness --> Nutrition
-		if(nutrition_energy_conversion && get_energy(H) == get_max_energy(H) && dark_gains > 0 && nutrition_conversion_scaling > 0)
-			H.nutrition = min(300, H.nutrition + (dark_gains * 5 * nutrition_conversion_scaling)) // Nutrition gain via darkness is capped at 300. 
+		//CHOMPEdit begin - Darkness --> Nutrition, but capped at 300. Eat normally to go above.
+		if(nutrition_energy_conversion && get_energy(H) >= get_max_energy(H) && dark_gains > 0 && nutrition_conversion_scaling > 0 && H.nutrition < 300)
+			H.nutrition += dark_gains * 5 * nutrition_conversion_scaling
 		//The lower part allows nutrition to go back into energy if you have above 500. This is commented out for now.
 		//else if(nutrition_energy_conversion && get_energy(H) < (get_max_energy(H)/2) && H.nutrition > 500 && nutrition_conversion_scaling > 0)
 		//	H.nutrition -= nutrition_conversion_scaling * 50

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -395,6 +395,7 @@
 	if(H.shadekin_display)
 		var/l_icon = 0
 		var/e_icon = 0
+		var/energy_normalised = round((get_energy(H) / get_max_energy(H))*100)
 
 		H.shadekin_display.invisibility = 0
 		if(T)
@@ -412,7 +413,7 @@
 				if(0.00 to 0.20)
 					l_icon = 4
 
-		switch(get_energy(H))
+		switch(energy_normalised)
 			if(0 to 24)
 				e_icon = 0
 			if(25 to 49)

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -491,7 +491,7 @@
 			H.shadekin_set_max_energy(100)
 			nutrition_conversion_scaling = 1 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(YELLOW_EYES)
-			total_health = 75
+			total_health = 50
 			energy_light = 0
 			energy_dark = 3
 			H.shadekin_set_max_energy(150)

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -287,8 +287,8 @@
 
 //CHOMPEdit Start - Toggle to Nutrition conversion
 /mob/living/carbon/human/proc/nutrition_conversion_toggle()
-	set name = "Toggle Energy <-> Nutrition conversions"
-	set desc = "Toggle dark energy and nutrition being converted into each other when full"
+	set name = "Toggle Darkness Feeding"
+	set desc = "Toggle darkness being used to nourish if energy is completely filled."
 	set category = "Shadekin"
 
 	var/datum/species/shadekin/SK = species
@@ -297,10 +297,10 @@
 		return FALSE
 
 	if(SK.nutrition_energy_conversion)
-		to_chat(src, "<span class='notice'>Nutrition and dark energy conversions disabled.</span>")
+		to_chat(src, "<span class='notice'>Darkness-feeding disabled.</span>")
 		SK.nutrition_energy_conversion = 0
 	else
-		to_chat(src, "<span class='notice'>Nutrition and dark energy conversions enabled.</span>")
+		to_chat(src, "<span class='notice'>Darkness-feeding enabled.</span>")
 		SK.nutrition_energy_conversion = 1
 //CHOMPEdit End
 


### PR DESCRIPTION
Rebalances shadekin HP/energy recharge/max energy

Nutrition now CANNOT be turned into energy. Being in the dark WILL feed you however, to a barely-satisfied amount.
No shadekin lose energy in the light now (Light is supposed to be not bothersome to shadekin)
Most shadekin have reduced HP except for greens
Most shadekin have increased energy except for purples
Yellows are now GLASS, but have overall best energy performance.

I believe the intention here is to push away from gamer and push towards weird strange otherplanar creature / roleplay instigation. Subject to change.

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: Nutrition cannot generate energy, but darkness generates a little nutrition to a limit.
balance: shadekin BLUE max hp 100 -> 75
balance: shadekin BLUE max energy 100 -> 125
balance: shadekin RED max hp 200 -> 150
balance: shadekin RED energy change in light -1 --> 0
balance: shadekin RED energy change in dark 0.1 --> 0.5
balance: shadekin RED max energy 100 -> 150
balance: shadekin PURPLE max hp 150 -> 100
balance: shadekin PURPLE energy change in light -0.5 -> 0
balance: shadekin PURPLE energy change in dark 1 -> 2
balance: shadekin YELLOW max hp 100 -> 50
balance: shadekin YELLOW energy change in light -2 -> 0
balance: shadekin YELLOW energy max 100 -> 150
balance: shadekin GREEN energy change in dark 2 -> 1
balance: shadekin GREEN max energy 100 -> 125
balance: shadekin ORANGE max hp 175 -> 125
balance: shadekin ORANGE energy change in light -0.5 -> 0
balance: shadekin ORANGE max energy 100 -> 175
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
