### PR TITLE
Buffing non-CE blueprints

### DIFF
--- a/code/game/objects/items/blueprints_vr.dm
+++ b/code/game/objects/items/blueprints_vr.dm
@@ -71,8 +71,8 @@
 	in_use = FALSE
 	preserve_item = 1
 	var/uses_charges = 0 					// If the area editor has limited uses.
-	var/initial_charges = 10
-	var/charges = 10						// The amount of uses the area editor has.
+	var/initial_charges = 25 //CHOMPedit
+	var/charges = 25						// The amount of uses the area editor has. //CHOMPedit
 	var/station_master = 1					// If the areaeditor can add charges to others.
 	var/wire_schematics = 0					// If the areaeditor can see wires.
 	var/can_override = 0						// If you want the areaeditor to override the 'Don't make a new area where one already exists' logic. Only given to CE blueprints.
@@ -244,7 +244,7 @@
 	desc = "A piece of paper that allows for expansion of the station and creation of new areas. There is a \"For Official Use Only\" stamp on it. NOT to be mistaken with the station blueprints."		// CHOMPEDIT : purdev (some spelling fixes)
 	station_master = 0
 	uses_charges = 1
-	can_override = 0
+	can_override = 1 //CHOMPedit, This will allow easier building on the planets, dont think blueprint grief is too big of a problem. -Lotion
 
 
 


### PR DESCRIPTION

## About The Pull Request
This PR will increase the engineer's station blueprints limited charges from 10 to 25, this also allows you to override other areas now (Like the plains of sif) this was originally gonna get bundled with outsider superposed pods changes but will make it separate PR for its own balancing decision. 

I aim to do this because 1. Dependency on a CE is required to recharge the blueprints and heads are are less common here due to whitelist requirements.
2. Outsiders will be getting writing blueprints in some select superposed pods in a separate PR.
## Changelog
:cl:
balance: Non-CE blueprint charges buffed from 10 -> 25
/:cl:
