### PR TITLE
[READY TO MERGE] Public Sheet Storage, Timeclock Changes

### DIFF
--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -221,7 +221,7 @@
 /obj/machinery/computer/timeclock/proc/checkCardCooldown()
 	if(!card)
 		return FALSE
-	var/time_left = 10 MINUTES - (world.time - card.last_job_switch)
+	var/time_left = 1 MINUTE - (world.time - card.last_job_switch) // CHOMPedit: 10 minute wait down to 1 minute.
 	if(time_left > 0)
 		to_chat(usr, "You need to wait another [round((time_left/10)/60, 1)] minute\s before you can switch.")
 		return FALSE
@@ -231,7 +231,8 @@
 	if(!card)
 		to_chat(usr, "<span class='notice'>No ID is inserted.</span>")
 		return FALSE
-	var/mob/living/carbon/human/H = usr
+/* CHOMPedit start.
+	var/mob/living/carbon/human/H = usr // CHOMPedit start - Allows anyone to change people's IDs.
 	if(!(istype(H)))
 		to_chat(usr, "<span class='warning'>Invalid user detected. Access denied.</span>")
 		return FALSE
@@ -241,6 +242,7 @@
 	else if(H.get_face_name() == "Unknown" || !(H.real_name == card.registered_name))
 		to_chat(usr, "<span class='warning'>Facial recognition scan failed. Access denied.</span>")
 		return FALSE
+CHOMPedit end. */
 	else
 		return TRUE
 

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -245,9 +245,9 @@
 		return FALSE
 CHOMPedit end. */
 	else
-		return TRUE
 		message_admins("[key_name_admin(usr)] has modified '[card.registered_name]' 's ID with a timeclock terminal. [ADMIN_JMP(location)]") // CHOMPedit: Logging
 		log_game("[key_name_admin(usr)] has modified '[card.registered_name]' 's ID with a timeclock terminal.") // CHOMPedit: Logging
+		return TRUE
 
 /obj/item/weapon/card/id
 	var/last_job_switch

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -228,11 +228,12 @@
 	return TRUE
 
 /obj/machinery/computer/timeclock/proc/checkFace()
+	var/turf/location = get_turf(src) // CHOMPedit: Needed for admin logs.
 	if(!card)
 		to_chat(usr, "<span class='notice'>No ID is inserted.</span>")
 		return FALSE
-/* CHOMPedit start.
-	var/mob/living/carbon/human/H = usr // CHOMPedit start - Allows anyone to change people's IDs.
+/* CHOMPedit start. Allows anyone to change people's IDs.
+	var/mob/living/carbon/human/H = usr
 	if(!(istype(H)))
 		to_chat(usr, "<span class='warning'>Invalid user detected. Access denied.</span>")
 		return FALSE
@@ -245,6 +246,8 @@
 CHOMPedit end. */
 	else
 		return TRUE
+		message_admins("[key_name_admin(usr)] has modified '[card.registered_name]' 's ID with a timeclock terminal. [ADMIN_JMP(location)]") // CHOMPedit: Logging
+		log_game("[key_name_admin(usr)] has modified '[card.registered_name]' 's ID with a timeclock terminal.") // CHOMPedit: Logging
 
 /obj/item/weapon/card/id
 	var/last_job_switch

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -55176,9 +55176,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 9
 	},
-/obj/machinery/smartfridge/sheets{
-	density = 0
-	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/rnd/lab)
 "iKA" = (
@@ -57897,6 +57895,16 @@
 /obj/effect/floor_decal/corner/green/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
+"kar" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/smartfridge/sheets/persistent_lossy,
+/obj/structure/fans/tiny,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/rnd/lab)
 "kay" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -123316,7 +123324,7 @@ iOI
 jUw
 kSM
 aGg
-kTh
+kar
 nRd
 kTh
 aGg

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -57898,7 +57898,10 @@
 "kar" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/fans/tiny,
-/obj/machinery/smartfridge/sheets/persistent_lossy,
+/obj/machinery/smartfridge/sheets/persistent_lossy{
+	name = "\improper Persistent Industrial Sheet Storage";
+	desc = "An industrial sized storage unit for materials. Following company policy with B-Shift, this particular storage unit will retain a percentage of its material in-between crew transfers."
+	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -58417,6 +58420,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
+"kod" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/smartfridge/sheets{
+	name = "\improper Non-Persistent Industrial Sheet Storage";
+	desc = "An industrial sized storage unit for materials. B-Shift's agreement to retain materials doesn't extend to this storage device, so you should probably only stock this with sheets you need."
+	},
+/obj/structure/fans/tiny,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/rnd/lab)
 "kot" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -123327,7 +123343,7 @@ iOI
 jUw
 kSM
 aGg
-kTh
+kod
 nRd
 kTh
 aGg

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -57897,14 +57897,17 @@
 /area/hallway/secondary/docking_hallway2)
 "kar" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/smartfridge/sheets/persistent_lossy,
 /obj/structure/fans/tiny,
-/obj/structure/window/reinforced,
+/obj/machinery/smartfridge/sheets/persistent_lossy,
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
 	},
 /turf/simulated/floor/plating,
-/area/rnd/lab)
+/area/quartermaster/office)
 "kay" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -106057,7 +106060,7 @@ bYD
 bRG
 bqo
 bqn
-bsn
+kar
 bug
 bCU
 bEJ
@@ -123324,7 +123327,7 @@ iOI
 jUw
 kSM
 aGg
-kar
+kTh
 nRd
 kTh
 aGg


### PR DESCRIPTION
:cl:
qol: Timeclock cooldown down to 1 minute, everyone can set anyone else to off-duty.
maptweak: Moved science's sheet storage to lobby to make it publicly accessible. Changed it to persistent lossy, which means stored sheets will transfer between rounds at a loss.
/:cl: