### PR TITLE
Shadekin related fixes

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -96,6 +96,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		return 0
 	if(M == user && user.a_intent != I_HURT)
 		return 0
+	if(M.is_incorporeal()) // CHOMPEdit - No attacking phased entities :)
+		return 0
 
 	/////////////////////////
 	user.lastattacked = M

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -199,6 +199,9 @@ steam.start() -- spawns the effect
 		return 0
 	if(istype(M,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
+		if(M.does_not_breathe) { // CHOMPedit - Making sure smoke doesn't affect lungless people
+			return 0
+		}
 		if(H.head && (H.head.item_flags & AIRTIGHT))
 			return 0
 	return 1

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -199,9 +199,8 @@ steam.start() -- spawns the effect
 		return 0
 	if(istype(M,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
-		if(M.does_not_breathe) { // CHOMPedit - Making sure smoke doesn't affect lungless people
+		if(!M.get_organ(O_LUNGS)) // CHOMPedit - Making sure smoke doesn't affect lungless people
 			return 0
-		}
 		if(H.head && (H.head.item_flags & AIRTIGHT))
 			return 0
 	return 1

--- a/code/game/objects/weapons.dm
+++ b/code/game/objects/weapons.dm
@@ -37,8 +37,6 @@
 			continue
 		if(!attack_can_reach(user, SM, 1))
 			continue
-		if(SM.is_incorporeal()) // CHOMPADD - Don't cleave phased entities.
-			continue
 		if(resolve_attackby(SM, user, attack_modifier = 0.5)) // Hit them with the weapon.  This won't cause recursive cleaving due to the cleaving variable being set to true.
 			hit_mobs++
 

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -77,7 +77,6 @@
 	breath_type = null
 	poison_type = null
 	water_breather = TRUE	//They don't quite breathe
-	does_not_breathe = TRUE // CHOMPEdit - No breathe 2
 
 	vision_flags = SEE_SELF|SEE_MOBS
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_UNDERWEAR
@@ -165,6 +164,7 @@
 	H.adjustBruteLoss(-(H.getBruteLoss() * 0.75))
 	H.adjustToxLoss(-(H.getToxLoss() * 0.75))
 	H.adjustCloneLoss(-(H.getCloneLoss() * 0.75))
+	H.germ_level = 0 // CHOMPAdd - Take away the germs, or we'll die AGAIN
 	H.vessel.add_reagent("blood",blood_volume-H.vessel.total_volume)
 	for(var/obj/item/organ/external/bp in H.organs)
 		bp.bandage()

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -77,6 +77,7 @@
 	breath_type = null
 	poison_type = null
 	water_breather = TRUE	//They don't quite breathe
+	does_not_breathe = TRUE // CHOMPEdit - No breathe 2
 
 	vision_flags = SEE_SELF|SEE_MOBS
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_UNDERWEAR

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -48,7 +48,7 @@ default behaviour is:
 		return 0
 
 /mob/living/Bump(atom/movable/AM)
-	if(now_pushing || !loc || buckled == AM)
+	if(now_pushing || !loc || buckled == AM || AM.is_incorporeal()) // CHOMPEdit - This should take care of phase interactions...
 		return
 	now_pushing = 1
 	if (istype(AM, /mob/living))

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -237,8 +237,6 @@
 				var/datum/sprite_accessory/tail/taur/tail = H.tail_style
 				src_message = tail.msg_owner_help_run
 				tmob_message = tail.msg_prey_help_run
-			if(tmob.is_incorporeal())	// CHOMPEdit - Nothing to step over.
-				return TRUE
 
 		//Smaller person stepping under larger person
 		else if(get_effective_size(TRUE) < tmob.get_effective_size(TRUE) && ishuman(tmob))
@@ -249,8 +247,6 @@
 				var/datum/sprite_accessory/tail/taur/tail = H.tail_style
 				src_message = tail.msg_prey_stepunder
 				tmob_message = tail.msg_owner_stepunder
-			if(tmob.is_incorporeal())	// CHOMPEdit - Can't run between what's not there
-				return TRUE
 
 		if(src_message)
 			to_chat(src, "<span class='filter_notice'>[STEP_TEXT_OWNER(src_message)]</span>")


### PR DESCRIPTION

Some shadekin stuff I've been meaning to fix, oop. Also creatures without lungs won't cough anymore when exposed to smoke.

The stuff in resizing_vr is now handled by Bump(), so that should cover all cases of kin getting knocked over or stepped on while phased.
## Changelog
:cl:
fix: Phased shadekins being able to be attacked
fix: Bump should ignore phased shadekins now
fix: Smoke won't make creatures without lungs cough
/:cl:
