### PR TITLE
Remove recursivemove + signals from being on EVERY machine by default

### DIFF
--- a/code/game/machinery/machinery_power.dm
+++ b/code/game/machinery/machinery_power.dm
@@ -104,7 +104,7 @@
 	. = ..()
 	update_power_on_move(src, old_loc, loc)
 
-	//ChompEDIT START -- only add this if we init on a non-turf (and non-null)
+	//ChompEDIT START -- only add this if we move into a non-turf (not null) and we've never been given recursive move handling
 	if(!recursive_set && loc && !isturf(loc))
 		recursive_set = TRUE
 		AddComponent(/datum/component/recursive_move)

--- a/code/game/machinery/machinery_power.dm
+++ b/code/game/machinery/machinery_power.dm
@@ -73,9 +73,9 @@
 // Do not do power stuff in New/Initialize until after ..()
 /obj/machinery/Initialize()
 	. = ..()
-	RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(update_power_on_move))
 	if(loc && !isturf(loc)) //ChompEDIT -- only add this if we init on a non-turf (and non-null)
 		AddComponent(/datum/component/recursive_move) //ChompEDIT
+		RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(update_power_on_move)) //ChompEDIT - we only need this for recursive moving
 	var/power = POWER_CONSUMPTION
 	REPORT_POWER_CONSUMPTION_CHANGE(0, power)
 	power_init_complete = TRUE
@@ -97,6 +97,7 @@
 	update_power_on_move(src, old_loc, loc)
 	if(loc && !isturf(loc)) //ChompEDIT -- only add this if we move to a non-turf
 		AddComponent(/datum/component/recursive_move) //ChompEDIT
+		RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(update_power_on_move), override = TRUE) // ChompEDIT
 	/* No
 	if(ismovable(old_loc)) // Unregister recursive movement.
 		UnregisterSignal(old_loc, COMSIG_OBSERVER_MOVED)

--- a/code/game/machinery/machinery_power.dm
+++ b/code/game/machinery/machinery_power.dm
@@ -70,12 +70,20 @@
 		return amount // If channel is powered then you can do it.
 	return 0
 
+/obj/machinery
+	var/recursive_set = FALSE //CHOMPEdit: bool to indicate if recursive movement detection ever got set. If it did, don't try to set it again!
+
 // Do not do power stuff in New/Initialize until after ..()
 /obj/machinery/Initialize()
 	. = ..()
-	if(loc && !isturf(loc)) //ChompEDIT -- only add this if we init on a non-turf (and non-null)
-		AddComponent(/datum/component/recursive_move) //ChompEDIT
-		RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(update_power_on_move)) //ChompEDIT - we only need this for recursive moving
+
+	//ChompEDIT START -- only add this if we init on a non-turf (and non-null)
+	if(loc && !isturf(loc))
+		recursive_set = TRUE
+		AddComponent(/datum/component/recursive_move)
+		RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(update_power_on_move)) //we only need this for recursive moving
+	//ChompEDIT END
+
 	var/power = POWER_CONSUMPTION
 	REPORT_POWER_CONSUMPTION_CHANGE(0, power)
 	power_init_complete = TRUE
@@ -95,9 +103,14 @@
 /obj/machinery/Moved(atom/old_loc, direction, forced = FALSE)
 	. = ..()
 	update_power_on_move(src, old_loc, loc)
-	if(loc && !isturf(loc)) //ChompEDIT -- only add this if we move to a non-turf
-		AddComponent(/datum/component/recursive_move) //ChompEDIT
-		RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(update_power_on_move), override = TRUE) // ChompEDIT
+
+	//ChompEDIT START -- only add this if we init on a non-turf (and non-null)
+	if(!recursive_set && loc && !isturf(loc))
+		recursive_set = TRUE
+		AddComponent(/datum/component/recursive_move)
+		RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(update_power_on_move)) //we only need this for recursive moving
+	//ChompEDIT END
+
 	/* No
 	if(ismovable(old_loc)) // Unregister recursive movement.
 		UnregisterSignal(old_loc, COMSIG_OBSERVER_MOVED)

--- a/code/game/machinery/machinery_power.dm
+++ b/code/game/machinery/machinery_power.dm
@@ -74,7 +74,7 @@
 /obj/machinery/Initialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(update_power_on_move))
-	AddComponent(/datum/component/recursive_move)
+	//AddComponent(/datum/component/recursive_move) //ChompEDIT - not sure if all machinery needs recursive move detection.
 	var/power = POWER_CONSUMPTION
 	REPORT_POWER_CONSUMPTION_CHANGE(0, power)
 	power_init_complete = TRUE

--- a/code/game/machinery/machinery_power.dm
+++ b/code/game/machinery/machinery_power.dm
@@ -74,7 +74,8 @@
 /obj/machinery/Initialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_OBSERVER_MOVED, PROC_REF(update_power_on_move))
-	//AddComponent(/datum/component/recursive_move) //ChompEDIT - not sure if all machinery needs recursive move detection.
+	if(loc && !isturf(loc)) //ChompEDIT -- only add this if we init on a non-turf (and non-null)
+		AddComponent(/datum/component/recursive_move) //ChompEDIT
 	var/power = POWER_CONSUMPTION
 	REPORT_POWER_CONSUMPTION_CHANGE(0, power)
 	power_init_complete = TRUE
@@ -94,6 +95,8 @@
 /obj/machinery/Moved(atom/old_loc, direction, forced = FALSE)
 	. = ..()
 	update_power_on_move(src, old_loc, loc)
+	if(loc && !isturf(loc)) //ChompEDIT -- only add this if we move to a non-turf
+		AddComponent(/datum/component/recursive_move) //ChompEDIT
 	/* No
 	if(ismovable(old_loc)) // Unregister recursive movement.
 		UnregisterSignal(old_loc, COMSIG_OBSERVER_MOVED)


### PR DESCRIPTION
## About The Pull Request

there are about 35k machines that all have this on and never really need it. 

This saves about: 35,000 x (datum + list() element + list() element)

## Changelog
:cl:
refactor: Remove obj/machinery recursivemove placement + signal registration as a default, instead an optional
/:cl:
