### PR TITLE
Silences throw-notifications on help intent

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1200,7 +1200,7 @@
 /mob/proc/throw_mode_off()
 	src.in_throw_mode = 0
 	if(client)
-		if(a_intent == I_HELP || client.prefs.throwmode_loud)
+		if(client.prefs.throwmode_loud) //CHOMPEdit: Throw notices are based on prefs, and dont ignore said prefs if you're on help intent
 			src.visible_message("<span class='notice'>[src] relaxes from their ready stance.</span>","<span class='notice'>You relax from your ready stance.</span>")
 	if(src.throw_icon) //in case we don't have the HUD and we use the hotkey
 		src.throw_icon.icon_state = "act_throw_off"
@@ -1208,7 +1208,7 @@
 /mob/proc/throw_mode_on()
 	src.in_throw_mode = 1
 	if(client)
-		if(a_intent == I_HELP || client.prefs.throwmode_loud)
+		if(client.prefs.throwmode_loud) //CHOMPEdit: Throw notices are based on prefs, and dont ignore said prefs if you're on help
 			if(src.get_active_hand())
 				src.visible_message("<span class='warning'>[src] winds up to throw [get_active_hand()]!</span>","<span class='notice'>You wind up to throw [get_active_hand()].</span>")
 			else


### PR DESCRIPTION
I HATE THIS STUPID CODEBASE! REBASE!!!
## About The Pull Request
Makes throw-notifications not appear on help intent if your prefs say no

No, this doesnt remove the notifications entirely, just makes them pref-based as it's supposed to be
## Changelog
:cl:
qol: Makes throw notifications only appear if your pref says yes
/:cl:
