### PR TITLE
Ghost-radio blacklisting

### DIFF
--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -416,6 +416,12 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 		if(data == DATA_ANTAG && istype(R, /mob/observer/dead) && R.is_preference_enabled(/datum/client_preference/ghost_radio))
 			continue
 
+		// ChompEDIT START - Ghost blacklist for certain spammy radio channels
+		var/list/ghostradio_freq_blacklist = list(ENT_FREQ, BDCM_FREQ)
+		if(istype(R, /mob/observer/dead) && R.is_preference_enabled(/datum/client_preference/ghost_radio) && (connection.frequency in ghostradio_freq_blacklist))
+			continue
+		// ChompEDIT END
+
 		// --- Check for compression ---
 		if(compression > 0)
 			heard_gibberish += R


### PR DESCRIPTION
Blacklists certain channels from ghost-radio to prevent spamminess
Currently set to:
Entertainment
Bodycams

:cl:
qol: Blacklist radio channels from ghost-radio (Entertainment, bodycams)
/:cl:
