### PR TITLE
Subsystem return update

### DIFF
--- a/code/__defines/dcs/signals_ch/signals_subsystem.dm
+++ b/code/__defines/dcs/signals_ch/signals_subsystem.dm
@@ -1,0 +1,7 @@
+// Subsystem signals. Format:
+// When the signal is called: (signal arguments)
+// All signals send the source datum of the signal as the first argument
+
+///Subsystem signals
+///From base of datum/controller/subsystem/Initialize
+#define COMSIG_SUBSYSTEM_POST_INITIALIZE "subsystem_post_initialize"

--- a/code/__defines/span_vr.dm
+++ b/code/__defines/span_vr.dm
@@ -94,6 +94,7 @@
 #define span_orange(str) ("<span class='orange'>" + str + "</span>")
 #define span_blue(str) ("<span class='blue'>" + str + "</span>")
 #define span_boldannounce(str) ("<span class='boldannounce'>" + str + "</span>") // CHOMPEdit - Boldannounce
+#define span_boldwarning(str) ("<span class='boldwarning'>" + str + "</span>") // CHOMPEdit - Boldwarning
 #define span_green(str) ("<span class='green'>" + str + "</span>")
 #define span_purple(str) ("<span class='purple'>" + str + "</span>")
 #define span_yellow(str) ("<span class='yellow'>" + str + "</span>")

--- a/code/__defines/subsystems.dm
+++ b/code/__defines/subsystems.dm
@@ -181,3 +181,6 @@ var/global/list/runlevel_flags = list(RUNLEVEL_LOBBY, RUNLEVEL_SETUP, RUNLEVEL_G
 	* * timer_subsystem the subsystem to insert this timer into
 */
 #define addtimer(args...) _addtimer(args, file = __FILE__, line = __LINE__)
+
+/// The timer key used to know how long subsystem initialization takes // CHOMPEdit
+#define SS_INIT_TIMER_KEY "ss_init" // CHOMPEdit

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -59,10 +59,6 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 
 	var/current_runlevel //!for scheduling different subsystems for different stages of the round
 
-	/// During initialization, will be the instanced subsytem that is currently initializing.
-	/// Outside of initialization, returns null.
-	var/current_initializing_subsystem = null
-
 	// CHOMPEdit Start
 	/// During initialization, will be the instanced subsytem that is currently initializing.
 	/// Outside of initialization, returns null.

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -63,6 +63,12 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	/// Outside of initialization, returns null.
 	var/current_initializing_subsystem = null
 
+	// CHOMPEdit Start
+	/// During initialization, will be the instanced subsytem that is currently initializing.
+	/// Outside of initialization, returns null.
+	var/current_initializing_subsystem = null
+	// CHOMPEdit End
+
 	var/static/restart_clear = 0
 	var/static/restart_timeout = 0
 	var/static/restart_count = 0
@@ -207,8 +213,10 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	for (var/datum/controller/subsystem/SS in subsystems)
 		if (SS.flags & SS_NO_INIT)
 			continue
-		SS.Initialize(REALTIMEOFDAY)
+		//SS.Initialize(REALTIMEOFDAY) // CHOMPEdit
+		init_subsystem(SS) // CHOMPEdit
 		CHECK_TICK
+	current_initializing_subsystem = null // CHOMPEdit
 	current_ticklimit = TICK_LIMIT_RUNNING
 	var/time = (REALTIMEOFDAY - start_timeofday) / 10
 
@@ -238,6 +246,82 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 	initializations_finished_with_no_players_logged_in = initialized_tod < REALTIMEOFDAY - 10
 	// Loop.
 	Master.StartProcessing(0)
+
+// CHOMPEdit Start
+/**
+ * Initialize a given subsystem and handle the results.
+ *
+ * Arguments:
+ * * subsystem - the subsystem to initialize.
+ */
+/datum/controller/master/proc/init_subsystem(datum/controller/subsystem/subsystem)
+	var/static/list/valid_results = list(
+		SS_INIT_FAILURE,
+		SS_INIT_NONE,
+		SS_INIT_SUCCESS,
+		SS_INIT_NO_NEED,
+	)
+
+	if (subsystem.flags & SS_NO_INIT || subsystem.subsystem_initialized) //Don't init SSs with the corresponding flag or if they already are initialized
+		return
+
+	current_initializing_subsystem = subsystem
+	rustg_time_reset(SS_INIT_TIMER_KEY)
+
+	var/result = subsystem.Initialize()
+
+	// Capture end time
+	var/time = rustg_time_milliseconds(SS_INIT_TIMER_KEY)
+	var/seconds = round(time / 1000, 0.01)
+
+	// Always update the blackbox tally regardless.
+	// SSblackbox.record_feedback("tally", "subsystem_initialize", time, subsystem.name)
+	feedback_set_details("subsystem_initialize", "[time] [subsystem.name]")
+
+	// Gave invalid return value.
+	if(result && !(result in valid_results))
+		warning("[subsystem.name] subsystem initialized, returning invalid result [result]. This is a bug.")
+
+	// just returned ..() or didn't implement Initialize() at all
+	if(result == SS_INIT_NONE)
+		warning("[subsystem.name] subsystem does not implement Initialize() or it returns ..(). If the former is true, the SS_NO_INIT flag should be set for this subsystem.")
+
+	if(result != SS_INIT_FAILURE)
+		// Some form of success, implicit failure, or the SS in unused.
+		subsystem.subsystem_initialized = TRUE
+
+		SEND_SIGNAL(subsystem, COMSIG_SUBSYSTEM_POST_INITIALIZE)
+	else
+		// The subsystem officially reports that it failed to init and wishes to be treated as such.
+		subsystem.subsystem_initialized = FALSE
+		subsystem.can_fire = FALSE
+
+	// The rest of this proc is printing the world log and chat message.
+	var/message_prefix
+
+	// If true, print the chat message with boldwarning text.
+	var/chat_warning = FALSE
+
+	switch(result)
+		if(SS_INIT_FAILURE)
+			message_prefix = "Failed to initialize [subsystem.name] subsystem after"
+			chat_warning = TRUE
+		if(SS_INIT_SUCCESS)
+			message_prefix = "Initialized [subsystem.name] subsystem within"
+		if(SS_INIT_NO_NEED)
+			// This SS is disabled or is otherwise shy.
+			return
+		else
+			// SS_INIT_NONE or an invalid value.
+			message_prefix = "Initialized [subsystem.name] subsystem with errors within"
+			chat_warning = TRUE
+
+	var/message = "[message_prefix] [seconds] second[seconds == 1 ? "" : "s"]!"
+	var/chat_message = chat_warning ? span_boldwarning(message) : span_boldannounce(message)
+
+	to_chat(world, chat_message)
+	log_world(message)
+// CHOMPEdit End
 
 /datum/controller/master/proc/SetRunLevel(new_runlevel)
 	var/old_runlevel = isnull(current_runlevel) ? "NULL" : runlevel_flags[current_runlevel]

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -224,15 +224,13 @@
 		if(SS_SLEEPING)
 			state = SS_PAUSING
 
-
-//used to initialize the subsystem AFTER the map has loaded
-/datum/controller/subsystem/Initialize(start_timeofday)
-	subsystem_initialized = TRUE
-	var/time = (REALTIMEOFDAY - start_timeofday) / 10
-	var/msg = "Initialized [name] subsystem within [time] second[time == 1 ? "" : "s"]!"
-	to_chat(world, "<span class='boldannounce'>[msg]</span>")
-	log_world(msg)
-	return time
+// CHOMPEdit Start
+/**
+ * Used to initialize the subsystem. This is expected to be overriden by subtypes.
+ */
+/datum/controller/subsystem/Initialize()
+	return SS_INIT_NONE
+// CHOMPEdit End
 
 //hook for printing stats to the "MC" statuspanel for admins to see performance and related stats etc.
 //CHOMPEdit Begin

--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -33,7 +33,8 @@ SUBSYSTEM_DEF(air)
 /datum/controller/subsystem/air/PreInit()
 	air_master = src
 
-/datum/controller/subsystem/air/Initialize(timeofday)
+/datum/controller/subsystem/air/Initialize() // CHOMPEdit
+	var/start_timeofday = REALTIMEOFDAY // CHOMPEdit
 	report_progress("Processing Geometry...")
 
 	current_cycle = 0
@@ -43,7 +44,8 @@ SUBSYSTEM_DEF(air)
 		S.update_air_properties()
 		CHECK_TICK
 
-	admin_notice({"<span class='danger'>Geometry initialized in [round(0.1*(REALTIMEOFDAY-timeofday),0.1)] seconds.</span>
+	// CHOMPEdit
+	admin_notice({"<span class='danger'>Geometry initialized in [round(0.1*(REALTIMEOFDAY-start_timeofday),0.1)](?) seconds.</span>
 <span class='info'>
 Total Simulated Turfs: [simulated_turf_count]
 Total Zones: [zones.len]
@@ -98,7 +100,7 @@ Total Unsimulated Turfs: [world.maxx*world.maxy*world.maxz - simulated_turf_coun
 		log_debug("Active Edges on ZAS Startup\n" + edge_log.Join("\n"))
 		startup_active_edge_log = edge_log.Copy()
 
-	..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/air/fire(resumed = 0)
 	var/timer

--- a/code/controllers/subsystems/alarm.dm
+++ b/code/controllers/subsystems/alarm.dm
@@ -18,7 +18,7 @@ SUBSYSTEM_DEF(alarm)
 
 /datum/controller/subsystem/alarm/Initialize()
 	all_handlers = list(atmosphere_alarm, camera_alarm, fire_alarm, motion_alarm, power_alarm)
-	. = ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/alarm/fire(resumed = FALSE)
 	if(!resumed)

--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -17,13 +17,13 @@ SUBSYSTEM_DEF(atoms)
 
 	var/list/BadInitializeCalls = list()
 
-/datum/controller/subsystem/atoms/Initialize(timeofday)
+/datum/controller/subsystem/atoms/Initialize() // CHOMPEdit
 	setupgenetics() //to set the mutations' place in structural enzymes, so initializers know where to put mutations.
 	initialized = INITIALIZATION_INNEW_MAPLOAD
 	to_world_log("Initializing objects")
 	admin_notice("<span class='danger'>Initializing objects</span>", R_DEBUG)
 	InitializeAtoms()
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/atoms/proc/InitializeAtoms(list/atoms)
 	if(initialized == INITIALIZATION_INSSATOMS)

--- a/code/controllers/subsystems/character_setup.dm
+++ b/code/controllers/subsystems/character_setup.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(character_setup)
 	name = "Character Setup"
 	init_order = INIT_ORDER_DEFAULT
 	priority = FIRE_PRIORITY_CHARSETUP
-	flags = SS_BACKGROUND
+	flags = SS_BACKGROUND | SS_NO_INIT // CHOMPEdit
 	wait = 1 SECOND
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 

--- a/code/controllers/subsystems/chemistry.dm
+++ b/code/controllers/subsystems/chemistry.dm
@@ -18,7 +18,7 @@ SUBSYSTEM_DEF(chemistry)
 /datum/controller/subsystem/chemistry/Initialize()
 	initialize_chemical_reagents()
 	initialize_chemical_reactions()
-	..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 //CHOMPEdit Begin
 /datum/controller/subsystem/chemistry/stat_entry(msg)

--- a/code/controllers/subsystems/circuits.dm
+++ b/code/controllers/subsystems/circuits.dm
@@ -17,9 +17,9 @@ SUBSYSTEM_DEF(circuit)
 /datum/controller/subsystem/circuit/Recover()
 	flags |= SS_NO_INIT // Make extra sure we don't initialize twice.
 
-/datum/controller/subsystem/circuit/Initialize(timeofday)
+/datum/controller/subsystem/circuit/Initialize() // CHOMPEdit
 	circuits_init()
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/circuit/proc/circuits_init()
 	//Cached lists for free performance

--- a/code/controllers/subsystems/dbcore.dm
+++ b/code/controllers/subsystems/dbcore.dm
@@ -41,7 +41,7 @@ SUBSYSTEM_DEF(dbcore)
 	//var/db_daemon_started = FALSE
 
 /datum/controller/subsystem/dbcore/Initialize()
-	return ..()
+	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/dbcore/stat_entry(msg)
 	msg = "P:[length(all_queries)]|Active:[length(queries_active)]|Standby:[length(queries_standby)]"

--- a/code/controllers/subsystems/events.dm
+++ b/code/controllers/subsystems/events.dm
@@ -21,7 +21,7 @@ SUBSYSTEM_DEF(events)
 		)
 	if(global.using_map.use_overmap)
 		GLOB.overmap_event_handler.create_events(global.using_map.overmap_z, global.using_map.overmap_size, global.using_map.overmap_event_areas)
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/events/fire(resumed)
 	if (!resumed)

--- a/code/controllers/subsystems/game_master.dm
+++ b/code/controllers/subsystems/game_master.dm
@@ -36,7 +36,7 @@ SUBSYSTEM_DEF(game_master)
 	if(config && !config.enable_game_master)
 		can_fire = FALSE
 
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/game_master/fire(resumed)
 	adjust_staleness(1)

--- a/code/controllers/subsystems/holomaps.dm
+++ b/code/controllers/subsystems/holomaps.dm
@@ -14,9 +14,9 @@ SUBSYSTEM_DEF(holomaps)
 /datum/controller/subsystem/holomaps/Recover()
 	flags |= SS_NO_INIT // Make extra sure we don't initialize twice.
 
-/datum/controller/subsystem/holomaps/Initialize(timeofday)
+/datum/controller/subsystem/holomaps/Initialize() // CHOMPEdit
 	generateHoloMinimaps()
-	. = ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/holomaps/stat_entry(msg)
 	if (!Debug2)

--- a/code/controllers/subsystems/input.dm
+++ b/code/controllers/subsystems/input.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(input)
 	name = "Input"
 	wait = 1 // SS_TICKER means this runs every tick
 	init_order = INIT_ORDER_INPUT
-	flags = SS_TICKER
+	flags = SS_TICKER | SS_NO_INIT // CHOMPEdit
 	priority = FIRE_PRIORITY_INPUT
 	runlevels = RUNLEVELS_DEFAULT | RUNLEVEL_LOBBY
 

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -11,12 +11,12 @@ SUBSYSTEM_DEF(job)
 	var/debug_messages = FALSE
 
 
-/datum/controller/subsystem/job/Initialize(timeofday)
+/datum/controller/subsystem/job/Initialize() // CHOMPEdit
 	if(!department_datums.len)
 		setup_departments()
 	if(!occupations.len)
 		setup_occupations()
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/job/proc/setup_occupations(faction = "Station")
 	occupations = list()

--- a/code/controllers/subsystems/lighting.dm
+++ b/code/controllers/subsystems/lighting.dm
@@ -12,7 +12,7 @@ SUBSYSTEM_DEF(lighting)
 	return ..()
 
 
-/datum/controller/subsystem/lighting/Initialize(timeofday)
+/datum/controller/subsystem/lighting/Initialize() // CHOMPEdit
 	if(!subsystem_initialized)
 		if (config.starlight)
 			for(var/area/A in world)
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(lighting)
 
 	fire(FALSE, TRUE)
 
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/lighting/fire(resumed, init_tick_checks)
 	MC_SPLIT_TICK_INIT(3)

--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -30,12 +30,12 @@ SUBSYSTEM_DEF(machines)
 	var/list/powernets = list()
 	var/list/powerobjs = list()
 
-/datum/controller/subsystem/machines/Initialize(timeofday)
+/datum/controller/subsystem/machines/Initialize() // CHOMPEdit
 	makepowernets()
 	admin_notice("<span class='danger'>Initializing atmos machinery.</span>", R_DEBUG)
 	setup_atmos_machinery(all_machines)
 	fire()
-	..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/machines/fire(resumed = 0)
 	var/timer = TICK_USAGE

--- a/code/controllers/subsystems/mail_ch.dm
+++ b/code/controllers/subsystems/mail_ch.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(mail)
 	wait = 60 SECONDS
 	priority = FIRE_PRIORITY_SUPPLY
 
-	flags = SS_NO_TICK_CHECK
+	flags = SS_NO_TICK_CHECK | SS_NO_INIT
 
 	var/mail_waiting = 0					// Pending mail
 	var/mail_per_process = 0.45				// Mail to be generated

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -13,7 +13,7 @@ SUBSYSTEM_DEF(mapping)
 	flags |= SS_NO_INIT // Make extra sure we don't initialize twice.
 	shelter_templates = SSmapping.shelter_templates
 
-/datum/controller/subsystem/mapping/Initialize(timeofday)
+/datum/controller/subsystem/mapping/Initialize() // CHOMPEdit
 	if(subsystem_initialized)
 		return
 	world.max_z_changed() // This is to set up the player z-level list, maxz hasn't actually changed (probably)
@@ -31,7 +31,7 @@ SUBSYSTEM_DEF(mapping)
 	// Lateload Code related to Expedition areas.
 	if(using_map) // VOREStation Edit: Re-enable this.
 		loadLateMaps()
-	..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/mapping/proc/load_map_templates()
 	for(var/datum/map_template/template as anything in subtypesof(/datum/map_template))

--- a/code/controllers/subsystems/media_tracks.dm
+++ b/code/controllers/subsystems/media_tracks.dm
@@ -13,10 +13,10 @@ SUBSYSTEM_DEF(media_tracks)
 	var/list/casino_tracks = list()
 	/// CHOMPstation edit end
 
-/datum/controller/subsystem/media_tracks/Initialize(timeofday)
+/datum/controller/subsystem/media_tracks/Initialize() // CHOMPEdit
 	load_tracks()
 	sort_tracks()
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/media_tracks/proc/load_tracks()
 	for(var/filename in config.jukebox_track_files)

--- a/code/controllers/subsystems/nightshift.dm
+++ b/code/controllers/subsystems/nightshift.dm
@@ -17,7 +17,7 @@ SUBSYSTEM_DEF(nightshift)
 	if(config.randomize_shift_time)
 		GLOB.gametime_offset = rand(0, 23) HOURS
 	*/
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/nightshift/fire(resumed = FALSE)
 	if(round_duration_in_ds < nightshift_first_check)

--- a/code/controllers/subsystems/overlays.dm
+++ b/code/controllers/subsystems/overlays.dm
@@ -27,15 +27,15 @@ SUBSYSTEM_DEF(overlays)
 		atom.flags &= ~OVERLAY_QUEUED
 		CHECK_TICK
 
-
-/datum/controller/subsystem/overlays/Initialize(timeofday)
-	fire(FALSE, TRUE)
-	..()
 //CHOMPEdit Begin
+/datum/controller/subsystem/overlays/Initialize()
+	fire(FALSE, TRUE)
+	return SS_INIT_SUCCESS
+
 /datum/controller/subsystem/overlays/stat_entry(msg)
 	msg = "Queued Atoms: [queue.len], Cache Size: [cache_size]"
 	return ..()
-//CHOMPEdit End
+
 /datum/controller/subsystem/overlays/fire(resumed, no_mc_tick)
 	var/count = 1
 	for (var/atom/atom as anything in queue)

--- a/code/controllers/subsystems/overmap_renamer_vr.dm
+++ b/code/controllers/subsystems/overmap_renamer_vr.dm
@@ -8,12 +8,9 @@ SUBSYSTEM_DEF(overmap_renamer)
 	runlevels = RUNLEVEL_INIT
 	flags = SS_NO_FIRE
 
-
-
-/datum/controller/subsystem/overmap_renamer/Initialize(timeofday)
+/datum/controller/subsystem/overmap_renamer/Initialize() // CHOMPEdit
 	update_names()
-
-	..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /*Shouldn't be a switch statement. We want ALL of the if(map_template.name in visitable_z_leves_name_list) to fire
 if we end up with multiple renamable lateload overmap objects.*/

--- a/code/controllers/subsystems/persistence.dm
+++ b/code/controllers/subsystems/persistence.dm
@@ -4,19 +4,21 @@ SUBSYSTEM_DEF(persistence)
 	flags = SS_NO_FIRE
 	var/list/tracking_values = list()
 	var/list/persistence_datums = list()
-	
+
 	/// Places our subsystem can spawn paintings (helps with art spawning differently across maps)
 	var/list/obj/structure/sign/painting/painting_frames = list()
 	var/list/all_paintings = list()
 	var/list/unpicked_paintings = list()
 
+// CHOMPEdit Start
 /datum/controller/subsystem/persistence/Initialize()
-	. = ..()
 	for(var/datum/persistent/P as anything in subtypesof(/datum/persistent))
 		if(initial(P.name))
 			P = new P
 			persistence_datums[P.type] = P
 			P.Initialize()
+	return SS_INIT_SUCCESS
+// CHOMPEdit End
 
 /datum/controller/subsystem/persistence/Shutdown()
 	for(var/thing in persistence_datums)

--- a/code/controllers/subsystems/planets.dm
+++ b/code/controllers/subsystems/planets.dm
@@ -14,10 +14,10 @@ SUBSYSTEM_DEF(planets)
 	var/static/list/needs_sun_update = list()
 	var/static/list/needs_temp_update = list()
 
-/datum/controller/subsystem/planets/Initialize(timeofday)
+/datum/controller/subsystem/planets/Initialize() // CHOMPEdit
 	admin_notice("<span class='danger'>Initializing planetary weather.</span>", R_DEBUG)
 	createPlanets()
-	..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/planets/proc/createPlanets()
 	var/list/planet_datums = using_map.planet_datums_to_make

--- a/code/controllers/subsystems/plants.dm
+++ b/code/controllers/subsystems/plants.dm
@@ -21,14 +21,16 @@ SUBSYSTEM_DEF(plants)
 	// Hydro trays and growing food normally just chill in SSobj
 	var/list/processing = list()
 	var/list/currentrun = list()
+
 //CHOMPEdit Begin
 /datum/controller/subsystem/plants/stat_entry(msg)
 	msg = "P:[processing.len]|S:[seeds.len]"
 	return ..()
-//CHOMPEdit End
-/datum/controller/subsystem/plants/Initialize(timeofday)
+
+/datum/controller/subsystem/plants/Initialize()
 	setup()
-	return ..()
+	return SS_INIT_SUCCESS
+//CHOMPEdit End
 
 // Predefined/roundstart varieties use a string key to make it
 // easier to grab the new variety when mutating. Post-roundstart

--- a/code/controllers/subsystems/player_tips.dm
+++ b/code/controllers/subsystems/player_tips.dm
@@ -5,12 +5,10 @@ SUBSYSTEM_DEF(player_tips)
 	name = "Periodic Player Tips"
 	priority = FIRE_PRIORITY_PLAYERTIPS
 	runlevels = RUNLEVEL_GAME
-
 	wait = 3000 //We check if it's time to send a tip every 5 minutes (300 seconds)
+	flags = SS_NO_INIT
+
 	var/static/datum/player_tips/player_tips = new
-
-
-
 
 /datum/controller/subsystem/player_tips/fire()
 	player_tips.send_tips()

--- a/code/controllers/subsystems/processing/fastprocess.dm
+++ b/code/controllers/subsystems/processing/fastprocess.dm
@@ -4,6 +4,7 @@ PROCESSING_SUBSYSTEM_DEF(fastprocess)
 	name = "Fast Processing"
 	wait = 2
 	stat_tag = "FP"
+	flags = SS_NO_INIT // CHOMPEdit
 
 /datum/controller/subsystem/processing/fastprocess/Recover()
 	log_debug("[name] subsystem Recover().")

--- a/code/controllers/subsystems/processing/instruments.dm
+++ b/code/controllers/subsystems/processing/instruments.dm
@@ -24,7 +24,7 @@ PROCESSING_SUBSYSTEM_DEF(instruments)
 /datum/controller/subsystem/processing/instruments/Initialize()
 	initialize_instrument_data()
 	synthesizer_instrument_ids = get_allowed_instrument_ids()
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/processing/instruments/proc/on_song_new(datum/song/S)
 	songs += S

--- a/code/controllers/subsystems/processing/turfs.dm
+++ b/code/controllers/subsystems/processing/turfs.dm
@@ -1,6 +1,7 @@
 PROCESSING_SUBSYSTEM_DEF(turfs)
 	name = "Turf Processing"
 	wait = 20
+	flags = SS_NO_INIT // CHOMPEdit
 
 /datum/controller/subsystem/processing/turfs/Recover()
 	log_debug("[name] subsystem Recover().")

--- a/code/controllers/subsystems/reflect_ch.dm
+++ b/code/controllers/subsystems/reflect_ch.dm
@@ -2,7 +2,7 @@
 SUBSYSTEM_DEF(reflector)
 	name = "Reflectors"
 	priority = FIRE_PRIORITY_REFLECTOR
-	flags = SS_BACKGROUND|SS_NO_INIT
+	flags = SS_BACKGROUND | SS_NO_INIT
 	wait = 5
 
 	var/stat_tag = "R" //Used for logging

--- a/code/controllers/subsystems/robot_sprites.dm
+++ b/code/controllers/subsystems/robot_sprites.dm
@@ -10,7 +10,7 @@ SUBSYSTEM_DEF(robot_sprites)
 
 /datum/controller/subsystem/robot_sprites/Initialize()
 	initialize_borg_sprites()
-	..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/robot_sprites/proc/initialize_borg_sprites()
 

--- a/code/controllers/subsystems/shuttles.dm
+++ b/code/controllers/subsystems/shuttles.dm
@@ -32,7 +32,7 @@ SUBSYSTEM_DEF(shuttles)
 
 	var/tmp/list/current_run                       // Shuttles remaining to process this fire() tick
 
-/datum/controller/subsystem/shuttles/Initialize(timeofday)
+/datum/controller/subsystem/shuttles/Initialize() // CHOMPEdit
 	last_landmark_registration_time = world.time
 	// Find all declared shuttle datums and initailize them. (Okay, queue them for initialization a few lines further down)
 	for(var/shuttle_type in subtypesof(/datum/shuttle)) // This accounts for most shuttles, though away maps can queue up more.
@@ -43,7 +43,7 @@ SUBSYSTEM_DEF(shuttles)
 			LAZYDISTINCTADD(shuttles_to_initialize, shuttle_type)
 	block_init_queue = FALSE
 	process_init_queues()
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/shuttles/fire(resumed = 0)
 	if (!resumed)

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -3,7 +3,7 @@
 SUBSYSTEM_DEF(skybox)
 	name = "Space skybox"
 	init_order = INIT_ORDER_SKYBOX
-	flags = SS_NO_FIRE
+	flags = SS_NO_FIRE | SS_NO_INIT // CHOMPEdit
 	var/static/list/skybox_cache = list()
 
 	var/static/mutable_appearance/normal_space
@@ -28,7 +28,7 @@ SUBSYSTEM_DEF(skybox)
 	normal_space.layer = TURF_LAYER
 	normal_space.icon = 'icons/turf/space.dmi'
 	normal_space.icon_state = "white"
-	
+
 	//Static
 	for (var/i in 0 to 25)
 		var/mutable_appearance/MA = new(normal_space)
@@ -36,12 +36,12 @@ SUBSYSTEM_DEF(skybox)
 		im.plane = DUST_PLANE
 		im.alpha = 128 //80
 		im.blend_mode = BLEND_ADD
-		
+
 		MA.cut_overlays()
 		MA.add_overlay(im)
 
 		dust_cache["[i]"] = MA
-	
+
 	//Moving
 	for (var/i in 0 to 14)
 		// NORTH/SOUTH
@@ -57,12 +57,12 @@ SUBSYSTEM_DEF(skybox)
 		im = image('icons/turf/space_dust_transit.dmi', "speedspace_ew_[i]")
 		im.plane = DUST_PLANE
 		im.blend_mode = BLEND_ADD
-		
+
 		MA.cut_overlays()
 		MA.add_overlay(im)
-		
+
 		speedspace_cache["EW_[i]"] = MA
-	
+
 	//Over-the-edge images
 	for (var/dir in alldirs)
 		var/mutable_appearance/MA = new(normal_space)
@@ -89,8 +89,9 @@ SUBSYSTEM_DEF(skybox)
 
 	. = ..()
 
-/datum/controller/subsystem/skybox/Initialize()
-	. = ..()
+// CHOMPEdit - Empty initialize?
+///datum/controller/subsystem/skybox/Initialize()
+//	. = ..()
 
 /datum/controller/subsystem/skybox/proc/get_skybox(z)
 	if(!subsystem_initialized)
@@ -101,9 +102,9 @@ SUBSYSTEM_DEF(skybox)
 
 /datum/controller/subsystem/skybox/proc/generate_skybox(z)
 	var/datum/skybox_settings/settings = global.using_map.get_skybox_datum(z)
-	
+
 	var/new_overlays = list()
-	
+
 	var/image/res = image(settings.icon)
 	res.appearance_flags = KEEP_TOGETHER
 
@@ -136,7 +137,7 @@ SUBSYSTEM_DEF(skybox)
 	for(var/datum/event/E in SSevents.active_events)
 		if(E.has_skybox_image && E.isRunning && (z in E.affecting_z))
 			new_overlays += E.get_skybox_image()
-	
+
 	for(var/image/I in new_overlays)
 		I.appearance_flags |= RESET_COLOR
 
@@ -161,7 +162,7 @@ SUBSYSTEM_DEF(skybox)
 	var/icon_state = "dyable"
 	var/color
 	var/random_color = FALSE
-	
+
 	var/use_stars = TRUE
 	var/star_icon = 'icons/skybox/skybox.dmi'
 	var/star_state = "stars"

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -3,7 +3,7 @@
 SUBSYSTEM_DEF(skybox)
 	name = "Space skybox"
 	init_order = INIT_ORDER_SKYBOX
-	flags = SS_NO_FIRE | SS_NO_INIT // CHOMPEdit
+	flags = SS_NO_FIRE
 	var/static/list/skybox_cache = list()
 
 	var/static/mutable_appearance/normal_space
@@ -89,9 +89,8 @@ SUBSYSTEM_DEF(skybox)
 
 	. = ..()
 
-// CHOMPEdit - Empty initialize?
-///datum/controller/subsystem/skybox/Initialize()
-//	. = ..()
+/datum/controller/subsystem/skybox/Initialize()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/skybox/proc/get_skybox(z)
 	if(!subsystem_initialized)

--- a/code/controllers/subsystems/sounds.dm
+++ b/code/controllers/subsystems/sounds.dm
@@ -25,7 +25,7 @@ SUBSYSTEM_DEF(sounds)
 
 /datum/controller/subsystem/sounds/Initialize()
 	setup_available_channels()
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/sounds/proc/setup_available_channels()
 	channel_list = list()

--- a/code/controllers/subsystems/sqlite.dm
+++ b/code/controllers/subsystems/sqlite.dm
@@ -7,11 +7,11 @@ SUBSYSTEM_DEF(sqlite)
 	flags = SS_NO_FIRE
 	var/database/sqlite_db = null
 
-/datum/controller/subsystem/sqlite/Initialize(timeofday)
+/datum/controller/subsystem/sqlite/Initialize() // CHOMPEdit
 	connect()
 	if(sqlite_db)
 		init_schema(sqlite_db)
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/sqlite/proc/connect()
 	if(!config.sqlite_enabled)

--- a/code/controllers/subsystems/sun.dm
+++ b/code/controllers/subsystems/sun.dm
@@ -1,6 +1,7 @@
 SUBSYSTEM_DEF(sun)
 	name = "Sun"
 	wait = 600
+	flags = SS_NO_INIT // CHOMPEdit
 	var/static/datum/sun/sun = new
 
 /datum/controller/subsystem/sun/fire()

--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(supply)
 		else
 			qdel(P)
 
-	. = ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 // Supply shuttle ticker - handles supply point regeneration. Just add points over time.
 /datum/controller/subsystem/supply/fire()

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -59,7 +59,7 @@ var/global/datum/controller/subsystem/ticker/ticker
 		)
 	)
 	GLOB.autospeaker = new (null, null, null, 1) //Set up Global Announcer
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/ticker/fire(resumed = FALSE)
 	switch(current_state)

--- a/code/controllers/subsystems/transcore_vr.dm
+++ b/code/controllers/subsystems/transcore_vr.dm
@@ -36,7 +36,7 @@ SUBSYSTEM_DEF(transcore)
 			warning("Instantiated transcore DB without a key: [t]")
 			continue
 		databases[db.key] = db
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/transcore/fire(resumed = 0)
 	var/timer = TICK_USAGE

--- a/code/controllers/subsystems/vis_overlays.dm
+++ b/code/controllers/subsystems/vis_overlays.dm
@@ -9,7 +9,7 @@ SUBSYSTEM_DEF(vis_overlays)
 
 /datum/controller/subsystem/vis_overlays/Initialize()
 	vis_overlay_cache = list()
-	return ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/vis_overlays/fire(resumed = FALSE)
 	if(!resumed)
@@ -82,7 +82,7 @@ SUBSYSTEM_DEF(vis_overlays)
 	if(istext(icon))
 		iconstate = icon
 		icon = src.icon
-		
+
 	return SSvis_overlays.add_vis_overlay(src, icon, iconstate, layer, plane, dir, alpha, add_appearance_flags, add_vis_flags, unique)
 
 /atom/proc/remove_vis_overlay(list/overlays)

--- a/code/controllers/subsystems/webhooks.dm
+++ b/code/controllers/subsystems/webhooks.dm
@@ -6,7 +6,7 @@ SUBSYSTEM_DEF(webhooks)
 
 /datum/controller/subsystem/webhooks/Initialize()
 	load_webhooks()
-	. = ..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/webhooks/proc/load_webhooks()
 

--- a/code/controllers/subsystems/xenoarch.dm
+++ b/code/controllers/subsystems/xenoarch.dm
@@ -14,9 +14,9 @@ SUBSYSTEM_DEF(xenoarch)
 	var/list/artifact_spawning_turfs = list()
 	var/list/digsite_spawning_turfs = list()
 
-/datum/controller/subsystem/xenoarch/Initialize(timeofday)
+/datum/controller/subsystem/xenoarch/Initialize() // CHOMPEdit
 	SetupXenoarch()
-	..()
+	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/xenoarch/Recover()
 	if (istype(SSxenoarch.artifact_spawning_turfs))

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -130,6 +130,7 @@
 #include "code\__defines\dcs\helpers.dm"
 #include "code\__defines\dcs\signals.dm"
 #include "code\__defines\dcs\signals_ch.dm"
+#include "code\__defines\dcs\signals_ch\signals_subsystem.dm"
 #include "code\__defines\traits\_traits.dm"
 #include "code\_global_vars\_regexes.dm"
 #include "code\_global_vars\bitfields.dm"


### PR DESCRIPTION

## About The Pull Request

Subsystems will now return SS_INIT_SUCCESS if properly initialized or SS_INIT_NO_NEED if not configured or SS_INIT_FAILURE if it errored.

By default subsystems will return SS_INIT_NONE which also is an **invalid** return (if subsystems either do not implement the Initialize proc, meaning it needs the SS_NO_INIT flag or returning ..(), meaning they have to implement to return SS_INIT_SUCCESS instead).

## Changelog
:cl:
qol: Subsystems return a status value after initializing
/:cl:
