### PR TITLE
makes inputs apply on click again

### DIFF
--- a/code/modules/admin/admin_tools.dm
+++ b/code/modules/admin/admin_tools.dm
@@ -1,10 +1,11 @@
-/client/proc/cmd_admin_check_player_logs() // CHOMPEdit
+/client/proc/cmd_admin_check_player_logs(var/mob/living/M) // CHOMPEdit
 	set category = "Admin"
 	set name = "Check Player Attack Logs"
 	set desc = "Check a player's attack logs."
 
 	// CHOMPEdit Begin
-	var/mob/living/M = tgui_input_list(usr, "Check a player's attack logs.", "Check Player Attack Logs", mob_list)
+	if(M?.client == usr.client)
+		M = tgui_input_list(usr, "Check a player's attack logs.", "Check Player Attack Logs", mob_list)
 
 	if(!M)
 		return
@@ -44,13 +45,14 @@
 
 	feedback_add_details("admin_verb","PL") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/cmd_admin_check_dialogue_logs() // CHOMPEdit
+/client/proc/cmd_admin_check_dialogue_logs(var/mob/living/M) // CHOMPEdit
 	set category = "Admin"
 	set name = "Check Player Dialogue Logs"
 	set desc = "Check a player's dialogue logs."
 
 	// CHOMPEdit Begin
-	var/mob/living/M = tgui_input_list(usr, "Check a player's dialogue logs.", "Check Player Dialogue Logs", mob_list)
+	if(M?.client == usr.client)
+		M = tgui_input_list(usr, "Check a player's dialogue logs.", "Check Player Dialogue Logs", mob_list)
 
 	if(!M)
 		return

--- a/code/modules/admin/verbs/resize.dm
+++ b/code/modules/admin/verbs/resize.dm
@@ -1,4 +1,4 @@
-/client/proc/resize() // CHOMPEdit
+/client/proc/resize(var/mob/living/L) // CHOMPEdit
 	set name = "Resize"
 	set desc = "Resizes any living mob without any restrictions on size."
 	set category = "Fun"
@@ -7,7 +7,8 @@
 	if(!check_rights(R_ADMIN|R_FUN|R_VAREDIT))
 		return
 
-	var/mob/living/L = tgui_input_list(usr, "Resizes any living mob without any restrictions on size.", "Resize", mob_list)
+	if(L?.client == usr.client)
+		L = tgui_input_list(usr, "Resizes any living mob without any restrictions on size.", "Resize", mob_list)
 
 	if(!L)
 		return


### PR DESCRIPTION
## About The Pull Request
fixes #7956
## Changelog
:cl:
fix: readds the updated inputs to the right click verbs again (one limitation, on self will always open the tgui selection)
/:cl:
