### PR TITLE
fax body for admin-sent faxes

### DIFF
--- a/modular_chomp/code/modules/paperwork/faxmachine.dm
+++ b/modular_chomp/code/modules/paperwork/faxmachine.dm
@@ -78,7 +78,14 @@
 
 
 /obj/machinery/photocopier/faxmachine/message_chat_admins(var/mob/sender, var/faxname, var/obj/item/sent, var/faxid, font_colour="#006100")
-	fax_discord_message("A fax; '[faxname]' was sent.\nSender: [sender.name]\nFax name: [sent.name]\nFax ID: **[faxid]**")
+	var/faxmsg
+	if(faxid || fexists("[config.fax_export_dir]/fax_[faxid].html"))
+		faxmsg = return_file_text("[config.fax_export_dir]/fax_[faxid].html")
+
+	if(faxmsg)
+		fax_discord_message("A fax; '[faxname]' was sent.\nSender: [sender.name]\nFax name: [sent.name]\nFax ID: **[faxid]**\nFax: ```[strip_html_properly(faxmsg)]```")
+	else
+		fax_discord_message("A fax; '[faxname]' was sent.\nSender: [sender.name]\nFax name: [sent.name]\nFax ID: **[faxid]**")
 
 
 /obj/machinery/photocopier/faxmachine/message_chat_rolerequest(var/font_colour="#006100", var/role_to_ping, var/reason, var/jobname)


### PR DESCRIPTION

:cl:
admin: Adminsent faxes include the body (if any) 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
