### PR TITLE
Oocpaneledit 2 (Copy of #7713)

### DIFF
--- a/code/game/objects/items/devices/body_snatcher_vr.dm
+++ b/code/game/objects/items/devices/body_snatcher_vr.dm
@@ -47,6 +47,14 @@
 					var/target_ooc_notes = M.ooc_notes
 					var/target_likes = M.ooc_notes_likes
 					var/target_dislikes = M.ooc_notes_dislikes
+					//CHOMPEdit Start
+					var/target_favs = M.ooc_notes_favs
+					var/target_maybes = M.ooc_notes_maybes
+					var/target_style = M.ooc_notes_style
+					var/user_favs = user.ooc_notes_favs
+					var/user_maybes = user.ooc_notes_maybes
+					var/user_style = user.ooc_notes_style
+					//CHOMPEdit End
 					var/user_ooc_notes = user.ooc_notes
 					var/user_likes = user.ooc_notes_likes
 					var/user_dislikes = user.ooc_notes_dislikes
@@ -63,6 +71,14 @@
 					M.ooc_notes = user_ooc_notes //Let's keep their OOC notes over to their new body.
 					M.ooc_notes_likes = user_likes
 					M.ooc_notes_dislikes = user_dislikes
+					//CHOMPEdit Start
+					M.ooc_notes_favs = user_favs
+					M.ooc_notes_maybes = user_maybes
+					M.ooc_notes_style = user_style
+					user.ooc_notes_favs = target_favs
+					user.ooc_notes_maybes = target_maybes
+					user.ooc_notes_style = target_style
+					//CHOMPEdit End
 					user.ooc_notes = target_ooc_notes
 					user.ooc_notes_likes = target_likes
 					user.ooc_notes_dislikes = target_dislikes

--- a/code/game/objects/items/devices/scanners/sleevemate.dm
+++ b/code/game/objects/items/devices/scanners/sleevemate.dm
@@ -18,8 +18,11 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 	var/datum/mind/stored_mind
 
 	var/ooc_notes = null //For holding prefs
+	var/ooc_notes_favs = null
 	var/ooc_notes_likes = null
+	var/ooc_notes_maybes = null
 	var/ooc_notes_dislikes = null
+	var/ooc_notes_style = FALSE
 
 	// Resleeving database this machine interacts with. Blank for default database
 	// Needs a matching /datum/transcore_db with key defined in code
@@ -36,6 +39,11 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 	ooc_notes = null
 	ooc_notes_likes = null
 	ooc_notes_dislikes = null
+	//CHOMPEdit Start
+	ooc_notes_favs = null
+	ooc_notes_maybes = null
+	ooc_notes_style = FALSE
+	//CHOMPEdit End
 	update_icon()
 
 /obj/item/device/sleevemate/proc/get_mind(mob/living/M)
@@ -43,6 +51,11 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 	ooc_notes = M.ooc_notes
 	ooc_notes_likes = M.ooc_notes_likes
 	ooc_notes_dislikes = M.ooc_notes_dislikes
+	//CHOMPEdit Start
+	ooc_notes_favs = M.ooc_notes_favs
+	ooc_notes_maybes = M.ooc_notes_maybes
+	ooc_notes_style = M.ooc_notes_style
+	//CHOMPEdit End
 	stored_mind = M.mind
 	M.ghostize()
 	stored_mind.current = null
@@ -54,6 +67,11 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 	M.ooc_notes = ooc_notes
 	M.ooc_notes_likes = ooc_notes_likes
 	M.ooc_notes_dislikes = ooc_notes_dislikes
+	//CHOMPEdit Start
+	M.ooc_notes_favs = ooc_notes_favs
+	M.ooc_notes_maybes = ooc_notes_maybes
+	M.ooc_notes_style = ooc_notes_style
+	//CHOMPEdit End
 	clear_mind()
 
 

--- a/code/modules/client/preference_setup/general/01_basic.dm
+++ b/code/modules/client/preference_setup/general/01_basic.dm
@@ -25,6 +25,11 @@
 	S["OOC_Notes"]				>> pref.metadata
 	S["OOC_Notes_Likes"]		>> pref.metadata_likes
 	S["OOC_Notes_Disikes"]		>> pref.metadata_dislikes
+	//CHOMPEdit Start
+	S["OOC_Notes_Maybes"]		>> pref.metadata_maybes
+	S["OOC_Notes_Favs"]			>> pref.metadata_favs
+	S["OOC_Notes_System"]		>> pref.matadata_ooc_style
+	//CHOMPEdit End
 
 /datum/category_item/player_setup_item/general/basic/save_character(var/savefile/S)
 	S["real_name"]				<< pref.real_name
@@ -41,6 +46,11 @@
 	S["OOC_Notes"]				<< pref.metadata
 	S["OOC_Notes_Likes"]		<< pref.metadata_likes
 	S["OOC_Notes_Disikes"]		<< pref.metadata_dislikes
+	//CHOMPEdit Start
+	S["OOC_Notes_Favs"]			<< pref.metadata_favs
+	S["OOC_Notes_Maybes"]		<< pref.metadata_maybes
+	S["OOC_Notes_System"]		<< pref.matadata_ooc_style
+	//CHOMPEdit End
 
 /datum/category_item/player_setup_item/general/basic/sanitize_character()
 	pref.age                = sanitize_integer(pref.age, get_min_age(), get_max_age(), initial(pref.age))
@@ -94,7 +104,10 @@
 	. += "<b>Age:</b> <a href='?src=\ref[src];age=1'>[pref.age]</a> <b>Birthday:</b> <a href='?src=\ref[src];bday_month=1'>[pref.bday_month]</a><b>/</b><a href='?src=\ref[src];bday_day=1'>[pref.bday_day]</a> - <b>Announce?:</b> <a href='?src=\ref[src];bday_announce=1'>[pref.bday_announce ? "Yes" : "Disabled"]</a><br>" //ChompEDIT - DISABLE the announcement
 	. += "<b>Spawn Point</b>: <a href='?src=\ref[src];spawnpoint=1'>[pref.spawnpoint]</a><br>"
 	if(config.allow_Metadata)
-		. += "<b>OOC Notes: <a href='?src=\ref[src];edit_ooc_notes=1'>Edit</a><a href='?src=\ref[src];edit_ooc_note_likes=1'>Likes</a><a href='?src=\ref[src];edit_ooc_note_dislikes=1'>Dislikes</a></b><br>"
+		//CHOMPEdit Start
+		. += "<b>OOC Notes: <a href='?src=\ref[src];edit_ooc_notes=1'>Edit</a><a href='?src=\ref[src];edit_ooc_note_favs=1'>Favs</a><a href='?src=\ref[src];edit_ooc_note_likes=1'>Likes</a><a href='?src=\ref[src];edit_ooc_note_maybes=1'>Maybes</a><a href='?src=\ref[src];edit_ooc_note_dislikes=1'>Dislikes</a></b><br>"
+		. += "Detailed field or short list system? <a href='?src=\ref[src];edit_ooc_note_style=1'>[pref.matadata_ooc_style ? "Lists" : "Fields"]</a><br><br>"
+		//CHOMPEdit End
 	. = jointext(.,null)
 
 /datum/category_item/player_setup_item/general/basic/OnTopic(var/href,var/list/href_list, var/mob/user)
@@ -231,6 +244,23 @@
 			if(new_metadata == "!clear")
 				new_metadata = ""
 			pref.metadata_dislikes = new_metadata
+	//CHOMPEdit Start
+	else if(href_list["edit_ooc_note_favs"])
+		var/new_metadata = strip_html_simple(tgui_input_text(usr, "Enter any information you'd like others to see relating to your FAVOURITE roleplay preferences. This will not be saved permanently unless you click save in the Character Setup panel! Type \"!clear\" to empty.", "Game Preference" , html_decode(pref.metadata_favs), multiline = TRUE,  prevent_enter = TRUE))
+		if(new_metadata && CanUseTopic(user))
+			if(new_metadata == "!clear")
+				new_metadata = ""
+			pref.metadata_favs = new_metadata
+	else if(href_list["edit_ooc_note_maybes"])
+		var/new_metadata = strip_html_simple(tgui_input_text(usr, "Enter any information you'd like others to see relating to your MAYBE roleplay preferences. This will not be saved permanently unless you click save in the Character Setup panel! Type \"!clear\" to empty.", "Game Preference" , html_decode(pref.metadata_maybes), multiline = TRUE,  prevent_enter = TRUE))
+		if(new_metadata && CanUseTopic(user))
+			if(new_metadata == "!clear")
+				new_metadata = ""
+			pref.metadata_maybes = new_metadata
+	else if(href_list["edit_ooc_note_style"])
+		pref.matadata_ooc_style = !pref.matadata_ooc_style
+		return TOPIC_REFRESH
+	//CHOMPEdit End
 	return ..()
 
 /datum/category_item/player_setup_item/general/basic/proc/get_genders()

--- a/code/modules/client/preference_setup/general/06_flavor.dm
+++ b/code/modules/client/preference_setup/general/06_flavor.dm
@@ -51,6 +51,11 @@
 	character.ooc_notes 				= pref.metadata //VOREStation Add
 	character.ooc_notes_likes			= pref.metadata_likes
 	character.ooc_notes_dislikes		= pref.metadata_dislikes
+	//CHOMPEdit Start
+	character.ooc_notes_maybes			= pref.metadata_maybes
+	character.ooc_notes_favs			= pref.metadata_favs
+	character.ooc_notes_style			= pref.matadata_ooc_style
+	//CHOMPEdit End
 	character.custom_link				= pref.custom_link
 
 /datum/category_item/player_setup_item/general/flavor/content(var/mob/user)

--- a/code/modules/client/verbs/character_directory.dm
+++ b/code/modules/client/verbs/character_directory.dm
@@ -61,10 +61,17 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 		var/name = null
 		var/species = null
 		var/ooc_notes = null
+		//CHOMPEdit Start
+		var/ooc_notes_favs = null
+		var/ooc_notes_likes = null
+		var/ooc_notes_maybes = null
+		var/ooc_notes_dislikes = null
+		var/ooc_notes_style = null
+		var/gendertag = null
+		var/sexualitytag = null
+		var/eventtag = vantag_choices_list[VANTAG_NONE]
+		//CHOMPEdit End
 		var/flavor_text = null
-		var/gendertag = null // CHOMPStation Edit: Character Directory Update
-		var/sexualitytag = null // CHOMPStation Edit: Character Directory Update
-		var/eventtag = vantag_choices_list[VANTAG_NONE] //CHOMPEdit
 		var/tag
 		var/erptag
 		var/character_ad
@@ -72,44 +79,75 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 			tag = C.mob.mind.directory_tag || "Unset"
 			erptag = C.mob.mind.directory_erptag || "Unset"
 			character_ad = C.mob.mind.directory_ad
+			//CHOMPEdit Start
 			gendertag = C.mob.mind.directory_gendertag || "Unset"
 			sexualitytag = C.mob.mind.directory_sexualitytag || "Unset"
 			eventtag = vantag_choices_list[C.mob.mind.vantag_preference]
+			//CHOMPEdit End
 		else
 			tag = C.prefs.directory_tag || "Unset"
 			erptag = C.prefs.directory_erptag || "Unset"
 			character_ad = C.prefs.directory_ad
+			//CHOMPEdit Start
 			gendertag = C.prefs.directory_gendertag || "Unset"
 			sexualitytag = C.prefs.directory_sexualitytag || "Unset"
 			eventtag = vantag_choices_list[C.prefs.vantag_preference]
+			//CHOMPEdit End
 
-		//CHOMPEdit Start
 		if(ishuman(C.mob))
 			var/mob/living/carbon/human/H = C.mob
-			var/strangername = H.real_name
+			var/strangername = H.real_name //CHOMPEdit
 			if(data_core && data_core.general)
 				if(!find_general_record("name", H.real_name))
-					if(!find_record("name", H.real_name, data_core.hidden_general))
-						strangername = "unknown"
+					if(!find_record("name", H.real_name, data_core.hidden_general)) //CHOMPEdit
+						strangername = "unknown" //CHOMPEdit
 			name = strangername
 			species = "[H.custom_species ? H.custom_species : H.species.name]"
 			ooc_notes = H.ooc_notes
-			if(H.ooc_notes_likes)
-				ooc_notes += "\n\nLIKES\n\n[H.ooc_notes_likes]"
-			if(H.ooc_notes_dislikes)
-				ooc_notes += "\n\nDISLIKES\n\n[H.ooc_notes_dislikes]"
-			if(LAZYLEN(H.flavor_texts)) //ChompEDIT
-				flavor_text = H.flavor_texts["general"] //ChompEDIT
+			//CHOMPEdit Start
+			if(H.ooc_notes_style && (H.ooc_notes_favs || H.ooc_notes_likes || H.ooc_notes_maybes || H.ooc_notes_dislikes))
+				ooc_notes = H.ooc_notes + "\n\n"
+				ooc_notes_favs = H.ooc_notes_favs
+				ooc_notes_likes = H.ooc_notes_likes
+				ooc_notes_maybes = H.ooc_notes_maybes
+				ooc_notes_dislikes = H.ooc_notes_dislikes
+				ooc_notes_style = H.ooc_notes_style
+			else
+				if(H.ooc_notes_favs)
+					ooc_notes += "\n\nFAVOURITES\n\n[H.ooc_notes_favs]"
+				if(H.ooc_notes_likes)
+					ooc_notes += "\n\nLIKES\n\n[H.ooc_notes_likes]"
+				if(H.ooc_notes_maybes)
+					ooc_notes += "\n\nMAYBES\n\n[H.ooc_notes_maybes]"
+				if(H.ooc_notes_dislikes)
+					ooc_notes += "\n\nDISLIKES\n\n[H.ooc_notes_dislikes]"
+			if(LAZYLEN(H.flavor_texts))
+				flavor_text = H.flavor_texts["general"]
+			//CHOMPEdit End
 
 		if(isAI(C.mob))
 			var/mob/living/silicon/ai/A = C.mob
 			name = A.name
 			species = "Artificial Intelligence"
 			ooc_notes = A.ooc_notes
-			if(A.ooc_notes_likes)
-				ooc_notes += "\n\nLIKES\n\n[A.ooc_notes_likes]"
-			if(A.ooc_notes_dislikes)
-				ooc_notes += "\n\nDISLIKES\n\n[A.ooc_notes_dislikes]"
+			//CHOMPEdit Start
+			if(A.ooc_notes_style && (A.ooc_notes_favs || A.ooc_notes_likes || A.ooc_notes_maybes || A.ooc_notes_dislikes))
+				ooc_notes = A.ooc_notes + "\n\n"
+				ooc_notes_favs = A.ooc_notes_favs
+				ooc_notes_likes = A.ooc_notes_likes
+				ooc_notes_maybes = A.ooc_notes_maybes
+				ooc_notes_dislikes = A.ooc_notes_dislikes
+				ooc_notes_style = A.ooc_notes_style
+			else
+				if(A.ooc_notes_favs)
+					ooc_notes += "\n\nFAVOURITES\n\n[A.ooc_notes_favs]"
+				if(A.ooc_notes_likes)
+					ooc_notes += "\n\nLIKES\n\n[A.ooc_notes_likes]"
+				if(A.ooc_notes_maybes)
+					ooc_notes += "\n\nMAYBES\n\n[A.ooc_notes_maybes]"
+				if(A.ooc_notes_dislikes)
+					ooc_notes += "\n\nDISLIKES\n\n[A.ooc_notes_dislikes]"
+			//CHOMPEdit End
 
 			flavor_text = null // No flavor text for AIs :c
 
@@ -120,18 +158,49 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 			name = R.name
 			species = "[R.modtype] [R.braintype]"
 			ooc_notes = R.ooc_notes
-			if(R.ooc_notes_likes)
-				ooc_notes += "\n\nLIKES\n\n[R.ooc_notes_likes]"
-			if(R.ooc_notes_dislikes)
-				ooc_notes += "\n\nDISLIKES\n\n[R.ooc_notes_dislikes]"
+			//CHOMPEdit Start
+			if(R.ooc_notes_style && (R.ooc_notes_favs || R.ooc_notes_likes || R.ooc_notes_maybes || R.ooc_notes_dislikes))
+				ooc_notes = R.ooc_notes + "\n\n"
+				ooc_notes_favs = R.ooc_notes_favs
+				ooc_notes_likes = R.ooc_notes_likes
+				ooc_notes_maybes = R.ooc_notes_maybes
+				ooc_notes_dislikes = R.ooc_notes_dislikes
+				ooc_notes_style = R.ooc_notes_style
+			else
+				if(R.ooc_notes_favs)
+					ooc_notes += "\n\nFAVOURITES\n\n[R.ooc_notes_favs]"
+				if(R.ooc_notes_likes)
+					ooc_notes += "\n\nLIKES\n\n[R.ooc_notes_likes]"
+				if(R.ooc_notes_maybes)
+					ooc_notes += "\n\nMAYBES\n\n[R.ooc_notes_maybes]"
+				if(R.ooc_notes_dislikes)
+					ooc_notes += "\n\nDISLIKES\n\n[R.ooc_notes_dislikes]"
+			//CHOMPEdit End
 
 			flavor_text = R.flavor_text
 
+		//CHOMPEdit Start
 		if(istype(C.mob, /mob/living/silicon/pai))
 			var/mob/living/silicon/pai/P = C.mob
 			name = P.name
 			species = "pAI"
 			ooc_notes = P.ooc_notes
+			if(P.ooc_notes_style && (P.ooc_notes_favs || P.ooc_notes_likes || P.ooc_notes_maybes || P.ooc_notes_dislikes))
+				ooc_notes = P.ooc_notes + "\n\n"
+				ooc_notes_favs = P.ooc_notes_favs
+				ooc_notes_likes = P.ooc_notes_likes
+				ooc_notes_maybes = P.ooc_notes_maybes
+				ooc_notes_dislikes = P.ooc_notes_dislikes
+				ooc_notes_style = P.ooc_notes_style
+			else
+				if(P.ooc_notes_favs)
+					ooc_notes += "\n\nFAVOURITES\n\n[P.ooc_notes_favs]"
+				if(P.ooc_notes_likes)
+					ooc_notes += "\n\nLIKES\n\n[P.ooc_notes_likes]"
+				if(P.ooc_notes_maybes)
+					ooc_notes += "\n\nMAYBES\n\n[P.ooc_notes_maybes]"
+				if(P.ooc_notes_dislikes)
+					ooc_notes += "\n\nDISLIKES\n\n[P.ooc_notes_dislikes]"
 			flavor_text = P.flavor_text
 
 		if(istype(C.mob, /mob/living/simple_mob))
@@ -139,8 +208,24 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 			name = S.name
 			species = S.character_directory_species()
 			ooc_notes = S.ooc_notes
+			if(S.ooc_notes_style && (S.ooc_notes_favs || S.ooc_notes_likes || S.ooc_notes_maybes || S.ooc_notes_dislikes))
+				ooc_notes = S.ooc_notes + "\n\n"
+				ooc_notes_favs = S.ooc_notes_favs
+				ooc_notes_likes = S.ooc_notes_likes
+				ooc_notes_maybes = S.ooc_notes_maybes
+				ooc_notes_dislikes = S.ooc_notes_dislikes
+				ooc_notes_style = S.ooc_notes_style
+			else
+				if(S.ooc_notes_favs)
+					ooc_notes += "\n\nFAVOURITES\n\n[S.ooc_notes_favs]"
+				if(S.ooc_notes_likes)
+					ooc_notes += "\n\nLIKES\n\n[S.ooc_notes_likes]"
+				if(S.ooc_notes_maybes)
+					ooc_notes += "\n\nMAYBES\n\n[S.ooc_notes_maybes]"
+				if(S.ooc_notes_dislikes)
+					ooc_notes += "\n\nDISLIKES\n\n[S.ooc_notes_dislikes]"
 			flavor_text = S.desc
-			//CHOMPEdit End
+		//CHOMPEdit End
 
 		// It's okay if we fail to find OOC notes and flavor text
 		// But if we can't find the name, they must be using a non-compatible mob type currently.
@@ -150,12 +235,19 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 		directory_mobs.Add(list(list(
 			"name" = name,
 			"species" = species,
+			//CHOMPEdit Start
+			"ooc_notes_favs" = ooc_notes_favs,
+			"ooc_notes_likes" = ooc_notes_likes,
+			"ooc_notes_maybes" = ooc_notes_maybes,
+			"ooc_notes_dislikes" = ooc_notes_dislikes,
+			"ooc_notes_style" = ooc_notes_style,
+			"gendertag" = gendertag,
+			"sexualitytag" = sexualitytag,
+			"eventtag" = eventtag,
+			//CHOMPEdit End
 			"ooc_notes" = ooc_notes,
 			"tag" = tag,
-			"gendertag" = gendertag, // CHOMPStation Edit: Character Directory Update
-			"sexualitytag" = sexualitytag, // CHOMPStation Edit: Character Directory Update
 			"erptag" = erptag,
-			"eventtag" = eventtag, //CHOMPEdit
 			"character_ad" = character_ad,
 			"flavor_text" = flavor_text,
 		)))
@@ -196,8 +288,7 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 			if(!new_tag)
 				return
 			return set_for_mind_or_prefs(user, action, new_tag, can_set_prefs, can_set_mind)
-		// CHOMPStation Edit End: Directory Update
-		if("setErpTag")
+		if ("setErpTag")
 			var/list/new_erptag = tgui_input_list(usr, "Pick a new ERP tag for the character directory", "Character ERP Tag", GLOB.char_directory_erptags)
 			if(!new_erptag)
 				return
@@ -268,6 +359,7 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 			if (can_set_mind)
 				user.mind.directory_ad = new_value
 			return TRUE
+		//CHOMPEdit Start
 		if ("setEventTag")
 			if (can_set_prefs)
 				user.client.prefs.vantag_preference = new_value
@@ -283,3 +375,4 @@ GLOBAL_DATUM(character_directory, /datum/character_directory)
 				user.client.prefs.directory_sexualitytag = new_value
 			if (can_set_mind)
 				user.mind.directory_sexualitytag = new_value
+		//CHOMPEdit End

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -536,6 +536,11 @@
 	ooc_notes = AI.ooc_notes
 	ooc_notes_likes = AI.ooc_notes_likes
 	ooc_notes_dislikes = AI.ooc_notes_dislikes
+	//CHOMPEdit Start
+	ooc_notes_favs = AI.ooc_notes_favs
+	ooc_notes_maybes = AI.ooc_notes_maybes
+	ooc_notes_style = AI.ooc_notes_style
+	//CHOMPEdit End
 	to_chat(src, span_notice("You feel a tingle in your circuits as your systems interface with \the [initial(src.name)]."))
 	if(AI.idcard.access)
 		botcard.access	|= AI.idcard.access
@@ -547,6 +552,11 @@
 		AI.ooc_notes = ooc_notes
 		AI.ooc_notes_likes = ooc_notes_likes
 		AI.ooc_notes_dislikes = ooc_notes_dislikes
+		//CHOMPEdit Start
+		AI.ooc_notes_favs = ooc_notes_favs
+		AI.ooc_notes_maybes = ooc_notes_maybes
+		AI.ooc_notes_style = ooc_notes_style
+		//CHOMPEdit End
 		paicard.forceMove(src.loc)
 		paicard = null
 		name = initial(name)

--- a/code/modules/mob/living/carbon/human/species/station/prommie_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prommie_blob.dm
@@ -412,6 +412,11 @@
 	blob.ooc_notes = ooc_notes
 	blob.ooc_notes_likes = ooc_notes_likes
 	blob.ooc_notes_dislikes = ooc_notes_dislikes
+	//CHOMPEdit Start
+	blob.ooc_notes_favs = ooc_notes_favs
+	blob.ooc_notes_maybes = ooc_notes_maybes
+	blob.ooc_notes_style = ooc_notes_style
+	//CHOMPEdit End
 	blob.transforming = FALSE
 	blob.name = name
 	blob.real_name = real_name //CHOMPEdit
@@ -501,6 +506,11 @@
 	ooc_notes = blob.ooc_notes // Updating notes incase they change them in blob form.
 	ooc_notes_likes = blob.ooc_notes_likes
 	ooc_notes_dislikes = blob.ooc_notes_dislikes
+	//CHOMPEdit Start
+	ooc_notes_favs = blob.ooc_notes_favs
+	ooc_notes_maybes = blob.ooc_notes_maybes
+	ooc_notes_style = blob.ooc_notes_style
+	//CHOMPEdit End
 	transforming = FALSE
 	blob.name = "Promethean Blob"
 	var/obj/item/hat = blob.hat

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -383,6 +383,11 @@ var/global/list/disallowed_protean_accessories = list(
 	blob.ooc_notes = ooc_notes
 	blob.ooc_notes_likes = ooc_notes_likes
 	blob.ooc_notes_dislikes = ooc_notes_dislikes
+	//CHOMPEdit Start
+	blob.ooc_notes_favs = ooc_notes_favs
+	blob.ooc_notes_maybes = ooc_notes_maybes
+	blob.ooc_notes_style = ooc_notes_style
+	//CHOMPEdit End
 	temporary_form = blob
 
 	//Mail them to nullspace
@@ -467,6 +472,11 @@ var/global/list/disallowed_protean_accessories = list(
 	ooc_notes = blob.ooc_notes // Lets give the protean any updated notes from blob form.
 	ooc_notes_likes = blob.ooc_notes_likes
 	ooc_notes_dislikes = blob.ooc_notes_dislikes
+	//CHOMPEdit Start
+	ooc_notes_favs = blob.ooc_notes_favs
+	ooc_notes_maybes = blob.ooc_notes_maybes
+	ooc_notes_style = blob.ooc_notes_style
+	//CHOMPEdit End
 	temporary_form = null
 
 	//Transfer vore organs

--- a/code/modules/mob/living/living_defines_vr.dm
+++ b/code/modules/mob/living/living_defines_vr.dm
@@ -14,7 +14,7 @@
 	var/custom_say = null
 	var/custom_ask = null
 	var/custom_exclaim = null
-	var/custom_whisper = null	
+	var/custom_whisper = null
 //custom temperature discomfort vars
 	var/list/custom_heat = list()
 	var/list/custom_cold = list()

--- a/code/modules/mob/living/living_vr.dm
+++ b/code/modules/mob/living/living_vr.dm
@@ -38,6 +38,11 @@
 		ooc_notes_window(usr)
 		set_metainfo_likes(FALSE)
 		set_metainfo_dislikes(FALSE)
+		//CHOMPEdit Start
+		set_metainfo_favs(FALSE)
+		set_metainfo_maybes(FALSE)
+		set_metainfo_ooc_style(FALSE)
+		//CHOMPEdit End
 
 /mob/living/proc/set_metainfo_panel()
 	if(usr != src)
@@ -87,11 +92,51 @@
 	if(!ooc_notes)
 		return
 	var/msg = ooc_notes
-	if(ooc_notes_likes)
-		msg += "<br><br><b>LIKES</b><br><br>[ooc_notes_likes]"
-	if(ooc_notes_dislikes)
-		msg += "<br><br><b>DISLIKES</b><br><br>[ooc_notes_dislikes]"
-	to_chat(usr, "<span class='chatexport'>[src]'s Metainfo:<br>[msg]</span>")
+	//CHOMPEdit Start
+	if(ooc_notes_style && (ooc_notes_favs || ooc_notes_likes || ooc_notes_maybes || ooc_notes_dislikes) && usr.client.is_preference_enabled(/datum/client_preference/vchat_enable)) // Oldchat hates proper formatting
+		msg += "<br><br>"
+		msg += "<table><tr>"
+		if(ooc_notes_favs)
+			msg += "<th><b>\t[span_blue("FAVOURITES")]</b></th>"
+		if(ooc_notes_likes)
+			msg += "<th><b>\t[span_green("LIKES")]</b></th>"
+		if(ooc_notes_maybes)
+			msg += "<th><b>\t[span_yellow("MAYBES")]</b></th>"
+		if(ooc_notes_dislikes)
+			msg += "<th><b>\t[span_red("DISLIKES")]</b></th>"
+		msg += "</tr><tr>"
+		if(ooc_notes_favs)
+			msg += "<td>"
+			for(var/line in splittext(ooc_notes_favs, "\n"))
+				msg += "\t[line]\n"
+			msg += "</td>"
+		if(ooc_notes_likes)
+			msg += "<td>"
+			for(var/line in splittext(ooc_notes_likes, "\n"))
+				msg += "\t[line]\n"
+			msg += "</td>"
+		if(ooc_notes_maybes)
+			msg += "<td>"
+			for(var/line in splittext(ooc_notes_maybes, "\n"))
+				msg += "\t[line]\n"
+			msg += "</td>"
+		if(ooc_notes_dislikes)
+			msg += "<td>"
+			for(var/line in splittext(ooc_notes_dislikes, "\n"))
+				msg += "\t[line]\n"
+			msg += "</td>"
+		msg += "</tr></table>"
+	else
+		if(ooc_notes_favs)
+			msg += "<br><br><b>[span_blue("FAVOURITES")]</b><br>[ooc_notes_favs]"
+		if(ooc_notes_likes)
+			msg += "<br><br><b>[span_green("LIKES")]</b><br>[ooc_notes_likes]"
+		if(ooc_notes_maybes)
+			msg += "<br><br><b>[span_yellow("MAYBES")]</b><br>[ooc_notes_maybes]"
+		if(ooc_notes_dislikes)
+			msg += "<br><br><b>[span_red("DISLIKES")]</b><br>[ooc_notes_dislikes]"
+	to_chat(usr, "<span class='chatexport'><b>[src]'s Metainfo:</b><br>[msg]</span>")
+	//CHOMPEdit End
 
 /mob/living/verb/set_custom_link()
 	set name = "Set Custom Link"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -214,6 +214,11 @@ var/list/ai_verbs_default = list(
 			ooc_notes = meta_info
 			ooc_notes_likes = client.prefs.metadata_likes
 			ooc_notes_dislikes = client.prefs.metadata_dislikes
+			//CHOMPEdit Start
+			ooc_notes_favs = client.prefs.metadata_favs
+			ooc_notes_maybes = client.prefs.metadata_maybes
+			ooc_notes_style = client.prefs.matadata_ooc_style
+			//CHOMPEdit End
 
 	if (malf && !(mind in malf.current_antagonists))
 		show_laws()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -151,6 +151,11 @@
 		ooc_notes = client.prefs.metadata
 		ooc_notes_likes = client.prefs.metadata_likes
 		ooc_notes_dislikes = client.prefs.metadata_dislikes
+		//CHOMPEdit Start
+		ooc_notes_favs = client.prefs.metadata_favs
+		ooc_notes_maybes = client.prefs.metadata_maybes
+		ooc_notes_style = client.prefs.matadata_ooc_style
+		//CHOMPEdit End
 
 	src << sound('sound/effects/pai_login.ogg', volume = 75)	//VOREStation Add
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -404,6 +404,11 @@
 			ooc_notes = meta_info
 			ooc_notes_likes = client.prefs.metadata_likes
 			ooc_notes_dislikes = client.prefs.metadata_dislikes
+			//CHOMPEdit Start
+			ooc_notes_favs = client.prefs.metadata_favs
+			ooc_notes_maybes = client.prefs.metadata_maybes
+			ooc_notes_style = client.prefs.matadata_ooc_style
+			//CHOMPEdit End
 		custom_link = client.prefs.custom_link
 
 /mob/living/silicon/robot/verb/namepick()

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
@@ -15,6 +15,14 @@
 	var/pred_ooc_notes
 	var/pred_ooc_likes
 	var/pred_ooc_dislikes
+	//CHOMPEdit Start
+	var/pred_ooc_favs
+	var/pred_ooc_maybes
+	var/pred_ooc_style
+	var/prey_ooc_favs
+	var/prey_ooc_maybes
+	var/prey_ooc_style
+	//CHOMPEdit End
 	var/prey_ooc_notes
 	var/prey_ooc_likes
 	var/prey_ooc_dislikes
@@ -114,6 +122,11 @@
 		prey_goes_here.ooc_notes = prey_ooc_notes
 		prey_goes_here.ooc_notes_likes = prey_ooc_likes
 		prey_goes_here.ooc_notes_dislikes = prey_ooc_dislikes
+		//CHOMPEdit Start
+		prey_goes_here.ooc_notes_favs = prey_ooc_favs
+		prey_goes_here.ooc_notes_maybes = prey_ooc_maybes
+		prey_goes_here.ooc_notes_style = prey_ooc_style
+		//CHOMPEdit End
 		prey_goes_here.verbs |= /mob/living/dominated_brain/proc/cease_this_foolishness
 
 
@@ -130,6 +143,11 @@
 		prey_goes_here.ooc_notes = prey_ooc_notes
 		prey_goes_here.ooc_notes_likes = prey_ooc_likes
 		prey_goes_here.ooc_notes_dislikes = prey_ooc_dislikes
+		//CHOMPEdit Start
+		prey_goes_here.ooc_notes_favs = prey_ooc_favs
+		prey_goes_here.ooc_notes_maybes = prey_ooc_maybes
+		prey_goes_here.ooc_notes_style = prey_ooc_style
+		//CHOMPEdit End
 
 	///////////////////
 
@@ -142,6 +160,11 @@
 	pred_body.ooc_notes = pred_ooc_notes
 	pred_body.ooc_notes_likes = pred_ooc_likes
 	pred_body.ooc_notes_dislikes = pred_ooc_dislikes
+	//CHOMPEdit Start
+	pred_body.ooc_notes_favs = pred_ooc_favs
+	pred_body.ooc_notes_maybes = pred_ooc_maybes
+	pred_body.ooc_notes_style = pred_ooc_style
+	//CHOMPEdit End
 	log_and_message_admins("[pred_body] is now controlled by [pred_body.ckey]. They were restored to control through prey domination, and had been controlled by [prey_ckey].")
 	pred_body.absorb_langs()
 	pred_body.prey_controlled = FALSE
@@ -244,6 +267,14 @@
 	pred_brain.prey_ooc_notes = prey.ooc_notes
 	pred_brain.prey_ooc_likes = prey.ooc_notes_likes
 	pred_brain.prey_ooc_dislikes = prey.ooc_notes_dislikes
+	//CHOMPEdit Start
+	pred_brain.prey_ooc_favs = prey.ooc_notes_favs
+	pred_brain.prey_ooc_maybes = prey.ooc_notes_maybes
+	pred_brain.prey_ooc_style = prey.ooc_notes_style
+	pred_brain.pred_ooc_favs = pred.ooc_notes_favs
+	pred_brain.pred_ooc_maybes = pred.ooc_notes_maybes
+	pred_brain.pred_ooc_style = pred.ooc_notes_style
+	//CHOMPEdit End
 	pred_brain.pred_ooc_notes = pred.ooc_notes
 	pred_brain.pred_ooc_likes = pred.ooc_notes_likes
 	pred_brain.pred_ooc_dislikes = pred.ooc_notes_dislikes
@@ -259,6 +290,11 @@
 	pred.ooc_notes = pred_brain.prey_ooc_notes
 	pred.ooc_notes_likes = pred_brain.prey_ooc_likes
 	pred.ooc_notes_dislikes = pred_brain.prey_ooc_dislikes
+	//CHOMPEdit Start
+	pred.ooc_notes_favs = pred_brain.prey_ooc_favs
+	pred.ooc_notes_maybes = pred_brain.prey_ooc_maybes
+	pred.ooc_notes_style = pred_brain.prey_ooc_style
+	//CHOMPEdit End
 
 	pred.verbs |= /mob/proc/release_predator
 
@@ -383,6 +419,14 @@
 	db.ooc_notes = M.ooc_notes
 	db.ooc_notes_likes = M.ooc_notes_likes
 	db.ooc_notes_dislikes = M.ooc_notes_dislikes
+	//CHOMPEdit Start
+	db.ooc_notes_favs = M.ooc_notes_favs
+	db.ooc_notes_maybes = M.ooc_notes_maybes
+	db.ooc_notes_style = M.ooc_notes_style
+	db.prey_ooc_favs = M.ooc_notes_favs
+	db.prey_ooc_maybes = M.ooc_notes_maybes
+	db.prey_ooc_style = M.ooc_notes_style
+	//CHOMPEdit End
 	db.prey_ooc_likes = M.ooc_notes_likes
 	db.prey_ooc_dislikes = M.ooc_notes_dislikes
 	db.verbs |= /mob/living/dominated_brain/proc/cease_this_foolishness
@@ -495,6 +539,14 @@
 	pred_brain.prey_ooc_notes = prey.ooc_notes
 	pred_brain.prey_ooc_likes = prey.ooc_notes_likes
 	pred_brain.prey_ooc_dislikes = prey.ooc_notes_dislikes
+	//CHOMPEdit Start
+	pred_brain.prey_ooc_favs = prey.ooc_notes_favs
+	pred_brain.prey_ooc_maybes = prey.ooc_notes_maybes
+	pred_brain.prey_ooc_style = prey.ooc_notes_style
+	pred_brain.pred_ooc_favs = pred.ooc_notes_favs
+	pred_brain.pred_ooc_maybes = pred.ooc_notes_maybes
+	pred_brain.pred_ooc_style = pred.ooc_notes_style
+	//CHOMPEdit End
 	pred_brain.pred_ooc_notes = pred.ooc_notes
 	pred_brain.pred_ooc_likes = pred.ooc_notes_likes
 	pred_brain.pred_ooc_dislikes = pred.ooc_notes_dislikes
@@ -509,6 +561,11 @@
 	pred.ooc_notes = pred_brain.prey_ooc_notes
 	pred.ooc_notes_likes = pred_brain.prey_ooc_likes
 	pred.ooc_notes_dislikes = pred_brain.prey_ooc_dislikes
+	//CHOMPEdit Start
+	pred.ooc_notes_favs = pred_brain.prey_ooc_favs
+	pred.ooc_notes_maybes = pred_brain.prey_ooc_maybes
+	pred.ooc_notes_style = pred_brain.prey_ooc_style
+	//CHOMPEdit End
 
 	pred.verbs |= /mob/proc/release_predator
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -21,6 +21,11 @@
 	ooc_notes = client.prefs.metadata
 	ooc_notes_likes = client.prefs.metadata_likes
 	ooc_notes_dislikes = client.prefs.metadata_dislikes
+	//CHOMPEdit Start
+	ooc_notes_favs = client.prefs.metadata_favs
+	ooc_notes_maybes = client.prefs.metadata_maybes
+	ooc_notes_style = client.prefs.matadata_ooc_style
+	//CHOMPEdit End
 	digestable = client.prefs_vr.digestable
 	devourable = client.prefs_vr.devourable
 	absorbable = client.prefs_vr.absorbable

--- a/code/modules/nifsoft/software/13_soulcatcher.dm
+++ b/code/modules/nifsoft/software/13_soulcatcher.dm
@@ -242,6 +242,11 @@
 		brainmob.ooc_notes = H.ooc_notes
 		brainmob.ooc_notes_likes = H.ooc_notes_likes
 		brainmob.ooc_notes_dislikes = H.ooc_notes_dislikes
+		//CHOMPEdit Start
+		brainmob.ooc_notes_favs = H.ooc_notes_favs
+		brainmob.ooc_notes_maybes = H.ooc_notes_maybes
+		brainmob.ooc_notes_style = H.ooc_notes_style
+		//CHOMPEdit End
 		brainmob.timeofhostdeath = H.timeofdeath
 		SStranscore.m_backup(brainmob.mind,0) //It does ONE, so medical will hear about it.
 

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -106,6 +106,11 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 			brainmob.ooc_notes = H.ooc_notes //VOREStation Edit
 			brainmob.ooc_notes_likes = H.ooc_notes_likes
 			brainmob.ooc_notes_dislikes = H.ooc_notes_dislikes
+			//CHOMPEdit Start
+			brainmob.ooc_notes_favs = H.ooc_notes_favs
+			brainmob.ooc_notes_maybes = H.ooc_notes_maybes
+			brainmob.ooc_notes_style = H.ooc_notes_style
+			//CHOMPEdit End
 
 		// Copy modifiers.
 		for(var/datum/modifier/M in H.modifiers)
@@ -258,6 +263,11 @@ GLOBAL_LIST_BOILERPLATE(all_brain_organs, /obj/item/organ/internal/brain)
 	H.ooc_notes = brainmob.ooc_notes // VOREStation Edit
 	H.ooc_notes_likes = brainmob.ooc_notes_likes
 	H.ooc_notes_dislikes = brainmob.ooc_notes_dislikes
+	//CHOMPEdit Start
+	H.ooc_notes_favs = brainmob.ooc_notes_favs
+	H.ooc_notes_maybes = brainmob.ooc_notes_maybes
+	H.ooc_notes_style = brainmob.ooc_notes_style
+	//CHOMPEdit End
 
 	H.nutrition = 260 //Enough to try to regenerate ONCE.
 	H.adjustBruteLoss(40)

--- a/code/modules/resleeving/infocore_records.dm
+++ b/code/modules/resleeving/infocore_records.dm
@@ -26,6 +26,11 @@
 	var/mind_oocnotes = ""
 	var/mind_ooclikes = ""
 	var/mind_oocdislikes = ""
+	//CHOMPEdit Start
+	var/mind_oocfavs = ""
+	var/mind_oocmaybes = ""
+	var/mind_oocstyle = FALSE
+	//CHOMPEdit End
 	var/nif_path
 	var/nif_durability
 	var/list/nif_software
@@ -86,6 +91,11 @@
 	var/body_oocnotes
 	var/body_ooclikes
 	var/body_oocdislikes
+	//CHOMPEdit Start
+	var/body_oocfavs
+	var/body_oocmaybes
+	var/body_oocstyle
+	//CHOMPEdit End
 	var/list/limb_data = list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_TORSO)
 	var/list/organ_data = list(O_HEART, O_EYES, O_LUNGS, O_BRAIN)
 	var/list/genetic_modifiers = list()

--- a/code/modules/resleeving/machines.dm
+++ b/code/modules/resleeving/machines.dm
@@ -124,6 +124,11 @@
 	H.ooc_notes = current_project.body_oocnotes
 	H.ooc_notes_likes = current_project.body_ooclikes
 	H.ooc_notes_dislikes = current_project.body_oocdislikes
+	//CHOMPEdit Start
+	H.ooc_notes_favs = current_project.body_oocfavs
+	H.ooc_notes_maybes = current_project.body_oocmaybes
+	H.ooc_notes_style = current_project.body_oocstyle
+	//CHOMPEdit End
 	H.flavor_texts = current_project.mydna.flavor.Copy()
 	H.resize(current_project.sizemult, FALSE)
 	H.appearance_flags = current_project.aflags
@@ -347,6 +352,11 @@
 	H.ooc_notes = current_project.body_oocnotes
 	H.ooc_notes_likes = current_project.body_ooclikes
 	H.ooc_notes_dislikes = current_project.body_oocdislikes
+	//CHOMPEdit Start
+	H.ooc_notes_favs = current_project.body_oocfavs
+	H.ooc_notes_maybes = current_project.body_oocmaybes
+	H.ooc_notes_style = current_project.body_oocstyle
+	//CHOMPEdit End
 	H.flavor_texts = current_project.mydna.flavor.Copy()
 	H.resize(current_project.sizemult)
 	H.appearance_flags = current_project.aflags
@@ -594,6 +604,11 @@
 	occupant.ooc_notes = MR.mind_oocnotes
 	occupant.ooc_notes_likes = MR.mind_ooclikes
 	occupant.ooc_notes_dislikes = MR.mind_oocdislikes
+	//CHOMPEdit Start
+	occupant.ooc_notes_favs = MR.mind_oocfavs
+	occupant.ooc_notes_maybes = MR.mind_oocmaybes
+	occupant.ooc_notes_style = MR.mind_oocstyle
+	//CHOMPEdit End
 
 	occupant.apply_vore_prefs() //Cheap hack for now to give them SOME bellies.
 	if(MR.one_time)

--- a/code/modules/resleeving/sleevecard.dm
+++ b/code/modules/resleeving/sleevecard.dm
@@ -47,6 +47,11 @@
 	infomorph.ooc_notes = MR.mind_oocnotes
 	infomorph.ooc_notes_likes = MR.mind_ooclikes
 	infomorph.ooc_notes_dislikes = MR.mind_oocdislikes
+	//CHOMPEdit Start
+	infomorph.ooc_notes_favs = MR.mind_oocfavs
+	infomorph.ooc_notes_maybes = MR.mind_oocmaybes
+	infomorph.ooc_notes_style = MR.mind_oocstyle
+	//CHOMPEdit End
 	infomorph.apply_vore_prefs() //Cheap hack for now to give them SOME bellies.
 
 	//Don't set 'real_name' because then we get a nice (as sleevecard) thing.

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -1145,6 +1145,16 @@
 			save_ooc_panel()
 	if(href_list["print_ooc_notes_to_chat"])
 		print_ooc_notes_to_chat()
+	//CHOMPEdit Start
+	if(href_list["edit_ooc_note_favs"])
+		if(usr == src)
+			set_metainfo_favs()
+	if(href_list["edit_ooc_note_maybes"])
+		if(usr == src)
+			set_metainfo_maybes()
+	if(href_list["set_metainfo_ooc_style"])
+		set_metainfo_ooc_style()
+	//CHOMPEdit End
 	return ..()
 
 /mob/living/proc/display_voreprefs(mob/user)	//Called by Topic() calls on instances of /mob/living (and subtypes) containing vore_prefs as an argument

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1471,7 +1471,7 @@ window "ooc_notes"
 	elem "ooc_notes"
 		type = MAIN
 		pos = 25,25
-		size = 500x600
+		size = 700x600 // CHOMP Edit
 		anchor1 = -1,-1
 		anchor2 = -1,-1
 		is-visible = false
@@ -1480,7 +1480,7 @@ window "ooc_notes"
 	elem "ooc_notes_panel"
 		type = BROWSER
 		pos = 0,0
-		size = 500x600
+		size = 700x600 // CHOMP Edit
 		anchor1 = 0,0
 		anchor2 = 80,100
 		saved-params = ""

--- a/modular_chomp/code/modules/client/preferences.dm
+++ b/modular_chomp/code/modules/client/preferences.dm
@@ -1,4 +1,9 @@
 /datum/preferences
+	//Our OOC Metadata additions
+	var/metadata_maybes = ""
+	var/metadata_favs = ""
+	var/matadata_ooc_style = FALSE
+
 	var/job_other_low = 0
 	var/job_other_med = 0
 	var/job_other_high = 0

--- a/modular_chomp/code/modules/mob/living/living.dm
+++ b/modular_chomp/code/modules/mob/living/living.dm
@@ -191,3 +191,35 @@ Maybe later, gotta figure out a way to click yourself when in a locker etc.
 	. = ..()
 	if(size_multiplier != 1 || icon_scale_x != 1 && center_offset > 0)
 		update_transform(TRUE)
+
+/mob/living/proc/set_metainfo_favs(var/reopen = TRUE)
+	if(usr != src)
+		return
+	var/new_metadata = strip_html_simple(tgui_input_text(usr, "Enter any information you'd like others to see relating to your FAVOURITE roleplay preferences. This will not be saved permanently unless you click save in the OOC notes panel!", "Game Preference" , html_decode(ooc_notes_favs), multiline = TRUE,  prevent_enter = TRUE))
+	if(CanUseTopic(usr))
+		ooc_notes_favs = new_metadata
+		client.prefs.metadata_favs = new_metadata
+		to_chat(usr, "<span class='filter_notice'>OOC note favs have been updated. Don't forget to save!</span>")
+		log_admin("[key_name(usr)] updated their OOC note favs mid-round.")
+		if(reopen)
+			ooc_notes_window(usr)
+
+/mob/living/proc/set_metainfo_maybes(var/reopen = TRUE)
+	if(usr != src)
+		return
+	var/new_metadata = strip_html_simple(tgui_input_text(usr, "Enter any information you'd like others to see relating to your MAYBE roleplay preferences. This will not be saved permanently unless you click save in the OOC notes panel!", "Game Preference" , html_decode(ooc_notes_maybes), multiline = TRUE,  prevent_enter = TRUE))
+	if(CanUseTopic(usr))
+		ooc_notes_maybes = new_metadata
+		client.prefs.metadata_maybes = new_metadata
+		to_chat(usr, "<span class='filter_notice'>OOC note maybes have been updated. Don't forget to save!</span>")
+		log_admin("[key_name(usr)] updated their OOC note maybes mid-round.")
+		if(reopen)
+			ooc_notes_window(usr)
+
+/mob/living/proc/set_metainfo_ooc_style(var/reopen = TRUE)
+	if(usr != src)
+		return
+	ooc_notes_style = !ooc_notes_style
+	client.prefs.matadata_ooc_style = !client.prefs.matadata_ooc_style
+	if(reopen)
+		ooc_notes_window(usr)

--- a/modular_chomp/code/modules/mob/living/living_defines.dm
+++ b/modular_chomp/code/modules/mob/living/living_defines.dm
@@ -1,0 +1,4 @@
+/mob/living
+	var/ooc_notes_favs = null
+	var/ooc_notes_maybes = null
+	var/ooc_notes_style = FALSE

--- a/modular_chomp/code/modules/mob/living/ooc_notes.dm
+++ b/modular_chomp/code/modules/mob/living/ooc_notes.dm
@@ -1,0 +1,207 @@
+/mob/living/ooc_notes_window(mob/user)
+	if(!ooc_notes)
+		return
+	//I tried to get it to accept things like emojis and all that, but, it wouldn't do! It would be cool if it did.
+	var/notes = replacetext(html_decode(src.ooc_notes), "\n", "<BR>")
+	var/favs = replacetext(html_decode(src.ooc_notes_favs), "\n", "<BR>")
+	var/likes = replacetext(html_decode(src.ooc_notes_likes), "\n", "<BR>")
+	var/maybes = replacetext(html_decode(src.ooc_notes_maybes), "\n", "<BR>")
+	var/dislikes = replacetext(html_decode(src.ooc_notes_dislikes), "\n", "<BR>")
+	var/style = src.ooc_notes_style
+	var/dat = {"
+	<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">
+	<html>
+		<head>
+			<style>
+				* {
+				box-sizing: border-box;
+				}
+				.collapsible {
+					background-color: #1a1e3f;
+					color: white;
+					width: 100%;
+					text-align: left;
+					font-size: 20px;
+				}
+				.collapsible_a {
+					background-color: #263d20;
+					color: white;
+					width: 100%;
+					text-align: left;
+					font-size: 20px;
+				}
+				.collapsible_b {
+					background-color: #3e3f1a;
+					color: white;
+					width: 100%;
+					text-align: left;
+					font-size: 20px;
+				}
+				.collapsible_c {
+					background-color: #3f1a1a;
+					color: white;
+					width: 100%;
+					text-align: left;
+					font-size: 20px;
+				}
+				.content {
+					padding: 5;
+					width: 100%;
+					background-color: #363636;
+				}
+				.column {
+					verflow-wrap: break-word;
+					float: left;
+					width: 25%;
+				}
+
+				.row:after {
+					content: "";
+					display: table;
+					clear: both;
+				}
+
+				</style>
+			</head>"}
+
+	dat += {"<body><table>"}
+	if(user == src)
+		dat += {"
+			<td class="button">
+				<a href='byond://?src=\ref[src];save_ooc_panel=1' class='button'>Save Character Preferences</a>
+			</td>
+			"}
+	dat += {"
+			<td class="button">
+				<a href='byond://?src=\ref[src];print_ooc_notes_to_chat=1' class='button'>Print to chat</a>
+			</td>
+			"}
+	if(style)
+		dat += {"
+			<td class="button">
+				<a href='byond://?src=\ref[src];set_metainfo_ooc_style=1' class='button'>Lists</a>
+			</td>
+			"}
+	else
+		dat += {"
+			<td class="button">
+				<a href='byond://?src=\ref[src];set_metainfo_ooc_style=1' class='button'>Fields</a>
+			</td>
+			"}
+	dat += {"</table>"}
+
+	if(user == src)
+		dat += {"
+				<br>
+				<table>
+					<td class="button">
+						<a href='byond://?src=\ref[src];edit_ooc_notes=1' class='button'>Edit</a>
+					</td>
+				</table>
+				"}
+
+	dat += {"
+		<br>
+			<div class="content">
+				<p>[notes]</p>
+			</div>
+		<br>
+		<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1">"}
+	if(style)
+		dat += {"<div class='row'><div class='column'>"}
+	if(favs || user == src)
+		dat += {"<div class="collapsible"><b><center>Favourites</center></b></div>"}
+	if(user == src)
+		dat += {"
+				<table>
+					<td class="button">
+						<a href='byond://?src=\ref[src];edit_ooc_note_favs=1' class='button'>Edit</a>
+					</td>
+				</table>
+				"}
+
+	if(favs)
+		dat += {"
+			<div class="content">
+			<p>[favs]</p>
+			</div>"}
+
+	if(style)
+		dat += {"</div>"}
+		dat += {"<div class='column'>"}
+	if(likes || user == src)
+		dat += {"<div class="collapsible_a"><b><center>Likes</center></b></div>"}
+	if(user == src)
+		dat += {"
+				<table>
+					<td class="button">
+						<a href='byond://?src=\ref[src];edit_ooc_note_likes=1' class='button'>Edit</a>
+					</td>
+				</table>
+				"}
+
+	if(likes)
+		dat += {"
+			<div class="content">
+				<p>[likes]</p>
+			</div>"}
+
+	if(style)
+		dat += {"</div>"}
+		dat += {"<div class='column'>"}
+	if(maybes || user == src)
+		dat += {"<div class="collapsible_b"><b><center>Maybes</center></b></div>"}
+	if(user == src)
+		dat += {"
+				<table>
+					<td class="button">
+						<a href='byond://?src=\ref[src];edit_ooc_note_maybes=1' class='button'>Edit</a>
+					</td>
+				</table>
+				"}
+
+	if(maybes)
+		dat += {"
+			<div class="content">
+				<p>[maybes]</p>
+			</div>
+			"}
+
+
+	if(style)
+		dat += {"</div>"}
+		dat += {"<div class='column'>"}
+	if(dislikes || user == src)
+		dat += {"<div class="collapsible_c"><b><center>Dislikes</center></b></div>"}
+	if(user == src)
+		dat += {"
+				<table>
+					<td class="button">
+						<a href='byond://?src=\ref[src];edit_ooc_note_dislikes=1' class='button'>Edit</a>
+					</td>
+				</table>
+				"}
+
+	if(dislikes)
+		dat += {"
+			<div class="content">
+				<p>[dislikes]</p>
+			</div>
+			"}
+	if(style)
+		dat += {"</div></div>"}
+	dat+= {"	</body>
+			</html>"}
+
+	var/key = "ooc_notes[src.real_name]"	//Generate a unique key so we can make unique clones of windows, that way we can have more than one
+	if(src.ckey)
+		key = "[key][src.ckey]"				//Add a ckey if they have one, in case their name is the same
+
+	winclone(user, "ooc_notes", key)		//Allows us to have more than one OOC notes panel open
+
+	winshow(user, key, TRUE)				//Register our window
+	var/datum/browser/popup = new(user, key, "OOC Notes: [src.name]", 500, 600)		//Create the window
+	popup.set_content(dat)	//Populate window contents
+	popup.open(FALSE) // Skip registring onclose on the browser pane
+	onclose(user, key, src) // We want to register on the window itself

--- a/tgui/packages/tgui/interfaces/chompstation/CharacterDirectory.jsx
+++ b/tgui/packages/tgui/interfaces/chompstation/CharacterDirectory.jsx
@@ -188,6 +188,65 @@ const ViewCharacter = (props) => {
       <Section level={2} title="OOC Notes">
         <Box style={{ 'word-break': 'break-all' }} preserveWhitespace>
           {props.overlay.ooc_notes || 'Unset.'}
+          {props.overlay.ooc_notes_style &&
+          (props.overlay.ooc_notes_favs ||
+            props.overlay.ooc_notes_likes ||
+            props.overlay.ooc_notes_maybes ||
+            props.overlay.ooc_notes_dislikes) ? (
+            <Table>
+              <Table.Row bold>
+                {props.overlay.ooc_notes_favs ? (
+                  <Table.Cell>FAVOURITES</Table.Cell>
+                ) : (
+                  ''
+                )}
+                {props.overlay.ooc_notes_likes ? (
+                  <Table.Cell>LIKES</Table.Cell>
+                ) : (
+                  ''
+                )}
+                {props.overlay.ooc_notes_maybes ? (
+                  <Table.Cell>MAYBES</Table.Cell>
+                ) : (
+                  ''
+                )}
+                {props.overlay.ooc_notes_dislikes ? (
+                  <Table.Cell>DISLIKES</Table.Cell>
+                ) : (
+                  ''
+                )}
+              </Table.Row>
+              <Table.Row>
+                <Table.Cell>
+                  <br />
+                </Table.Cell>
+              </Table.Row>
+              <Table.Row>
+                {props.overlay.ooc_notes_favs ? (
+                  <Table.Cell>{props.overlay.ooc_notes_favs}</Table.Cell>
+                ) : (
+                  ''
+                )}
+                {props.overlay.ooc_notes_likes ? (
+                  <Table.Cell>{props.overlay.ooc_notes_likes}</Table.Cell>
+                ) : (
+                  ''
+                )}
+                {props.overlay.ooc_notes_maybes ? (
+                  <Table.Cell>{props.overlay.ooc_notes_maybes}</Table.Cell>
+                ) : (
+                  ''
+                )}
+                {overlay.ooc_notes_dislikes ? (
+                  <Table.Cell>{props.overlay.ooc_notes_dislikes}</Table.Cell>
+                ) : (
+                  ''
+                )}
+              </Table.Row>
+            </Table>
+          ) : (
+            ''
+          )}
         </Box>
       </Section>
       <Section level={2} title="Flavor Text">

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4762,6 +4762,8 @@
 #include "modular_chomp\code\modules\mob\language\language.dm"
 #include "modular_chomp\code\modules\mob\living\emote.dm"
 #include "modular_chomp\code\modules\mob\living\living.dm"
+#include "modular_chomp\code\modules\mob\living\living_defines.dm"
+#include "modular_chomp\code\modules\mob\living\ooc_notes.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\carbon.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\brain\MMI.dm"
 #include "modular_chomp\code\modules\mob\living\carbon\human\emote.dm"


### PR DESCRIPTION
This is a copy of #7713 due to git problems.

Closes #7713 

🆑Kashargul
qol: allows the ooc panel to be used in field / list mode and adds two more categories for more detailed information
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
