### PR TITLE
Canisters detach from ports if they get destroyed

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -168,7 +168,12 @@ update_flag
 
 	if (src.health <= 10)
 		var/atom/location = src.loc
+		var/obj/machinery/atmospherics/portables_connector/port = locate() in location // CHOMPEdit - Finds if there's a port
 		location.assume_air(air_contents)
+
+		if(port && anchored) // CHOMPEdit - if it blew up, frees up the port
+			disconnect()
+			anchored = 0
 
 		src.destroyed = 1
 		playsound(src, 'sound/effects/spray.ogg', 10, 1, -3)

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -117,7 +117,7 @@
 		update_icon()
 		return
 
-	else if (W.has_tool_quality(TOOL_WRENCH))
+	else if (W.has_tool_quality(TOOL_WRENCH) && !(src.destroyed)) // CHOMPEdit - Make sure it's not broken
 		if(connected_port)
 			disconnect()
 			to_chat(user, "<span class='notice'>You disconnect \the [src] from the port.</span>")


### PR DESCRIPTION

Don't worry Engineering, the ports will be free now if the canister happens to blow up :)
## Changelog
:cl:
fix: Broken canisters staying attached to the port
fix: Being able to attach broken canisters to ports
/:cl:
