### PR TITLE
Dominate Predator : mob/ssd changes

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -61,6 +61,50 @@ var/global/list/item_vore_blacklist = list(
 		/obj/item/weapon/disk/nuclear,
 		/obj/item/clothing/suit/storage/hooded/wintercoat/roiz)
 
+//CHOMPEdit start - Global Whitelist mobs for takeover (mind binder/domination)
+var/global/list/mob_takeover_whitelist = list(
+		/mob/living/carbon,
+		/mob/living/silicon,
+		/mob/living/simple_mob/animal/sif,
+		/mob/living/simple_mob/animal/passive,
+		/mob/living/simple_mob/slime,
+		/mob/living/bot,
+		/mob/living/simple_mob/vore/horse,
+		/mob/living/simple_mob/vore/wolf,
+		/mob/living/simple_mob/animal/giant_spider,
+		/mob/living/simple_mob/vore/pakkun,
+		/mob/living/simple_mob/vore/otie,
+		/mob/living/simple_mob/vore/scel,
+		/mob/living/simple_mob/vore/aggressive/corrupthound,
+		/mob/living/simple_mob/vore/rabbit,
+		/mob/living/simple_mob/vore/redpanda,
+		/mob/living/simple_mob/vore/fennec,
+		/mob/living/simple_mob/vore/fennix,
+		/mob/living/simple_mob/vore/bee,
+		/mob/living/simple_mob/animal/space/bear,
+		/mob/living/simple_mob/vore/aggressive/dino,
+		/mob/living/simple_mob/vore/aggressive/lizardman,
+		/mob/living/simple_mob/vore/aggressive/frog,
+		/mob/living/simple_mob/vore/aggressive/rat,
+		/mob/living/simple_mob/vore/jelly,
+		/mob/living/simple_mob/animal/hyena,
+		/mob/living/simple_mob/vore/solargrub,
+		/mob/living/simple_mob/vore/sect_queen,
+		/mob/living/simple_mob/vore/sect_drone,
+		/mob/living/simple_mob/vore/xeno_defanged,
+		/mob/living/simple_mob/vore/aggressive/panther,
+		/mob/living/simple_mob/vore/aggressive/giant_snake,
+		/mob/living/simple_mob/vore/aggressive/deathclaw,
+		/mob/living/simple_mob/vore/weretiger,
+		/mob/living/simple_mob/vore/bigdragon/friendly/maintpred,
+		/mob/living/simple_mob/vore/alienanimals/catslug,
+		/mob/living/simple_mob/vore/alienanimals/teppi,
+		/mob/living/simple_mob/vore/squirrel/big,
+		/mob/living/simple_mob/vore/raptor,
+		/mob/living/simple_mob/vore/bat,
+		)
+//CHOMPEdit end
+
 //Classic Vore sounds
 var/global/list/classic_vore_sounds = list(
 		"Gulp" = 'sound/vore/gulp.ogg',

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
@@ -238,20 +238,24 @@
 	to_chat(prey, "<span class='notice'>You attempt to exert your control over \the [pred]...</span>")
 	log_admin("[key_name_admin(prey)] attempted to take over [pred].")
 
+//CHOMPEdit start - Ability to use dominate pred trait against whitelisted mobs
 	if(pred.ckey) //check if body is assigned to another player currently
 		if(tgui_alert(pred, "\The [prey] has elected to attempt to take control of you. Is this something you will allow to happen?", "Allow Prey Domination",list("No","Yes")) != "Yes")
 			to_chat(prey, "<span class='warning'>\The [pred] declined your request for control.</span>")
 			return
 		if(tgui_alert(pred, "Are you sure? If you should decide to revoke this, you will have the ability to do so in your 'Abilities' tab.", "Allow Prey Domination",list("No","Yes")) != "Yes")
 			return
-	else if("original_player" in pred.vars) //check if the body has a original player aka isn't a player that ghosted out of body
+	else if(!pred.client && "original_player" in pred.vars) //check if the body belonged to a player and give proper log about it while preparing it
+		log_and_message_admins("[key_name_admin(prey)] is taking control over [pred] while they are out of their body.")
+		pred.ckey="DOMPLY[rand(100000,999999)]"
+		is_mob=1
+	else if(!is_type_in_list(pred, mob_takeover_whitelist)) //check if the dominated mob is not on the whitelist
 		to_chat(prey, "<span class='warning'>[pred] is unable to be dominated.</span>")
 		return
-	else //at this point we end up with a mob without a player assigned to them (ckey) and one that wasn't originally controlled by a plater (original_player)
-		pred.ckey="DOM-MOB-[rand(100000,999999)]" //this is cursed, but it does work
+	else //at this point we end up with a mob
+		pred.ckey="DOMMOB[rand(100000,999999)]" //this is cursed, but it does work and is cleaned up after
 		is_mob=1
-
-
+//CHOMPEdit end
 
 	to_chat(pred, "<span class='warning'>You can feel the will of another overwriting your own, control of your body being sapped away from you...</span>")
 	to_chat(prey, "<span class='warning'>You can feel the will of your host diminishing as you exert your will over them!</span>")
@@ -317,9 +321,10 @@
 	if(delete_source)
 		qdel(prey)
 
+//CHOMPEdit start - extra variable for mobs that assist cleanup
 	if(is_mob == 1)
 		pred_brain.was_mob=1
-
+//CHOMPEdit End
 
 /mob/proc/release_predator()
 	set category = "Abilities"
@@ -332,13 +337,13 @@
 			if(db.ckey == db.pred_ckey)
 				to_chat(src, "<span class='notice'>You ease off of your control, releasing \the [db].</span>")
 				to_chat(db, "<span class='notice'>You feel the alien presence fade, and restore control of your body to you of their own will...</span>")
-				if(db.was_mob==1)//if the dominated being was a mob reset their ckey to null
+				if(db.was_mob==1) //CHOMPEdit start - clean up if the dominated body was a playerless mob
 					db.pred_ckey=null
 					db.ckey=null
 					db.restore_control()
 				else
 					db.restore_control()
-				return
+				return //CHOMPEdit end
 			else
 				continue
 	to_chat(src, "<span class='danger'>You haven't been taken over, and shouldn't have this verb. I'll clean that up for you. Report this on the github, it is a bug.</span>")

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
@@ -26,7 +26,7 @@
 	var/prey_ooc_notes
 	var/prey_ooc_likes
 	var/prey_ooc_dislikes
-	var/was_mob=0					//tracks if the dominated being was a mob
+	var/was_mob=0 //CHOMPAdd - tracks if the dominated being was a mob
 
 /mob/living/dominated_brain/New(loc, var/mob/living/pred, preyname, var/mob/living/prey)
 	. = ..()
@@ -199,7 +199,7 @@
 	set category = "Abilities"
 	set name = "Dominate Predator"
 	set desc = "Connect to and dominate the brain of your predator."
-	var/is_mob=0 //is character a non player mob
+	var/is_mob=0 ////CHOMPAdd - tracks if character is a non player mob
 
 	var/mob/living/pred
 	var/mob/living/prey = src
@@ -214,6 +214,11 @@
 	else
 		to_chat(prey, "<span class='notice'>You are not inside anyone.</span>")
 		return
+
+//CHOMPRemove - this check is handled in "CHOMPEdit start - Ability to use dominate pred trait against whitelisted mobs"
+//	if(!pred.ckey)
+//		to_chat(prey, "<span class='notice'>\The [pred] isn't able to be dominated.</span>")
+//		return
 
 	if(prey.stat == DEAD)
 		to_chat(prey, "<span class='warning'>You cannot do that in your current state.</span>")

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
@@ -26,6 +26,7 @@
 	var/prey_ooc_notes
 	var/prey_ooc_likes
 	var/prey_ooc_dislikes
+	var/was_mob=0					//tracks if the dominated being was a mob
 
 /mob/living/dominated_brain/New(loc, var/mob/living/pred, preyname, var/mob/living/prey)
 	. = ..()
@@ -198,6 +199,7 @@
 	set category = "Abilities"
 	set name = "Dominate Predator"
 	set desc = "Connect to and dominate the brain of your predator."
+	var/is_mob=0 //is character a non player mob
 
 	var/mob/living/pred
 	var/mob/living/prey = src
@@ -217,9 +219,6 @@
 		to_chat(prey, "<span class='warning'>You cannot do that in your current state.</span>")
 		return
 
-	if(!pred.ckey)
-		to_chat(prey, "<span class='notice'>\The [pred] isn't able to be dominated.</span>")
-		return
 	if(isrobot(pred) && jobban_isbanned(prey, "Cyborg"))
 		to_chat(prey, "<span class='warning'>Forces beyond your comprehension forbid you from taking control of [pred].</span>")
 		return
@@ -238,11 +237,22 @@
 		return
 	to_chat(prey, "<span class='notice'>You attempt to exert your control over \the [pred]...</span>")
 	log_admin("[key_name_admin(prey)] attempted to take over [pred].")
-	if(tgui_alert(pred, "\The [prey] has elected to attempt to take control of you. Is this something you will allow to happen?", "Allow Prey Domination",list("No","Yes")) != "Yes")
-		to_chat(prey, "<span class='warning'>\The [pred] declined your request for control.</span>")
+
+	if(pred.ckey) //check if body is assigned to another player currently
+		if(tgui_alert(pred, "\The [prey] has elected to attempt to take control of you. Is this something you will allow to happen?", "Allow Prey Domination",list("No","Yes")) != "Yes")
+			to_chat(prey, "<span class='warning'>\The [pred] declined your request for control.</span>")
+			return
+		if(tgui_alert(pred, "Are you sure? If you should decide to revoke this, you will have the ability to do so in your 'Abilities' tab.", "Allow Prey Domination",list("No","Yes")) != "Yes")
+			return
+	else if("original_player" in pred.vars) //check if the body has a original player aka isn't a player that ghosted out of body
+		to_chat(prey, "<span class='warning'>[pred] is unable to be dominated.</span>")
 		return
-	if(tgui_alert(pred, "Are you sure? If you should decide to revoke this, you will have the ability to do so in your 'Abilities' tab.", "Allow Prey Domination",list("No","Yes")) != "Yes")
-		return
+	else //at this point we end up with a mob without a player assigned to them (ckey) and one that wasn't originally controlled by a plater (original_player)
+		pred.ckey="DOM-MOB-[rand(100000,999999)]" //this is cursed, but it does work
+		is_mob=1
+
+
+
 	to_chat(pred, "<span class='warning'>You can feel the will of another overwriting your own, control of your body being sapped away from you...</span>")
 	to_chat(prey, "<span class='warning'>You can feel the will of your host diminishing as you exert your will over them!</span>")
 	if(!do_after(prey, 10 SECONDS, exclusive = TRUE))
@@ -307,6 +317,10 @@
 	if(delete_source)
 		qdel(prey)
 
+	if(is_mob == 1)
+		pred_brain.was_mob=1
+
+
 /mob/proc/release_predator()
 	set category = "Abilities"
 	set name = "Restore Control"
@@ -318,7 +332,12 @@
 			if(db.ckey == db.pred_ckey)
 				to_chat(src, "<span class='notice'>You ease off of your control, releasing \the [db].</span>")
 				to_chat(db, "<span class='notice'>You feel the alien presence fade, and restore control of your body to you of their own will...</span>")
-				db.restore_control()
+				if(db.was_mob==1)//if the dominated being was a mob reset their ckey to null
+					db.pred_ckey=null
+					db.ckey=null
+					db.restore_control()
+				else
+					db.restore_control()
 				return
 			else
 				continue

--- a/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/dominated_brain.dm
@@ -250,7 +250,7 @@
 			return
 		if(tgui_alert(pred, "Are you sure? If you should decide to revoke this, you will have the ability to do so in your 'Abilities' tab.", "Allow Prey Domination",list("No","Yes")) != "Yes")
 			return
-	else if(!pred.client && "original_player" in pred.vars) //check if the body belonged to a player and give proper log about it while preparing it
+	else if(!pred.client && ("original_player" in pred.vars)) //check if the body belonged to a player and give proper log about it while preparing it
 		log_and_message_admins("[key_name_admin(prey)] is taking control over [pred] while they are out of their body.")
 		pred.ckey="DOMPLY[rand(100000,999999)]"
 		is_mob=1

--- a/modular_chomp/code/game/objects/items/devices/mind_binder.dm
+++ b/modular_chomp/code/game/objects/items/devices/mind_binder.dm
@@ -11,47 +11,6 @@
 	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 2, TECH_ILLEGAL = 1)
 	possessed_voice = list()
 	var/self_bind = FALSE
-	var/list/whitelisted = list(
-		/mob/living/carbon,
-		/mob/living/silicon,
-		/mob/living/simple_mob/animal/sif,
-		/mob/living/simple_mob/animal/passive,
-		/mob/living/simple_mob/slime,
-		/mob/living/bot,
-		/mob/living/simple_mob/vore/horse,
-		/mob/living/simple_mob/vore/wolf,
-		/mob/living/simple_mob/animal/giant_spider,
-		/mob/living/simple_mob/vore/pakkun,
-		/mob/living/simple_mob/vore/otie,
-		/mob/living/simple_mob/vore/scel,
-		/mob/living/simple_mob/vore/aggressive/corrupthound,
-		/mob/living/simple_mob/vore/rabbit,
-		/mob/living/simple_mob/vore/redpanda,
-		/mob/living/simple_mob/vore/fennec,
-		/mob/living/simple_mob/vore/fennix,
-		/mob/living/simple_mob/vore/bee,
-		/mob/living/simple_mob/animal/space/bear,
-		/mob/living/simple_mob/vore/aggressive/dino,
-		/mob/living/simple_mob/vore/aggressive/lizardman,
-		/mob/living/simple_mob/vore/aggressive/frog,
-		/mob/living/simple_mob/vore/aggressive/rat,
-		/mob/living/simple_mob/vore/jelly,
-		/mob/living/simple_mob/animal/hyena,
-		/mob/living/simple_mob/vore/solargrub,
-		/mob/living/simple_mob/vore/sect_queen,
-		/mob/living/simple_mob/vore/sect_drone,
-		/mob/living/simple_mob/vore/xeno_defanged,
-		/mob/living/simple_mob/vore/aggressive/panther,
-		/mob/living/simple_mob/vore/aggressive/giant_snake,
-		/mob/living/simple_mob/vore/aggressive/deathclaw,
-		/mob/living/simple_mob/vore/weretiger,
-		/mob/living/simple_mob/vore/bigdragon/friendly/maintpred,
-		/mob/living/simple_mob/vore/alienanimals/catslug,
-		/mob/living/simple_mob/vore/alienanimals/teppi,
-		/mob/living/simple_mob/vore/squirrel/big,
-		/mob/living/simple_mob/vore/raptor,
-		/mob/living/simple_mob/vore/bat,
-		) // Limit to safe types
 
 /obj/item/device/mindbinder/New()
 	..()
@@ -84,7 +43,7 @@
 		A = H.held_mob
 	if(istype(A, /mob/living))
 		var/mob/living/M = A
-		if(!is_type_in_list(A, whitelisted))
+		if(!is_type_in_list(A, mob_takeover_whitelist))
 			to_chat(usr,"<span class='danger'>The target's mind is too complex to be affected!</span>")
 			return
 		if(usr == M)


### PR DESCRIPTION
Gives dominate predator trait ability to dominate mobs / out of body players
Also makes the whitelist from mind binder a global one

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Adds ability to dominate mobs via the dominate predator trait, this means that any player with said trait is able to dominate non player mobs with a belly that are on the var/global/list/mob_takeover_whitelist whitelist.

var/global/list/mob_takeover_whitelist became a global whitelist that contains mind binder's whitelist.
The device and dominate predator trait now use it.

Additionally to make it more in line with the mind binder it is now possible to take over bodies without active players in them just like one can do with a mind binder(with proper logging of such occurrences)
That means if for example we would use mind binder to take the mind off someone's body we can then dominate them
SSD players are still safe

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Ability to dominate mob via dominate predator
add: Ability to dominate body without player's mind  (The same way one can do via mind binder)
code: Mob whitelist from mind binder became a global list var/global/list/mob_takeover_whitelist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
