### PR TITLE
Makes scrubbers deal with the final trace of a scrubbed gas

### DIFF
--- a/code/ATMOSPHERICS/_atmospherics_helpers.dm
+++ b/code/ATMOSPHERICS/_atmospherics_helpers.dm
@@ -120,7 +120,7 @@
 			//ChompEDIT Start - scrub the remainding trace
 			if (source.gas[g] > 0.0)
 				source.gas[g] = 0
-				sink.adjust_gas(g, source.gas[g], update=0)
+				sink.adjust_gas(g, source.gas[g], update=1)
 			//ChompEDIT End
 			continue
 

--- a/code/ATMOSPHERICS/_atmospherics_helpers.dm
+++ b/code/ATMOSPHERICS/_atmospherics_helpers.dm
@@ -119,8 +119,8 @@
 		if (source.gas[g] < MINIMUM_MOLES_TO_FILTER)
 			//ChompEDIT Start - scrub the remainding trace
 			if (source.gas[g] > 0.0)
-				source.gas[g] = 0
-				sink.adjust_gas(g, source.gas[g], update=1)
+				sink.adjust_gas(g, source.gas[g], update=0)
+				source.gas -= g
 			//ChompEDIT End
 			continue
 

--- a/code/ATMOSPHERICS/_atmospherics_helpers.dm
+++ b/code/ATMOSPHERICS/_atmospherics_helpers.dm
@@ -124,7 +124,18 @@
 		total_filterable_moles += source.gas[g]
 
 	if (total_filterable_moles < MINIMUM_MOLES_TO_FILTER) //if we cant transfer enough gas just stop to avoid further processing
+		//ChompEDIT START - make sure scrubbing finishes. This just kills the remnant gasses for free
+		if(total_filterable_moles > 0)
+			for (var/g in filtering)
+				var/srcgas = source.gas[g]
+				if (srcgas < 0)
+					source.adjust_gas(g, -srcgas, update=0)
+					sink.adjust_gas_temp(g, srcgas, source.temperature, update=0)
+			sink.update_values()
+			source.update_values()
+		//ChompEDIT END
 		return -1
+
 
 	//now that we know the total amount of filterable gas, we can calculate the amount of power needed to scrub one mole of gas
 	var/total_specific_power = 0		//the power required to remove one mole of filterable gas
@@ -439,7 +450,7 @@
 		var/sink_heat_capacity = sink.heat_capacity()
 		var/transfer_heat_capacity = source.heat_capacity()*estimate_moles/source_total_moles
 		air_temperature = (sink.temperature*sink_heat_capacity  + source.temperature*transfer_heat_capacity) / (sink_heat_capacity + transfer_heat_capacity)
-	
+
 	//get the number of moles that would have to be transfered to bring sink to the target pressure
 	return pressure_delta*output_volume/(air_temperature * R_IDEAL_GAS_EQUATION)
 

--- a/code/ATMOSPHERICS/_atmospherics_helpers.dm
+++ b/code/ATMOSPHERICS/_atmospherics_helpers.dm
@@ -117,6 +117,11 @@
 	var/list/specific_power_gas = list()	//the power required to remove one mole of pure gas, for each gas type
 	for (var/g in filtering)
 		if (source.gas[g] < MINIMUM_MOLES_TO_FILTER)
+			//ChompEDIT Start - scrub the remainding trace
+			if (source.gas[g] > 0.0)
+				source.gas[g] = 0
+				sink.adjust_gas(g, source.gas[g], update=0)
+			//ChompEDIT End
 			continue
 
 		var/specific_power = calculate_specific_power_gas(g, source, sink)/ATMOS_FILTER_EFFICIENCY
@@ -439,7 +444,7 @@
 		var/sink_heat_capacity = sink.heat_capacity()
 		var/transfer_heat_capacity = source.heat_capacity()*estimate_moles/source_total_moles
 		air_temperature = (sink.temperature*sink_heat_capacity  + source.temperature*transfer_heat_capacity) / (sink_heat_capacity + transfer_heat_capacity)
-	
+
 	//get the number of moles that would have to be transfered to bring sink to the target pressure
 	return pressure_delta*output_volume/(air_temperature * R_IDEAL_GAS_EQUATION)
 

--- a/code/ATMOSPHERICS/_atmospherics_helpers.dm
+++ b/code/ATMOSPHERICS/_atmospherics_helpers.dm
@@ -124,18 +124,7 @@
 		total_filterable_moles += source.gas[g]
 
 	if (total_filterable_moles < MINIMUM_MOLES_TO_FILTER) //if we cant transfer enough gas just stop to avoid further processing
-		//ChompEDIT START - make sure scrubbing finishes. This just kills the remnant gasses for free
-		if(total_filterable_moles > 0)
-			for (var/g in filtering)
-				var/srcgas = source.gas[g]
-				if (srcgas < 0)
-					source.adjust_gas(g, -srcgas, update=0)
-					sink.adjust_gas_temp(g, srcgas, source.temperature, update=0)
-			sink.update_values()
-			source.update_values()
-		//ChompEDIT END
 		return -1
-
 
 	//now that we know the total amount of filterable gas, we can calculate the amount of power needed to scrub one mole of gas
 	var/total_specific_power = 0		//the power required to remove one mole of filterable gas
@@ -450,7 +439,7 @@
 		var/sink_heat_capacity = sink.heat_capacity()
 		var/transfer_heat_capacity = source.heat_capacity()*estimate_moles/source_total_moles
 		air_temperature = (sink.temperature*sink_heat_capacity  + source.temperature*transfer_heat_capacity) / (sink_heat_capacity + transfer_heat_capacity)
-
+	
 	//get the number of moles that would have to be transfered to bring sink to the target pressure
 	return pressure_delta*output_volume/(air_temperature * R_IDEAL_GAS_EQUATION)
 

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -191,11 +191,11 @@
 
 #undef SPECIFIC_ENTROPY_VACUUM
 
-//Updates the total_moles count and trims any empty gases. //ChompEDIT Also trims gases below the minimum filter threshold
+//Updates the total_moles count and trims any empty gases.
 /datum/gas_mixture/proc/update_values()
 	total_moles = 0
 	for(var/g in gas)
-		if(gas[g] <= MINIMUM_MOLES_TO_FILTER) //chompEDIT MINIMUM_MOLES_TO_FILTER instead of 0, prevents stuck gases
+		if(gas[g] <= 0)
 			gas -= g
 		else
 			total_moles += gas[g]

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -191,11 +191,11 @@
 
 #undef SPECIFIC_ENTROPY_VACUUM
 
-//Updates the total_moles count and trims any empty gases.
+//Updates the total_moles count and trims any empty gases. //ChompEDIT Also trims gases below the minimum filter threshold
 /datum/gas_mixture/proc/update_values()
 	total_moles = 0
 	for(var/g in gas)
-		if(gas[g] <= 0)
+		if(gas[g] <= MINIMUM_MOLES_TO_FILTER) //chompEDIT MINIMUM_MOLES_TO_FILTER instead of 0, prevents stuck gases
 			gas -= g
 		else
 			total_moles += gas[g]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

An annoying thing for atmospherics, a leak would always leave a trace gas behind that was unscrubbable. This will scrub it. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
code: Atmos scrubbers kill the final trace left behind after their minimum threshold for scrubbing is passed. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
