### PR TITLE
Move 'manage PDA identities' verb to Fun

### DIFF
--- a/code/modules/eventkit/gm_interfaces/fake_pda_conversations.dm
+++ b/code/modules/eventkit/gm_interfaces/fake_pda_conversations.dm
@@ -5,7 +5,7 @@
 
 
 /client/proc/fake_pdaconvos()
-	set category = "EventKit"
+	set category = "Fun" //ChompEDIT - shunt this for fun due to tab clutter.
 	set name = "Manage PDA identities"
 	set desc = "Creates fake identities for use in setting up PDA props"
 


### PR DESCRIPTION
title

:cl:
admin: PDA identities 'Eventkit' --> 'fun', tab clutter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
