### PR TITLE
Fix a missed check that allows you to spawn as jobs you shouldn't at roundstart

### DIFF
--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -31,6 +31,12 @@
 		pass = FALSE
 		to_chat(src,"<span class='warning'>You are not allowed to spawn in as this species.</span>")
 
+	//CHOMPEdit Begin - Check species job bans... (Only used for shadekin)
+	if(J.is_species_banned(client?.prefs?.species, client?.prefs?.organ_data["brain"]))
+		pass = FALSE
+		to_chat(src,"<span class='warning'>Your species is not permitted to take this role or job.</span>")
+	//CHOMPEdit End
+
 	//Custom species checks
 	if (client?.prefs?.species == "Custom Species")
 

--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -12620,19 +12620,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hangar/two)
-"dPg" = (
-/obj/structure/cable/blue{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/reinforced,
-/area/hangar/two)
 "dPz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -74870,7 +74857,7 @@ bWE
 aGB
 diS
 aKE
-dPg
+vNk
 vNk
 cCf
 dWL


### PR DESCRIPTION
## About The Pull Request
## Changelog
:cl:
fix: Job restriction bypass at roundstart
fix: fix a cabling mistake in hangar 2
/:cl:
