### PR TITLE
Update some links to guidelines/rules

### DIFF
--- a/modular_chomp/code/game/jobs/job/noncrew.dm
+++ b/modular_chomp/code/game/jobs/job/noncrew.dm
@@ -3,7 +3,7 @@
     disallow_jobhop = TRUE
     total_positions = 6
     spawn_positions = 6
-    supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property. Please read (<a href='https://wiki.chompstation13.net/index.php/Rules#Outsiders_Guidelines'>the Outsider Guidelines</a>) clearly before playing"
+    supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property. Please read <a href='https://wiki.chompstation13.net/index.php/Rules#Outsiders_Guidelines'>the Outsider Guidelines</a> clearly before playing"
 
     flag = NONCREW
     departments = list(DEPARTMENT_NONCREW)
@@ -36,7 +36,7 @@
     disallow_jobhop = TRUE
     total_positions = 5
     spawn_positions = 5
-    supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property. Please read (<a href='https://wiki.chompstation13.net/index.php/Rules#Shadekin/%22Anomaly%22_Guidelines'>the Shadekin Guidelines</a>) clearly before playing"
+    supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property. Please read <a href='https://wiki.chompstation13.net/index.php/Rules#Shadekin/%22Anomaly%22_Guidelines'>the Shadekin Guidelines</a> clearly before playing"
 
     flag = NONCREW
     departments = list(DEPARTMENT_NONCREW)

--- a/modular_chomp/code/game/jobs/job/noncrew.dm
+++ b/modular_chomp/code/game/jobs/job/noncrew.dm
@@ -3,7 +3,7 @@
     disallow_jobhop = TRUE
     total_positions = 6
     spawn_positions = 6
-    supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property"
+    supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property. Please read (<a href='https://wiki.chompstation13.net/index.php/Rules#Outsiders_Guidelines'>the Outsider Guidelines</a>) clearly before playing"
 
     flag = NONCREW
     departments = list(DEPARTMENT_NONCREW)
@@ -36,7 +36,7 @@
     disallow_jobhop = TRUE
     total_positions = 5
     spawn_positions = 5
-    supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property"
+    supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property. Please read (<a href='https://wiki.chompstation13.net/index.php/Rules#Shadekin/%22Anomaly%22_Guidelines'>the Shadekin Guidelines</a>) clearly before playing"
 
     flag = NONCREW
     departments = list(DEPARTMENT_NONCREW)


### PR DESCRIPTION
Outsider and Anomaly / shadekin should now get a guideline link on spawn.

:cl:
add: Guidelines for shadekin and outsider, linked on spawn.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
