### PR TITLE
Fixes a mistake made in SSmachines upgrade that made conveyors not work

### DIFF
--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -33,7 +33,6 @@ SUBSYSTEM_DEF(machines)
 /datum/controller/subsystem/machines/Initialize(timeofday)
 	makepowernets()
 	admin_notice("<span class='danger'>Initializing atmos machinery.</span>", R_DEBUG)
-	machines = all_machines //stupid god damn globals
 	setup_atmos_machinery(all_machines)
 	fire()
 	..()

--- a/code/global.dm
+++ b/code/global.dm
@@ -1,6 +1,6 @@
 // Items that ask to be called every cycle.
 var/global/datum/datacore/data_core = null
-var/global/list/machines                 = list()	// ALL Machines, wether processing or not.
+var/global/list/machines                 = SSmachines.all_machines //I would upgrade all instances of global.machines to SSmachines.all_machines but it's used in so many places and a search returns so many matches for 'machines' that isn't a use of the global...
 
 var/global/list/active_diseases          = list()
 var/global/list/hud_icon_reference       = list()


### PR DESCRIPTION
fixes a mistake i made here
https://github.com/CHOMPStation2/CHOMPStation2/pull/7855

:cl:
fix: globals referencing order mistake in SSmachines
/:cl:
