### PR TITLE
Fix observer/move (Shields not following you)

### DIFF
--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -32,6 +32,12 @@ GLOBAL_DATUM_INIT(moved_event, /decl/observ/moved, new)
 	. = ..()
 	am.RegisterSignal(src,COMSIG_OBSERVER_MOVED, /atom/movable/proc/recursive_move, override = TRUE)
 
+/atom/movable/Initialize(mapload)
+	. = ..()
+	if(istype(loc, /atom/movable)) // on initialise, if i'm inside a thing, preregister this.
+		var/atom/movable/am = loc
+		RegisterSignal(am, COMSIG_OBSERVER_MOVED, /atom/movable/proc/recursive_move, override = TRUE)
+
 /atom/movable/Exited(var/atom/movable/am, atom/old_loc)
 	. = ..()
 	am.UnregisterSignal(src,COMSIG_OBSERVER_MOVED)


### PR DESCRIPTION


:cl:
fix: observer_move applied on init (if in a mob) as well as enter and exit
/:cl:
