### PR TITLE
Reenables Doorbells

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
     "editor.codeActionsOnSave": {
 		"source.fixAll.eslint": "explicit"
 	},
-    "files.eol": "\n",
+    "files.eol": "auto",
     "files.encoding": "utf8",
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
@@ -27,7 +27,7 @@
     ],
     "tgstationTestExplorer.project.resultsType": "json",
     "[dm]": {
-        "files.eol": "\r\n",
+        "files.eol": "\n",
         "editor.detectIndentation": false,
         "editor.insertSpaces": false
     },

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1003,7 +1003,6 @@ About the new airlock wires panel:
 		..(user)
 	return
 
-/* // CHOMPEDIT: disabling becaue alt-clicking to view a turf is pretty important.
 /obj/machinery/door/airlock/AltClick(mob/user as mob)
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
@@ -1026,7 +1025,6 @@ About the new airlock wires panel:
 		src.add_fingerprint(user)
 		playsound(src, knock_unpowered_sound, 50, 0, 3)
 	return
-*/ //ChompEDIT - disable end
 
 /obj/machinery/door/airlock/tgui_act(action, params)
 	if(..())


### PR DESCRIPTION
Please don't mind the filechange size, this is just a removal of some chompedits. CRLF/LF changes haven't been spread to all files and so we'll likely be seeing a huge influx of bloated filechanges for a while.

:cl:
add: Reenabled doorbells on airlocks and knocking on regular doors. This can be done by leftalt-clicking on a door.
/:cl: