### PR TITLE
Fixes Recorder/Trombone/Saxophone

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_utility_ch.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_utility_ch.dm
@@ -109,13 +109,13 @@
 	cost = 3
 
 /datum/gear/utility/saxophone
-	display_name = "Recorder"
+	display_name = "Saxophone"
 	description = "Another lovely intrument to serenade the crew"
 	path = /obj/item/instrument/saxophone
 	cost = 3
 
 /datum/gear/utility/trombone
-	display_name = "Recorder"
+	display_name = "Trombone"
 	description = "A trombone"
 	path = /obj/item/instrument/trombone
 	cost = 3


### PR DESCRIPTION
Recorder Trombone and Saxophone no longer overwrite eachothers loadout slots

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes the loadout so Recorder and Saxophone actually exist and Trombone has the correct name,
<!-- Describe The Pull Request. -->

## Changelog
Technically adds Recorder and Saxophone by fixing the loadout IDs.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Recorder into loadout
add: Saxophone into loadout
fix: loadout names for Trombone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
