### PR TITLE
Small Engineering QoL Improvement

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -8876,14 +8876,9 @@
 /turf/simulated/floor/tiled/airless,
 /area/rnd/test_area)
 "azM" = (
-/obj/structure/closet/crate/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
+/obj/structure/closet/crate/solar,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
-/obj/item/stack/material/lead{
-	amount = 30
-	},
 /turf/simulated/floor,
 /area/engineering/storage)
 "azN" = (
@@ -46472,8 +46467,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/secondary/entry/D3)
 "eiI" = (
-/obj/structure/closet/crate/solar,
+/obj/structure/closet/crate/radiation,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/stack/material/lead{
+	amount = 30
+	},
 /turf/simulated/floor,
 /area/engineering/storage)
 "ejk" = (
@@ -62088,6 +62088,7 @@
 /obj/item/weapon/tool/crowbar,
 /obj/item/weapon/tool/crowbar/red,
 /obj/item/weapon/storage/box/lights/mixed,
+/obj/item/device/lightreplacer,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/workshop)
 "muM" = (

--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -66777,10 +66777,10 @@ hDj
 jtd
 xJr
 vxU
-cay
-cay
 hpy
 hpy
+cay
+cay
 lok
 lok
 aCX


### PR DESCRIPTION

## About The Pull Request
My other thing is on hold for the moment so, eh, throwing out a few small QoL map alterations for engineers.
## Changelog
:cl:
add: Added a light replacer in the engineering tools area so you don't have to run all the way to the carrier to fix lights easier anymore
qol: Swapped the solar crate and radiation crate around in engineering storage so the lead is easier to get to. Cause let's be honest, the solar crate is less often used and a pain to move out of the way every round
qol: Swapped the CO2 and Phoron canister start locations around in the carrier R-UST, to make the locations closer to where they're supposed to be and so _certain_ engineers don't go blowing up the R-UST with phoron in the hot loop
/:cl:
