### PR TITLE
Remove fake_attacker - EXTREME qdel /image usage

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -217,7 +217,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 			return 1
 	return 0*/
 
-/* Chomp REMOVE fake_attacker - EXTREME image qdel usage. Look at the attack_loop and updateimage procs and weep.
+/* //ChompREMOVE fake_attacker - EXTREME image qdel usage. Look at the attack_loop and updateimage procs and weep.
 /obj/effect/fake_attacker
 	icon = null
 	icon_state = null

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -217,6 +217,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 			return 1
 	return 0*/
 
+/* Chomp REMOVE fake_attacker - EXTREME image qdel usage. Look at the attack_loop and updateimage procs and weep.
 /obj/effect/fake_attacker
 	icon = null
 	icon_state = null
@@ -414,3 +415,4 @@ var/list/non_fakeattack_weapons = list(/obj/item/weapon/gun/projectile, /obj/ite
 	*/
 
 	F.updateimage()
+*/ //ChompREMOVE End

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1281,8 +1281,8 @@
 
 		if(hallucination)
 			if(hallucination >= 20 && !(species.flags & (NO_POISON|IS_PLANT|NO_HALLUCINATION)) )
-				if(prob(3))
-					fake_attack(src)
+				//if(prob(3)) //ChompREMOVE fake_attacker - EXTREME image qdel usage.
+					//fake_attack(src) //ChompREMOVE fake_attacker - EXTREME image qdel usage.
 				if(!handling_hal)
 					spawn handle_hallucinations() //The not boring kind!
 				if(client && prob(5))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Read the code of the part in hallucination and weep. This operates on a while(1) loop and qdels 4 /images every SINGLE loop. This was causing some problems. Look at an SM and you might crash the server

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
del: Remove hallucination 'fake_attacker' 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
