### PR TITLE
Ion Storm Trigger

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -4,6 +4,7 @@
 	has_skybox_image = TRUE
 	announceWhen = -1 // Never (setup may override)
 	var/botEmagChance = 0 //VOREStation Edit
+	var/ionBorgs = TRUE // CHOMPStation Edit
 	var/cloud_hueshift
 	var/list/players = list()
 
@@ -53,6 +54,20 @@
 		to_chat(target, law)
 		target.add_ion_law(law)
 		target.show_laws()
+		ionBorgs = FALSE // CHOMPEdit
+
+	// CHOMPEdit Start
+	if(ionBorgs)	// Making sure an AI hasn't been given an Ion law...
+		for (var/mob/living/silicon/target in silicon_mob_list)
+			if(!(target.z in affecting_z) || prob(33))
+				continue
+			var/law = target.generate_ion_law()
+			to_chat(target, "<span class='danger'>You have detected a change in your laws information:</span>")
+			to_chat(target, law)
+			target.add_ion_law(law)
+			target.show_laws()
+	// CHOMPEdit End
+
 /* //VOREstation edit. Was fucking up all PDA messagess.
 	if(message_servers)
 		for (var/obj/machinery/message_server/MS in message_servers)

--- a/modular_chomp/code/modules/event/event_container_ch.dm
+++ b/modular_chomp/code/modules/event/event_container_ch.dm
@@ -85,7 +85,7 @@
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grub Infestation",			/datum/event/grub_infestation,			-20,	list(ASSIGNMENT_SECURITY = 40, ASSIGNMENT_ENGINEER = 40), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Infected Room",			/datum/event/infectedroom,				-30,	list(ASSIGNMENT_MEDICAL = 30, ASSIGNMENT_JANITOR = 10, ASSIGNMENT_ANY = 1), 	1, min_jobs = list(ASSIGNMENT_MEDICAL = 2)),
 		// Pure RP fun, no mechanical effects.
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					-50,	list(ASSIGNMENT_AI = 80, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_SCIENTIST = 5), min_jobs = list(ASSIGNMENT_SCIENTIST = 1, ASSIGNMENT_CYBORG = 2)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					-125,	list(ASSIGNMENT_AI = 80, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_SCIENTIST = 5), min_jobs = list(ASSIGNMENT_SCIENTIST = 1, ASSIGNMENT_CYBORG = 3)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Jellyfish School",			/datum/event/jellyfish_migration,		5,		list(ASSIGNMENT_ANY = 1, ASSIGNMENT_SECURITY = 5, ASSIGNMENT_MEDICAL = 3), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Maintenance Predator",		/datum/event/maintenance_predator,		75,		list(ASSIGNMENT_SECURITY = 25, ASSIGNMENT_SCIENTIST = 10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meaty Ore Shower",			/datum/event/meteor_wave/meatyores,		-50,	list(ASSIGNMENT_ENGINEER = 45), 1, min_jobs = list(ASSIGNMENT_ENGINEER = 2)),

--- a/modular_chomp/code/modules/event/event_container_ch.dm
+++ b/modular_chomp/code/modules/event/event_container_ch.dm
@@ -85,7 +85,7 @@
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grub Infestation",			/datum/event/grub_infestation,			-20,	list(ASSIGNMENT_SECURITY = 40, ASSIGNMENT_ENGINEER = 40), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Infected Room",			/datum/event/infectedroom,				-30,	list(ASSIGNMENT_MEDICAL = 30, ASSIGNMENT_JANITOR = 10, ASSIGNMENT_ANY = 1), 	1, min_jobs = list(ASSIGNMENT_MEDICAL = 2)),
 		// Pure RP fun, no mechanical effects.
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					0,		list(ASSIGNMENT_AI = 80, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_SCIENTIST = 5), min_jobs = list(ASSIGNMENT_AI = 1)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					-50,	list(ASSIGNMENT_AI = 80, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_SCIENTIST = 5), min_jobs = list(ASSIGNMENT_SCIENTIST = 1, ASSIGNMENT_CYBORG = 2)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Jellyfish School",			/datum/event/jellyfish_migration,		5,		list(ASSIGNMENT_ANY = 1, ASSIGNMENT_SECURITY = 5, ASSIGNMENT_MEDICAL = 3), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Maintenance Predator",		/datum/event/maintenance_predator,		75,		list(ASSIGNMENT_SECURITY = 25, ASSIGNMENT_SCIENTIST = 10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meaty Ore Shower",			/datum/event/meteor_wave/meatyores,		-50,	list(ASSIGNMENT_ENGINEER = 45), 1, min_jobs = list(ASSIGNMENT_ENGINEER = 2)),


### PR DESCRIPTION
## About The Pull Request
One small problem with this event: It requires an AI to be active. AI players are very rare, but we have quite a bunch of borg players; Changing this to require at least two borgs to be online and one Scientist that could hopefully reset the borg's laws if they happened to receive an Ion law.

Currently it requires 1 AI player
This would change it to 3 borgs needed, plus 1 Scientist

## Changelog
:cl:
balance: Modified Ion Storm requirements to be more common
/:cl:
