### PR TITLE
Remove sky islands, retouch wilderness shelter for single Z courtesy of Bib

### DIFF
--- a/maps/southern_cross/overmap/sectors.dm
+++ b/maps/southern_cross/overmap/sectors.dm
@@ -7,9 +7,8 @@
 [i]Transponder[/i]: Transmitting (CIV), Vir IFF
 [b]Notice[/b]: The Vir government welcomes you to this world."}
 
-	map_z = list(Z_LEVEL_SURFACE, Z_LEVEL_SURFACE_MINE, Z_LEVEL_SURFACE_WILD, Z_LEVEL_SURFACE_SKYLANDS)
-
-	map_z = list(Z_LEVEL_SURFACE, Z_LEVEL_SURFACE_MINE, Z_LEVEL_SURFACE_WILD, Z_LEVEL_SURFACE_SKYLANDS, Z_LEVEL_SURFACE_VALLEY)
+	map_z = list(Z_LEVEL_SURFACE, Z_LEVEL_SURFACE_MINE, Z_LEVEL_SURFACE_WILD, Z_LEVEL_SURFACE_VALLEY)
+	//Z_LEVEL_SURFACE_SKYLANDS, //removed due to lack of use
 
 	initial_generic_waypoints = list(
 		"outpost_nw",
@@ -65,7 +64,8 @@
 	start_y =  10
 	known = 1 // lets Sectors appear on shuttle navigation for easy finding.
 
-	extra_z_levels = list(Z_LEVEL_TRANSIT, Z_LEVEL_MISC,Z_LEVEL_SURFACE, Z_LEVEL_SURFACE_MINE, Z_LEVEL_SURFACE_WILD, Z_LEVEL_SURFACE_SKYLANDS, Z_LEVEL_SURFACE_VALLEY) //This should allow for comms to reach people from the station. Basically this defines all the areas of Southern Cross and the Sif local system on the overmap.
+	extra_z_levels = list(Z_LEVEL_TRANSIT, Z_LEVEL_MISC,Z_LEVEL_SURFACE, Z_LEVEL_SURFACE_MINE, Z_LEVEL_SURFACE_WILD, Z_LEVEL_SURFACE_VALLEY) //This should allow for comms to reach people from the station. Basically this defines all the areas of Southern Cross and the Sif local system on the overmap.
+	// "Z_LEVEL_SURFACE_SKYLANDS, " //removed due to lack of use
 
 	initial_generic_waypoints = list(
 		"d1_aux_a",

--- a/maps/southern_cross/southern_cross-10.dmm
+++ b/maps/southern_cross/southern_cross-10.dmm
@@ -550,6 +550,7 @@
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter/dorms)
 "fY" = (
+/obj/effect/zone_divider,
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
 	id = "wilderness_shelter_1st_floor";
@@ -557,7 +558,6 @@
 	pixel_y = -26;
 	req_one_access = list(1,5,10,12,13,18,31,43,47,48,50)
 	},
-/obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
 "gi" = (
@@ -599,6 +599,11 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
@@ -948,6 +953,15 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/shelter)
+"tx" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/exterior)
 "tB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -978,7 +992,12 @@
 	pixel_x = 24;
 	req_one_access = list(1,5,10,12,13,18,31,43,47,48,50)
 	},
-/turf/simulated/floor/outdoors/dirt/sif/planetuse,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter/exterior)
 "tO" = (
 /obj/effect/zone_divider,
@@ -1205,6 +1224,12 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
 "AZ" = (
+/obj/machinery/atmospheric_field_generator/perma/underdoors,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/simple_door/sifwood,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
@@ -1212,7 +1237,6 @@
 	layer = 3;
 	name = "Wilderness Shelter Shutters"
 	},
-/obj/machinery/atmospheric_field_generator/perma/underdoors,
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
 "Ba" = (
@@ -1685,6 +1709,14 @@
 	},
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter/utilityroom)
+"VK" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/exterior)
 "Wo" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -42378,9 +42410,9 @@ aT
 aT
 aT
 KX
-aT
+VK
 tK
-bz
+tx
 ac
 ab
 "}
@@ -45983,7 +46015,7 @@ aT
 aV
 aV
 aW
-aW
+aT
 ba
 yZ
 bv
@@ -46241,7 +46273,7 @@ iB
 aV
 aV
 aW
-aW
+aT
 ba
 xj
 rv
@@ -46499,7 +46531,7 @@ iB
 aV
 aV
 aW
-aG
+bz
 ba
 sJ
 bv
@@ -46757,7 +46789,7 @@ iB
 aV
 aV
 aW
-aW
+aT
 cr
 EB
 Px
@@ -47015,7 +47047,7 @@ yL
 aV
 aV
 aW
-aW
+aT
 ba
 ba
 ba
@@ -47273,7 +47305,7 @@ ap
 aV
 aW
 aW
-aW
+aT
 bz
 Ge
 mP
@@ -49338,7 +49370,7 @@ aG
 aG
 aG
 aW
-aW
+aT
 bz
 bz
 bz

--- a/maps/southern_cross/southern_cross-10.dmm
+++ b/maps/southern_cross/southern_cross-10.dmm
@@ -239,8 +239,6 @@
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter)
 "be" = (
-/obj/structure/ladder/up,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},

--- a/maps/southern_cross/southern_cross-10.dmm
+++ b/maps/southern_cross/southern_cross-10.dmm
@@ -441,12 +441,40 @@
 /turf/simulated/mineral/sif,
 /turf/simulated/mineral/sif,
 /area/surface/outside/wilderness/mountains)
+"bG" = (
+/turf/simulated/floor/tiled/freezer,
+/area/surface/outpost/shelter/dorms)
+"bR" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "bX" = (
 /obj/effect/map_effect/portal/line/side_b{
 	dir = 1
 	},
 /turf/simulated/wall/solidrock,
 /area/surface/outside/wilderness/mountains)
+"ca" = (
+/obj/structure/bed/chair/bay/comfy/blue{
+	dir = 2
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
+"cr" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "wilderness_shelter_2nd_floor";
+	layer = 4;
+	name = "Wilderness Shelter Shutters"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "cA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -455,6 +483,15 @@
 	},
 /turf/simulated/wall/log_sif,
 /area/surface/outpost/shelter)
+"cD" = (
+/obj/machinery/camera/network/carrier{
+	c_tag = "WILD - Shelter Crew Dorms";
+	dir = 4
+	},
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/carpet/turcarpet,
+/area/surface/outpost/shelter/dorms)
 "cG" = (
 /obj/effect/zone_divider,
 /obj/effect/zone_divider,
@@ -472,6 +509,14 @@
 /obj/item/stack/marker_beacon,
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
+"dh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "dO" = (
 /obj/machinery/light{
 	dir = 8
@@ -502,9 +547,8 @@
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/shelter)
 "ez" = (
-/obj/machinery/light,
-/turf/simulated/floor/outdoors/grass/sif/planetuse,
-/area/surface/outpost/shelter/exterior)
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "fY" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 1;
@@ -516,6 +560,13 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
+"gi" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/structure/closet/crate/bin,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "gy" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
@@ -551,6 +602,46 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
+"hf" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/machinery/cell_charger,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -5
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -5
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -5
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -5
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "hu" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -573,11 +664,29 @@
 	tree_chance = 0
 	},
 /area/surface/outpost/shelter/exterior)
+"ib" = (
+/obj/structure/simple_door/sifwood,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "iB" = (
 /turf/simulated/floor/outdoors/grass/sif/planetuse{
 	tree_chance = 0
 	},
 /area/surface/outpost/shelter/exterior)
+"iV" = (
+/obj/structure/table/standard,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/glass,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
 "jf" = (
 /obj/effect/shuttle_landmark{
 	landmark_tag = "wilderness_s";
@@ -595,6 +704,15 @@
 	tree_chance = 0
 	},
 /area/surface/outpost/shelter/exterior)
+"jX" = (
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/soap/nanotrasen,
+/obj/item/weapon/soap/nanotrasen,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/freezer,
+/area/surface/outpost/shelter/dorms)
 "kd" = (
 /turf/simulated/floor/outdoors/grass/sif/forest/planetuse{
 	tree_chance = 0
@@ -626,6 +744,25 @@
 /obj/effect/map_effect/perma_light/concentrated/incandescent,
 /turf/simulated/floor/water,
 /area/surface/outpost/wall/checkpoint)
+"ln" = (
+/obj/machinery/camera/network/carrier{
+	c_tag = "WILD - Shelter Second Floor Utilities"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
+"lX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
 "mh" = (
 /obj/structure/table/sifwooden_reinforced,
 /obj/structure/extinguisher_cabinet{
@@ -653,21 +790,35 @@
 /obj/item/device/geiger/wall/south,
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
+"mP" = (
+/obj/structure/toilet,
+/turf/simulated/floor/tiled/freezer,
+/area/surface/outpost/shelter/dorms)
 "mR" = (
-/obj/structure/railing/grey,
-/turf/simulated/floor/outdoors/grass/sif/planetuse,
-/area/surface/outpost/shelter/exterior)
+/obj/structure/bed/chair/comfy/blue{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/turcarpet,
+/area/surface/outpost/shelter/dorms)
 "nA" = (
 /obj/item/stack/marker_beacon,
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
 "nN" = (
-/turf/simulated/wall/rsifwood,
-/area/surface/outside/wilderness/mountains)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "op" = (
-/obj/structure/stairs/spawner/west,
-/turf/simulated/floor/outdoors/dirt/sif/planetuse,
-/area/surface/outside/path/wilderness)
+/obj/machinery/alarm/sifwilderness{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "oO" = (
 /obj/effect/step_trigger/teleporter/bridge/east_to_west,
 /obj/structure/railing{
@@ -681,6 +832,33 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/grass/sif/forest/planetuse,
 /area/surface/outside/wilderness/normal)
+"oU" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/yellowdouble,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
+"oW" = (
+/obj/structure/simple_door/sifwood,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
+"pn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
+"pQ" = (
+/obj/machinery/button/remote/blast_door{
+	dir = 4;
+	id = "wilderness_shelter_2nd_floor_2";
+	name = "Wilderness Shelter Shutters";
+	pixel_x = -26;
+	req_one_access = null
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "qe" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "WILD - Shelter First Aid";
@@ -704,16 +882,59 @@
 /obj/structure/closet/hydrant{
 	pixel_y = -32
 	},
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/tool/crowbar/red,
+/obj/item/weapon/tool/crowbar/red,
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
+"qq" = (
+/obj/structure/coatrack,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "qr" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outside/path/wilderness)
+"rl" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/storage/toolbox/emergency{
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_y = -1
+	},
+/obj/machinery/alarm/sifwilderness{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
+"rv" = (
+/obj/machinery/bluespace_beacon{
+	alpha = 0;
+	desc = "A device that draws power from bluespace and creates a permanent tracking beacon. This one has a cloaking field. How keen of you to notice!";
+	name = "Wilderness Shelter Bluespace Gigabeacon"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "sC" = (
 /obj/structure/railing,
 /turf/simulated/floor/water/deep,
 /area/surface/outside/river/svartan)
+"sJ" = (
+/obj/structure/closet/medical_wall{
+	name = "Wilderness Shelter first-aid closet";
+	pixel_y = 31;
+	starts_with = list(/obj/item/roller,/obj/item/bodybag/cryobag,/obj/item/weapon/storage/firstaid/regular=2,/obj/item/weapon/storage/pill_bottle/spaceacillin)
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "sR" = (
 /obj/effect/zone_divider,
 /obj/item/stack/marker_beacon,
@@ -742,6 +963,11 @@
 	name = "west bump";
 	pixel_x = -24
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
 "tK" = (
@@ -760,6 +986,17 @@
 	tree_chance = 0
 	},
 /area/surface/outside/wilderness/normal)
+"tS" = (
+/obj/structure/closet,
+/obj/item/weapon/storage/box/lights/bulbs,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/melee/umbrella/random,
+/obj/item/weapon/melee/umbrella/random,
+/obj/item/weapon/melee/umbrella/random,
+/obj/item/weapon/melee/umbrella/random,
+/obj/item/weapon/melee/umbrella/random,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
 "ub" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -778,14 +1015,74 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/water,
 /area/surface/outside/ocean)
+"uu" = (
+/obj/machinery/light{
+	layer = 3
+	},
+/obj/machinery/autolathe,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
+"vq" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/storage/box{
+	max_storage_space = 20;
+	name = "box of 7.62mm practice clips";
+	pixel_x = 3;
+	pixel_y = 3;
+	starts_with = list(/obj/item/ammo_magazine/clip/c762/practice=10)
+	},
+/obj/item/weapon/storage/bag/trash{
+	pixel_x = -9;
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/bag/trash{
+	pixel_x = -9;
+	pixel_y = -5
+	},
+/obj/item/weapon/storage/box{
+	max_storage_space = 20;
+	name = "box of 7.62mm practice clips";
+	pixel_x = 3;
+	pixel_y = -1;
+	starts_with = list(/obj/item/ammo_magazine/clip/c762/practice=10)
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = -24;
+	pixel_y = -4
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "vz" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/grass/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
+"vO" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 3
+	},
+/obj/machinery/button/windowtint{
+	id = "dorm_wildey";
+	pixel_x = -22
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "wg" = (
 /obj/machinery/light,
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
+"xj" = (
+/obj/structure/closet/walllocker_double/survival/north{
+	name = "Wilderness Shelter Emergency Survival Wall Cabinet";
+	starts_with = list(/obj/item/device/gps=5,/obj/item/weapon/material/knife/tacknife/survival=5,/obj/random/mre=5,/obj/item/device/flashlight/color/yellow=5,/obj/item/device/flashlight/flare=5,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle=5,/obj/item/weapon/whetstone)
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "xt" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/dirt,
@@ -812,6 +1109,19 @@
 	},
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
+"xZ" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
+"yb" = (
+/obj/machinery/power/thermoregulator/southerncross{
+	pixel_x = 1;
+	pixel_y = 26
+	},
+/obj/structure/table/standard,
+/obj/fiftyspawner/plastic,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
 "ys" = (
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
@@ -828,6 +1138,21 @@
 	tree_chance = 0
 	},
 /area/surface/outpost/shelter/exterior)
+"yZ" = (
+/obj/structure/closet/secure_closet/medical_wall{
+	name = "Wilderness Shelter defibrillator closet";
+	pixel_y = 31;
+	req_access = null;
+	req_one_access = list(1,3,43,66,67);
+	starts_with = list(/obj/item/device/defib_kit/loaded)
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "zb" = (
 /obj/structure/table/rack,
 /obj/fiftyspawner/glass,
@@ -835,6 +1160,14 @@
 /obj/fiftyspawner/rglass,
 /obj/fiftyspawner/rglass,
 /turf/simulated/floor/plating,
+/area/surface/outpost/shelter/utilityroom)
+"zv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter/utilityroom)
 "As" = (
 /turf/simulated/floor/wood{
@@ -848,6 +1181,12 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/rocks/sif/planetuse,
 /area/surface/outside/wilderness/normal)
+"AP" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "AX" = (
 /obj/effect/map_effect/portal/line/side_a{
 	dir = 4
@@ -858,14 +1197,11 @@
 /turf/simulated/floor/water/deep,
 /area/surface/outside/river/svartan)
 "AY" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/table/sifwooden_reinforced,
-/obj/item/weapon/tool/crowbar/red,
-/obj/item/weapon/tool/crowbar/red,
-/obj/item/weapon/storage/box/lights/mixed,
-/obj/item/weapon/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
 "AZ" = (
@@ -879,6 +1215,28 @@
 /obj/machinery/atmospheric_field_generator/perma/underdoors,
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
+"Ba" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
+"Bz" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/gun/projectile/shotgun/pump/rifle/practice{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/projectile/shotgun/pump/rifle/practice{
+	pixel_y = 6
+	},
+/obj/item/device/binoculars{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/item/device/binoculars{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "BF" = (
 /obj/effect/map_effect/portal/line/side_a{
 	dir = 4
@@ -890,12 +1248,72 @@
 	outdoors = 1
 	},
 /area/surface/outside/river/svartan)
+"BY" = (
+/obj/structure/simple_door/sifwood,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
+"Cb" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/surface/outpost/shelter/dorms)
+"CI" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
+"CJ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "Dk" = (
 /obj/structure/sign/department/medbay{
 	name = "FIRST AID"
 	},
 /turf/simulated/wall/log_sif,
 /area/surface/outpost/shelter)
+"EB" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "wilderness_shelter_2nd_floor";
+	name = "Wilderness Shelter Shutters";
+	pixel_x = 26;
+	req_one_access = null
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
+"EF" = (
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green,
+/obj/structure/curtain/open/bed,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/surface/outpost/shelter/dorms)
+"FY" = (
+/obj/structure/closet/hydrant{
+	pixel_y = -26
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
 "Gd" = (
 /obj/structure/table/rack,
 /obj/item/weapon/circuitboard/machine/rtg/advanced,
@@ -911,6 +1329,9 @@
 /obj/fiftyspawner/rods,
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
+"Ge" = (
+/turf/simulated/wall/log_sif,
+/area/surface/outpost/shelter/dorms)
 "Gw" = (
 /obj/structure/reagent_dispensers/fueltank/high,
 /turf/simulated/floor/plating,
@@ -925,10 +1346,23 @@
 	},
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
+"HZ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/surface/outpost/shelter/dorms)
 "Iw" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
+"Ix" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
 "IA" = (
 /obj/structure/curtain/medical{
 	name = "medical curtain"
@@ -941,6 +1375,23 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/shelter)
+"ID" = (
+/obj/machinery/power/thermoregulator/southerncross{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 1
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "IZ" = (
 /turf/simulated/mineral/sif,
 /area/surface/outside/wilderness/normal)
@@ -964,6 +1415,36 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/shelter)
+"Ki" = (
+/obj/structure/bed/chair/comfy/blue,
+/turf/simulated/floor/carpet/turcarpet,
+/area/surface/outpost/shelter/dorms)
+"KU" = (
+/obj/machinery/light/small,
+/obj/structure/closet/secure_closet/guncabinet{
+	anchored = 1;
+	req_one_access = list(1,3,43,67)
+	},
+/obj/item/weapon/storage/box/syndie_kit{
+	max_storage_space = 20;
+	name = "box of 7.62mm clips";
+	starts_with = list(/obj/item/ammo_magazine/clip/c762=10)
+	},
+/obj/item/weapon/storage/box/syndie_kit{
+	max_storage_space = 20;
+	name = "box of 7.62mm clips";
+	starts_with = list(/obj/item/ammo_magazine/clip/c762=10)
+	},
+/obj/item/device/binoculars,
+/obj/item/device/binoculars,
+/obj/item/weapon/gun/projectile/shotgun/pump/rifle{
+	pixel_y = -3
+	},
+/obj/item/weapon/gun/projectile/shotgun/pump/rifle{
+	pixel_y = 6
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "KX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -975,6 +1456,10 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/water/deep,
 /area/surface/outside/river/svartan)
+"Lx" = (
+/obj/structure/curtain/open/bed,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/surface/outpost/shelter/dorms)
 "LI" = (
 /obj/structure/railing{
 	dir = 8
@@ -992,6 +1477,12 @@
 /obj/structure/simple_door/sifwood,
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter)
+"Ml" = (
+/obj/machinery/light{
+	layer = 3
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "No" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/water/deep/ocean,
@@ -1008,6 +1499,18 @@
 	},
 /turf/simulated/shuttle/wall/voidcraft,
 /area/surface/outpost/wall/checkpoint)
+"Oy" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/dorms)
 "OU" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -1020,6 +1523,28 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white,
+/area/surface/outpost/shelter)
+"Pa" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/obj/structure/mirror{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/surface/outpost/shelter/dorms)
+"Px" = (
+/obj/machinery/camera/network/carrier{
+	c_tag = "WILD - Shelter Second Floor";
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter)
 "Qz" = (
 /obj/structure/railing{
@@ -1067,6 +1592,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
+"Rw" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/power/thermoregulator/southerncross{
+	dir = 4;
+	pixel_x = -26;
+	pixel_y = 2
+	},
+/obj/structure/closet/crate/bin,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter)
 "Sd" = (
 /obj/machinery/light{
 	dir = 8
@@ -1132,6 +1673,18 @@
 	},
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outside/wilderness/normal)
+"UK" = (
+/obj/structure/simple_door/sifwood,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
 "Wo" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -1208,6 +1761,35 @@
 "XD" = (
 /turf/simulated/wall/solidrock,
 /area/surface/outside/wilderness/deep)
+"XK" = (
+/obj/structure/table/standard,
+/obj/structure/bedsheetbin{
+	pixel_x = 2
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = -5;
+	pixel_y = 2
+	},
+/turf/simulated/floor/wood/sif,
+/area/surface/outpost/shelter/utilityroom)
+"Yc" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/window/reinforced/polarized/full{
+	id = "dorm_wildey"
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "dorm_wildey"
+	},
+/obj/machinery/door/blast/shutters{
+	dir = 2;
+	id = "wilderness_shelter_2nd_floor_2";
+	layer = 4;
+	name = "Wilderness Shelter Shutters"
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/shelter/dorms)
 "Yq" = (
 /obj/machinery/power/thermoregulator/southerncross{
 	pixel_x = 1;
@@ -1258,8 +1840,31 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/shelter/utilityroom)
+"Zz" = (
+/obj/structure/table/sifwooden_reinforced,
+/obj/item/weapon/deck/cah{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/weapon/deck/cah/black{
+	pixel_x = 1;
+	pixel_y = -1
+	},
+/obj/item/weapon/deck/cards{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/weapon/deck/holder{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/turf/simulated/floor/carpet/turcarpet,
+/area/surface/outpost/shelter/dorms)
 "ZG" = (
 /obj/structure/showcase/sign{
 	desc = "This appears to be a sign warning people that the other side is extremely hazardous.";
@@ -42548,7 +43153,7 @@ bt
 by
 ba
 Yq
-ys
+AY
 WB
 aU
 ab
@@ -42806,7 +43411,7 @@ bv
 bB
 ba
 Jk
-ys
+AY
 mj
 aU
 ab
@@ -43064,7 +43669,7 @@ bv
 be
 ba
 gE
-ys
+AY
 hu
 aU
 ab
@@ -43322,7 +43927,7 @@ bv
 bv
 Mk
 ys
-ys
+AY
 ub
 aU
 ab
@@ -43580,7 +44185,7 @@ IA
 td
 ba
 Gd
-ys
+AY
 Rr
 aU
 ab
@@ -43838,7 +44443,7 @@ OU
 SE
 ba
 Xn
-ys
+AY
 el
 aU
 ab
@@ -44096,7 +44701,7 @@ WE
 Jq
 ba
 zb
-ys
+AY
 Gw
 aU
 ab
@@ -44354,7 +44959,7 @@ es
 bs
 ba
 Uj
-ys
+AY
 qf
 aU
 ab
@@ -44606,7 +45211,7 @@ aW
 aW
 aT
 aT
-bz
+xA
 ba
 Wo
 qe
@@ -44863,14 +45468,14 @@ aV
 aW
 aW
 aT
-aT
-xA
 ba
 ba
+ba
+Mk
 ba
 ba
 aU
-aU
+UK
 aU
 aU
 ab
@@ -45119,18 +45724,18 @@ aT
 aT
 aV
 aV
-aV
+aW
 aT
-aT
-bz
-bz
-bz
-bz
-bz
-ac
-ac
-ac
-ac
+cr
+Rw
+vq
+bv
+rl
+ba
+ln
+pn
+CI
+aU
 ab
 "}
 (171,1,1) = {"
@@ -45377,18 +45982,18 @@ aT
 aT
 aV
 aV
-aV
 aW
 aW
-bz
-bz
-bz
-bz
-bz
-ac
-ac
-ac
-ac
+ba
+yZ
+bv
+bv
+Bz
+ba
+Ix
+pn
+iV
+aU
 ab
 "}
 (172,1,1) = {"
@@ -45635,18 +46240,18 @@ iB
 iB
 aV
 aV
-aV
 aW
 aW
-aW
-bz
-bz
-bz
-bz
-ac
-ac
-ac
-ac
+ba
+xj
+rv
+bv
+KU
+ba
+XK
+pn
+uu
+aU
 ab
 "}
 (173,1,1) = {"
@@ -45893,18 +46498,18 @@ iB
 iB
 aV
 aV
-aV
+aW
 aG
-aW
-aW
-bz
-bz
-bz
-bz
-ac
-ac
-ac
-ac
+ba
+sJ
+bv
+ca
+hf
+ba
+yb
+pn
+FY
+aU
 ab
 "}
 (174,1,1) = {"
@@ -46151,18 +46756,18 @@ iB
 iB
 aV
 aV
-aV
-aG
 aW
 aW
-bz
-bz
-bz
-bz
-ac
-ac
-ac
-ac
+cr
+EB
+Px
+dh
+dh
+ib
+zv
+lX
+tS
+aU
 ab
 "}
 (175,1,1) = {"
@@ -46409,18 +47014,18 @@ iB
 yL
 aV
 aV
-aV
-aG
 aW
 aW
-aW
-bz
-bz
-bz
-bz
-ac
-ac
-ac
+ba
+ba
+ba
+ba
+ba
+ba
+aU
+BY
+aU
+aU
 ab
 "}
 (176,1,1) = {"
@@ -46666,19 +47271,19 @@ aV
 aV
 ap
 aV
-ap
-aG
-aG
 aW
 aW
 aW
 bz
-bz
-bz
-bz
-ac
-ac
-ac
+Ge
+mP
+Pa
+jX
+Ge
+CJ
+nN
+xZ
+Ge
 ab
 "}
 (177,1,1) = {"
@@ -46919,24 +47524,24 @@ aG
 ap
 aG
 aG
-ap
 aG
 aG
-ap
-aV
-ap
 aG
 aG
 aG
 aG
 aW
-aW
+aG
 bz
-bz
+Ge
+Cb
+bG
+HZ
+oW
 ez
 nN
-ac
-ac
+qq
+Ge
 ab
 "}
 (178,1,1) = {"
@@ -47181,20 +47786,20 @@ aG
 aG
 aG
 aG
-aV
-ap
-aG
-aG
-aW
 aG
 aG
 aW
 aW
 bz
-mR
-op
-ac
-ac
+Ge
+Ge
+Ge
+Ge
+Ge
+ez
+nN
+ez
+Ge
 ab
 "}
 (179,1,1) = {"
@@ -47435,24 +48040,24 @@ aG
 aG
 aG
 aG
-ap
-aG
-aG
-ap
 aG
 aG
 aG
-aG
-aW
 aG
 aG
 aG
 aW
 aW
+bz
+Yc
+vO
+pQ
+Ki
+cD
 mR
-aW
-ac
-ac
+nN
+Ml
+Ge
 ab
 "}
 (180,1,1) = {"
@@ -47694,23 +48299,23 @@ aG
 aG
 aG
 aG
-ap
 aG
-aG
-ap
-aG
-aG
-aG
-aW
 aG
 aG
 aG
 aG
 aW
 aW
-aW
-ac
-ac
+bz
+Yc
+ez
+ez
+Ki
+Zz
+mR
+nN
+Ba
+Ge
 ab
 "}
 (181,1,1) = {"
@@ -47957,18 +48562,18 @@ aG
 aG
 aG
 aG
-aG
-aG
 aW
-aG
-aG
-aG
-aG
-aG
-aG
-aG
-ac
-ac
+aW
+bz
+Ge
+Lx
+Lx
+ez
+bR
+ez
+nN
+qq
+Ge
 ab
 "}
 (182,1,1) = {"
@@ -48215,18 +48820,18 @@ aG
 aG
 aG
 aG
-aG
-aG
 aW
-aG
-aG
-aG
-aG
-aG
-aG
-ac
-ac
-ac
+aW
+bz
+Ge
+oU
+EF
+op
+AP
+Oy
+ID
+gi
+Ge
 ab
 "}
 (183,1,1) = {"
@@ -48474,17 +49079,17 @@ aG
 aG
 aG
 aG
-aG
 aW
-aG
-aG
-aG
-aG
-aG
-aG
-ac
-ac
-ac
+bz
+Ge
+Ge
+Ge
+Ge
+Ge
+Ge
+Ge
+Ge
+Ge
 ab
 "}
 (184,1,1) = {"
@@ -48732,14 +49337,14 @@ aG
 aG
 aG
 aG
-aG
 aW
-aG
-aG
-aG
-aG
-aG
-aG
+aW
+bz
+bz
+bz
+bz
+bz
+bz
 ac
 ac
 ac
@@ -48990,14 +49595,14 @@ aG
 aG
 aG
 aG
-aG
-aG
-aG
-aG
-aG
-aG
-aG
-aG
+aW
+aW
+bz
+bz
+bz
+bz
+bz
+bz
 ac
 ac
 ac
@@ -49248,8 +49853,8 @@ aG
 aG
 aG
 aG
-aG
-aG
+aW
+aW
 aG
 aG
 aG
@@ -49506,7 +50111,7 @@ aG
 aG
 aG
 aG
-aG
+aW
 aW
 aG
 aG
@@ -50024,7 +50629,7 @@ aG
 aG
 aG
 aW
-aG
+aW
 aG
 aG
 aG
@@ -50539,7 +51144,7 @@ aG
 aG
 aG
 aG
-aG
+aW
 aW
 aG
 aG

--- a/maps/southern_cross/southern_cross-5.dmm
+++ b/maps/southern_cross/southern_cross-5.dmm
@@ -13663,10 +13663,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/gen_room/smes_right)
-"ze" = (
-/obj/machinery/telecomms/relay/preset/southerncross/skylands,
-/turf/simulated/floor/tiled/techmaint,
-/area/surface/outpost/main/tcomm)
 "zf" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -70536,7 +70532,7 @@ uh
 BB
 xI
 nw
-ze
+nw
 Er
 AW
 ha

--- a/maps/southern_cross/southern_cross.dm
+++ b/maps/southern_cross/southern_cross.dm
@@ -51,7 +51,7 @@
 		#include "southern_cross-8.dmm" //Centcom z7
 		#include "southern_cross-9.dmm" //Transit z8
 		#include "southern_cross-10.dmm" //Sif wilds z9
-		#include "southern_cross-12.dmm" //Skylands z10
+//		#include "southern_cross-12.dmm" //Skylands z10 //Remove due to lack of use
 		#include "southern_cross-13.dmm" //Valley z11 seemingly. For stranger critters and POIs.
 	#endif
 //	#include "southern_cross-casino.dmm" //CHOMPedit: Disabled to save resources and loaded in during events - Jack

--- a/maps/southern_cross/southern_cross.dm
+++ b/maps/southern_cross/southern_cross.dm
@@ -52,7 +52,7 @@
 		#include "southern_cross-9.dmm" //Transit z8
 		#include "southern_cross-10.dmm" //Sif wilds z9
 //		#include "southern_cross-12.dmm" //Skylands z10 //Remove due to lack of use
-		#include "southern_cross-13.dmm" //Valley z11 seemingly. For stranger critters and POIs.
+		#include "southern_cross-13.dmm" //Valley z10 seemingly. For stranger critters and POIs.
 	#endif
 //	#include "southern_cross-casino.dmm" //CHOMPedit: Disabled to save resources and loaded in during events - Jack
 

--- a/maps/southern_cross/southern_cross_areas.dm
+++ b/maps/southern_cross/southern_cross_areas.dm
@@ -98,6 +98,7 @@
 	name = "Mountains"
 	icon_state = "darkred"
 
+/* //Sky islands removal, lack of use
 /area/surface/outside/wilderness/skylands
 	name = "Floating Islands"
 	icon_state = "blue"
@@ -106,6 +107,7 @@
 	name = "Sky"
 	icon_state = "red"
 	luminosity = 1
+*/
 
 /area/surface/outside/path/wilderness
 

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -16,13 +16,13 @@ but they don't actually change anything about the load order
 #define Z_LEVEL_CENTCOM					7
 #define Z_LEVEL_TRANSIT					8
 #define Z_LEVEL_SURFACE_WILD			9
-#define Z_LEVEL_SURFACE_SKYLANDS		10
-#define Z_LEVEL_SURFACE_VALLEY 			11
-#define Z_LEVEL_VR_REALM                12
-#define Z_LEVEL_FUELDEPOT				13
-#define Z_LEVEL_AEROSTAT				14
-#define Z_LEVEL_NS_MINE					15
-#define Z_LEVEL_GATEWAY					16
+//#define Z_LEVEL_SURFACE_SKYLANDS		10 //Sky islands removal due to lack of use
+#define Z_LEVEL_SURFACE_VALLEY 			10
+#define Z_LEVEL_VR_REALM                11
+#define Z_LEVEL_FUELDEPOT				12
+#define Z_LEVEL_AEROSTAT				13
+#define Z_LEVEL_NS_MINE					14
+#define Z_LEVEL_GATEWAY					15
 
 //#define Z_LEVEL_SURFACE_CASINO			xx	//CHOMPedit - KSC = So there is weather on the casino. //Raz - When you do casino again, launch it in a test server, note what z-level it is on, and then replace xx with that z-level you noted. Revert back to xx and comment out when done.
 //#define Z_LEVEL_EMPTY_SPACE				xx //CHOMPedit: Disabling empty space as now the overmap generates empty space on demand.
@@ -246,11 +246,13 @@ but they don't actually change anything about the load order
 	flags = MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONTACT|MAP_LEVEL_CONSOLES
 	base_turf = /turf/simulated/floor/outdoors/rocks
 
+/* //Sky islands removal due to lack of use
 /datum/map_z_level/southern_cross/surface_skylands
 	z = Z_LEVEL_SURFACE_SKYLANDS
 	name = "Floating Islands"
 	flags = MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONTACT|MAP_LEVEL_CONSOLES
 	base_turf = /turf/simulated/open
+*/
 
 /datum/map_z_level/southern_cross/surface_valley
 	z = Z_LEVEL_SURFACE_VALLEY
@@ -317,7 +319,7 @@ but they don't actually change anything about the load order
 		Z_LEVEL_SURFACE,
 		Z_LEVEL_SURFACE_MINE,
 		Z_LEVEL_SURFACE_WILD,
-		Z_LEVEL_SURFACE_SKYLANDS,
+		//Z_LEVEL_SURFACE_SKYLANDS, //Sky islands removal due to lack of use
 		Z_LEVEL_SURFACE_VALLEY
 	)
 //Z_LEVEL_SURFACE_CASINO //CHOMPedit - KSC = So there is weather on the Casino. //Move this into /datum/planet/sif and remember to add a coma for the new entry, for when you need the casino again

--- a/maps/southern_cross/southern_cross_presets.dm
+++ b/maps/southern_cross/southern_cross_presets.dm
@@ -72,10 +72,12 @@ var/const/NETWORK_CARRIER  = "Exploration Carrier" //CHOMPedit: Exploration outp
 	listening_level = Z_LEVEL_MISC
 	autolinkers = list("exp_relay")
 
+/* //Sky islands removal due to lack of use
 /obj/machinery/telecomms/relay/preset/southerncross/skylands
 	id = "Sky Island Relay"
 	listening_level = Z_LEVEL_SURFACE_SKYLANDS
 	autolinkers = list("sky_relay")
+*/
 
 /obj/machinery/telecomms/relay/preset/southerncross/valley
 	id = "Valley Relay"
@@ -100,8 +102,9 @@ var/const/NETWORK_CARRIER  = "Exploration Carrier" //CHOMPedit: Exploration outp
 	id = "Hub"
 	network = "tcommsat"
 	autolinkers = list("hub",
-		"d1_relay", "d2_relay", "d3_relay", "pnt_relay", "cve_relay", "wld_relay", "tns_relay", "cnt_relay", "explorer", "exp_relay", "sky_relay", "valley_relay",
+		"d1_relay", "d2_relay", "d3_relay", "pnt_relay", "cve_relay", "wld_relay", "tns_relay", "cnt_relay", "explorer", "exp_relay", "valley_relay",
 		//"belt_relay", // Chompstation edit - adds belt outpost to relays.	Temp Removal of Belt Relay TFF 15/2/20, Added Valley comn stuff 2/14/2023
+		//"sky_relay", // Sky islands removal due to lack of use
 		"science", "medical", "supply", "service", "common", "command", "engineering", "security", "unused",
 		"hb_relay", "receiverA", "broadcasterA"
 	) //CHOMPedit: Adds "exp_relay"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Removes the sky islands, a fairly unused part of the Z layers.
Also touches up the wilderness shelter to move it's components down to the now single Z.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Wilderness shelter now flattened, thank you Bib bob
del: sky islands removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
