### PR TITLE
Chat tags use assets

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -349,16 +349,17 @@
 //The icon var could be local in the proc, but it's a waste of resources
 //	to always create it and then throw it out.
 /var/icon/text_tag_icons = 'icons/chattags.dmi'
-/var/list/text_tag_cache = list()
+GLOBAL_LIST_EMPTY(text_tag_cache)
+
 /proc/create_text_tag(var/tagname, var/tagdesc = tagname, var/client/C = null)
 	if(!(C && C.is_preference_enabled(/datum/client_preference/chat_tags)))
 		return tagdesc
-	if(!text_tag_cache[tagname])
-		var/icon/tag = icon(text_tag_icons, tagname)
-		text_tag_cache[tagname] = tag
+	if(!GLOB.text_tag_cache[tagname])
+		var/datum/asset/spritesheet/chatassets = get_asset_datum(/datum/asset/spritesheet/chat)
+		GLOB.text_tag_cache[tagname] = chatassets.icon_tag(tagname)
 	if(!C.tgui_panel.is_ready() || C.tgui_panel.oldchat)
 		return "<IMG src='\ref[text_tag_icons]' class='text_tag' iconstate='[tagname]'" + (tagdesc ? " alt='[tagdesc]'" : "") + ">"
-	return icon2html(text_tag_cache[tagname], C, extra_classes = "text_tag")
+	return GLOB.text_tag_cache[tagname]
 
 /proc/create_text_tag_old(var/tagname, var/tagdesc = tagname, var/client/C = null)
 	if(!(C && C.is_preference_enabled(/datum/client_preference/chat_tags)))

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -356,7 +356,7 @@ GLOBAL_LIST_EMPTY(text_tag_cache)
 		return tagdesc
 	if(!GLOB.text_tag_cache[tagname])
 		var/datum/asset/spritesheet/chatassets = get_asset_datum(/datum/asset/spritesheet/chat)
-		GLOB.text_tag_cache[tagname] = chatassets.icon_tag(tagname)
+		GLOB.text_tag_cache[tagname] = {"<span class='[chatassets.icon_class_name(tagname)] text_tag'></span>"}
 	if(!C.tgui_panel.is_ready() || C.tgui_panel.oldchat)
 		return "<IMG src='\ref[text_tag_icons]' class='text_tag' iconstate='[tagname]'" + (tagdesc ? " alt='[tagdesc]'" : "") + ">"
 	return GLOB.text_tag_cache[tagname]

--- a/code/modules/asset_cache/assets/chat.dm
+++ b/code/modules/asset_cache/assets/chat.dm
@@ -2,5 +2,4 @@
 	name = "chat"
 
 /datum/asset/spritesheet/chat/create_spritesheets()
-	//honk
-	//This function has to be overridden otherwise it will generate runtimes
+	InsertAll("", text_tag_icons) //Chomp - OOC, LOOC ect icons


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:
fix: Fixes a runtime and makes chat tags (OOC, LOOC, ect) use a cache properly. 
/:cl:
