### PR TITLE
Butchering metroids drops their meat

### DIFF
--- a/modular_chomp/code/modules/mob/living/simple_mob/butchering.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/butchering.dm
@@ -9,6 +9,7 @@
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/deathclawmeat
 
 /mob/living/simple_mob/metroid
+	meat_amount = 6
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/metroidmeat
 
 /mob/living/simple_mob/metroid/can_butcher(var/mob/user, var/obj/item/I)	// Override for special butchering checks.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds the missing amount of meat that a metroid should have been dropping, allowing them to be butchered.
<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Added an amount of meat to drop to metroids
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
