### PR TITLE
Removes Kara's 2 Z layers (NS Mines, Aerostat), but keeps the OM destination

### DIFF
--- a/maps/southern_cross/overmap/planets/kara/kara.dm
+++ b/maps/southern_cross/overmap/planets/kara/kara.dm
@@ -31,7 +31,7 @@
 [b]Notice[/b]: CONDEMNED! NO ENTRY! -Vir System Authority"}
 
 	map_z = list(Z_LEVEL_AEROSTAT) // Using the aerostat as the map as it is the only z-level in the atmosphere. Located in /maps/southern_cross/overmap/planets/kara/aerostat/
-	initial_generic_waypoints = list("northern_star_mine_dock", "northern_star_mine_echidna_dock") //northern_star.dm landmarks
+	initial_generic_waypoints = list("northern_star_mine_dock", "northern_star_mine_echidna_dock", "aerostat_west","aerostat_east","aerostat_south","aerostat_northwest","aerostat_northeast") //northern_star.dm landmarks
 	start_x  = 14
 	start_y  = 14
 	skybox_offset_x = 128
@@ -43,7 +43,6 @@
 	atmosphere_color = "#C19562"
 	icon_state = "chlorine"
 	known = 1
-	initial_generic_waypoints = list("aerostat_west","aerostat_east","aerostat_south","aerostat_northwest","aerostat_northeast")
 
 
 /obj/effect/overmap/visitable/planet/kara/get_skybox_representation()

--- a/maps/southern_cross/overmap/planets/kara/kara.dm
+++ b/maps/southern_cross/overmap/planets/kara/kara.dm
@@ -30,7 +30,7 @@
 [i]Transponder[/i]: Transmitting (CIV), Vir IFF
 [b]Notice[/b]: CONDEMNED! NO ENTRY! -Vir System Authority"}
 
-	//map_z = list(Z_LEVEL_AEROSTAT) // Using the aerostat as the map as it is the only z-level in the atmosphere. Located in /maps/southern_cross/overmap/planets/kara/aerostat/
+	map_z = list(Z_LEVEL_AEROSTAT) // Using the aerostat as the map as it is the only z-level in the atmosphere. Located in /maps/southern_cross/overmap/planets/kara/aerostat/ //NOT USED, Kara Z layers removed.
 	initial_generic_waypoints = list("northern_star_mine_dock", "northern_star_mine_echidna_dock") //northern_star.dm landmarks
 	start_x  = 14
 	start_y  = 14

--- a/maps/southern_cross/overmap/planets/kara/kara.dm
+++ b/maps/southern_cross/overmap/planets/kara/kara.dm
@@ -30,7 +30,7 @@
 [i]Transponder[/i]: Transmitting (CIV), Vir IFF
 [b]Notice[/b]: CONDEMNED! NO ENTRY! -Vir System Authority"}
 
-	map_z = list(Z_LEVEL_AEROSTAT) // Using the aerostat as the map as it is the only z-level in the atmosphere. Located in /maps/southern_cross/overmap/planets/kara/aerostat/ //NOT USED, Kara Z layers removed.
+	map_z = list(Z_LEVEL_AEROSTAT) // Using the aerostat as the map as it is the only z-level in the atmosphere. Located in /maps/southern_cross/overmap/planets/kara/aerostat/
 	initial_generic_waypoints = list("northern_star_mine_dock", "northern_star_mine_echidna_dock") //northern_star.dm landmarks
 	start_x  = 14
 	start_y  = 14

--- a/maps/southern_cross/overmap/planets/kara/kara.dm
+++ b/maps/southern_cross/overmap/planets/kara/kara.dm
@@ -30,7 +30,7 @@
 [i]Transponder[/i]: Transmitting (CIV), Vir IFF
 [b]Notice[/b]: CONDEMNED! NO ENTRY! -Vir System Authority"}
 
-	map_z = list(Z_LEVEL_AEROSTAT) // Using the aerostat as the map as it is the only z-level in the atmosphere. Located in /maps/southern_cross/overmap/planets/kara/aerostat/
+	//map_z = list(Z_LEVEL_AEROSTAT) // Using the aerostat as the map as it is the only z-level in the atmosphere. Located in /maps/southern_cross/overmap/planets/kara/aerostat/
 	initial_generic_waypoints = list("northern_star_mine_dock", "northern_star_mine_echidna_dock") //northern_star.dm landmarks
 	start_x  = 14
 	start_y  = 14

--- a/maps/southern_cross/overmap/planets/kara/kara_OM_only.dm
+++ b/maps/southern_cross/overmap/planets/kara/kara_OM_only.dm
@@ -19,7 +19,7 @@
 // Overmap object for Kara, hanging in the void of space
 /obj/effect/overmap/visitable/planet/kara
 	name = "Kara"
-	desc = "Uninhabitable gas giant. Derelict installations present in the upper atmosphere."
+	desc = "Uninhabitable gas giant."
 	scanner_desc = @{"[i]Stellar Body[/i]: Kara
 [i]Registration[/i]: Vir System Authority
 [i]Class[/i]: Installation
@@ -56,3 +56,9 @@
 	. = ..()
 
 	docking_codes = null
+
+/obj/effect/overmap/visitable/planet/kara/find_z_levels()
+	return
+
+/obj/effect/overmap/visitable/planet/kara/register_z_levels()
+	return

--- a/maps/southern_cross/overmap/planets/kara/kara_OM_only.dm
+++ b/maps/southern_cross/overmap/planets/kara/kara_OM_only.dm
@@ -1,0 +1,58 @@
+//Atmosphere properties //CHOMP Comment: I guess this Kara planetary information should go here. Kara is a gas giant, it ain't gonna be getting very many other maps.
+#define KARA_ONE_ATMOSPHERE	101.5 //kPa
+#define KARA_AVG_TEMP			150 //kelvin
+
+#define KARA_PER_N2		0.10 //percent
+#define KARA_PER_O2		0.03
+#define KARA_PER_N2O		0.00 //Currently no capacity to 'start' a turf with this. See turf.dm
+#define KARA_PER_CO2		0.87
+#define KARA_PER_PHORON	0.00
+
+//Math only beyond this point
+#define KARA_MOL_PER_TURF		(KARA_ONE_ATMOSPHERE*CELL_VOLUME/(KARA_AVG_TEMP*R_IDEAL_GAS_EQUATION))
+#define KARA_MOL_N2			(KARA_MOL_PER_TURF * KARA_PER_N2)
+#define KARA_MOL_O2			(KARA_MOL_PER_TURF * KARA_PER_O2)
+#define KARA_MOL_N2O			(KARA_MOL_PER_TURF * KARA_PER_N2O)
+#define KARA_MOL_CO2			(KARA_MOL_PER_TURF * KARA_PER_CO2)
+#define KARA_MOL_PHORON		(KARA_MOL_PER_TURF * KARA_PER_PHORON)
+
+// Overmap object for Kara, hanging in the void of space
+/obj/effect/overmap/visitable/planet/kara
+	name = "Kara"
+	desc = "Uninhabitable gas giant. Derelict installations present in the upper atmosphere."
+	scanner_desc = @{"[i]Stellar Body[/i]: Kara
+[i]Registration[/i]: Vir System Authority
+[i]Class[/i]: Installation
+[i]Transponder[/i]: Transmitting (CIV), Vir IFF
+[b]Notice[/b]: CONDEMNED! NO ENTRY! -Vir System Authority"}
+
+	map_z = list() // Using the aerostat as the map as it is the only z-level in the atmosphere. Located in /maps/southern_cross/overmap/planets/kara/aerostat/
+	initial_generic_waypoints = list() //northern_star.dm landmarks
+	start_x  = 14
+	start_y  = 14
+	skybox_offset_x = 128
+	skybox_offset_y = 128
+	surface_color = "#AD9100" // While many of these vars don't really make sense for a gas giant, they're necessary for the planet image generation we currently have.
+	mountain_color = "#A58A00" // Maybe we'll have a proper gas giant later.
+	water_color = "#A88D00"
+	ice_color = "#AD9100"
+	atmosphere_color = "#C19562"
+	icon_state = "chlorine"
+	known = 1
+
+
+/obj/effect/overmap/visitable/planet/kara/get_skybox_representation()
+	var/image/tmp = ..()
+	tmp.pixel_x = skybox_offset_x
+	tmp.pixel_y = skybox_offset_y
+	return tmp
+
+/obj/effect/overmap/visitable/planet/kara/Initialize()
+	atmosphere = new(CELL_VOLUME) // Necessary for the planet overmap icon to generate properly, but gas type does not seem to matter.
+	atmosphere.adjust_gas_temp("carbon_dioxide", KARA_MOL_CO2, KARA_AVG_TEMP)
+	atmosphere.adjust_gas_temp("nitrogen", KARA_MOL_N2, KARA_AVG_TEMP)
+	atmosphere.adjust_gas_temp("oxygen", KARA_MOL_O2, KARA_AVG_TEMP)
+
+	. = ..()
+
+	docking_codes = null

--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -14313,6 +14313,10 @@
 "ltw" = (
 /turf/simulated/wall/r_wall,
 /area/expoutpost/reactorroom)
+"ltL" = (
+/obj/effect/overmap/visitable/planet/kara,
+/turf/space,
+/area/space)
 "lvx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -64865,7 +64869,7 @@ cwA
 cwA
 cwA
 cwA
-cwA
+ltL
 cwA
 cwA
 xEV

--- a/maps/southern_cross/southern_cross.dm
+++ b/maps/southern_cross/southern_cross.dm
@@ -65,8 +65,9 @@
 	#include "overmap/sectors.dm" //This is actually the sector for Sif. This also includes places like the main station and the surface
 	//KARA - Planet
 	#include "overmap/planets/kara/kara.dm" //And this is the sector for Kara. I have decided to better organize future planets and maps for them
-	#include "overmap/planets/kara/northern_star/northern_star.dm" //This is the actual map info that we're using for kara
-	#include "overmap/planets/kara/aerostat/aerostat.dm" //This is an installation for Kara.
+	//KARA Z layers - Disabled due to low usage. These are heavy mini-station-like Z layers too.
+	//#include "overmap/planets/kara/northern_star/northern_star.dm" //This is the actual map info that we're using for kara
+	//#include "overmap/planets/kara/aerostat/aerostat.dm" //This is an installation for Kara.
 	//SPACE - Anything random in space
 	#include "overmap/space/fueldepot.dm" //This is a fuel depot in space.
 

--- a/maps/southern_cross/southern_cross.dm
+++ b/maps/southern_cross/southern_cross.dm
@@ -63,11 +63,14 @@
 	#include "overmap/shuttles.dm"
 	//SIF - Planet
 	#include "overmap/sectors.dm" //This is actually the sector for Sif. This also includes places like the main station and the surface
+	/* Disabled due to low usage. These are heavy mini-station-like Z layers too.
 	//KARA - Planet
 	#include "overmap/planets/kara/kara.dm" //And this is the sector for Kara. I have decided to better organize future planets and maps for them
-	//KARA Z layers - Disabled due to low usage. These are heavy mini-station-like Z layers too.
-	//#include "overmap/planets/kara/northern_star/northern_star.dm" //This is the actual map info that we're using for kara
-	//#include "overmap/planets/kara/aerostat/aerostat.dm" //This is an installation for Kara.
+	//KARA Z layers
+	#include "overmap/planets/kara/northern_star/northern_star.dm" //This is the actual map info that we're using for kara
+	#include "overmap/planets/kara/aerostat/aerostat.dm" //This is an installation for Kara.
+	*/
+
 	//SPACE - Anything random in space
 	#include "overmap/space/fueldepot.dm" //This is a fuel depot in space.
 

--- a/maps/southern_cross/southern_cross.dm
+++ b/maps/southern_cross/southern_cross.dm
@@ -63,7 +63,7 @@
 	#include "overmap/shuttles.dm"
 	//SIF - Planet
 	#include "overmap/sectors.dm" //This is actually the sector for Sif. This also includes places like the main station and the surface
-	/* Disabled due to low usage. These are heavy mini-station-like Z layers too.
+	/* //Disabled due to low usage. These are heavy mini-station-like Z layers too.
 	//KARA - Planet
 	#include "overmap/planets/kara/kara.dm" //And this is the sector for Kara. I have decided to better organize future planets and maps for them
 	//KARA Z layers

--- a/maps/southern_cross/southern_cross.dm
+++ b/maps/southern_cross/southern_cross.dm
@@ -63,6 +63,7 @@
 	#include "overmap/shuttles.dm"
 	//SIF - Planet
 	#include "overmap/sectors.dm" //This is actually the sector for Sif. This also includes places like the main station and the surface
+	#include "overmap/planets/kara/kara_OM_only.dm" //Kara, but just an OM icon
 	/* //Disabled due to low usage. These are heavy mini-station-like Z layers too.
 	//KARA - Planet
 	#include "overmap/planets/kara/kara.dm" //And this is the sector for Kara. I have decided to better organize future planets and maps for them

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -120,9 +120,9 @@ but they don't actually change anything about the load order
 	// Framework for porting Tether's lateload Z-Level system //Stock lateload maps
 	lateload_z_levels = list(
 			list("VR World"),
-			list("Fuel Depot - Z1 Space"),
-			list("Kara Aerostat - Z1 Aerostat"),
-			list("Kara - Z1 Northern Star")
+			list("Fuel Depot - Z1 Space")
+			//list("Kara Aerostat - Z1 Aerostat"), //Remove Kara Z layers
+			//list("Kara - Z1 Northern Star") //Remove Kara Z layers
 			)
 
 	//CHOMPStation Addition End

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -20,9 +20,10 @@ but they don't actually change anything about the load order
 #define Z_LEVEL_SURFACE_VALLEY 			11
 #define Z_LEVEL_VR_REALM                12
 #define Z_LEVEL_FUELDEPOT				13
-#define Z_LEVEL_AEROSTAT				14
-#define Z_LEVEL_NS_MINE					15
-#define Z_LEVEL_GATEWAY					16
+#define Z_LEVEL_GATEWAY					14
+
+//#define Z_LEVEL_AEROSTAT				15 //Disabled due to lack of use
+//#define Z_LEVEL_NS_MINE				16 //Disabled due to lack of use
 
 //#define Z_LEVEL_SURFACE_CASINO			xx	//CHOMPedit - KSC = So there is weather on the casino. //Raz - When you do casino again, launch it in a test server, note what z-level it is on, and then replace xx with that z-level you noted. Revert back to xx and comment out when done.
 //#define Z_LEVEL_EMPTY_SPACE				xx //CHOMPedit: Disabling empty space as now the overmap generates empty space on demand.

--- a/maps/southern_cross/submaps/_southern_cross_submaps.dm
+++ b/maps/southern_cross/submaps/_southern_cross_submaps.dm
@@ -12,8 +12,8 @@
 // This is for integration tests only.
 // Always add any new away missions/gateways/lateloaded maps that are not PoIs here.
 #if AWAY_MISSION_TEST
-#include "../overmap/planets/kara/aerostat/aerostat.dmm"
-#include "../overmap/planets/kara/northern_star/northern_star_mine.dmm"
+//#include "../overmap/planets/kara/aerostat/aerostat.dmm" //Disabled due to low usage
+//#include "../overmap/planets/kara/northern_star/northern_star_mine.dmm" //Disabled due to low usage
 #include "../overmap/space/fueldepot.dmm"
 #include "gateway/BaseBlep.dmm"
 #include "gateway/maddnesslab.dmm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

This removes Kara's two (heavy) Z layers from loading in the server, which should free up resources for other plans.

I figured out how to keep Kara's OM icon as a destination (with no landing zones), so that is done too.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
del: Removed 2x Kara Z layers (Aerostat, Mines)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
