### PR TITLE
auto list swap fix for vorebelly contents + some ui icons

### DIFF
--- a/code/modules/tgui/modules/crew_monitor.dm
+++ b/code/modules/tgui/modules/crew_monitor.dm
@@ -5,12 +5,13 @@
 /datum/tgui_module/crew_monitor/ui_assets(mob/user)
 	return list(
 		get_asset_datum(/datum/asset/simple/nanomaps),
+		get_asset_datum(/datum/asset/simple/headers)
 	)
 
 /datum/tgui_module/crew_monitor/tgui_act(action, params, datum/tgui/ui)
 	if(..())
 		return TRUE
-		
+
 	if(action && !issilicon(usr))
 		playsound(tgui_host(), "terminal_type", 50, 1)
 
@@ -34,7 +35,7 @@
 /datum/tgui_module/crew_monitor/tgui_interact(mob/user, datum/tgui/ui = null)
 	var/z = get_z(user)
 	var/list/map_levels = using_map.get_map_levels(z, TRUE, om_range = DEFAULT_OVERMAP_RANGE)
-	
+
 	if(!map_levels.len)
 		to_chat(user, "<span class='warning'>The crew monitor doesn't seem like it'll work here.</span>")
 		if(ui)
@@ -64,7 +65,7 @@
 	// This is apparently necessary, because the above loop produces an emergent behavior
 	// of telling you what coordinates someone is at even without sensors on,
 	// because it strictly sorts by zlevel from bottom to top, and by coordinates from top left to bottom right.
-	shuffle_inplace(crewmembers) 
+	shuffle_inplace(crewmembers)
 	data["crewmembers"] = crewmembers
 
 	return data

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -50,7 +50,7 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 	var/mob/host // Note, we do this in case we ever want to allow people to view others vore panels
 	var/unsaved_changes = FALSE
 	var/show_pictures = TRUE
-	var/icon_overflow = FALSE
+	var/icon_overflow = FALSE //CHOMPEdit
 	var/max_icon_content = 21 //CHOMPedit: Contents above this disable icon mode. 21 for nice 3 rows to fill the default panel window.
 
 /datum/vore_look/New(mob/new_host)
@@ -113,7 +113,7 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 
 	data["unsaved_changes"] = unsaved_changes
 	data["show_pictures"] = show_pictures
-	data["overflow"] = icon_overflow
+	data["icon_overflow"] = icon_overflow //CHOMPEdit
 
 	var/atom/hostloc = host.loc
 	//CHOMPAdd Start - Allow VorePanel to show pred belly details even while indirectly inside

--- a/modular_chomp/code/modules/reagents/machinery/dispenser/chem_synthesizer_ch.dm
+++ b/modular_chomp/code/modules/reagents/machinery/dispenser/chem_synthesizer_ch.dm
@@ -472,6 +472,11 @@
 		return
 	tgui_interact(user)
 
+/obj/machinery/chemical_synthesizer/ui_assets(mob/user)
+	return list(
+		get_asset_datum(/datum/asset/spritesheet/chem_master),
+	)
+
 // This proc is lets users create recipes step-by-step and exports a comma delineated list to chat. It's intended to teach how to use the machine.
 /obj/machinery/chemical_synthesizer/proc/babystep_recipe(mob/user)
 	var/rec_name = sanitizeSafe(input(user, "Name your recipe. Consider including the output volume.", "Recipe naming", null) as text, MAX_NAME_LEN)

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreContentsPanel.tsx
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreContentsPanel.tsx
@@ -5,8 +5,11 @@ import { Button, Flex, LabeledList } from '../../../components';
 import { stats } from './constants';
 
 export const VoreContentsPanel = (props) => {
-  const { act, data } = useBackend<{ show_pictures: BooleanLike }>();
-  const { show_pictures } = data;
+  const { act, data } = useBackend<{
+    show_pictures: BooleanLike;
+    icon_overflow: BooleanLike;
+  }>();
+  const { show_pictures, icon_overflow } = data;
   const { contents, belly, outside = false } = props;
 
   return (
@@ -22,7 +25,7 @@ export const VoreContentsPanel = (props) => {
         </Button>
       )) ||
         null}
-      {(show_pictures && (
+      {(show_pictures && !icon_overflow && (
         <Flex wrap="wrap" justify="center" align="center">
           {contents.map((thing) => (
             <Flex.Item key={thing} basis="33%">

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreUserPreferences.jsx
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreUserPreferences.jsx
@@ -57,7 +57,7 @@ export const VoreUserPreferences = (props) => {
     selective_active,
   } = data.prefs;
 
-  const { show_pictures, overflow } = data;
+  const { show_pictures, icon_overflow } = data;
 
   const preferences = {
     digestion: {
@@ -591,11 +591,11 @@ export const VoreUserPreferences = (props) => {
               (show_pictures
                 ? 'Contents shown as pictures.'
                 : 'Contents shown as lists.') +
-              (show_pictures && overflow
+              (show_pictures && icon_overflow
                 ? 'Temporarily disabled. Stomach contents above limits.'
                 : '')
             }
-            backgroundColor={show_pictures && overflow ? 'orange' : ''}
+            backgroundColor={show_pictures && icon_overflow ? 'orange' : ''}
             onClick={() => act('show_pictures')}
           >
             Contents Preference: {show_pictures ? 'Show Pictures' : 'Show List'}


### PR DESCRIPTION
## About The Pull Request
fixes #7968
fixes #7919
## Changelog
:cl:
fix: fixes an issue where the vorebelly contents did not collapse to a list as supposed to for more than 21 ingested items
fix: fixes the assets on the chemSynthesizer being not properly initialized 
fix: fixes ntos icon direct loading on crew monitor
/:cl:
