### PR TITLE
Move recursive listening to component

### DIFF
--- a/code/datums/components/recursive_move.dm
+++ b/code/datums/components/recursive_move.dm
@@ -1,0 +1,87 @@
+/**
+ * This component behaves similar to connect_loc_behalf but for all turfs in range, hooking into a signal on each of them.
+ * Just like connect_loc_behalf, It can react to that signal on behalf of a seperate listener.
+ * Good for components, though it carries some overhead. Can't be an element as that may lead to bugs.
+ */
+/datum/component/recursive_move
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS //This makes it so pretty much nothing happens when a duplicate component is created since we don't actually override InheritComponent
+	var/atom/movable/holder
+	var/list/parents = list()
+	var/noparents = FALSE
+
+/datum/component/recursive_move/Initialize()
+	holder = parent
+	setup_parents()
+	RegisterSignal(holder, COMSIG_PARENT_QDELETING, PROC_REF(on_holder_qdel))
+
+/datum/component/recursive_move/proc/setup_parents()
+	var/atom/movable/cur_parent = holder.loc
+	while(istype(cur_parent))
+		parents += cur_parent
+		RegisterSignal(cur_parent, COMSIG_ATOM_EXITED, PROC_REF(heirarchy_changed))
+		RegisterSignal(cur_parent, COMSIG_PARENT_QDELETING, PROC_REF(on_qdel))
+		cur_parent = cur_parent.loc
+
+	if(length(parents))
+		//Only need to watch top parent for movement. Everything is covered by Exited
+		RegisterSignal(parents[parents.len], COMSIG_ATOM_ENTERING, PROC_REF(top_moved))
+
+	//If we have no parents of type atom/movable then we wait to see if that changes, checking every time our holder moves.
+	if(!length(parents) && !noparents)
+		noparents = TRUE
+		RegisterSignal(parent, COMSIG_ATOM_ENTERING, PROC_REF(setup_parents))
+
+	if(length(parents) && noparents)
+		noparents = FALSE
+		UnregisterSignal(parent, COMSIG_ATOM_ENTERING)
+
+
+/datum/component/recursive_move/proc/unregister_signals()
+	if(!length(parents))
+		return
+	for(var/atom/movable/cur_parent in parents)
+		UnregisterSignal(cur_parent, COMSIG_PARENT_QDELETING)
+		UnregisterSignal(cur_parent, COMSIG_ATOM_EXITED)
+
+
+	UnregisterSignal(parents[parents.len], COMSIG_ATOM_ENTERING)
+
+//Parent at top of heirarchy moved.
+/datum/component/recursive_move/proc/top_moved(var/atom/movable/am, var/atom/new_loc, var/atom/old_loc)
+	SIGNAL_HANDLER
+	SEND_SIGNAL(holder, COMSIG_OBSERVER_MOVED, old_loc, new_loc)
+
+/datum/component/recursive_move/proc/heirarchy_changed(var/atom/old_loc, var/atom/movable/am, var/atom/new_loc)
+	SIGNAL_HANDLER
+	SEND_SIGNAL(holder, COMSIG_OBSERVER_MOVED, old_loc, new_loc)
+	//Rebuild our list of parents
+	reset_parents()
+	setup_parents()
+
+/datum/component/recursive_move/proc/on_qdel()
+	reset_parents()
+	noparents = TRUE
+	RegisterSignal(parent, COMSIG_ATOM_ENTERING, PROC_REF(setup_parents))
+
+/datum/component/recursive_move/proc/on_holder_qdel()
+	reset_parents()
+	qdel(src)
+
+/datum/component/recursive_move/Destroy()
+	reset_parents()
+
+/datum/component/recursive_move/proc/reset_parents()
+	unregister_signals()
+	parents.Cut()
+
+//the banana peel of testing stays
+/obj/item/weapon/bananapeel/testing
+	name = "banana peel of testing"
+	desc = "spams world log with debugging information"
+
+/obj/item/weapon/bananapeel/testing/proc/shmove(var/atom/source, var/atom/old_loc, var/atom/new_loc)
+	world.log << "the [source] moved from [old_loc]([old_loc.x],[old_loc.y],[old_loc.z]) to [new_loc]([new_loc.x],[new_loc.y],[new_loc.z])"
+
+/obj/item/weapon/bananapeel/testing/Initialize()
+	AddComponent(/datum/component/recursive_move)
+	RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(shmove))

--- a/code/datums/observation/helpers.dm
+++ b/code/datums/observation/helpers.dm
@@ -1,6 +1,7 @@
+/*
 /atom/movable/proc/recursive_move(var/atom/movable/am, var/old_loc, var/new_loc)
 	SEND_SIGNAL(src,COMSIG_OBSERVER_MOVED, old_loc, new_loc)
-
+*/
 /atom/movable/proc/move_to_destination(var/atom/movable/am, var/old_loc, var/new_loc)
 	var/turf/T = get_turf(new_loc)
 	if(T && T != loc)
@@ -12,6 +13,7 @@
 /datum/proc/qdel_self()
 	qdel(src)
 
+/*
 /proc/register_all_movement(var/event_source, var/datum/listener)
 	listener.RegisterSignal(event_source,COMSIG_OBSERVER_MOVED, /atom/movable/proc/recursive_move)
 	//GLOB.dir_set_event.register(event_source, listener, /atom/proc/recursive_dir_set)
@@ -19,3 +21,4 @@
 /proc/unregister_all_movement(var/event_source, var/datum/listener)
 	listener.UnregisterSignal(event_source,COMSIG_OBSERVER_MOVED)
 	//GLOB.dir_set_event.unregister(event_source, listener, /atom/proc/recursive_dir_set)
+*/

--- a/code/datums/observation/moved.dm
+++ b/code/datums/observation/moved.dm
@@ -28,6 +28,7 @@ GLOBAL_DATUM_INIT(moved_event, /decl/observ/moved, new)
 /********************
 * Movement Handling *
 ********************/
+/*
 /atom/movable/Entered(var/atom/movable/am, atom/old_loc)
 	. = ..()
 	am.RegisterSignal(src,COMSIG_OBSERVER_MOVED, /atom/movable/proc/recursive_move, override = TRUE)
@@ -41,7 +42,7 @@ GLOBAL_DATUM_INIT(moved_event, /decl/observ/moved, new)
 /atom/movable/Exited(var/atom/movable/am, atom/old_loc)
 	. = ..()
 	am.UnregisterSignal(src,COMSIG_OBSERVER_MOVED)
-
+*/
 // Entered() typically lifts the moved event, but in the case of null-space we'll have to handle it.
 /atom/movable/Move()
 	var/old_loc = loc

--- a/code/game/machinery/machinery_power.dm
+++ b/code/game/machinery/machinery_power.dm
@@ -73,14 +73,18 @@
 // Do not do power stuff in New/Initialize until after ..()
 /obj/machinery/Initialize()
 	. = ..()
+	RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(update_power_on_move))
+	AddComponent(/datum/component/recursive_move)
 	var/power = POWER_CONSUMPTION
 	REPORT_POWER_CONSUMPTION_CHANGE(0, power)
 	power_init_complete = TRUE
 
 // Or in Destroy at all, but especially after the ..().
 /obj/machinery/Destroy()
+	/*
 	if(ismovable(loc))
 		UnregisterSignal(loc, COMSIG_OBSERVER_MOVED) // Unregister just in case
+	*/
 	var/power = POWER_CONSUMPTION
 	REPORT_POWER_CONSUMPTION_CHANGE(power, 0)
 	. = ..()
@@ -90,10 +94,12 @@
 /obj/machinery/Moved(atom/old_loc, direction, forced = FALSE)
 	. = ..()
 	update_power_on_move(src, old_loc, loc)
+	/* No
 	if(ismovable(old_loc)) // Unregister recursive movement.
 		UnregisterSignal(old_loc, COMSIG_OBSERVER_MOVED)
 	if(ismovable(loc)) // Register for recursive movement (if the thing we're inside moves)
 		RegisterSignal(loc, COMSIG_OBSERVER_MOVED, PROC_REF(update_power_on_move), override = TRUE)
+	*/
 
 /obj/machinery/proc/update_power_on_move(atom/movable/mover, atom/old_loc, atom/new_loc)
 	var/area/old_area = get_area(old_loc)

--- a/code/game/mecha/equipment/tools/shield_omni.dm
+++ b/code/game/mecha/equipment/tools/shield_omni.dm
@@ -78,6 +78,7 @@
 	. = ..()
 	my_mech = loc
 	RegisterSignal(my_mech, COMSIG_OBSERVER_MOVED, /obj/item/shield_projector/proc/update_shield_positions)
+	my_mech.AddComponent(/datum/component/recursive_move)
 	update_shift(my_mech)
 
 /obj/item/shield_projector/rectangle/mecha/proc/update_shift(atom/movable/mech)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -743,6 +743,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 			H.toggle_zoom_hud()	// If the user has already limited their HUD this avoids them having a HUD when they zoom in
 		H.set_viewsize(viewsize)
 		zoom = 1
+		H.AddComponent(/datum/component/recursive_move)
 		RegisterSignal(H, COMSIG_OBSERVER_MOVED, PROC_REF(zoom), override = TRUE)
 
 		var/tilesize = 32

--- a/code/game/objects/items/devices/communicator/phone.dm
+++ b/code/game/objects/items/devices/communicator/phone.dm
@@ -350,6 +350,7 @@
 	comm.visible_message("<span class='danger'>[icon2html(src,viewers(src))] New video connection from [comm].</span>")
 	update_active_camera_screen()
 	RegisterSignal(video_source, COMSIG_OBSERVER_MOVED, PROC_REF(update_active_camera_screen))
+	video_source.AddComponent(/datum/component/recursive_move)
 	update_icon()
 
 // Proc: end_video()

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -46,6 +46,7 @@ var/list/GPS_list = list()
 	if(istype(loc, /mob))
 		holder = loc
 		RegisterSignal(holder, COMSIG_OBSERVER_MOVED, PROC_REF(update_compass), override = TRUE)
+		holder.AddComponent(/datum/component/recursive_move)
 		//GLOB.dir_set_event.register(holder, src, PROC_REF(update_compass))
 
 	if(holder && tracking)

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -206,11 +206,13 @@
 /obj/item/weapon/storage/bag/ore/equipped(mob/user)
 	..()
 	if(user.get_inventory_slot(src) == slot_wear_suit || slot_l_hand || slot_l_hand || slot_belt) //Basically every place they can go. Makes sure it doesn't unregister if moved to other slots.
+		user.AddComponent(/datum/component/recursive_move)
 		RegisterSignal(user, COMSIG_OBSERVER_MOVED, /obj/item/weapon/storage/bag/ore/proc/autoload, user, override = TRUE)
 
 /obj/item/weapon/storage/bag/ore/dropped(mob/user)
 	..()
 	if(user.get_inventory_slot(src) == slot_wear_suit || slot_l_hand || slot_l_hand || slot_belt) //See above. This should really be a define.
+		user.AddComponent(/datum/component/recursive_move)
 		RegisterSignal(user, COMSIG_OBSERVER_MOVED, /obj/item/weapon/storage/bag/ore/proc/autoload, user, override = TRUE)
 	else
 		UnregisterSignal(user, COMSIG_OBSERVER_MOVED)

--- a/code/modules/clothing/spacesuits/rig/modules/specific/pat_module_vr.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/specific/pat_module_vr.dm
@@ -38,6 +38,7 @@
 
 	var/mob/living/carbon/human/H = holder.wearer
 	to_chat(H,"<span class='notice'>You activate the P.A.T. module.</span>")
+	H.AddComponent(/datum/component/recursive_move)
 	RegisterSignal(H, COMSIG_OBSERVER_MOVED, /obj/item/rig_module/pat_module/proc/boop)
 
 /obj/item/rig_module/pat_module/deactivate()

--- a/code/modules/holomap/station_holomap.dm
+++ b/code/modules/holomap/station_holomap.dm
@@ -112,6 +112,7 @@
 			user.client.images |= holomap_datum.station_map
 
 			watching_mob = user
+			watching_mob.AddComponent(/datum/component/recursive_move)
 			RegisterSignal(watching_mob, COMSIG_OBSERVER_MOVED, /obj/machinery/station_map/proc/checkPosition)
 			//GLOB.dir_set_event.register(watching_mob, src, /obj/machinery/station_map/proc/checkPosition)
 			RegisterSignal(watching_mob, COMSIG_OBSERVER_DESTROYED, /obj/machinery/station_map/proc/stopWatching)

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -448,6 +448,7 @@
 
 /obj/item/integrated_circuit/output/holographic_projector/Initialize()
 	. = ..()
+	AddComponent(/datum/component/recursive_move)
 	RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(on_moved))
 
 /obj/item/integrated_circuit/output/holographic_projector/Destroy()

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -214,6 +214,7 @@
 	say("Down on the floor, [suspect_name]! You have [SECBOT_WAIT_TIME*2] seconds to comply.")
 	playsound(src, pick(preparing_arrest_sounds), 50)
 	// Register to be told when the target moves
+	target.AddComponent(/datum/component/recursive_move)
 	RegisterSignal(target, COMSIG_OBSERVER_MOVED, /mob/living/bot/secbot/proc/target_moved)
 
 // Callback invoked if the registered target moves

--- a/code/modules/nifsoft/software/13_soulcatcher.dm
+++ b/code/modules/nifsoft/software/13_soulcatcher.dm
@@ -427,6 +427,7 @@
 	real_name = brainmob.real_name	//And the OTHER name
 
 	forceMove(get_turf(parent_human))
+	parent_human.AddComponent(/datum/component/recursive_move)
 	RegisterSignal(parent_human, COMSIG_OBSERVER_MOVED, /mob/observer/eye/ar_soul/proc/human_moved)
 
 	//Time to play dressup

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -77,6 +77,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 		L.looking_elsewhere = 1
 		L.handle_vision()
 	user.set_viewsize(world.view + extra_view)
+	user.AddComponent(/datum/component/recursive_move)
 	RegisterSignal(user, COMSIG_OBSERVER_MOVED, /obj/machinery/computer/ship/proc/unlook, override = TRUE) //This needs override or else it will spam runtimes because it is called repeatedly.
 	// TODO GLOB.stat_set_event.register(user, src, /obj/machinery/computer/ship/proc/unlook)
 	LAZYDISTINCTADD(viewers, WEAKREF(user))

--- a/code/modules/paperwork/paper_sticky.dm
+++ b/code/modules/paperwork/paper_sticky.dm
@@ -97,6 +97,7 @@
 
 /obj/item/weapon/paper/sticky/Initialize()
 	. = ..()
+	AddComponent(/datum/component/recursive_move)
 	RegisterSignal(src, COMSIG_OBSERVER_MOVED, /obj/item/weapon/paper/sticky/proc/reset_persistence_tracking)
 
 /obj/item/weapon/paper/sticky/proc/reset_persistence_tracking()

--- a/code/modules/shieldgen/directional_shield.dm
+++ b/code/modules/shieldgen/directional_shield.dm
@@ -102,6 +102,7 @@
 	START_PROCESSING(SSobj, src)
 	if(always_on)
 		create_shields()
+	AddComponent(/datum/component/recursive_move)
 	RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(moved_event))
 	return ..()
 

--- a/code/modules/tgui/modules/appearance_changer.dm
+++ b/code/modules/tgui/modules/appearance_changer.dm
@@ -65,6 +65,7 @@
 
 	owner = H
 	if(owner)
+		owner.AddComponent(/datum/component/recursive_move)
 		RegisterSignal(owner, COMSIG_OBSERVER_MOVED, PROC_REF(update_active_camera_screen))
 	check_whitelist = check_species_whitelist
 	whitelist = species_whitelist

--- a/code/modules/tgui/modules/camera.dm
+++ b/code/modules/tgui/modules/camera.dm
@@ -144,6 +144,7 @@
 		if(active_camera)
 			UnregisterSignal(active_camera, COMSIG_OBSERVER_MOVED)
 		active_camera = C
+		active_camera.AddComponent(/datum/component/recursive_move)
 		RegisterSignal(active_camera, COMSIG_OBSERVER_MOVED, PROC_REF(update_active_camera_screen))
 		playsound(tgui_host(), get_sfx("terminal_type"), 25, FALSE)
 		update_active_camera_screen()
@@ -171,6 +172,7 @@
 				if(active_camera)
 					UnregisterSignal(active_camera, COMSIG_OBSERVER_MOVED)
 				active_camera = target
+				active_camera.AddComponent(/datum/component/recursive_move)
 				RegisterSignal(active_camera, COMSIG_OBSERVER_MOVED, PROC_REF(update_active_camera_screen))
 				playsound(tgui_host(), get_sfx("terminal_type"), 25, FALSE)
 				update_active_camera_screen()

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -403,6 +403,7 @@
 #include "code\datums\components\connect_range_ch.dm"
 #include "code\datums\components\material_container.dm"
 #include "code\datums\components\overlay_lighting.dm"
+#include "code\datums\components\recursive_move.dm"
 #include "code\datums\components\resize_guard.dm"
 #include "code\datums\components\crafting\crafting.dm"
 #include "code\datums\components\crafting\crafting_external.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Moves recursive listening to a component so that every single atom/movable doesn't have signals for it. Tested some of the things that relied on recursive movement, however I still recommend testmerge for this in case of missed edge cases.

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
code: recursive listening now is a component
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
