### PR TITLE
Optimisations: Cache-ing ghosts/NewPlayers

### DIFF
--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -23,8 +23,6 @@ var/global/list/joblist = list()					//list of all jobstypes, minus borg and AI
 #define all_genders_define_list list(MALE,FEMALE,PLURAL,NEUTER,HERM) //VOREStaton Edit
 #define all_genders_text_list list("Male","Female","Plural","Neuter","Herm") //VOREStation Edit
 
-var/list/mannequins_
-
 // Times that players are allowed to respawn ("ckey" = world.time)
 GLOBAL_LIST_EMPTY(respawn_timers)
 
@@ -104,16 +102,6 @@ var/global/list/string_slot_flags = list(
 	"holster" = SLOT_HOLSTER
 )
 
-GLOBAL_LIST_EMPTY(mannequins)
-/proc/get_mannequin(var/ckey = "NULL")
-	var/mob/living/carbon/human/dummy/mannequin/M = GLOB.mannequins[ckey]
-	if(!istype(M))
-		GLOB.mannequins[ckey] = new /mob/living/carbon/human/dummy/mannequin(null)
-		M = GLOB.mannequins[ckey]
-	return M
-
-/proc/del_mannequin(var/ckey = "NULL")
-	GLOB.mannequins-= ckey
 
 //////////////////////////
 /////Initial Building/////
@@ -336,6 +324,7 @@ GLOBAL_LIST_EMPTY(legacy_globals)
 	//Note: these lists cannot be changed to a new list anywhere in code!
 	//If they are, these will cause the old list to stay around!
 	//Check by searching for "<GLOBAL_NAME> =" in the entire codebase
+	//GLOB.legacy_globals["GLOBAL_LIST"] = GLOBAL_LIST
 	GLOB.legacy_globals["player_list"] = player_list
 	GLOB.legacy_globals["mob_list"] = mob_list
 	GLOB.legacy_globals["human_mob_list"] = human_mob_list
@@ -351,7 +340,6 @@ GLOBAL_LIST_EMPTY(legacy_globals)
 	GLOB.legacy_globals["event_triggers"] = event_triggers
 	GLOB.legacy_globals["side_effects"] = side_effects
 	GLOB.legacy_globals["mechas_list"] = mechas_list
-	GLOB.legacy_globals["mannequins_"] = mannequins_
 	//visual nets
 	GLOB.legacy_globals["visual_nets"] = visual_nets
 	GLOB.legacy_globals["cameranet"] = cameranet

--- a/code/_helpers/mobcache_players.dm
+++ b/code/_helpers/mobcache_players.dm
@@ -1,0 +1,301 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////// MOBCACHING SYSTEM //////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// This system will cache client mobs that are reused frequently
+// This system is intended for static, uninteractable mobs
+// e.g...
+// /mob/new_player
+// /mob/observer/dead
+// /mob/living/carbon/human/dummy/mannequin
+//
+//
+//
+// Please see the blocks below for the various procs and their usage
+//
+//
+
+
+
+//-------------------- Mannequin --------------------
+GLOBAL_LIST_EMPTY(mobcache_mannequins)
+
+// Either creates a new mannequin associated with a ckey, or fetches it from the mobcache if it exists
+// The rest of the code should NEVER create new or qdel mannequins except for special cases
+/proc/get_mannequin(var/ckey = "NULL")
+	var/mob/living/carbon/human/dummy/mannequin/M = GLOB.mobcache_mannequins[ckey]
+	if(!istype(M))
+		GLOB.mobcache_mannequins[ckey] = new /mob/living/carbon/human/dummy/mannequin(null)
+		M = GLOB.mobcache_mannequins[ckey]
+	return GLOB.mobcache_mannequins[ckey]
+
+// Deletes a mannequin from the mobcache and removes it's ref from the cache
+// this should never be needed, but if future timeout cleanup is needed, this can be used.
+/proc/del_mannequin(var/ckey = "NULL")
+	var/mob/M = GLOB.mobcache_mannequins[ckey]
+	if(!istype(M)) // Database entry was null, we're done
+		GLOB.mobcache_mannequins -= ckey
+		return
+	qdel(M) // qdel if M is a type.
+	GLOB.mobcache_mannequins -= ckey // remove after the qdel
+
+
+
+
+
+//-------------------- mob/observer/dead --------------------
+GLOBAL_LIST_EMPTY(mobcache_observer_deads)
+
+// Either summons a cached /mob/observer/dead or creates one if it doesn't exist
+// When using this, you should always try to assign the returned mob to a ckey IMMEDIATELY thereafter
+// If there is a case where you want to fetch a ghost without inserting a /client, contact me
+// otherwise summon_actions will have no client!
+/proc/get_observer_dead(var/ckey = "NULL", var/turf/position = null, var/mob/target_appearance)
+	var/mob/observer/dead/OD = GLOB.mobcache_observer_deads[ckey]
+	if(!istype(OD)) // no observer
+		OD = new /mob/observer/dead(target_appearance) // so create one
+		OD.moveToNullspace() // move it out of the target_appearance mob
+		GLOB.mobcache_observer_deads[ckey] = OD
+
+	if(!istype(OD)) //check for magical failures
+		log_and_message_admins("MOBCACHE: get_observer_dead failed!")
+		return FALSE
+
+	//At this point we've found our observer
+	if(istype(target_appearance)) // dress it if a target appearance is defined
+		OD.redress(target_appearance)
+	if(isturf(position)) // Move it to our target turf if it is defined
+		OD.forceMove(position)
+
+	_OD_summon_actions_callback(OD) // this will actually execute after the caller of this function!
+	return GLOB.mobcache_observer_deads[ckey] // assign our output
+
+// internal use only. waitfor...sleep(0) more performant than spawn(0)
+/proc/_OD_summon_actions_callback(var/mob/observer/dead/OD)
+	set waitfor = FALSE // ...setting waitfor = false in a proc means that...
+	sleep(0) // ...when we sleep, we return and allow our caller to process the return and finish itself...
+	OD._mobcache_summon() // ... and then we call this AFTER the fact. this is apparently more optimal than spawn(0).
+
+// Attempts to dismiss a /mob/observer/dead
+// Doesn't need a ckey, so it can be called on logout
+// Will check to see if the target mob exists in the database.
+// If it does, it knows it has a reference, so it will call the dismiss_actions FIRST (a sort of virtual Destroy())
+// THEN AFTERWARDS it teleports it to nullspace for storage.
+// If you dismiss a mob that doesn't have a mobcache reference, it will instead qdel it and throw a warning. Ideally, this won't happen
+/proc/dismiss_observer_dead(var/mob/observer/dead/OD)
+	if(!istype(OD))
+		return
+
+	//see if our dismissal observer exists
+	for(var/key in GLOB.mobcache_observer_deads)
+		if(GLOB.mobcache_observer_deads[key] == OD)
+			OD._mobcache_dismiss() // Call this FIRST! Don't call it in nullspace!!
+			OD.moveToNullspace() // observer is in our observer db - hide in nullspace
+			return
+
+	//if it doesn't, qdel it
+	log_and_message_admins("MOBCACHE: An unknown mob/observer/dead was qdelled due to not being databased")
+	qdel(OD) // observer is not in observer db - qdel
+
+// Attmpts to delete a /mob/observer/dead from the mobcache and removes it's ref from the cache
+// this should never be needed, but if future timeout cleanup is needed, this can be used.
+// force : if the new_player mob you're trying to delete has a client, force=TRUE: Ghostize them. force=FALSE: abort.
+// returns TRUE if successful, FALSE if not.
+/proc/del_observer_dead(var/ckey = "NULL", force = FALSE)
+	var/mob/M = GLOB.mobcache_observer_deads[ckey]
+	if(!istype(M)) // No database entry exists, we automatically succeed
+		GLOB.mobcache_observer_deads -= ckey // remove a potential null
+		return TRUE
+
+	// found a client
+	if(M.client)
+		if(force)
+			log_and_message_admins("MOBCACHE: Removed a /mob/new_player when it had an active client! The user was ghosted")
+			if(!M.ghostize())
+				log_and_message_admins("MOBCACHE: The previous ghosting action failed! Jesus christ.") //this REALLY shouldn't happen
+				return FALSE //somehow the ghostizing fails
+			return TRUE //user was ghosted
+		else
+			log_and_message_admins("MOBCACHE: Attempted to remove a /mob/new_player when it had an active client! aborted")
+			return FALSE // force=false, so don't try to ghost them
+
+	// no client
+	qdel(GLOB.mobcache_observer_deads[ckey])
+	GLOB.mobcache_observer_deads -= ckey
+	return TRUE // success
+
+
+
+
+
+//-------------------- mob/newplayer --------------------
+GLOBAL_LIST_EMPTY(mobcache_newplayers)
+
+// fetches a /mob/new_player from the database. This should almost never have to create one,
+// because a connecting new client has one created for it on /world.
+// when it is created, it registers itself in /mob/new_player/New() using the update_newplayer_from_current function below
+/proc/get_newplayer(var/ckey = "NULL")
+	var/mob/new_player/NP = GLOB.mobcache_newplayers[ckey]
+	if(!istype(NP))
+		NP = new /mob/new_player/(null)
+		GLOB.mobcache_newplayers[ckey] = NP
+
+	_NP_summon_actions_callback(NP)
+	return GLOB.mobcache_newplayers[ckey]
+
+// internal use only. waitfor...sleep(0) more performant than spawn(0)
+/proc/_NP_summon_actions_callback(var/mob/new_player/NP)
+	set waitfor = FALSE // ...setting waitfor = false in a proc means that...
+	sleep(0) // ...when we sleep, we return and allow our caller to process the return and finish itself...
+	NP._mobcache_summon() // ... and then we call this AFTER the fact. this is apparently more optimal than spawn(0).
+
+// since new_players is the default mob (created by /world when a brand new client connects),
+// we cannot create it. It's created for us. So, we have this proc to update the database after the fact...
+// This chould be called on /mob/new_player/New()
+// that way, new only ever runs once for a user. thereafter, the new_player mob is cached and puts their ckey back in when resummoned
+/proc/update_newplayer_from_current(var/mob/new_player/NP, var/ckey = "NULL")
+	if(!istype(NP, /mob/new_player))
+		return
+
+	if(ckey in GLOB.mobcache_newplayers) //ckey key exists
+		if(GLOB.mobcache_newplayers[ckey] == NP) //ckey key's ref is same as new - no update needed
+			return
+		else
+			log_and_message_admins("MOBCACHE: New /mob/new_player created when an old one existed! Removing old one.")
+			if(!del_newplayer(ckey)) //ckey's ref was different - delete the old ref
+				log_and_message_admins("MOBCACHE: Old /mob/new_player had a client! Something has gone horribly wrong.")
+				return
+
+
+	GLOB.mobcache_newplayers[ckey] = NP
+
+// This attempts to remove a /mob/new_player from the database and then delete it
+// It should rarely be needed if everything works right
+// force : if the new_player mob you're trying to delete has a client, force=TRUE: Ghostize them. force=FALSE: abort.
+// ideally, avoid using force=TRUE
+// Ghosting someone out of a new_player mob is kind of weird... but then again it should never really happen. Better than kicking them!
+// returns TRUE if successful, FALSE if not.
+/proc/del_newplayer(var/ckey = "NULL", force = FALSE)
+	var/mob/M = GLOB.mobcache_newplayers[ckey]
+	if(!istype(M)) // No database entry exists, we automatically succeed
+		GLOB.mobcache_newplayers -= ckey // remove a potential null
+		return TRUE
+
+	// found a client
+	if(M.client)
+		if(force)
+			log_and_message_admins("MOBCACHE: Removed a /mob/new_player when it had an active client! The user was ghosted")
+			if(!M.ghostize())
+				log_and_message_admins("MOBCACHE: The previous ghosting action failed! Jesus christ.") //this REALLY shouldn't happen
+				return FALSE //somehow the ghostizing fails
+			return TRUE //user was ghosted
+		else
+			log_and_message_admins("MOBCACHE: Attempted to remove a /mob/new_player when it had an active client! aborted")
+			return FALSE // force=false, so don't try to ghost them
+
+	// no client
+	qdel(GLOB.mobcache_newplayers[ckey])
+	GLOB.mobcache_newplayers -= ckey
+	return TRUE // success
+
+// A new_mob is never really 'dismissed'. It already exists in nullspace, just a place to hold someone perousing the menu..
+// nonetheless, we have this to handle instead where a qdel used to go.
+/proc/dismiss_new_player(var/mob/new_player/NP)
+	if(!istype(NP))
+		return
+
+	//see if our dismissal observer exists
+	for(var/key in GLOB.mobcache_newplayers)
+		if(GLOB.mobcache_newplayers[key] == NP)
+			NP._mobcache_dismiss() // Call this FIRST
+			if(NP.loc) // if they escaped
+				log_and_message_admins("MOBCACHE: A mob/new_player somehow got out of Nullspace! Sending them home...") // how tho
+				NP.moveToNullspace() // go home
+			return
+
+	//if it doesn't, qdel it
+	log_and_message_admins("MOBCACHE: An unknown mob/new_player was qdelled due to not being databased")
+	qdel(NP) // observer is not in observer db - qdel
+
+
+
+
+//-------------------- mob subtype procs --------------------
+// For any full type used in the mobcache;
+// for all behaviors and calls of that type's New/Initialize/LateInitialize that is UNDONE in that type's Logout;
+//
+// You must define the same SET behaviors in the same type's mobcache_summon_actions (for new/initialize/lateinitialize assignments linked to Logout unassignments)
+// And the same corresponding UNSET behavior in the same type's mobcache_dismiss_actions (for LOGOUT unassignments linked to New/Initialize/Lateinitialize assignments)
+//
+// And the same for all subtypes (IF the type uses ..())
+//
+// Basically, if a mob was expected to be created, used and then destroyed,
+// you need to 'simulate' the Creation and Destruction behavior in summon_actions and dismiss_actions.
+//
+// Try to not destroy stuff on logout/dismissal that doesn't NEED to be destroyed.
+// Sometimes it has to be done though. And that's what this is for.
+//
+//
+
+//------------------ dismiss/summon FILTERED CALL procs -------------------
+// This is used to filter the exact types that should be calling mobcache_dismiss_actions and mobcache_summon_actions
+// Only /mob subtypes actually defined as cached here should have ANY behavior work for them
+// These procs ensure the correct types execute the correct proc/overrides of proc.
+//
+
+
+/mob/proc/final/_mobcache_dismiss()
+	if(istype(src, /mob/new_player))
+		var/mob/new_player/NP = src
+		NP?.mobcache_dismiss_actions()
+		return
+
+	if(istype(src, /mob/observer/dead))
+		var/mob/observer/dead/OD = src
+		OD?.mobcache_dismiss_actions()
+		return
+	log_and_message_admins("MOBCACHE: an invalid mob called mobcache_dismiss")
+
+/mob/proc/final/_mobcache_summon()
+	if(istype(src, /mob/new_player))
+		var/mob/new_player/NP = src
+		NP?.mobcache_summon_actions()
+		return
+
+	if(istype(src, /mob/observer/dead))
+		var/mob/observer/dead/OD = src
+		OD?.mobcache_summon_actions()
+		return
+	log_and_message_admins("MOBCACHE: an invalid mob called mobcache_summon")
+
+
+
+//------------------ dismiss/summon ACTIONS/BEHAVIOR procs -------------------
+//
+// DO NOT CALL THE PROCS BELOW ANYWHERE. They should ONLY BE CALLED by the corresponding _mobcache_summon and _mobcache_destroy ABOVE!!
+// ONLY OVERRIDE THEM with the behaviors you need to mimic for your cached types!
+//
+
+// Actions to call when dismissing the observer (Virtual Destroy)
+// This is called similar to logout, shortly AFTER it.
+// No /client, called JUST BEFORE the observer is sent to nullspace
+/mob/proc/mobcache_dismiss_actions()
+	return .
+
+
+// Actions to call when summoning the observer (Virtual New/Initialise)
+// This is similar to login
+// (hopefully) called AFTER the client has logged in
+/mob/proc/mobcache_summon_actions()
+	if(istype(src, /mob/new_player)) // root behaviors for /mob/newplayers
+		if(!client)
+			log_and_message_admins("MOBCACHE: A new_player was summoned but not given a client!")
+
+	if(istype(src, /mob/observer/dead)) // root behaviors for /mob/observer/dead
+		if(!client)
+			log_and_message_admins("MOBCACHE: A observer was summoned but not given a client!")
+
+		if(!isturf(loc)) // we ended up in nullspace somehow
+			to_chat(src, "<span class='danger'>Could not locate an observer spawn point. Use the Teleport verb to jump to the station map.</span>")
+
+	return .

--- a/code/_onclick/hud/ability_screen_objects.dm
+++ b/code/_onclick/hud/ability_screen_objects.dm
@@ -183,12 +183,20 @@
 	if(!ability_master)	//VOREStation Edit: S H A D E K I N
 		ability_master = new /obj/screen/movable/ability_master(src)
 
+/mob/mobcache_summon_actions()
+	. = ..()
+	if(!ability_master)	//VOREStation Edit: S H A D E K I N
+		ability_master = new /obj/screen/movable/ability_master(src)
 
 /mob/Destroy()
 	if(ability_master)
 		QDEL_NULL(ability_master)
 	. = ..()
 
+/mob/mobcache_dismiss_actions()
+	if(ability_master)
+		QDEL_NULL(ability_master)
+	. = ..()
 
 ///////////ACTUAL ABILITIES////////////
 //This is what you click to do things//

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -161,6 +161,7 @@ var/list/global_huds = list(
 
 /datum/hud
 	var/mob/mymob
+	var/client/instantiated_client
 
 	var/hud_shown = 1			//Used for the HUD toggle (F12)
 	var/inventory_shown = 1		//the inventory
@@ -204,7 +205,9 @@ var/list/global_huds = list(
 	..()
 
 /datum/hud/Destroy()
+	uninstantiate()
 	. = ..()
+	miniobjs = null
 	QDEL_NULL_LIST(minihuds)
 	grab_intent = null
 	hurt_intent = null
@@ -326,9 +329,38 @@ var/list/global_huds = list(
 	mymob.update_action_buttons()
 	reorganize_alerts()
 
+/datum/hud/proc/uninstantiate()
+	if(!instantiated_client)
+		return
+
+	instantiated_client.screen -= miniobjs
+	instantiated_client.screen -= grab_intent
+	instantiated_client.screen -= hurt_intent
+	instantiated_client.screen -= disarm_intent
+	instantiated_client.screen -= help_intent
+	instantiated_client.screen -= lingchemdisplay
+	instantiated_client.screen -= wiz_instability_display
+	instantiated_client.screen -= wiz_energy_display
+	instantiated_client.screen -= blobpwrdisplay
+	instantiated_client.screen -= blobhealthdisplay
+	instantiated_client.screen -= r_hand_hud_object
+	instantiated_client.screen -= l_hand_hud_object
+	instantiated_client.screen -= action_intent
+	instantiated_client.screen -= move_intent
+	instantiated_client.screen -= adding
+	instantiated_client.screen -= other
+	instantiated_client.screen -= other_important
+	instantiated_client.screen -= hotkeybuttons
+	instantiated_client.screen -= ammo_hud_list
+	instantiated_client = null
+	return
+
 /mob/proc/create_mob_hud(datum/hud/HUD, apply_to_client = TRUE)
 	if(!client)
 		return 0
+	if(HUD.instantiated_client && HUD.instantiated_client != client) //theoretically this should never happen
+		HUD.uninstantiate()
+	HUD.instantiated_client = client
 
 	HUD.ui_style = ui_style2icon(client?.prefs?.UI_style)
 	HUD.ui_color = client?.prefs?.UI_style_color

--- a/code/game/objects/items/devices/communicator/communicator.dm
+++ b/code/game/objects/items/devices/communicator/communicator.dm
@@ -366,6 +366,19 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	else
 		exonet.make_address("communicator-[key]-[src.real_name]")
 
+// summon_actions, when the observer is summoned back from nullspace by the mobcache
+// basically equivalent to a new/initialize
+/mob/observer/dead/mobcache_summon_actions()
+	. = ..()
+	if(exonet) //If it exists, recreate it just incase
+		QDEL_NULL(exonet)
+
+	exonet = new(src)
+	if(client)
+		exonet.make_address("communicator-[src.client]-[src.client.prefs.real_name]")
+	else
+		exonet.make_address("communicator-[key]-[src.real_name]")
+
 // Proc: Destroy()
 // Parameters: None
 // Description: Removes the ghost's address and nulls the exonet datum, to allow qdel()ing.
@@ -374,7 +387,14 @@ var/global/list/obj/item/device/communicator/all_communicators = list()
 	if(exonet)
 		exonet.remove_address()
 		qdel_null(exonet)
-	return ..()
+
+// dismiss_actions is when the observer is stashed away in nullspace
+// basically equivalent to a delete
+/mob/observer/dead/mobcache_dismiss_actions()
+	. = ..()
+	if(exonet)
+		exonet.remove_address()
+		qdel_null(exonet)
 
 // Proc: register_device()
 // Parameters: 1 (user - the person to use their name for)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1399,7 +1399,7 @@ var/datum/announcement/minor/admin_min_announcer = new
 	log_admin("[key_name(usr)] stuffed [frommob.ckey] into [tomob.name].")
 	feedback_add_details("admin_verb","CGD")
 	tomob.ckey = frommob.ckey
-	qdel(frommob)
+	//qdel(frommob)
 	return 1
 
 /datum/admins/proc/force_antag_latespawn()

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -10,3 +10,26 @@
 	if(cleanup_timer)
 		deltimer(cleanup_timer)
 		cleanup_timer = null
+
+	//Reassert these due to the mob being cached
+	//mob/Login() resets the invisibility/sight/plane stuff
+	invisibility = INVISIBILITY_OBSERVER
+	layer = BELOW_MOB_LAYER
+	plane = PLANE_GHOSTS
+	alpha = 127
+
+	sight |= SEE_TURFS | SEE_MOBS | SEE_OBJS | SEE_SELF
+	see_invisible = SEE_INVISIBLE_OBSERVER
+	see_in_dark = world.view //I mean. I don't even know if byond has occlusion culling... but...
+
+/mob/observer/dead/mobcache_summon_actions()
+	. = ..()
+	//ghost floaty anim
+	animate(src, pixel_y = 2, time = 10, loop = -1)
+	animate(pixel_y = default_pixel_y, time = 10, loop = -1)
+	observer_mob_list |= src
+
+/mob/observer/dead/mobcache_dismiss_actions()
+	. = ..()
+	//atop any animations
+	animate(src)

--- a/code/modules/mob/dead/observer/logout.dm
+++ b/code/modules/mob/dead/observer/logout.dm
@@ -1,9 +1,21 @@
 /mob/observer/dead/Logout()
 	..()
 	spawn(0)
-		if(src && !key)	//we've transferred to another mob. This ghost should be deleted.
-			qdel(src)
+		if(src && !ckey)	//we've transferred to another mob. This ghost should be deleted.
+			dismiss_observer_dead(src)
 		else
 			if(mind && mind.assigned_role) //CHOMPEdit
 				return //CHOMPEdit
-			cleanup_timer = QDEL_IN_STOPPABLE(src, 10 MINUTES)
+			cleanup_timer = addtimer(CALLBACK(src, PROC_REF(timed_cleanup)), 10 MINUTES, TIMER_STOPPABLE)
+
+/mob/observer/dead/proc/timed_cleanup() //returns TRUE if successful cleanup, FALSE if aborted
+	if(src && !ckey)	//A key is still parked here
+		log_and_message_admins("A cleaned up /mob/observer/dead magically lost it's key!")
+	else
+		if(mind && mind.assigned_role) //CHOMPEdit
+			log_and_message_admins("A cleaned up /mob/observer/dead magically gained a mind with an assigned role!")
+			return FALSE//CHOMPEdit
+		var/mob/new_player/NP = get_newplayer(ckey)
+		NP.ckey = ckey
+	dismiss_observer_dead(src)
+	return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -63,8 +63,7 @@
 		QDEL_NULL(nif)	//VOREStation Add
 	worn_clothing.Cut()
 
-
-	if(vessel)
+	if(!QDELETED(vessel))
 		QDEL_NULL(vessel)
 	return ..()
 

--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -12,7 +12,8 @@
 		ai_holder.go_sleep()
 		to_chat(src,"<span class='notice'>Mob AI disabled while you are controlling the mob.</span>")
 
-	AddComponent(/datum/component/character_setup)
+	if(!(GetComponent(/datum/component/character_setup)))
+		AddComponent(/datum/component/character_setup)
 
 	// Vore stuff
 	verbs |= /mob/living/proc/escapeOOC

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -445,10 +445,10 @@
 
 	announce_ghost_joinleave(client, 0)
 
-	var/mob/new_player/M = new /mob/new_player()
+	var/mob/new_player/M = get_newplayer(ckey)
 	if(!client)
 		log_game("[usr.key] AM failed due to disconnect.")
-		qdel(M)
+		//qdel(M)
 		return
 
 	M.has_respawned = TRUE //When we returned to main menu, send respawn message

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -41,13 +41,23 @@ var/obj/effect/lobby_image = new /obj/effect/lobby_image
 		mind.active = 1
 		mind.current = src
 
+	//since we don't call ..(), we need to do some things on login that /mob does.
+	client.images = null				//remove the images such as AIs being unable to see runes
+	client.screen = list()				//remove hud items just in case
+	if(hud_used)	qdel(hud_used)		//remove the hud objects
+	hud_used = new /datum/hud(src)
+
 	loc = null
 	client.screen += lobby_image
 	my_client = client
 	sight |= SEE_TURFS
 	player_list |= src
 
+	world.update_status()
+
 	created_for = ckey
+
+	update_newplayer_from_current(src, ckey)
 
 	new_player_panel()
 	spawn(40)

--- a/code/modules/mob/new_player/logout.dm
+++ b/code/modules/mob/new_player/logout.dm
@@ -6,12 +6,18 @@
 		my_client.screen -= lobby_image
 		my_client = null
 
+	if(panel)
+		QDEL_NULL(panel)
+
 	..()
 
 	//if(created_for)
 		//del_mannequin(created_for) No need to delete this, honestly. It saves up hardly any memory in the long run and fucks the GC in the short run.
 
+	/* //We store the new_player mob in a global now, no qdelling please
 	if(!spawning)//Here so that if they are spawning and log out, the other procs can play out and they will have a mob to come back to.
 		key = null//We null their key before deleting the mob, so they are properly kicked out.
 		qdel(src)
+	*/
+	dismiss_new_player(src)
 	return

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -180,8 +180,7 @@
 			//Make a new mannequin quickly, and allow the observer to take the appearance
 			var/mob/living/carbon/human/dummy/mannequin = get_mannequin(client.ckey)
 			client.prefs.dress_preview_mob(mannequin)
-			var/mob/observer/dead/observer = new(mannequin)
-			observer.moveToNullspace() //Let's not stay in our doomed mannequin
+			var/mob/observer/dead/observer = get_observer_dead(ckey, null, mannequin)
 			//qdel(mannequin)
 
 			spawning = 1
@@ -207,7 +206,7 @@
 				observer.verbs -= /mob/observer/dead/verb/toggle_antagHUD        // Poor guys, don't know what they are missing!
 			observer.key = key
 			observer.set_respawn_timer(time_till_respawn()) // Will keep their existing time if any, or return 0 and pass 0 into set_respawn_timer which will use the defaults
-			qdel(src)
+			//qdel(src)
 
 			return 1
 
@@ -511,7 +510,7 @@
 				cryst.bound_mob.capture_caught = TRUE
 				cryst.persist_storable = FALSE
 			cryst.update_icon()
-			qdel(src)
+			//qdel(src)
 			return
 	//CHOMPEdit end
 
@@ -542,7 +541,7 @@
 		ticker.mode.latespawn(character)
 
 		qdel(C) //Deletes empty core (really?)
-		qdel(src) //Deletes new_player
+		//qdel(src) //Deletes new_player
 		return
 
 	// Equip our custom items only AFTER deploying to spawn points eh?
@@ -611,7 +610,7 @@
 		if(gut)
 			character.forceMove(gut)
 
-	qdel(src) // Delete new_player mob
+	//qdel(src) // Delete new_player mob
 
 /mob/new_player/proc/AnnounceCyborg(var/mob/living/character, var/rank, var/join_message, var/channel, var/zlevel)
 	if (ticker.current_state == GAME_STATE_PLAYING)

--- a/modular_chomp/code/modules/mob/dead/observer/observer.dm
+++ b/modular_chomp/code/modules/mob/dead/observer/observer.dm
@@ -9,6 +9,13 @@
 		body_backup = null
 	return ..()
 
+/mob/observer/mobcache_dismiss_actions() //body backup is set by the caller of ghostize, a dismissal is just getting rid of it.
+	if(body_backup)
+		body_backup.moveToNullspace() //YEET
+		qdel(body_backup)
+		body_backup = null
+	. = ..()
+
 // Persistence vars not included as we probably don't want losing limbs in the game mean losing limbs in real life. Definitely can't backfire.
 /mob/observer/dead/verb/fake_enter_vr()
 	set name = "Join virtual reality"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -158,6 +158,7 @@
 #include "code\_helpers\logging.dm"
 #include "code\_helpers\logging_vr.dm"
 #include "code\_helpers\matrices.dm"
+#include "code\_helpers\mobcache_players.dm"
 #include "code\_helpers\mobs.dm"
 #include "code\_helpers\names.dm"
 #include "code\_helpers\sanitize_values.dm"


### PR DESCRIPTION

## About The Pull Request

Caches player-owned /mob/observer/deads and /mob/new_players as these are reused frequently

## Changelog
🆑
refactor: Refactor how /mob/new_player and /mob/observer/dead are handled (one of each is cached per ckey instead of destroy/new)
/:cl:
