### PR TITLE
Some more image qdel prevention

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -55,7 +55,9 @@
 		tf_mob_holder = null
 	//VOREStation Addition End
 
-	qdel(selected_image)
+	//qdel(selected_image) //ChompEDIT - no qdelling /image vars
+	QDEL_NULL(selected_image) //ChompEDIT - no qdelling /image vars
+	QDEL_NULL(hud_list) //ChompEDIT - no qdelling /image vars
 	QDEL_NULL(vorePanel) //VOREStation Add
 	QDEL_LIST_NULL(vore_organs) //VOREStation Add
 	temp_language_sources = null //VOREStation Add

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -57,7 +57,7 @@
 
 	//qdel(selected_image) //ChompEDIT - no qdelling /image vars
 	QDEL_NULL(selected_image) //ChompEDIT - no qdelling /image vars
-	QDEL_NULL(hud_list) //ChompEDIT - no qdelling /image vars
+	QDEL_LIST_NULL(hud_list) //ChompEDIT - no qdelling /image vars
 	QDEL_NULL(vorePanel) //VOREStation Add
 	QDEL_LIST_NULL(vore_organs) //VOREStation Add
 	temp_language_sources = null //VOREStation Add

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -54,10 +54,16 @@
 	if(tf_mob_holder)
 		tf_mob_holder = null
 	//VOREStation Addition End
+	//ChompEDIT START
+	if(selected_image) // prune out images
+		selected_image = null
+	if(hud_list) //prune out images in hud_list
+		for(var/item in hud_list)
+			if(item)
+				item = null
+	//ChompEDIT END
 
-	//qdel(selected_image) //ChompEDIT - no qdelling /image vars
-	QDEL_NULL(selected_image) //ChompEDIT - no qdelling /image vars
-	QDEL_LIST_NULL(hud_list) //ChompEDIT - no qdelling /image vars
+	qdel(selected_image)
 	QDEL_NULL(vorePanel) //VOREStation Add
 	QDEL_LIST_NULL(vore_organs) //VOREStation Add
 	temp_language_sources = null //VOREStation Add


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

qdelling var/image causes huge overhead for hard delete, here's a few more that seem to crop up

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: No qdelling hud element and selected_image /images
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
