### PR TITLE
Runtime in explosions/organs

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -234,6 +234,7 @@
 	mineitemtype = /obj/item/weapon/mine/emp
 
 /obj/effect/mine/emp/explode(var/mob/living/M)
+	triggered = 1 //ChompEDIT recursing mines
 	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread()
 	s.set_up(3, 1, src)
 	s.start()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -400,7 +400,7 @@ var/list/organ_cache = list()
 	if(istype(owner))
 		var/datum/reagent/blood/organ_blood = locate(/datum/reagent/blood) in reagents.reagent_list
 		if(!organ_blood || !organ_blood.data["blood_DNA"])
-			owner.vessel.trans_to(src, 5, 1, 1)
+			owner.vessel?.trans_to(src, 5, 1, 1)
 
 		if(owner && vital)
 			if(user)


### PR DESCRIPTION
A nasty runtime that looks like it can break recursive explosions in progress

:cl:
fix: Organ/limb removal on explosion runtime
fix: infinite EMP mine recursion
/:cl:
