### PR TITLE
Remove guide comments workflow

### DIFF
--- a/.github/workflows/remove_guide_comments.yml
+++ b/.github/workflows/remove_guide_comments.yml
@@ -1,0 +1,18 @@
+# Removes guide comments from PRs when opened, so that when we merge them
+# and reuse the pull request description, the clutter is not left behind
+name: Remove guide comments
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  remove_guide_comments:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Remove guide comments
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { removeGuideComments } = await import('${{ github.workspace }}/tools/pull_request_hooks/removeGuideComments.js')
+          await removeGuideComments({ github, context })

--- a/.github/workflows/remove_guide_comments.yml
+++ b/.github/workflows/remove_guide_comments.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Remove guide comments
       uses: actions/github-script@v6
       with:

--- a/tools/pull_request_hooks/removeGuideComments.js
+++ b/tools/pull_request_hooks/removeGuideComments.js
@@ -1,0 +1,41 @@
+import fs from "fs";
+
+const REGEX_COMMENT = /<!--.+?-->/g;
+
+// Make sure we only remove default comments
+const comments = [];
+
+for (const match of fs
+  .readFileSync(".github/PULL_REQUEST_TEMPLATE.md", { encoding: "utf8" })
+  .matchAll(REGEX_COMMENT)) {
+  comments.push(match[0]);
+}
+
+function escapeRegex(string) {
+  return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&");
+}
+
+export async function removeGuideComments({ github, context }) {
+  let newBody = context.payload.pull_request.body;
+
+  if (!newBody) {
+	console.log("PR body is empty, skipping...");
+	return;
+  }
+
+  for (const comment of comments) {
+    newBody = newBody.replace(
+      new RegExp(`^\\s*${escapeRegex(comment)}\\s*`, "gm"),
+      "\n"
+    );
+  }
+
+  if (newBody !== context.payload.pull_request.body) {
+    await github.rest.pulls.update({
+      pull_number: context.payload.pull_request.number,
+      repo: context.repo.repo,
+      owner: context.repo.owner,
+      body: newBody,
+    });
+  }
+}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
This workflow will automatically remove the guide comments from PRs (when editing the description).

<!-- This is a custom comment and should not be removed! -->

There is a custom comment above this line (invisible if not editing the PR).
It should not disappear after posting the PR.
<!-- Describe The Pull Request. -->

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
