### PR TITLE
Adds boneless trait

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/neutral.dm
@@ -16,3 +16,18 @@
 /datum/trait/neutral/hide/apply(var/datum/species/S,var/mob/living/carbon/human/H)
 	..()
 	H.verbs |= /mob/living/proc/hide
+
+/datum/trait/neutral/boneless
+	name = "Boneless"
+	desc = "You have no bones! Though your limbs are also easier to gib in exchange."
+	cost = 0
+	custom_only = TRUE
+	can_take = ORGANICS
+
+/datum/trait/neutral/boneless/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	for(var/obj/item/organ/external/ex_organ in H.organs)
+		ex_organ.cannot_break = 1
+		ex_organ.dislocated = -1
+		ex_organ.spread_dam = 1
+		ex_organ.max_damage = floor(ex_organ.max_damage * 0.45)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Boneless trait, for custom species organics only. Cannot break or dislocate limbs, but damage is spread and max limb damage is set to 45% of the normal limb's damage amount.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: New trait boneless
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
