### PR TITLE
fix ascending through floors

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -58,9 +58,14 @@
 				to_chat(src, "<span class='warning'>You stopped swimming downwards.</span>")
 				return 0
 
-		else if(!destination.CanZPass(src, direction))
+		else if(!destination.CanZPass(src, direction)) // one for the down and non-special case
 			to_chat(src, "<span class='warning'>\The [destination] blocks your way.</span>")
 			return 0
+
+	else if(!destination.CanZPass(src, direction)) // and one for up
+		to_chat(src, "<span class='warning'>\The [destination] blocks your way.</span>")
+		return 0
+
 
 	var/area/area = get_area(src)
 	if(area.has_gravity() && !can_overcome_gravity())


### PR DESCRIPTION
Bug was introduced here:
#6889 
Specifically:
https://github.com/CHOMPStation2/CHOMPStation2/pull/6889/files#diff-284f84b4d2e4bef4fe808771c2a07749f5f1513a292ea10f225435fa0d983e16L49

The check was accidently only made to work on going down instead of both directions when the special case was added.

:cl:
fix: fixed ascending through floors
/:cl:
