### PR TITLE
Deprecates BYOND 514

### DIFF
--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -5,54 +5,21 @@
 #define ATAN2(x, y) arctan(x, y)
 #define between(x, y, z) clamp(y, x, z)
 
-// This file contains defines allowing targeting byond versions newer than the supported
-
-//Update this whenever you need to take advantage of more recent byond features
-#define MIN_COMPILER_VERSION 514
-#define MIN_COMPILER_BUILD 1556
+// Update this whenever you need to take advantage of more recent byond features
+#define MIN_COMPILER_VERSION 515
+#define MIN_COMPILER_BUILD 1590
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
-//Don't forget to update this part
+// Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 514.1556 or higher
-#endif
-
-#if (DM_VERSION == 514 && DM_BUILD > 1575 && DM_BUILD <= 1577)
-#error Your version of BYOND currently has a crashing issue that will prevent you from running Dream Daemon test servers.
-#error We require developers to test their content, so an inability to test means we cannot allow the compile.
-#error Please consider downgrading to 514.1575 or lower.
+#error You need version 515.1590 or higher
 #endif
 
 // Keep savefile compatibilty at minimum supported level
-#if DM_VERSION >= 515
 /savefile/byond_version = MIN_COMPILER_VERSION
-#endif
 
-// 515 split call for external libraries into call_ext
-#if DM_VERSION < 515
-#define LIBCALL call
-#else
-#define LIBCALL call_ext
-#endif
-
-// So we want to have compile time guarantees these methods exist on local type, unfortunately 515 killed the .proc/procname and .verb/verbname syntax so we have to use nameof()
+// So we want to have compile time guarantees these methods exist on local type
+// We use wrappers for this in case some part of the api ever changes, and to make their function more clear
 // For the record: GLOBAL_VERB_REF would be useless as verbs can't be global.
-
-#if DM_VERSION < 515
-
-/// Call by name proc references, checks if the proc exists on either this type or as a global proc.
-#define PROC_REF(X) (.proc/##X)
-/// Call by name verb references, checks if the verb exists on either this type or as a global verb.
-#define VERB_REF(X) (.verb/##X)
-
-/// Call by name proc reference, checks if the proc exists on either the given type or as a global proc
-#define TYPE_PROC_REF(TYPE, X) (##TYPE.proc/##X)
-/// Call by name verb reference, checks if the verb exists on either the given type or as a global verb
-#define TYPE_VERB_REF(TYPE, X) (##TYPE.verb/##X)
-
-/// Call by name proc reference, checks if the proc is an existing global proc
-#define GLOBAL_PROC_REF(X) (/proc/##X)
-
-#else
 
 /// Call by name proc references, checks if the proc exists on either this type or as a global proc.
 #define PROC_REF(X) (nameof(.proc/##X))
@@ -66,5 +33,3 @@
 
 /// Call by name proc reference, checks if the proc is an existing global proc
 #define GLOBAL_PROC_REF(X) (/proc/##X)
-
-#endif

--- a/code/game/socket_talk.dm
+++ b/code/game/socket_talk.dm
@@ -8,15 +8,15 @@
 		src.enabled = config.socket_talk
 
 		if(enabled)
-			LIBCALL("DLLSocket.so","establish_connection")("127.0.0.1","8019")
+			call_ext("DLLSocket.so","establish_connection")("127.0.0.1","8019") // CHOMPEdit
 
 	proc
 		send_raw(message)
 			if(enabled)
-				return LIBCALL("DLLSocket.so","send_message")(message)
+				return call_ext("DLLSocket.so","send_message")(message) // CHOMPEdit
 		receive_raw()
 			if(enabled)
-				return LIBCALL("DLLSocket.so","recv_message")()
+				return call_ext("DLLSocket.so","recv_message")() // CHOMPEdit
 		send_log(var/log, var/message)
 			return send_raw("type=log&log=[log]&message=[message]")
 		send_keepalive()

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -8,7 +8,7 @@
 		if(UNIX) lib = "libprof.so"
 		else CRASH("unsupported platform")
 
-	var/init = LIBCALL(lib, "init")()
+	var/init = call_ext(lib, "init")()
 	if("0" != init) CRASH("[lib] init error: [init]")
 // CHOMPedit End
 
@@ -70,7 +70,7 @@
 	// CHOMPStation Addition: Spaceman DMM Debugging
 	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 	if (debug_server)
-		LIBCALL(debug_server, "auxtools_init")()
+		call_ext(debug_server, "auxtools_init")()
 		enable_debugging()
 	// CHOMPStation Add End
 
@@ -840,7 +840,7 @@ var/global/game_id = null
 /world/Del()
 	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
 	if (debug_server)
-		LIBCALL(debug_server, "auxtools_shutdown")()
+		call_ext(debug_server, "auxtools_shutdown")()
 	. = ..()
 
 // CHOMPStation Add End: Spaceman DMM Debugger

--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -18,7 +18,7 @@
 							nudge_lib = "lib/nudge.so"
 
 						spawn(0)
-							LIBCALL(nudge_lib, "nudge")("[config.comms_password]","[config.irc_bot_host]","[channel]","[escape_shell_arg(msg)]")
+							call_ext(nudge_lib, "nudge")("[config.comms_password]","[config.irc_bot_host]","[channel]","[escape_shell_arg(msg)]") // CHOMPEdit
 					else
 						spawn(0)
 							ext_python("ircbot_message.py", "[config.comms_password] [config.irc_bot_host] [channel] [escape_shell_arg(msg)]")

--- a/code/modules/webhooks/_webhook.dm
+++ b/code/modules/webhooks/_webhook.dm
@@ -10,7 +10,7 @@
 	if (!target_url)
 		return -1
 
-	var/result = LIBCALL(HTTP_POST_DLL_LOCATION, "send_post_request")(target_url, payload, json_encode(list("Content-Type" = "application/json")))
+	var/result = call_ext(HTTP_POST_DLL_LOCATION, "send_post_request")(target_url, payload, json_encode(list("Content-Type" = "application/json"))) // CHOMPEdit
 
 	result = cached_json_decode(result)
 	if (result["error_code"])


### PR DESCRIPTION

## About The Pull Request

This PR fully deprecates BYOND version 514 (as there are already other procs like refcount() that are only available in 515 inside of the GC).

The minimum required version has been set to the first available BYOND 515 beta. This will be bumped up further once more actually stable versions of BYOND have been released.

This means that some stuff in the compat code has changed:
- LIBCALL has been replaced with call_ext in the code
- The checks or special code for 514 inside the compat file has been removed

## Changelog
:cl:
code: A warning will now be shown that the byond version is outdated if trying to compile the 515 code with 514.
/:cl:
