### PR TITLE
Properly defines a few global vars

### DIFF
--- a/code/controllers/failsafe.dm
+++ b/code/controllers/failsafe.dm
@@ -4,7 +4,7 @@
   * Pretty much pokes the MC to make sure it's still alive.
  **/
 
-var/datum/controller/failsafe/Failsafe
+GLOBAL_REAL(Failsafe, /datum/controller/failsafe) // CHOMPEdit - Managed Globals
 
 /datum/controller/failsafe // This thing pretty much just keeps poking the master controller
 	name = "Failsafe"

--- a/code/game/birthday.dm
+++ b/code/game/birthday.dm
@@ -1,21 +1,21 @@
 /mob/living/carbon/human/proc/consider_birthday()
-	if(!bday_month || !bday_day)	//If we don't have one of these set, don't worry about it
+	if(!bday_month || !bday_day) //If we don't have one of these set, don't worry about it
 		return
-	if(real_name != client.prefs.real_name)	//let's not celebrate the birthday of that weird mob we got dropped into
+	if(real_name != client.prefs.real_name) //let's not celebrate the birthday of that weird mob we got dropped into
 		return
-	if(!(client.prefs.last_birthday_notification < world_time_year))	//you only get notified once a year
+	if(!(client.prefs.last_birthday_notification < GLOB.world_time_year)) //you only get notified once a year // CHOMPEdit - Managed Globals
 		return
-	if((world_time_month == bday_month) && (world_time_day == bday_day))	//it is your birthday
+	if((GLOB.world_time_month == bday_month) && (GLOB.world_time_day == bday_day)) //it is your birthday // CHOMPEdit - Managed Globals
 		birthday(1)
-	else if(world_time_month > bday_month)	//your birthday was in a previous month
+	else if(GLOB.world_time_month > bday_month) //your birthday was in a previous month // CHOMPEdit - Managed Globals
 		birthday()
-	else if((world_time_month == bday_month) && (world_time_day > bday_day))	//your birthday was earlier this month
+	else if((GLOB.world_time_month == bday_month) && (GLOB.world_time_day > bday_day)) //your birthday was earlier this month // CHOMPEdit - Managed Globals
 		birthday()
 
 /mob/living/carbon/human/proc/birthday(var/birthday = 0)
 	var/msg
 	var/lastyear = client.prefs.last_birthday_notification
-	client.prefs.last_birthday_notification = world_time_year	//We only want to ask once a year per character, this persists, update early in case of shenanigans
+	client.prefs.last_birthday_notification = GLOB.world_time_year //We only want to ask once a year per character, this persists, update early in case of shenanigans // CHOMPEdit - Managed Globals
 	if(birthday)	//woo
 		msg = "Today is your birthday! Do you want to increase your character's listed age?"
 		/* //Chomp DISABLE - Absolutely not.
@@ -30,7 +30,7 @@
 		if(lastyear == 0)	//We've never been asked, so let's just assume you were keeping track before now and only add 1
 			age += 1
 		else
-			var/howmuch = world_time_year - lastyear
+			var/howmuch = GLOB.world_time_year - lastyear // CHOMPEdit - Managed Globals
 			age += howmuch
 		to_chat(src, "<span class = 'notice'>You are now [age]! Happy birthday!</span>")
 		client.prefs.age = age	//Set the age on the character sheet

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -1,6 +1,6 @@
 #define WHITELISTFILE "data/whitelist.txt"
 
-var/list/whitelist = list()
+GLOBAL_LIST_EMPTY(whitelist) // CHOMPEdit - Managed Globals
 
 /hook/startup/proc/loadWhitelist()
 	if(config.usewhitelist)
@@ -8,17 +8,17 @@ var/list/whitelist = list()
 	return 1
 
 /proc/load_whitelist()
-	whitelist = file2list(WHITELISTFILE)
-	if(!whitelist.len)	whitelist = null
+	GLOB.whitelist = file2list(WHITELISTFILE) // CHOMPEdit - Managed Globals
+	if(!GLOB.whitelist.len)	GLOB.whitelist = null // CHOMPEdit - Managed Globals
 
 /proc/check_whitelist(mob/M /*, var/rank*/)
 	if(!config.usewhitelist) //CHOMPedit: I guess this is an override for the blanket whitelist system.
 		return 1 //CHOMPedit
-	if(!whitelist)
+	if(!GLOB.whitelist) // CHOMPEdit - Managed Globals
 		return 0
-	return ("[M.ckey]" in whitelist)
+	return ("[M.ckey]" in GLOB.whitelist) // CHOMPEdit - Managed Globals
 
-/var/list/alien_whitelist = list()
+GLOBAL_LIST_EMPTY(alien_whitelist) // CHOMPEdit - Managed Globals
 
 /hook/startup/proc/loadAlienWhitelist()
 	if(config.usealienwhitelist)
@@ -40,10 +40,10 @@ var/list/whitelist = list()
 			if(key != ckey(key))
 				warning("Alien whitelist entry appears to have key, not ckey: [line]") // The key contains invalid ckey characters
 				continue
-			var/list/our_whitelists = alien_whitelist[key] // Try to see if we have one already and add to it
+			var/list/our_whitelists = GLOB.alien_whitelist[key] // Try to see if we have one already and add to it // CHOMPEdit - Managed Globals
 			if(!our_whitelists) // Guess this is their first/only whitelist entry
 				our_whitelists = list()
-				alien_whitelist[key] = our_whitelists
+				GLOB.alien_whitelist[key] = our_whitelists // CHOMPEdit - Managed Globals
 			our_whitelists += left_and_right[2]
 
 /proc/is_alien_whitelisted(mob/M, var/datum/species/species)
@@ -60,7 +60,7 @@ var/list/whitelist = list()
 		return TRUE
 
 	//Search the whitelist
-	var/list/our_whitelists = alien_whitelist[M.ckey]
+	var/list/our_whitelists = GLOB.alien_whitelist[M.ckey] // CHOMPEdit - Managed Globals
 	if("All" in our_whitelists)
 		return TRUE
 	if(species.name in our_whitelists)
@@ -83,7 +83,7 @@ var/list/whitelist = list()
 		return TRUE
 
 	//Search the whitelist
-	var/list/our_whitelists = alien_whitelist[M.ckey]
+	var/list/our_whitelists = GLOB.alien_whitelist[M.ckey] // CHOMPEdit - Managed Globals
 	if("All" in our_whitelists)
 		return TRUE
 	if(language.name in our_whitelists)
@@ -105,8 +105,8 @@ var/list/whitelist = list()
 		return 1
 
 	//If we have a loaded file, search it
-	if(alien_whitelist)
-		for (var/s in alien_whitelist)
+	if(GLOB.alien_whitelist) // CHOMPEdit - Managed Globals
+		for (var/s in GLOB.alien_whitelist) // CHOMPEdit - Managed Globals
 			if(findtext(s,"[M.ckey] - [module]"))
 				return 1
 			if(findtext(s,"[M.ckey] - All"))

--- a/code/game/jobs/whitelist_vr.dm
+++ b/code/game/jobs/whitelist_vr.dm
@@ -1,4 +1,4 @@
-var/list/job_whitelist = list()
+GLOBAL_LIST_EMPTY(job_whitelist) // CHOMPEdit - Managed Globals
 
 /hook/startup/proc/loadJobWhitelist()
 	if(config.use_jobwhitelist) // CHOMPedit
@@ -10,7 +10,7 @@ var/list/job_whitelist = list()
 	if (!text)
 		log_misc("Failed to load config/jobwhitelist.txt")
 	else
-		job_whitelist = splittext(text, "\n")
+		GLOB.job_whitelist = splittext(text, "\n") // CHOMPEdit - Managed Globals
 
 /proc/is_job_whitelisted(mob/M, var/rank)
 	if(!config.use_jobwhitelist) // CHOMPedit
@@ -22,10 +22,10 @@ var/list/job_whitelist = list()
 		return 1
 	if(check_rights(R_ADMIN, 0) || check_rights(R_DEBUG, 0) || check_rights(R_EVENT, 0)) // CHOMPedit
 		return 1
-	if(!job_whitelist)
+	if(!GLOB.job_whitelist) // CHOMPEdit - Managed Globals
 		return 0
 	if(M && rank)
-		for (var/s in job_whitelist)
+		for (var/s in GLOB.job_whitelist) // CHOMPEdit - Managed Globals
 			if(findtext(s,"[lowertext(M.ckey)] - [lowertext(rank)]"))
 				return 1
 			if(findtext(s,"[M.ckey] - All"))

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -28,7 +28,7 @@
 		//	delete_me = 1
 			return
 		//VOREStation Add end
-		if("Observer-Start") // Ghosts are the only thing that use the latejoin list afaik and it complains if there's nothing in the list. 
+		if("Observer-Start") // Ghosts are the only thing that use the latejoin list afaik and it complains if there's nothing in the list.
 			latejoin += src
 			simulated = TRUE
 			return
@@ -39,11 +39,11 @@
 			return
 		//CHOMPEdit Begin
 		if("JoinLateStationGateway")
-			latejoin_gatewaystation += loc
+			GLOB.latejoin_gatewaystation += loc
 			delete_me = 1
 			return
 		if("JoinLateSifPlains")
-			latejoin_plainspath += loc
+			GLOB.latejoin_plainspath += loc
 			delete_me = 1
 			return
 		//CHOMPEdit End

--- a/code/game/turfs/flooring/seasonal.dm
+++ b/code/game/turfs/flooring/seasonal.dm
@@ -1,23 +1,25 @@
-var/world_time_season
-var/world_time_year
-var/world_time_month
-var/world_time_day
+// CHOMPEdit Start - Managed Globals
+GLOBAL_VAR(world_time_season)
+GLOBAL_VAR(world_time_year)
+GLOBAL_VAR(world_time_month)
+GLOBAL_VAR(world_time_day)
+// CHOMPEdit End
 
 /proc/setup_season()
-	world_time_month = text2num(time2text(world.timeofday, "MM")) 	// get the current month
-	switch(world_time_month)
+	GLOB.world_time_month = text2num(time2text(world.timeofday, "MM")) 	// get the current month // CHOMPEdit - Managed Globals
+	switch(GLOB.world_time_month) // CHOMPEdit - Managed Globals
 		if(1 to 2)
-			world_time_season = "winter"
+			GLOB.world_time_season = "winter" // CHOMPEdit - Managed Globals
 		if(3 to 5)
-			world_time_season = "spring"
+			GLOB.world_time_season = "spring" // CHOMPEdit - Managed Globals
 		if(6 to 8)
-			world_time_season = "summer"
+			GLOB.world_time_season = "summer" // CHOMPEdit - Managed Globals
 		if(9 to 11)
-			world_time_season = "autumn"
+			GLOB.world_time_season = "autumn" // CHOMPEdit - Managed Globals
 		if(12)
-			world_time_season = "winter"
-	world_time_day = text2num(time2text(world.timeofday, "DD"))
-	world_time_year = text2num(time2text(world.timeofday, "YYYY"))
+			GLOB.world_time_season = "winter" // CHOMPEdit - Managed Globals
+	GLOB.world_time_day = text2num(time2text(world.timeofday, "DD")) // CHOMPEdit - Managed Globals
+	GLOB.world_time_year = text2num(time2text(world.timeofday, "YYYY")) // CHOMPEdit - Managed Globals
 
 /turf/simulated/floor/outdoors/grass/seasonal
 	name = "grass"
@@ -36,9 +38,9 @@ var/world_time_day
 	var/tree_types = list()
 	var/snow_chance = 10
 
-/turf/simulated/floor/outdoors/grass/seasonal/Initialize() //There are A LOT of chompedits here, I guess. 
+/turf/simulated/floor/outdoors/grass/seasonal/Initialize() //There are A LOT of chompedits here, I guess.
 
-	switch(world_time_season)
+	switch(GLOB.world_time_season)
 		if("spring")
 			tree_types = list(
 				/obj/structure/flora/tree/bigtree,
@@ -191,7 +193,7 @@ var/world_time_day
 
 /turf/simulated/floor/outdoors/grass/seasonal/proc/update_desc()
 
-	switch(world_time_season)
+	switch(GLOB.world_time_season) // CHOMPEdit - Managed Globals
 		if("spring")
 			desc = "Lush green grass, flourishing! Little flowers peek out from between the blades here and there!"
 		if("summer")
@@ -205,10 +207,10 @@ var/world_time_day
 /turf/simulated/floor/outdoors/grass/seasonal/update_icon(update_neighbors)
 	. = ..()
 	update_desc()
-	switch(world_time_season)
+	switch(GLOB.world_time_season) // CHOMPEdit - Managed Globals
 		if("spring")
 			if(prob(50))
-				var/cache_key = "[world_time_season]-overlay[rand(1,19)]"
+				var/cache_key = "[GLOB.world_time_season]-overlay[rand(1,19)]" // CHOMPEdit - Managed Globals
 				if(!overlays_cache[cache_key])
 					var/image/I = image(icon = src.icon, icon_state = cache_key, layer = ABOVE_TURF_LAYER) // Icon should be abstracted out
 					I.plane = TURF_PLANE
@@ -220,7 +222,7 @@ var/world_time_day
 			return
 		if("autumn")
 			if(prob(33))
-				var/cache_key = "[world_time_season]-overlay[rand(1,6)]"
+				var/cache_key = "[GLOB.world_time_season]-overlay[rand(1,6)]" // CHOMPEdit - Managed Globals
 				if(!overlays_cache[cache_key])
 					var/image/I = image(icon = src.icon, icon_state = cache_key, layer = ABOVE_TURF_LAYER) // Icon should be abstracted out
 					I.plane = TURF_PLANE
@@ -275,14 +277,14 @@ var/world_time_day
 
 /turf/simulated/floor/water/seasonal/Initialize()
 	. = ..()
-	switch(world_time_season)
+	switch(GLOB.world_time_season) // CHOMPEdit - Managed Globals
 		if("winter")
 			if(prob(99))
 				ChangeTurf(/turf/simulated/floor/outdoors/ice)
 
 /turf/simulated/floor/water/deep/seasonal/Initialize()
 	. = ..()
-	switch(world_time_season)
+	switch(GLOB.world_time_season) // CHOMPEdit - Managed Globals
 		if("winter")
 			if(prob(75))
 				ChangeTurf(/turf/simulated/floor/outdoors/ice)

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -25,7 +25,7 @@ var/image/no_ceiling_image = null
 			icon_state = flooring.icon_base
 									//VOREStation Addition Start
 			if(flooring.check_season)
-				icon_state = "[icon_state]-[world_time_season]"	//VOREStation Addition End
+				icon_state = "[icon_state]-[GLOB.world_time_season]"	//VOREStation Addition End // CHOMPEdit - Managed Globals
 			if(flooring.has_base_range)
 				icon_state = "[icon_state][rand(0,flooring.has_base_range)]"
 				flooring_override = icon_state

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -264,7 +264,7 @@ var/list/gear_datums = list()
 	if(!description)
 		var/obj/O = path
 		description = initial(O.desc)
-	gear_tweaks = list(gear_tweak_free_name, gear_tweak_free_desc, gear_tweak_item_tf_spawn, GLOB.gear_tweak_free_matrix_recolor) //CHOMPEdit - Item TF spawnpoints
+	gear_tweaks = list(gear_tweak_free_name, gear_tweak_free_desc, GLOB.gear_tweak_item_tf_spawn, GLOB.gear_tweak_free_matrix_recolor) //CHOMPEdit - Item TF spawnpoints
 
 /datum/gear_data
 	var/path

--- a/code/modules/events/roaming_wildlife.dm
+++ b/code/modules/events/roaming_wildlife.dm
@@ -10,7 +10,7 @@
 	for(var/obj/effect/landmark/C in landmarks_list)
 		if(istype(C, /obj/effect/landmark/wildlife))
 			var/obj/effect/landmark/wildlife/WLLM = C
-			if(world_time_season == "winter" && WLLM.wildlife_type == 1)		//fish forbidden in winter because ice now aparently
+			if(GLOB.world_time_season == "winter" && WLLM.wildlife_type == 1) //fish forbidden in winter because ice now aparently // CHOMPEdit - Managed Globals
 				continue
 			possible_spawns.Add(C)
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -322,7 +322,7 @@
 	//VOREStatation Edit Start: shell restrictions //CHOMPstaton change to blacklist
 	if(shell)
 		modules.Add(robot_module_types)
-		modules.Remove(shell_module_blacklist)
+		modules.Remove(GLOB.shell_module_blacklist) // CHOMPEdit - Managed Globals
 		//CHOMPedit Add
 		if(crisis || security_level == SEC_LEVEL_RED || crisis_override)
 			to_chat(src, span_red("Crisis mode active. Combat module available."))

--- a/code/modules/mob/living/simple_mob/subtypes/animal/squirrel.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/squirrel.dm
@@ -153,7 +153,7 @@
 /mob/living/simple_mob/vore/squirrel/Initialize()
 	. = ..()
 	if(do_seasons)
-		switch(world_time_season)
+		switch(GLOB.world_time_season) // CHOMPEdit - Managed Globals
 			if("spring")
 				if(prob(1))
 					winterize()

--- a/code/modules/mob/login_ch.dm
+++ b/code/modules/mob/login_ch.dm
@@ -1,6 +1,6 @@
 /mob/Login()
 	. = ..()
 	set_listening(LISTENING_PLAYER)
-	if(global_vantag_hud)
+	if(GLOB.global_vantag_hud)
 		vantag_hud = TRUE
 		recalculate_vis()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -705,7 +705,7 @@
 			stat(null, "Time Dilation: [round(SStime_track.time_dilation_current,1)]% AVG:([round(SStime_track.time_dilation_avg_fast,1)]%, [round(SStime_track.time_dilation_avg,1)]%, [round(SStime_track.time_dilation_avg_slow,1)]%)")
 			if(ticker && ticker.current_state != GAME_STATE_PREGAME)
 				stat("Station Time", stationtime2text())
-				var/date = "[stationdate2text()], [capitalize(world_time_season)]"
+				var/date = "[stationdate2text()], [capitalize(GLOB.world_time_season)]" // CHOMPEdit - Managed Globals
 				stat("Station Date", date)
 				stat("Round Duration", roundduration2text())
 

--- a/modular_chomp/code/game/objects/effects/step_triggers.dm
+++ b/modular_chomp/code/game/objects/effects/step_triggers.dm
@@ -1,5 +1,5 @@
-var/static/list/mapped_autostrips = list()
-var/static/list/mapped_autostrips_mob = list()
+GLOBAL_LIST_EMPTY(mapped_autostrips)
+GLOBAL_LIST_EMPTY(mapped_autostrips_mob)
 
 /*
 This should actually be refactored if it ever needs to be used again into just being
@@ -74,8 +74,8 @@ But for now, for what it's been used for, it works.
 
 /obj/effect/step_trigger/autostrip/proc/initMappedLink()
 	. = FALSE
-	target = mapped_autostrips[targetid]
-	Mtarget = mapped_autostrips_mob[targetid]
+	target = GLOB.mapped_autostrips[targetid]
+	Mtarget = GLOB.mapped_autostrips_mob[targetid]
 	if(target)
 		. = TRUE
 
@@ -93,11 +93,11 @@ But for now, for what it's been used for, it works.
 /obj/effect/autostriptarget/Initialize(mapload)
 	. = ..()
 	if(targetid)
-		mapped_autostrips[targetid] = src
+		GLOB.mapped_autostrips[targetid] = src
 
 /obj/effect/autostriptarget/mob
 	name = "Autostrip target to send mobs to."
 
 /obj/effect/autostriptarget/mob/Initialize(mapload)
 	if(targetid)
-		mapped_autostrips_mob[targetid] = src
+		GLOB.mapped_autostrips_mob[targetid] = src

--- a/modular_chomp/code/global.dm
+++ b/modular_chomp/code/global.dm
@@ -1,11 +1,11 @@
 
-var/list/shell_module_blacklist = list(
+GLOBAL_LIST_INIT(shell_module_blacklist, list(
 	"Sci-borg", "Research"
-	)
-var/list/latejoin_gatewaystation = list()
-var/list/latejoin_plainspath = list()
+	))
+GLOBAL_LIST_EMPTY(latejoin_gatewaystation)
+GLOBAL_LIST_EMPTY(latejoin_plainspath)
 
-var/list/talk_sound_map = rlist(
+GLOBAL_LIST_INIT(talk_sound_map, rlist(
 								list(
 									"beep-boop",
 									"goon speak 1",
@@ -40,12 +40,12 @@ var/list/talk_sound_map = rlist(
 									goon_speak_skelly_sound,
 									xeno_speak_sound // CHOMPedit
 									)
-								)
+								))
 
 /proc/get_talk_sound(var/voice_sound)
 	if(!voice_sound)
-		return talk_sound_map[1]
-	return talk_sound_map[2][voice_sound]
+		return GLOB.talk_sound_map[1]
+	return GLOB.talk_sound_map[2][voice_sound]
 
 /proc/rlist(var/list/keys,var/list/values) //short for reversible list generator
 	var/list/rlist = list(list(),list(),FALSE,0)

--- a/modular_chomp/code/modules/admin/verbs/randomverbs.dm
+++ b/modular_chomp/code/modules/admin/verbs/randomverbs.dm
@@ -1,13 +1,15 @@
-var/global_vantag_hud = 0
+GLOBAL_VAR_INIT(global_vantag_hud, 0)
 
-/client/proc/toggle_vantag_hud_global(var/mob/target as mob)
+/client/proc/toggle_vantag_hud_global(mob/target as mob)
 	set category = "Fun"
 	set name = "Toggle Global Event HUD"
 	set desc = "Give everyone the Event HUD."
 
-	global_vantag_hud = !global_vantag_hud
-	if(global_vantag_hud)
+	GLOB.global_vantag_hud = !GLOB.global_vantag_hud
+	if(GLOB.global_vantag_hud)
 		for(var/mob/living/L in living_mob_list)
 			if(L.ckey)
 				L.vantag_hud = TRUE
 				L.recalculate_vis()
+
+	to_chat(src, "<span class='warning'>Global Event HUD has been turned [GLOB.global_vantag_hud ? "on" : "off"].</span>")

--- a/modular_chomp/code/modules/client/preference_setup/loadout/gear_tweaks.dm
+++ b/modular_chomp/code/modules/client/preference_setup/loadout/gear_tweaks.dm
@@ -1,4 +1,4 @@
-var/datum/gear_tweak/item_tf_spawn/gear_tweak_item_tf_spawn = new()
+GLOBAL_DATUM_INIT(gear_tweak_item_tf_spawn, /datum/gear_tweak/item_tf_spawn, new())
 
 /datum/gear_tweak/item_tf_spawn
 

--- a/modular_chomp/code/modules/client/preferences_spawnpoints.dm
+++ b/modular_chomp/code/modules/client/preferences_spawnpoints.dm
@@ -5,7 +5,7 @@
 
 /datum/spawnpoint/stationgateway/New()
 	..()
-	turfs = latejoin_gatewaystation
+	turfs = GLOB.latejoin_gatewaystation
 
 /datum/spawnpoint/vore
 	display_name = "Vorespawn - Prey"
@@ -31,4 +31,4 @@
 
 /datum/spawnpoint/plainspath/New()
 	..()
-	turfs = latejoin_plainspath
+	turfs = GLOB.latejoin_plainspath

--- a/modular_chomp/code/modules/event/meatyores.dm
+++ b/modular_chomp/code/modules/event/meatyores.dm
@@ -34,30 +34,30 @@
 /datum/event/meteor_wave/meatyores/proc/get_meatyores()
 	switch(severity)
 		if(EVENT_LEVEL_MAJOR)
-			return meatyores_major
+			return GLOB.meatyores_major
 		if(EVENT_LEVEL_MODERATE)
-			return meatyores_moderate
+			return GLOB.meatyores_moderate
 		else
-			return meatyores_minor
+			return GLOB.meatyores_minor
 
-var/list/meatyores_minor = list(
+GLOBAL_LIST_INIT(meatyores_minor, list(
 	/obj/effect/meteor/medium/meatyore     = 80,
 	/obj/effect/meteor/dust/meatyore       = 30,
 	/obj/effect/meteor/irradiated/meatyore = 30,
 	/obj/effect/meteor/big/meatyore        = 30,
 	/obj/effect/meteor/flaming/meatyore    = 10,
-)
+))
 
-var/list/meatyores_moderate = list(
+GLOBAL_LIST_INIT(meatyores_moderate, list(
 	/obj/effect/meteor/medium/meatyore     = 80,
 	/obj/effect/meteor/big/meatyore        = 30,
 	/obj/effect/meteor/dust/meatyore       = 30,
 	/obj/effect/meteor/irradiated/meatyore = 30,
 	/obj/effect/meteor/flaming/meatyore    = 10,
 	/obj/effect/meteor/emp/meatyore        = 10,
-)
+))
 
-var/list/meatyores_major = list(
+GLOBAL_LIST_INIT(meatyores_major, list(
 	/obj/effect/meteor/medium/meatyore     = 80,
 	/obj/effect/meteor/big/meatyore        = 30,
 	/obj/effect/meteor/dust/meatyore       = 30,
@@ -65,4 +65,4 @@ var/list/meatyores_major = list(
 	/obj/effect/meteor/emp/meatyore        = 30,
 	/obj/effect/meteor/flaming/meatyore    = 10,
 	/obj/effect/meteor/tunguska/meatyore   = 1,
-)
+))

--- a/modular_chomp/code/modules/flufftext/Dreaming.dm
+++ b/modular_chomp/code/modules/flufftext/Dreaming.dm
@@ -1,5 +1,5 @@
 /*
-var/list/dreams = list(
+	dreams = list(
 	"an ID card","a bottle","a familiar face","a crewmember","a toolbox","a Security Officer","the Site Manager",
 	"voices from all around","deep space","a doctor","the engine","a traitor","an ally","darkness",
 	"light","a scientist","a monkey","a catastrophe","a loved one","a gun","warmth","freezing","the sun",

--- a/modular_chomp/code/modules/recycling/v_garbosystem.dm
+++ b/modular_chomp/code/modules/recycling/v_garbosystem.dm
@@ -111,7 +111,7 @@
 			if(items_taken >= voracity)
 				break
 		if(items_taken) //Lazy coder sound design moment.
-			Recycled_Items = Recycled_Items + items_taken
+			GLOB.Recycled_Items = GLOB.Recycled_Items + items_taken
 			playsound(src, 'sound/items/poster_being_created.ogg', 50, 1)
 			playsound(src, 'sound/items/electronic_assembly_emptying.ogg', 50, 1)
 			playsound(src, 'sound/effects/metalscrape2.ogg', 50, 1)
@@ -142,4 +142,4 @@
 	if(grinder)
 		return grinder.attack_hand(user)
 
-var/Recycled_Items = 0
+GLOBAL_VAR_INIT(Recycled_Items, 0)


### PR DESCRIPTION

## About The Pull Request

A few of the global vars have been changed to use the actual defines (found in code/__defines/__globals.dm).

This will get them properly tracked inside of the globals controller.

## Changelog
:cl:
qol: A few global vars are now properly managed
admin: The loaded whitelists can be now edited in-game (so that players can be whitelisted before the round has to be restarted)
/:cl:
