### PR TITLE
Blacklists fulton beacons in the Cargo Shuttle

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -58,6 +58,8 @@ SUBSYSTEM_DEF(supply)
 		return 1										//VOREStation Addition: Translocator beacons
 	if(istype(A,/obj/machinery/power/quantumpad)) //	//VOREStation Add: Quantum pads
 		return 1					//VOREStation Add: Quantum pads
+	if(istype(A,/obj/structure/extraction_point )) // CHOMPStation Add: Fulton beacons
+		return 1
 
 	for(var/atom/B in A.contents)
 		if(.(B))


### PR DESCRIPTION

Title
## Changelog
:cl:
fix: Fulton beacons won't be sent to CentCom
/:cl:
