### PR TITLE
Fixes putting mob holders instead of the mobs they were holding into disposal bins

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -143,8 +143,12 @@
 	user.drop_item()
 	if(I)
 		if(istype(I, /obj/item/weapon/holder/micro))
-			log_and_message_admins("placed [I.name]  inside \the [src]", user)
-		I.forceMove(src)
+			log_and_message_admins("placed [I.name] inside \the [src]", user)
+			var/obj/item/weapon/holder/H = I
+			H.held_mob.forceMove(src)
+		else
+			I.forceMove(src)
+			explosion()
 
 	to_chat(user, "You place \the [I] into the [src].")
 	for(var/mob/M in viewers(src))


### PR DESCRIPTION

## About The Pull Request
you can now dispose of micros properly, instead of them getting stuck inside.
(that's a joke. The bug prevented them from escaping.)
## Changelog
:cl:
fix: Fixed Micros getting stuck in disposal bins
/:cl:
