### PR TITLE
Attempting to please two crowds RE Shadekins and tcomms

### DIFF
--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -26916,19 +26916,11 @@
 /turf/simulated/floor/plating,
 /area/construction/firstdeck/construction3)
 "rxy" = (
-/obj/structure/table/standard,
-/obj/item/weapon/stock_parts/micro_laser,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/micro_laser/high,
-/obj/item/weapon/stock_parts/micro_laser/high,
-/obj/item/weapon/stock_parts/micro_laser/high,
-/obj/item/weapon/stock_parts/micro_laser/high,
 /obj/machinery/alarm{
 	pixel_y = 22
+	},
+/obj/structure/closet/emcloset{
+	anchored = 1
 	},
 /turf/simulated/floor,
 /area/tcomm/tcomstorage)
@@ -26980,6 +26972,16 @@
 /obj/item/weapon/circuitboard/teleporter,
 /obj/item/weapon/circuitboard/teleporter_hub,
 /obj/item/weapon/circuitboard/teleporter_station,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/micro_laser,
 /turf/simulated/floor,
 /area/tcomm/tcomstorage)
 "rzN" = (


### PR DESCRIPTION
Adds a anchored emergency closet to the TCOMMS turret room with the crystals. Particularly swift-reacting shadekin might be able to hide from the turrets in here.

This is an attempt to please both "Lethal consequences" and "less than lethal consequences" crowd.

Lethal consequences crowd still have the lethal turret room as the trap
Less than lethal consequences crowd have a locker to try hide in now.

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Emergency closet shelter in the tcomms supplies room
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
