### PR TITLE
Outsider SuperPose pods now require power plus misc improvments.

### DIFF
--- a/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
+++ b/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
@@ -1,5 +1,6 @@
 // Unique areas were requested for each superpose map for future use. The plain superpose area is for future varedits to all superpose submaps.
 /area/survivalpod/superpose
+	requires_power = TRUE
 
 /area/survivalpod/superpose/CrashedInfestedShip
 

--- a/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
+++ b/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
@@ -9,6 +9,7 @@
 /area/survivalpod/superpose/CultShip
 
 /area/survivalpod/superpose/DemonPool
+	requires_power = FALSE
 
 /area/survivalpod/superpose/Dinner
 
@@ -41,8 +42,10 @@
 /area/survivalpod/superpose/SmallCombatShip
 
 /area/survivalpod/superpose/SurvivalBarracks
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalCargo
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalDIY_11x11
 
@@ -51,30 +54,43 @@
 /area/survivalpod/superpose/SurvivalDIY_9x9
 
 /area/survivalpod/superpose/SurvivalDinner
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalEngineering
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalHome
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalHydro
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalJanitor
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalLeisure
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalLuxuryBar
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalLuxuryHome
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalMedical
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalPool
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalQuarters
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalScience
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalSecurity
+	requires_power = FALSE
 
 /area/survivalpod/superpose/TinyCombatShip
 
@@ -85,22 +101,29 @@
 /area/survivalpod/superpose/AnimalHospital
 
 /area/survivalpod/superpose/RestaurationBar
+	requires_power = FALSE
 
 /area/survivalpod/superpose/BroadcastingPod
 
 /area/survivalpod/superpose/DemonPoolV2
+	requires_power = FALSE
 
 /area/survivalpod/superpose/PirateShip
 
 /area/survivalpod/superpose/SurvivalHomeV2
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalMechFab
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalMethLab
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalScienceV2
+	requires_power = FALSE
 
 /area/survivalpod/superpose/SurvivalSecurityV2
+	requires_power = FALSE
 
 /area/survivalpod/superpose/HillOutpost
 

--- a/modular_chomp/code/modules/mining/shelters_ch.dm
+++ b/modular_chomp/code/modules/mining/shelters_ch.dm
@@ -8,18 +8,21 @@
 	description = "ERROR: string 'description' cannot be null!"
 	mappath = null
 
+/* Does not spawn properly
 /datum/map_template/shelter/superpose/CrashedInfestedShip
 	shelter_id = "CrashedInfestedShip"
 	mappath = "modular_chomp/maps/submaps/shelters/CrashedInfestedShip-56x25.dmm"
 	name = "Crashed infested ship."
 	description = "A large alien ship that is heavily damaged, there is signs of xeno infestation."
+*/
 
+/* Does not spawn properly
 /datum/map_template/shelter/superpose/CrashedQurantineShip
 	shelter_id = "CrashedQurantineShip"
 	mappath = "modular_chomp/maps/submaps/shelters/CrashedQurantineShip-25x25.dmm"
 	name = "Crashed Qurantine Ship."
 	description = "A white medical ship that is heavily damaged, there is signs of a viral outbreak."
-
+*/
 /datum/map_template/shelter/superpose/CultShip
 	shelter_id = "CultShip"
 	mappath = "modular_chomp/maps/submaps/shelters/CultShip-28x17.dmm"
@@ -68,11 +71,13 @@
 	name = "Hydroponics cave."
 	description = "A burried hydroponics facility with various living quarters needs and equipment."
 
+/* Does not spawn properly/Too OP for outsider use
 /datum/map_template/shelter/superpose/LargeAlienShip
 	shelter_id = "LargeAlienShip"
 	mappath = "modular_chomp/maps/submaps/shelters/LargeAlienShip-57x25.dmm"
 	name = "Large alien ship."
 	description = "A large alien ship filled with various alien machines and items."
+*/
 
 /datum/map_template/shelter/superpose/LoneHome
 	shelter_id = "LoneHome"
@@ -92,11 +97,13 @@
 	name = "Mech storage facility."
 	description = "An old abandoned mech fabrication facility, most of the facility seems functional."
 
+/* Does not spawn properly/too OP for outsider use
 /datum/map_template/shelter/superpose/MercShip
 	shelter_id = "MercShip"
 	mappath = "modular_chomp/maps/submaps/shelters/MercShip-57x25.dmm"
 	name = "Mercenary ship."
 	description = "A old mercenery ship filled with various trading goods."
+*/
 
 /datum/map_template/shelter/superpose/MethLab
 	shelter_id = "MethLab"

--- a/modular_chomp/code/modules/mining/shelters_ch.dm
+++ b/modular_chomp/code/modules/mining/shelters_ch.dm
@@ -10,7 +10,7 @@
 
 /datum/map_template/shelter/superpose/CrashedInfestedShip
 	shelter_id = "CrashedInfestedShip"
-	mappath = "modular_chomp/maps/submaps/shelters/CrashedInfestedShip-60x29.dmm"
+	mappath = "modular_chomp/maps/submaps/shelters/CrashedInfestedShip-56x25.dmm"
 	name = "Crashed infested ship."
 	description = "A large alien ship that is heavily damaged, there is signs of xeno infestation."
 
@@ -94,7 +94,7 @@
 
 /datum/map_template/shelter/superpose/MercShip
 	shelter_id = "MercShip"
-	mappath = "modular_chomp/maps/submaps/shelters/MercShip-60x29.dmm"
+	mappath = "modular_chomp/maps/submaps/shelters/MercShip-57x25.dmm"
 	name = "Mercenary ship."
 	description = "A old mercenery ship filled with various trading goods."
 

--- a/modular_chomp/maps/submaps/shelters/AnimalHospital-20x28.dmm
+++ b/modular_chomp/maps/submaps/shelters/AnimalHospital-20x28.dmm
@@ -137,9 +137,28 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/AnimalHospital)
+"iQ" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/survivalpod/superpose/AnimalHospital)
 "ji" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/survivalpod/superpose/AnimalHospital)
@@ -198,6 +217,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/AnimalHospital)
+"lS" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/survivalpod/superpose/AnimalHospital)
 "mC" = (
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled,
@@ -208,6 +238,17 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/survivalpod/superpose/AnimalHospital)
+"mU" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/survivalpod/superpose/AnimalHospital)
@@ -269,6 +310,15 @@
 /obj/item/clothing/mask/surgical,
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/AnimalHospital)
+"qw" = (
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/survivalpod/superpose/AnimalHospital)
 "qL" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
@@ -290,6 +340,14 @@
 "rI" = (
 /obj/fiftyspawner/titanium,
 /obj/item/stack/cable_coil/silver,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/AnimalHospital)
 "st" = (
@@ -306,9 +364,18 @@
 /turf/simulated/floor/tiled,
 /area/survivalpod/superpose/AnimalHospital)
 "sI" = (
-/obj/item/weapon/storage/toolbox/mechanical,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/item/device/flashlight/glowstick/blue,
+/obj/item/device/flashlight/glowstick/blue,
+/obj/item/device/flashlight/glowstick/blue,
+/obj/item/device/flashlight,
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/AnimalHospital)
@@ -458,6 +525,29 @@
 	},
 /turf/simulated/floor/tiled,
 /area/survivalpod/superpose/AnimalHospital)
+"DG" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/survivalpod/superpose/AnimalHospital)
+"FF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/full,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/AnimalHospital)
 "GG" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -473,6 +563,12 @@
 	pixel_y = 5
 	},
 /obj/item/weapon/storage/firstaid/regular,
+/obj/item/clothing/accessory/stethoscope,
+/obj/item/clothing/suit/storage/toggle/labcoat,
+/obj/item/clothing/suit/storage/toggle/labcoat,
+/obj/item/clothing/suit/storage/toggle/labcoat,
+/obj/item/device/flashlight/pen,
+/obj/item/device/flashlight/pen,
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/AnimalHospital)
 "Hl" = (
@@ -581,6 +677,20 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled,
 /area/survivalpod/superpose/AnimalHospital)
+"Ls" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	pixel_x = 26
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled,
+/area/survivalpod/superpose/AnimalHospital)
 "LW" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 1
@@ -601,12 +711,13 @@
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/AnimalHospital)
 "Mw" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/item/device/flashlight/glowstick/blue,
-/obj/item/device/flashlight/glowstick/blue,
-/obj/item/device/flashlight/glowstick/blue,
-/obj/item/device/flashlight,
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable,
 /turf/simulated/floor/plating,
+/area/survivalpod/superpose/AnimalHospital)
+"Mx" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/simulated/floor/outdoors/dirt,
 /area/survivalpod/superpose/AnimalHospital)
 "MA" = (
 /obj/structure/table/standard,
@@ -637,17 +748,25 @@
 "Og" = (
 /turf/simulated/wall/titanium,
 /area/survivalpod/superpose/AnimalHospital)
+"OH" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/survivalpod/superpose/AnimalHospital)
 "OL" = (
-/obj/structure/table/glass,
-/obj/item/clothing/suit/storage/toggle/labcoat,
-/obj/item/clothing/suit/storage/toggle/labcoat,
-/obj/item/clothing/suit/storage/toggle/labcoat,
-/obj/item/device/flashlight/pen,
-/obj/item/device/flashlight/pen,
-/obj/item/clothing/accessory/stethoscope,
-/obj/item/clothing/accessory/stethoscope,
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/power/smes/batteryrack/mapped,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/AnimalHospital)
@@ -733,6 +852,14 @@
 "Vr" = (
 /turf/template_noop,
 /area/survivalpod/superpose/AnimalHospital)
+"Vt" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/survivalpod/superpose/AnimalHospital)
 "VV" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/outdoors/dirt,
@@ -750,6 +877,11 @@
 /obj/machinery/door/airlock/medical{
 	req_one_access = null
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/AnimalHospital)
 "Ww" = (
@@ -762,7 +894,23 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
+/area/survivalpod/superpose/AnimalHospital)
+"XM" = (
+/obj/machinery/door/airlock/glass_medical{
+	req_one_access = null
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/AnimalHospital)
 "Yb" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -778,6 +926,17 @@
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
+/area/survivalpod/superpose/AnimalHospital)
+"Zl" = (
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
 /area/survivalpod/superpose/AnimalHospital)
 "ZZ" = (
 /turf/simulated/floor/plating,
@@ -850,7 +1009,7 @@ Vr
 KQ
 KQ
 KQ
-KQ
+Mx
 rl
 Hl
 KQ
@@ -1214,14 +1373,14 @@ Iq
 Iq
 Qq
 Ww
-mC
+qw
 Wu
 rI
 sI
 Mw
 Og
 OL
-Iq
+Vt
 Iq
 Iq
 Iq
@@ -1244,14 +1403,14 @@ Iq
 RM
 Og
 eN
-vx
+OH
 Og
 Og
 Og
 Og
 Og
-Mb
-zk
+FF
+XM
 Mb
 Og
 Mb
@@ -1275,13 +1434,13 @@ Nv
 Og
 Yb
 XF
+DG
+DG
+DG
+DG
+DG
 ji
-ji
-ji
-ji
-ji
-ji
-Cj
+Zl
 fK
 IH
 cS
@@ -1304,14 +1463,14 @@ eU
 oa
 Og
 LW
-gX
-gX
-gX
-GG
-gX
-gX
-GG
-gX
+Ls
+mU
+mU
+iQ
+mU
+mU
+iQ
+lS
 gX
 gX
 GG

--- a/modular_chomp/maps/submaps/shelters/BroadcastingPod-11x9.dmm
+++ b/modular_chomp/maps/submaps/shelters/BroadcastingPod-11x9.dmm
@@ -4,6 +4,11 @@
 /area/survivalpod/superpose/BroadcastingPod)
 "c" = (
 /obj/machinery/light,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/survivalpod/superpose/BroadcastingPod)
 "e" = (
@@ -31,6 +36,14 @@
 /obj/item/weapon/folder,
 /turf/simulated/floor/atoll,
 /area/survivalpod/superpose/BroadcastingPod)
+"j" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/BroadcastingPod)
 "k" = (
 /obj/machinery/door/airlock/freezer,
 /turf/simulated/shuttle/plating/skipjack,
@@ -43,6 +56,17 @@
 /area/survivalpod/superpose/BroadcastingPod)
 "m" = (
 /obj/structure/fans,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/BroadcastingPod)
+"n" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/survivalpod/superpose/BroadcastingPod)
 "o" = (
@@ -157,6 +181,14 @@
 /obj/random/soap,
 /obj/item/weapon/material/knife/machete/hatchet,
 /obj/item/weapon/storage/box/flare,
+/obj/item/weapon/circuitboard/batteryrack,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/matter_bin,
 /turf/simulated/shuttle/floor/voidcraft,
 /area/survivalpod/superpose/BroadcastingPod)
 "A" = (
@@ -198,6 +230,11 @@
 "F" = (
 /obj/structure/table/glass,
 /obj/item/device/camerabug,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/survivalpod/superpose/BroadcastingPod)
 "G" = (
@@ -214,6 +251,11 @@
 /obj/item/device/tape/random,
 /obj/item/device/tape/random{
 	pixel_y = -4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/survivalpod/superpose/BroadcastingPod)
@@ -318,6 +360,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/closet/crate/solar,
 /turf/simulated/shuttle/floor/voidcraft,
 /area/survivalpod/superpose/BroadcastingPod)
 "P" = (
@@ -351,6 +394,10 @@
 /obj/item/device/tvcamera{
 	pixel_y = 5;
 	pixel_x = -5
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/survivalpod/superpose/BroadcastingPod)
@@ -396,7 +443,7 @@ O
 x
 Q
 o
-o
+n
 a
 "}
 (3,1,1) = {"
@@ -407,7 +454,7 @@ l
 l
 l
 o
-o
+j
 k
 "}
 (4,1,1) = {"
@@ -429,7 +476,7 @@ v
 v
 a
 Y
-o
+j
 M
 "}
 (6,1,1) = {"

--- a/modular_chomp/maps/submaps/shelters/CrashedQurantineShip-25x17.dmm
+++ b/modular_chomp/maps/submaps/shelters/CrashedQurantineShip-25x17.dmm
@@ -10,26 +10,38 @@
 /turf/simulated/mineral/floor/ignore_mapgen,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ad" = (
-/turf/simulated/shuttle/wall,
+/obj/structure/grille,
+/obj/structure/shuttle/window,
+/obj/machinery/door/blast/regular{
+	dir = 8;
+	id = "QShuttlePoIDoors";
+	layer = 3.3;
+	name = "Emergency Lockdown Shutters"
+	},
+/obj/item/tape/medical{
+	dir = 4;
+	icon_state = "tape_door_0";
+	layer = 3.4
+	},
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ae" = (
 /obj/item/weapon/tool/crowbar/red,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
+/obj/machinery/power/apc/hyper{
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -26
 	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "af" = (
 /obj/item/trash/chips,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ag" = (
 /obj/random/maintenance,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ah" = (
 /obj/machinery/door/blast/regular{
@@ -46,31 +58,25 @@
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ai" = (
 /obj/item/trash/cigbutt,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aj" = (
 /obj/machinery/door/airlock/command{
 	icon_state = "door_locked";
 	locked = 1
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ak" = (
 /obj/item/weapon/tank/emergency/oxygen/engi,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "al" = (
 /obj/structure/sign/biohazard{
 	dir = 1
 	},
-/turf/simulated/shuttle/wall/hard_corner,
+/turf/simulated/wall/thull,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "am" = (
 /obj/machinery/door/airlock{
@@ -85,59 +91,47 @@
 	contraband = null;
 	products = list(/obj/item/weapon/reagent_containers/food/snacks/candy=0,/obj/item/weapon/reagent_containers/food/drinks/dry_ramen=0,/obj/item/weapon/reagent_containers/food/snacks/chips=0,/obj/item/weapon/reagent_containers/food/snacks/sosjerky=0,/obj/item/weapon/reagent_containers/food/snacks/no_raisin=0,/obj/item/weapon/reagent_containers/food/snacks/packaged/spacetwinkie=0,/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers=0,/obj/item/weapon/reagent_containers/food/snacks/tastybread=0,/obj/item/weapon/reagent_containers/food/snacks/skrellsnacks=0)
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ao" = (
 /obj/item/weapon/pickaxe/drill,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ap" = (
 /obj/effect/decal/remains/xeno,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aq" = (
 /obj/machinery/button{
 	name = "Cargo Hatch"
 	},
-/turf/simulated/shuttle/wall,
+/turf/simulated/wall/thull,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ar" = (
 /obj/machinery/computer{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor,
+/turf/simulated/floor/tiled/milspec/raised,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "as" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/vomit,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "at" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "au" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "av" = (
 /obj/machinery/door/airlock/engineering{
@@ -145,21 +139,16 @@
 	locked = 1;
 	name = "Cargo Bay"
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aw" = (
 /obj/item/weapon/material/shard,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ax" = (
 /obj/random/paicard,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ay" = (
 /obj/effect/decal/remains/human,
@@ -171,21 +160,17 @@
 	desc = "It's a ballcap bearing the colors of Major Bill's Shipping. This one looks at least a few decades out of date.";
 	name = "old shipping cap"
 	},
-/turf/simulated/shuttle/floor,
+/turf/simulated/floor/tiled/milspec/raised,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "az" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aA" = (
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aB" = (
 /obj/structure/grille,
@@ -197,7 +182,7 @@
 	dir = 1;
 	health = 1e+006
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aC" = (
 /obj/structure/grille,
@@ -206,14 +191,12 @@
 	dir = 1;
 	health = 1e+006
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aD" = (
 /obj/item/clothing/mask/breath,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aE" = (
 /obj/structure/grille,
@@ -225,40 +208,31 @@
 	dir = 1;
 	health = 1e+006
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aF" = (
 /obj/item/clothing/suit/space/emergency,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aG" = (
 /obj/machinery/door/airlock/glass,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aH" = (
 /obj/item/trash/candy,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aI" = (
 /obj/structure/table/rack,
 /obj/structure/loot_pile/maint/boxfort,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aJ" = (
 /obj/structure/table/rack,
 /obj/item/weapon/shovel,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aK" = (
 /obj/structure/closet/crate/secure/science{
@@ -270,14 +244,12 @@
 /obj/item/weapon/virusdish/random,
 /obj/item/weapon/virusdish/random,
 /obj/item/weapon/virusdish/random,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aL" = (
 /obj/structure/table/standard,
 /obj/item/device/taperecorder,
-/turf/simulated/shuttle/floor,
+/turf/simulated/floor/tiled/milspec/raised,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aM" = (
 /obj/structure/inflatable/door,
@@ -289,24 +261,18 @@
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aP" = (
 /obj/structure/bed/chair,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aQ" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aR" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aS" = (
 /obj/structure/bed/chair,
@@ -316,71 +282,51 @@
 	desc = "It's a ballcap bearing the colors of Major Bill's Shipping. This one looks at least a few decades out of date.";
 	name = "old shipping cap"
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aT" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/remains/human,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aU" = (
 /obj/effect/decal/remains/xeno,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aV" = (
 /obj/item/weapon/material/shard{
 	icon_state = "medium"
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aW" = (
 /obj/item/weapon/coin/silver,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aX" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "aZ" = (
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bf" = (
 /obj/item/weapon/tank/emergency/oxygen/engi,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bh" = (
 /obj/item/trash/sosjerky,
 /obj/effect/decal/remains/human,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bi" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/mask/breath,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bj" = (
 /obj/structure/grille,
@@ -391,7 +337,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bk" = (
 /obj/structure/grille,
@@ -402,18 +348,18 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bl" = (
 /obj/machinery/button{
 	dir = 4;
 	name = "Cargo Access"
 	},
-/turf/simulated/shuttle/wall,
+/turf/simulated/wall/thull,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bm" = (
 /obj/machinery/recharge_station,
-/turf/simulated/shuttle/floor,
+/turf/simulated/floor/tiled/milspec/raised,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bn" = (
 /obj/structure/toilet{
@@ -421,21 +367,17 @@
 	},
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/remains/human,
-/turf/simulated/shuttle/floor,
+/turf/simulated/floor/tiled/milspec/raised,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bo" = (
 /obj/effect/decal/cleanable/vomit,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bp" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bq" = (
 /obj/machinery/door/airlock{
@@ -447,26 +389,20 @@
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bs" = (
 /obj/structure/bed/chair,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bt" = (
 /obj/structure/bed/chair,
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/space/emergency,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bu" = (
 /obj/machinery/vending/cola{
 	contraband = null;
 	products = list(/obj/item/weapon/reagent_containers/food/drinks/cans/cola=0,/obj/item/weapon/reagent_containers/food/drinks/cans/space_mountain_wind=0,/obj/item/weapon/reagent_containers/food/drinks/cans/dr_gibb=0,/obj/item/weapon/reagent_containers/food/drinks/cans/starkist=0,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle=0,/obj/item/weapon/reagent_containers/food/drinks/cans/space_up=0,/obj/item/weapon/reagent_containers/food/drinks/cans/iced_tea=0,/obj/item/weapon/reagent_containers/food/drinks/cans/grape_juice=0,/obj/item/weapon/reagent_containers/food/drinks/cans/gingerale=0)
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bv" = (
 /obj/structure/closet/crate,
@@ -545,9 +481,7 @@
 /obj/item/stack/material/smolebricks{
 	amount = 50
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bw" = (
 /obj/structure/closet/walllocker_double/north,
@@ -596,9 +530,7 @@
 /obj/item/weapon/storage/box/survival/comp,
 /obj/item/weapon/storage/toolbox/brass,
 /obj/item/weapon/storage/box/khcrystal,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bx" = (
 /obj/structure/shuttle/engine/heater{
@@ -608,37 +540,27 @@
 /area/survivalpod/superpose/CrashedQurantineShip)
 "by" = (
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bz" = (
 /obj/item/trash/syndi_cakes,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bA" = (
 /obj/item/trash/cigbutt,
 /obj/item/weapon/tank/emergency/oxygen,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bB" = (
 /obj/item/weapon/material/knife/tacknife/boot,
 /obj/item/clothing/mask/breath,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bD" = (
 /obj/item/trash/sosjerky,
 /obj/item/weapon/storage/box/donut/empty,
 /obj/item/weapon/reagent_containers/food/drinks/sillycup,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bE" = (
 /obj/structure/grille,
@@ -650,7 +572,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bF" = (
 /obj/structure/grille,
@@ -661,33 +583,27 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bG" = (
 /obj/item/trash/tastybread,
 /obj/item/weapon/material/butterfly/boxcutter,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bH" = (
 /obj/structure/salvageable/data_os,
-/turf/simulated/shuttle/floor,
+/turf/simulated/floor/tiled/milspec/raised,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bI" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/decal/cleanable/mucus/mapped,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bJ" = (
 /obj/item/trash/cheesie,
 /obj/effect/decal/remains/human,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bL" = (
 /obj/structure/bed/chair{
@@ -695,9 +611,7 @@
 	},
 /obj/effect/decal/remains/human,
 /obj/item/clothing/mask/breath,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bM" = (
 /obj/structure/table/rack,
@@ -705,39 +619,27 @@
 	desc = "It's a ballcap bearing the colors of Major Bill's Shipping. This one looks at least a few decades out of date.";
 	name = "old shipping cap"
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bN" = (
 /obj/effect/decal/cleanable/vomit,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bO" = (
 /obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bP" = (
 /obj/item/weapon/virusdish/random,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bQ" = (
 /obj/structure/ore_box,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bR" = (
 /obj/effect/decal/remains/mouse,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bS" = (
 /obj/item/tape/medical{
@@ -758,15 +660,11 @@
 	desc = "It's a ballcap bearing the colors of Major Bill's Shipping. This one looks at least a few decades out of date.";
 	name = "old shipping cap"
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bU" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bV" = (
 /obj/item/taperoll/medical,
@@ -774,18 +672,14 @@
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bW" = (
 /obj/effect/decal/remains/human,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bX" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/effect/decal/remains/xeno,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "bY" = (
 /obj/structure/closet/crate,
@@ -863,9 +757,7 @@
 	rank = "Miner";
 	registered_name = "Nadia Chu"
 	},
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ca" = (
 /obj/item/tape/medical{
@@ -881,15 +773,11 @@
 "cb" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/toolbox/emergency,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_white"
-	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "cc" = (
 /obj/item/poster,
-/turf/simulated/shuttle/floor{
-	icon_state = "floor_yellow"
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "cd" = (
 /obj/item/tape/medical{
@@ -909,7 +797,7 @@
 /turf/simulated/shuttle/plating,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ch" = (
-/turf/simulated/shuttle/wall/hard_corner,
+/turf/simulated/wall/thull,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "cj" = (
 /obj/machinery/door/airlock/external{
@@ -931,7 +819,7 @@
 /area/survivalpod/superpose/CrashedQurantineShip)
 "ck" = (
 /obj/structure/sign/biohazard,
-/turf/simulated/shuttle/wall/hard_corner,
+/turf/simulated/wall/thull,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "cl" = (
 /obj/structure/grille,
@@ -977,6 +865,22 @@
 "ky" = (
 /obj/structure/closet/crate/medical,
 /turf/simulated/mineral/floor/ignore_mapgen,
+/area/survivalpod/superpose/CrashedQurantineShip)
+"su" = (
+/obj/machinery/door/airlock/external{
+	desc = "It opens and closes. It is stamped with the logo of Major Bill's Transportation";
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = null;
+	locked = 1;
+	name = "MBT-540"
+	},
+/obj/item/tape/medical{
+	dir = 4;
+	icon_state = "tape_door_0";
+	layer = 3.4
+	},
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/CrashedQurantineShip)
 "vi" = (
 /obj/structure/table/steel,
@@ -1072,11 +976,11 @@ aa
 ab
 ab
 ab
-ad
+ch
 cl
 cl
 cl
-ad
+ch
 ab
 ac
 ab
@@ -1090,13 +994,13 @@ aa
 aa
 ab
 ab
-ad
-ad
+ch
+ch
 ar
 ay
 ar
-ad
-ad
+ch
+ch
 ab
 ab
 ab
@@ -1108,15 +1012,15 @@ ab
 aa
 aa
 ab
-ad
-ad
-ad
+ch
+ch
+ch
 as
 ai
 bT
-ad
-ad
-ad
+ch
+ch
+ch
 bS
 ca
 ab
@@ -1129,13 +1033,13 @@ aa
 ab
 cl
 bn
-ad
+ch
 bH
 ai
 aL
-ad
+ch
 bm
-cl
+ad
 ab
 cd
 ab
@@ -1148,11 +1052,11 @@ aa
 aO
 ch
 am
-ad
-ad
+ch
+ch
 aj
-ad
-ad
+ch
+ch
 bq
 ch
 aO
@@ -1173,7 +1077,7 @@ ak
 ae
 bW
 bG
-cj
+su
 aO
 cd
 ab
@@ -1192,7 +1096,7 @@ az
 af
 aW
 bI
-cj
+su
 aM
 cd
 ab
@@ -1204,13 +1108,13 @@ aa
 aa
 aO
 al
-ad
+ch
 ap
 at
-ad
+ch
 aP
 aA
-ad
+ch
 ck
 aO
 cd
@@ -1222,7 +1126,7 @@ ab
 aa
 aa
 ab
-cl
+ad
 bs
 bz
 bL
@@ -1230,7 +1134,7 @@ aB
 aR
 aX
 bX
-cl
+ad
 ab
 cd
 ce
@@ -1241,7 +1145,7 @@ ab
 aa
 aa
 aa
-ad
+ch
 bs
 aA
 aQ
@@ -1249,7 +1153,7 @@ aC
 aS
 aA
 aQ
-ad
+ch
 ab
 cd
 cm
@@ -1260,7 +1164,7 @@ ab
 aa
 aa
 aa
-cl
+ad
 bt
 bA
 aQ
@@ -1268,7 +1172,7 @@ aE
 aT
 aZ
 bZ
-cl
+ad
 ab
 cd
 cn
@@ -1279,15 +1183,15 @@ ab
 aa
 aa
 ab
-ad
-ad
+ch
+ch
 bB
 au
-ad
+ch
 aP
 bf
-ad
-ad
+ch
+ch
 ab
 cd
 Ll
@@ -1298,7 +1202,7 @@ ab
 aa
 ab
 ab
-ad
+ch
 an
 bW
 bN
@@ -1306,7 +1210,7 @@ aF
 bU
 bh
 cb
-ad
+ch
 bV
 cd
 hs
@@ -1317,7 +1221,7 @@ ab
 aa
 ac
 ab
-ad
+ch
 bu
 bD
 bO
@@ -1325,7 +1229,7 @@ aH
 aU
 bi
 bM
-ad
+ch
 ab
 cd
 hs
@@ -1336,15 +1240,15 @@ aa
 aa
 ab
 ab
-ad
-ad
-ad
+ch
+ch
+ch
 av
-ad
+ch
 av
-ad
-ad
-ad
+ch
+ch
+ch
 ab
 cd
 hs
@@ -1355,7 +1259,7 @@ aa
 aa
 ab
 ab
-ad
+ch
 bv
 bE
 bP
@@ -1363,7 +1267,7 @@ aI
 aV
 bj
 bQ
-ad
+ch
 ab
 cd
 ab
@@ -1374,7 +1278,7 @@ aa
 aa
 aa
 ab
-ad
+ch
 ao
 aG
 aA
@@ -1382,7 +1286,7 @@ aA
 aA
 aG
 cc
-ad
+ch
 ab
 cd
 hJ
@@ -1393,7 +1297,7 @@ aa
 aa
 aa
 ab
-ad
+ch
 bw
 bF
 aw
@@ -1401,7 +1305,7 @@ aJ
 bR
 bk
 aA
-ad
+ch
 bY
 cd
 Xh
@@ -1410,57 +1314,57 @@ aa
 "}
 (21,1,1) = {"
 aa
-ad
-ad
-ad
-ad
-ad
+ch
+ch
+ch
+ch
+ch
 ax
 aA
 bP
-ad
-ad
-ad
-ad
-ad
+ch
+ch
+ch
+ch
+ch
 Yj
 ab
 ab
 "}
 (22,1,1) = {"
 aa
-ad
+ch
 bx
-ad
+ch
 bx
 aq
 aA
 aK
 ag
-ad
+ch
 bx
-ad
+ch
 bx
-ad
+ch
 ab
 ab
 ab
 "}
 (23,1,1) = {"
 ab
-ad
+ch
 cf
-ad
+ch
 cf
-ad
+ch
 ah
 ah
 ah
 bl
 cf
-ad
+ch
 cf
-ad
+ch
 UU
 ab
 ac

--- a/modular_chomp/maps/submaps/shelters/CultShip-28x17.dmm
+++ b/modular_chomp/maps/submaps/shelters/CultShip-28x17.dmm
@@ -1,106 +1,1302 @@
-"aw" = (/turf/simulated/wall/cult,/area/survivalpod/superpose/CultShip)
-"aP" = (/obj/structure/table/fancyblack,/obj/item/weapon/book/tome/imbued,/obj/item/weapon/digestion_remains/skull/unathi,/obj/item/device/soulstone,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/CultShip)
-"be" = (/obj/structure/cult/pylon,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"bq" = (/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/CultShip)
-"bW" = (/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"cH" = (/obj/effect/floor_decal/techfloor{dir = 6},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"dJ" = (/obj/structure/grille/cult,/obj/structure/window/phoronreinforced/full,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 4},/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
-"eP" = (/obj/structure/shuttle/engine/heater{dir = 4; icon_state = "heater"},/turf/simulated/wall/cult,/area/survivalpod/superpose/CultShip)
-"fd" = (/obj/structure/bed/double/padded,/obj/item/weapon/bedsheet/hosdouble,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/CultShip)
-"fw" = (/obj/machinery/light/floortube/flicker{dir = 8; pixel_x = -3},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"fZ" = (/obj/item/clothing/shoes/cult,/obj/item/clothing/suit/cultrobes/alt,/obj/item/clothing/head/helmet/space/cult,/obj/structure/table/fancyblack,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"gU" = (/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil/green,/obj/item/stack/cable_coil/blue,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/structure/table/rack/shelf/steel,/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"he" = (/obj/structure/cult/pylon,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/CultShip)
-"jq" = (/obj/effect/floor_decal/techfloor,/obj/machinery/light/floortube/flicker{pixel_y = 13},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"js" = (/obj/effect/floor_decal/techfloor/corner{dir = 4},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/CultShip)
-"jv" = (/obj/structure/cult/talisman,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"jO" = (/obj/effect/catwalk_plated/white,/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
-"kf" = (/obj/structure/grille/cult,/obj/structure/window/phoronreinforced/full,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod,/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
-"kT" = (/obj/structure/bed/chair/bay/comfy/purple{dir = 8},/obj/effect/floor_decal/techfloor{dir = 9},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"mT" = (/obj/structure/toilet/prison{name = "toilet"; pixel_y = 10},/obj/structure/window/reinforced/survival_pod{dir = 4; opacity = 1},/obj/structure/curtain/open/shower/security,/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"nj" = (/obj/machinery/light/floortube/flicker{dir = 8; pixel_x = 5},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/CultShip)
-"nq" = (/obj/item/weapon/melee/cultblade,/obj/structure/table/fancyblack,/obj/item/device/soulstone,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"oY" = (/obj/structure/cult/talisman,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/CultShip)
-"py" = (/obj/machinery/door/airlock/phoron,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/CultShip)
-"pJ" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 1},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/CultShip)
-"rC" = (/obj/structure/constructshell/cult,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/CultShip)
-"us" = (/obj/machinery/atmospherics/pipe/tank/phoron/full{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/CultShip)
-"vf" = (/turf/simulated/wall/phoron,/area/survivalpod/superpose/CultShip)
-"vl" = (/obj/machinery/light/floortube/flicker{pixel_y = 5},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/CultShip)
-"vG" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/CultShip)
-"vX" = (/obj/structure/curtain/open/shower/security,/obj/machinery/shower{pixel_y = 20},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"wl" = (/obj/effect/floor_decal/techfloor/corner,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"xg" = (/obj/effect/floor_decal/techfloor,/obj/structure/cult/forge,/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"xh" = (/obj/item/clothing/shoes/cult,/obj/item/clothing/suit/cultrobes/alt,/obj/item/clothing/head/helmet/space/cult,/obj/structure/table/fancyblack,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/CultShip)
-"xq" = (/obj/effect/catwalk_plated/dark,/obj/machinery/pointdefense,/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"yi" = (/obj/structure/closet/walllocker_double/north,/obj/item/device/gps,/obj/item/sticky_pad/random,/obj/item/device/starcaster_news,/obj/item/weapon/pen/blue,/obj/item/device/pda,/obj/item/weapon/card/id/external,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/clothing/accessory/permit/gun,/obj/item/device/camera,/obj/item/device/binoculars,/obj/item/device/threadneedle,/obj/random/soap,/obj/item/weapon/towel/random,/obj/item/bodybag/cryobag,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/color/yellow,/obj/item/device/radio,/obj/item/device/radio,/obj/item/weapon/flame/lighter/random,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/device/suit_cooling_unit/emergency,/obj/item/stack/nanopaste,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,/obj/item/weapon/storage/backpack/messenger,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/clothing/accessory/poncho/thermal,/obj/item/weapon/storage/box/survival/comp,/obj/item/weapon/storage/toolbox/brass,/obj/item/weapon/storage/box/khcrystal,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"ym" = (/obj/structure/grille/cult,/obj/structure/window/phoronreinforced/full,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 4},/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
-"yq" = (/obj/structure/grille/cult,/obj/structure/window/phoronreinforced/full,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 8},/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
-"yE" = (/obj/structure/table/marble{color = "#B03A2E"},/obj/random/soap{pixel_y = 5},/obj/random/soap,/obj/item/weapon/towel/random{pixel_y = 4},/obj/item/weapon/towel/random{pixel_y = 4},/obj/item/weapon/towel/random{pixel_y = 8},/obj/item/weapon/towel/random{pixel_y = 8},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"Ai" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/light/floortube/flicker{pixel_y = -3},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"Bw" = (/obj/structure/bed/chair/wood/wings{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/CultShip)
-"BV" = (/obj/item/weapon/storage/backpack/cultpack,/obj/structure/table/fancyblack,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/CultShip)
-"CY" = (/obj/machinery/porta_turret/alien/destroyed,/obj/effect/catwalk_plated/white,/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"De" = (/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"Dz" = (/obj/structure/bed/chair/wood/wings{dir = 8},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/CultShip)
-"EA" = (/obj/structure/cult/tome,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/CultShip)
-"Ff" = (/obj/effect/catwalk_plated/white,/obj/machinery/pointdefense,/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"Fw" = (/obj/structure/grille/cult,/obj/structure/window/phoronreinforced/full,/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 8},/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
-"HF" = (/obj/effect/floor_decal/techfloor,/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"II" = (/obj/effect/floor_decal/techfloor{dir = 5},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"IX" = (/obj/structure/grille/cult,/obj/structure/window/phoronreinforced/full,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 8},/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
-"Kj" = (/obj/structure/closet/cabinet,/obj/random/curseditem,/obj/random/curseditem,/obj/item/weapon/melee/cursedblade,/obj/item/weapon/melee/cultblade,/obj/item/weapon/beartrap/hunting,/obj/item/weapon/beartrap/hunting,/obj/item/stack/material/phoron{amount = 25},/obj/item/stack/material/phoron{amount = 25},/obj/item/device/soulstone,/obj/item/device/soulstone,/obj/item/weapon/storage/belt/soulstone/full,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/CultShip)
-"Kq" = (/obj/structure/undies_wardrobe,/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"Kt" = (/obj/machinery/power/port_gen/pacman,/obj/item/stack/material/phoron{amount = 25},/obj/structure/cable/green{d2 = 8; icon_state = "0-8"},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"KV" = (/obj/machinery/atmospherics/unary/engine/biggest{dir = 8},/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
-"Ln" = (/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"LR" = (/obj/effect/floor_decal/techfloor{dir = 4},/obj/machinery/light/floortube/flicker{dir = 8; pixel_x = -3},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/CultShip)
-"Md" = (/obj/machinery/porta_turret/alien/destroyed,/obj/effect/catwalk_plated/dark,/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"Mg" = (/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/CultShip)
-"Mh" = (/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"Mo" = (/obj/effect/floor_decal/techfloor,/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/CultShip)
-"MH" = (/obj/structure/bed/chair/wood/wings{dir = 4},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"Nl" = (/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/CultShip)
-"NH" = (/obj/machinery/power/smes/buildable{icon = 'icons/obj/alien_smes.dmi'; icon_state = "unit"; input_level = 950000; name = "Alien Royal Capacitor"; output_level = 950000},/obj/effect/floor_decal/techfloor{dir = 5},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"NJ" = (/obj/item/weapon/material/knife/ritual,/obj/structure/table/fancyblack,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"NQ" = (/obj/effect/catwalk_plated/dark,/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
-"Oh" = (/obj/structure/salvageable/console_os{dir = 4},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/CultShip)
-"Op" = (/obj/structure/constructshell/cult,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"ON" = (/obj/structure/salvageable/computer,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"OU" = (/obj/structure/sink{dir = 4; pixel_x = 11},/obj/structure/mirror{dir = 8; pixel_x = 25},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"Pi" = (/obj/machinery/atmospherics/pipe/tank/phoron/full{dir = 4},/turf/simulated/floor/redgrid/animated,/area/survivalpod/superpose/CultShip)
-"PR" = (/turf/simulated/floor/redgrid/animated,/area/survivalpod/superpose/CultShip)
-"Qh" = (/obj/structure/grille/cult,/obj/structure/window/phoronreinforced/full,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 4},/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
-"UE" = (/obj/structure/bed/chair/bay/comfy/purple{dir = 8},/obj/effect/floor_decal/techfloor{dir = 10},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"UG" = (/turf/template_noop,/area/template_noop)
-"VA" = (/obj/effect/floor_decal/emblem/black,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/CultShip)
-"VL" = (/obj/effect/floor_decal/techfloor/corner,/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"Wd" = (/obj/machinery/door/airlock/phoron,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"Wm" = (/obj/effect/floor_decal/techfloor{dir = 6},/obj/machinery/power/smes/buildable{icon = 'icons/obj/alien_smes.dmi'; icon_state = "unit"; input_level = 950000; name = "Alien Royal Capacitor"; output_level = 950000},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"WT" = (/obj/structure/table/fancyblack,/obj/item/weapon/flame/candle/candelabra/everburn{pixel_y = 8},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/CultShip)
-"Xw" = (/obj/structure/grille/cult,/obj/structure/window/phoronreinforced/full,/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 4},/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
-"Yl" = (/obj/effect/floor_decal/techfloor/corner{dir = 4},/turf/simulated/floor/cult,/area/survivalpod/superpose/CultShip)
-"Yu" = (/obj/machinery/door/airlock/phoron,/obj/structure/fans/hardlight/colorable/abductor,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/CultShip)
-"YN" = (/obj/effect/floor_decal/techfloor{dir = 4},/obj/machinery/power/apc/alarms_hidden{dir = 1; pixel_y = 20},/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/CultShip)
-"YO" = (/obj/structure/cult/talisman,/obj/item/device/soulstone,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/CultShip)
-"ZJ" = (/turf/simulated/floor/tiled/steel_dirty{color = "grey"},/area/survivalpod/superpose/CultShip)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aw" = (
+/turf/simulated/wall/cult,
+/area/survivalpod/superpose/CultShip)
+"aP" = (
+/obj/structure/table/fancyblack,
+/obj/item/weapon/book/tome/imbued,
+/obj/item/weapon/digestion_remains/skull/unathi,
+/obj/item/device/soulstone,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/CultShip)
+"be" = (
+/obj/structure/cult/pylon,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"bq" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/CultShip)
+"bW" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"cH" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"dJ" = (
+/obj/structure/grille/cult,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"eP" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 4;
+	icon_state = "heater"
+	},
+/turf/simulated/wall/cult,
+/area/survivalpod/superpose/CultShip)
+"fd" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/hosdouble,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/CultShip)
+"fw" = (
+/obj/machinery/light/floortube/flicker{
+	dir = 8;
+	pixel_x = -3
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"fZ" = (
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/suit/cultrobes/alt,
+/obj/item/clothing/head/helmet/space/cult,
+/obj/structure/table/fancyblack,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"gU" = (
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/blue,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"he" = (
+/obj/structure/cult/pylon,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/CultShip)
+"iH" = (
+/obj/machinery/door/airlock/phoron,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/CultShip)
+"jq" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/light/floortube/flicker{
+	pixel_y = 13
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"js" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/CultShip)
+"jv" = (
+/obj/structure/cult/talisman,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"jO" = (
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"kf" = (
+/obj/structure/grille/cult,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod,
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"kT" = (
+/obj/structure/bed/chair/bay/comfy/purple{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"mT" = (
+/obj/structure/toilet/prison{
+	name = "toilet";
+	pixel_y = 10
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4;
+	opacity = 1
+	},
+/obj/structure/curtain/open/shower/security,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"nj" = (
+/obj/machinery/light/floortube/flicker{
+	dir = 8;
+	pixel_x = 5
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/CultShip)
+"nq" = (
+/obj/item/weapon/melee/cultblade,
+/obj/structure/table/fancyblack,
+/obj/item/device/soulstone,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"oY" = (
+/obj/structure/cult/talisman,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/CultShip)
+"py" = (
+/obj/machinery/door/airlock/phoron,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/CultShip)
+"pJ" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/CultShip)
+"rC" = (
+/obj/structure/constructshell/cult,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/CultShip)
+"us" = (
+/obj/machinery/atmospherics/pipe/tank/phoron/full{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/CultShip)
+"vf" = (
+/turf/simulated/wall/phoron,
+/area/survivalpod/superpose/CultShip)
+"vl" = (
+/obj/machinery/light/floortube/flicker{
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/CultShip)
+"vG" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/CultShip)
+"vX" = (
+/obj/structure/curtain/open/shower/security,
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"wl" = (
+/obj/effect/floor_decal/techfloor/corner,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"xg" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/cult/forge,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"xh" = (
+/obj/item/clothing/shoes/cult,
+/obj/item/clothing/suit/cultrobes/alt,
+/obj/item/clothing/head/helmet/space/cult,
+/obj/structure/table/fancyblack,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/CultShip)
+"xq" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/pointdefense,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"yi" = (
+/obj/structure/closet/walllocker_double/north,
+/obj/item/device/gps,
+/obj/item/sticky_pad/random,
+/obj/item/device/starcaster_news,
+/obj/item/weapon/pen/blue,
+/obj/item/device/pda,
+/obj/item/weapon/card/id/external,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/device/camera,
+/obj/item/device/binoculars,
+/obj/item/device/threadneedle,
+/obj/random/soap,
+/obj/item/weapon/towel/random,
+/obj/item/bodybag/cryobag,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/color/yellow,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/weapon/flame/lighter/random,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/stack/nanopaste,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,
+/obj/item/weapon/storage/backpack/messenger,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/clothing/accessory/poncho/thermal,
+/obj/item/weapon/storage/box/survival/comp,
+/obj/item/weapon/storage/toolbox/brass,
+/obj/item/weapon/storage/box/khcrystal,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"ym" = (
+/obj/structure/grille/cult,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"yq" = (
+/obj/structure/grille/cult,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"yE" = (
+/obj/structure/table/marble{
+	color = "#B03A2E"
+	},
+/obj/random/soap{
+	pixel_y = 5
+	},
+/obj/random/soap,
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 4
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/obj/item/weapon/towel/random{
+	pixel_y = 8
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"Ai" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/light/floortube/flicker{
+	pixel_y = -3
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"Bw" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/CultShip)
+"BU" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/CultShip)
+"BV" = (
+/obj/item/weapon/storage/backpack/cultpack,
+/obj/structure/table/fancyblack,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/CultShip)
+"CY" = (
+/obj/machinery/porta_turret/alien/destroyed,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"De" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"Dz" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/CultShip)
+"EA" = (
+/obj/structure/cult/tome,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/CultShip)
+"Ff" = (
+/obj/effect/catwalk_plated/white,
+/obj/machinery/pointdefense,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"Fw" = (
+/obj/structure/grille/cult,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"HF" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"II" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"IX" = (
+/obj/structure/grille/cult,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"Kj" = (
+/obj/structure/closet/cabinet,
+/obj/random/curseditem,
+/obj/random/curseditem,
+/obj/item/weapon/melee/cursedblade,
+/obj/item/weapon/melee/cultblade,
+/obj/item/weapon/beartrap/hunting,
+/obj/item/weapon/beartrap/hunting,
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/item/device/soulstone,
+/obj/item/device/soulstone,
+/obj/item/weapon/storage/belt/soulstone/full,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/CultShip)
+"Kq" = (
+/obj/structure/undies_wardrobe,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"Kt" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"KV" = (
+/obj/machinery/atmospherics/unary/engine/biggest{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"Ln" = (
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"LR" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/light/floortube/flicker{
+	dir = 8;
+	pixel_x = -3
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/CultShip)
+"Md" = (
+/obj/machinery/porta_turret/alien/destroyed,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"Mg" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/CultShip)
+"Mh" = (
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"Mo" = (
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/CultShip)
+"MH" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"Nl" = (
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/CultShip)
+"NH" = (
+/obj/machinery/power/smes/buildable{
+	icon = 'icons/obj/alien_smes.dmi';
+	icon_state = "unit";
+	input_level = 950000;
+	name = "Alien Royal Capacitor";
+	output_level = 950000
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"NJ" = (
+/obj/item/weapon/material/knife/ritual,
+/obj/structure/table/fancyblack,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"NQ" = (
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"Oh" = (
+/obj/structure/salvageable/console_os{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/CultShip)
+"Op" = (
+/obj/structure/constructshell/cult,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"OE" = (
+/obj/structure/grille/cult,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"ON" = (
+/obj/structure/salvageable/computer,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"OU" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	dir = 8;
+	pixel_x = 25
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"Pi" = (
+/obj/machinery/atmospherics/pipe/tank/phoron/full{
+	dir = 4
+	},
+/turf/simulated/floor/redgrid/animated,
+/area/survivalpod/superpose/CultShip)
+"PR" = (
+/obj/structure/closet/crate/solar,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/redgrid/animated,
+/area/survivalpod/superpose/CultShip)
+"Qh" = (
+/obj/structure/grille/cult,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"UE" = (
+/obj/structure/bed/chair/bay/comfy/purple{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"UG" = (
+/turf/template_noop,
+/area/template_noop)
+"VA" = (
+/obj/effect/floor_decal/emblem/black,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/CultShip)
+"VL" = (
+/obj/effect/floor_decal/techfloor/corner,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"Wd" = (
+/obj/machinery/door/airlock/phoron,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"Wm" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/machinery/power/smes/buildable{
+	icon = 'icons/obj/alien_smes.dmi';
+	icon_state = "unit";
+	input_level = 950000;
+	name = "Alien Royal Capacitor";
+	output_level = 950000
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"WT" = (
+/obj/structure/table/fancyblack,
+/obj/item/weapon/flame/candle/candelabra/everburn{
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/CultShip)
+"Xw" = (
+/obj/structure/grille/cult,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
+"Yl" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 4
+	},
+/turf/simulated/floor/cult,
+/area/survivalpod/superpose/CultShip)
+"Yu" = (
+/obj/machinery/door/airlock/phoron,
+/obj/structure/fans/hardlight/colorable/abductor,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/CultShip)
+"YN" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/power/apc/alarms_hidden{
+	dir = 1;
+	pixel_y = 20
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/CultShip)
+"YO" = (
+/obj/structure/cult/talisman,
+/obj/item/device/soulstone,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/CultShip)
+"ZJ" = (
+/turf/simulated/floor/tiled/steel_dirty{
+	color = "grey"
+	},
+/area/survivalpod/superpose/CultShip)
 
 (1,1,1) = {"
-UGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUG
-UGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGCYawawawUGUGUG
-UGUGUGUGUGUGUGUGUGUGUGUGUGUGvfawyqkfQhawawawePZJZJUGUGUG
-UGUGUGUGUGUGUGUGUGxqawyqkfQhawbeNlMhNlawYNKtIXZJZJUGUGUG
-UGUGUGUGUGvfawYuawawawxhfZxhyiNlMhNlwlpyMgPRFwKVZJUGUGUG
-UGMdawyqQhawpJnjawMhNlMhNlVLHFHFjqHFWmawLRgUawNQjONQUGUG
-UGawawjvheawvGnjawNlOpNlOpDeawawyqQhawawMgPiawawawjOUGUG
-UGymOhUEHFawawYuawHFHFHFHFcHawKjbqbqfdawMoxgvfePZJZJUGUG
-UGdJONvlbqWdbqvlbqVAvlbqvlbqpybqbqbqWTawvlusvfePZJZJUGUG
-UGXwOhkTbWawbWbWbWbWbWbWbWIIawBwaPbqfdawawawvfePKVZJUGUG
-UGawawoYbeawNlMhNlMhrCMhrCDeawawyqQhawawmTvXawawawNQUGUG
-UGCYawyqQhawMHEAYODzMhNlMhYlbWbWAibWNHawfwOUawjONQjOUGUG
-UGUGUGUGUGvfawawawawawnqBVNJNlMhNlMhjspyLnLnIXZJZJUGUGUG
-UGUGUGUGUGUGUGUGUGFfawyqkfQhawheMhNlMhawKqyEFwZJZJUGUGUG
-UGUGUGUGUGUGUGUGUGUGUGUGUGUGvfawyqkfQhawawawePKVZJUGUGUG
-UGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGMdawawawUGUGUG
-UGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUGUG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+"}
+(2,1,1) = {"
+UG
+UG
+UG
+UG
+UG
+Md
+aw
+ym
+dJ
+Xw
+aw
+CY
+UG
+UG
+UG
+UG
+UG
+"}
+(3,1,1) = {"
+UG
+UG
+UG
+UG
+UG
+aw
+aw
+Oh
+ON
+Oh
+aw
+aw
+UG
+UG
+UG
+UG
+UG
+"}
+(4,1,1) = {"
+UG
+UG
+UG
+UG
+UG
+yq
+jv
+UE
+vl
+kT
+oY
+yq
+UG
+UG
+UG
+UG
+UG
+"}
+(5,1,1) = {"
+UG
+UG
+UG
+UG
+UG
+Qh
+he
+HF
+bq
+bW
+be
+Qh
+UG
+UG
+UG
+UG
+UG
+"}
+(6,1,1) = {"
+UG
+UG
+UG
+UG
+vf
+aw
+aw
+aw
+Wd
+aw
+aw
+aw
+vf
+UG
+UG
+UG
+UG
+"}
+(7,1,1) = {"
+UG
+UG
+UG
+UG
+aw
+pJ
+vG
+aw
+bq
+bW
+Nl
+MH
+aw
+UG
+UG
+UG
+UG
+"}
+(8,1,1) = {"
+UG
+UG
+UG
+UG
+Yu
+nj
+nj
+Yu
+vl
+bW
+Mh
+EA
+aw
+UG
+UG
+UG
+UG
+"}
+(9,1,1) = {"
+UG
+UG
+UG
+UG
+aw
+aw
+aw
+aw
+bq
+bW
+Nl
+YO
+aw
+UG
+UG
+UG
+UG
+"}
+(10,1,1) = {"
+UG
+UG
+UG
+xq
+aw
+Mh
+Nl
+HF
+VA
+bW
+Mh
+Dz
+aw
+Ff
+UG
+UG
+UG
+"}
+(11,1,1) = {"
+UG
+UG
+UG
+aw
+aw
+Nl
+Op
+HF
+vl
+bW
+rC
+Mh
+aw
+aw
+UG
+UG
+UG
+"}
+(12,1,1) = {"
+UG
+UG
+UG
+yq
+xh
+Mh
+Nl
+HF
+bq
+bW
+Mh
+Nl
+nq
+yq
+UG
+UG
+UG
+"}
+(13,1,1) = {"
+UG
+UG
+UG
+kf
+fZ
+Nl
+Op
+HF
+vl
+bW
+rC
+Mh
+BV
+kf
+UG
+UG
+UG
+"}
+(14,1,1) = {"
+UG
+UG
+UG
+Qh
+xh
+VL
+De
+cH
+bq
+II
+De
+Yl
+NJ
+Qh
+UG
+UG
+UG
+"}
+(15,1,1) = {"
+UG
+UG
+vf
+aw
+yi
+HF
+aw
+aw
+py
+aw
+aw
+bW
+Nl
+aw
+vf
+UG
+UG
+"}
+(16,1,1) = {"
+UG
+UG
+aw
+be
+Nl
+HF
+aw
+Kj
+bq
+Bw
+aw
+bW
+Mh
+he
+aw
+UG
+UG
+"}
+(17,1,1) = {"
+UG
+UG
+yq
+Nl
+Mh
+jq
+yq
+bq
+bq
+aP
+yq
+Ai
+Nl
+Mh
+yq
+UG
+UG
+"}
+(18,1,1) = {"
+UG
+UG
+kf
+Mh
+Nl
+HF
+Qh
+bq
+bq
+bq
+Qh
+bW
+Mh
+Nl
+kf
+UG
+UG
+"}
+(19,1,1) = {"
+UG
+UG
+Qh
+Nl
+wl
+Wm
+aw
+fd
+WT
+fd
+aw
+NH
+js
+Mh
+Qh
+UG
+UG
+"}
+(20,1,1) = {"
+UG
+UG
+aw
+aw
+iH
+OE
+aw
+aw
+aw
+aw
+aw
+aw
+py
+aw
+aw
+UG
+UG
+"}
+(21,1,1) = {"
+UG
+UG
+aw
+YN
+BU
+LR
+Mg
+Mo
+vl
+aw
+mT
+fw
+Ln
+Kq
+aw
+UG
+UG
+"}
+(22,1,1) = {"
+UG
+CY
+aw
+Kt
+PR
+gU
+Pi
+xg
+us
+aw
+vX
+OU
+Ln
+yE
+aw
+Md
+UG
+"}
+(23,1,1) = {"
+UG
+aw
+eP
+IX
+Fw
+aw
+aw
+vf
+vf
+vf
+aw
+aw
+IX
+Fw
+eP
+aw
+UG
+"}
+(24,1,1) = {"
+UG
+aw
+ZJ
+ZJ
+KV
+NQ
+aw
+eP
+eP
+eP
+aw
+jO
+ZJ
+ZJ
+KV
+aw
+UG
+"}
+(25,1,1) = {"
+UG
+aw
+ZJ
+ZJ
+ZJ
+jO
+aw
+ZJ
+ZJ
+KV
+aw
+NQ
+ZJ
+ZJ
+ZJ
+aw
+UG
+"}
+(26,1,1) = {"
+UG
+UG
+UG
+UG
+UG
+NQ
+jO
+ZJ
+ZJ
+ZJ
+NQ
+jO
+UG
+UG
+UG
+UG
+UG
+"}
+(27,1,1) = {"
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+"}
+(28,1,1) = {"
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
+UG
 "}

--- a/modular_chomp/maps/submaps/shelters/Dinner-25x25.dmm
+++ b/modular_chomp/maps/submaps/shelters/Dinner-25x25.dmm
@@ -9,7 +9,8 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/survivalpod/superpose/Dinner)
 "ad" = (
-/turf/simulated/wall,
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/lino,
 /area/survivalpod/superpose/Dinner)
 "ae" = (
 /obj/structure/window/reinforced/full,
@@ -52,7 +53,7 @@
 /area/survivalpod/superpose/Dinner)
 "am" = (
 /obj/structure/sink/kitchen,
-/turf/simulated/wall,
+/turf/simulated/wall/concrete,
 /area/survivalpod/superpose/Dinner)
 "an" = (
 /obj/structure/flora/tree/sif,
@@ -71,7 +72,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/space_heater,
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
 "ar" = (
@@ -165,8 +165,8 @@
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
 "aF" = (
+/obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/table/hardwoodtable,
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
 "aG" = (
@@ -187,9 +187,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/survivalpod/superpose/Dinner)
 "aJ" = (
+/obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/item/weapon/reagent_containers/food/condiment/small/saltshaker,
-/obj/structure/table/hardwoodtable,
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
 "aK" = (
@@ -234,9 +234,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/survivalpod/superpose/Dinner)
 "aO" = (
+/obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/item/weapon/reagent_containers/food/condiment/small/peppermill,
-/obj/structure/table/hardwoodtable,
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
 "aP" = (
@@ -272,7 +272,7 @@
 /area/survivalpod/superpose/Dinner)
 "aU" = (
 /obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/appliance/cooker/oven,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
 "aV" = (
@@ -313,14 +313,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/survivalpod/superpose/Dinner)
 "be" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/appliance/mixer/cereal,
-/obj/effect/floor_decal/corner/red/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
 "bf" = (
@@ -422,10 +420,7 @@
 /area/survivalpod/superpose/Dinner)
 "bh" = (
 /obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/bar_coffee{
-	dir = 8;
-	pixel_x = 4
-	},
+/obj/machinery/chemical_dispenser/bar_coffee,
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
 "bi" = (
@@ -458,6 +453,11 @@
 "bo" = (
 /obj/structure/table/woodentable,
 /obj/random/mug,
+/obj/item/weapon/circuitboard/batteryrack,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/matter_bin,
 /turf/simulated/floor/lino,
 /area/survivalpod/superpose/Dinner)
 "bp" = (
@@ -531,26 +531,15 @@
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
 "bu" = (
-/obj/structure/table/hardwoodtable,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
 "bv" = (
 /turf/simulated/floor/tiled/hydro,
 /area/survivalpod/superpose/Dinner)
 "bw" = (
-/obj/structure/toilet/prison{
-	name = "toilet";
-	pixel_y = 10
-	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 4
-	},
-/obj/structure/curtain/black{
-	icon_state = "open";
-	layer = 2;
-	name = "privacy curtain";
-	opacity = 0
-	},
+/obj/structure/toilet,
 /turf/simulated/floor/tiled/hydro,
 /area/survivalpod/superpose/Dinner)
 "bx" = (
@@ -576,34 +565,15 @@
 	dir = 4;
 	pixel_x = -32
 	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = -9
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -27
-	},
 /turf/simulated/floor/tiled/hydro,
 /area/survivalpod/superpose/Dinner)
 "bB" = (
 /obj/machinery/light/small,
-/obj/structure/table/standard,
-/obj/random/soap,
-/obj/random/soap{
-	pixel_y = 5
-	},
 /turf/simulated/floor/tiled/hydro,
 /area/survivalpod/superpose/Dinner)
 "bC" = (
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = -9
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -27
-	},
+/obj/structure/table/standard,
+/obj/item/stack/cable_coil,
 /turf/simulated/floor/tiled/hydro,
 /area/survivalpod/superpose/Dinner)
 "da" = (
@@ -612,41 +582,15 @@
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
 "dQ" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	dir = 1
-	},
-/obj/structure/table/bench/marble,
-/obj/structure/curtain/black,
-/turf/simulated/floor/tiled,
-/area/survivalpod/superpose/Dinner)
-"eR" = (
-/obj/structure/window/reinforced/survival_pod{
-	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	opacity = 1
-	},
-/obj/structure/table/bench/marble,
-/obj/structure/flora/pottedplant/overgrown{
-	pixel_y = 7
-	},
-/obj/structure/curtain/black,
-/turf/simulated/floor/tiled,
+/turf/simulated/wall/concrete,
 /area/survivalpod/superpose/Dinner)
 "gw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/survivalpod/superpose/Dinner)
 "hm" = (
 /obj/machinery/power/port_gen/pacman,
-/turf/simulated/floor,
-/area/survivalpod/superpose/Dinner)
-"lo" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/survivalpod/superpose/Dinner)
 "lT" = (
@@ -654,20 +598,13 @@
 /turf/simulated/floor/lino,
 /area/survivalpod/superpose/Dinner)
 "qd" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12;
+	pixel_y = 2
 	},
-/obj/machinery/chem_master/condimaster,
-/turf/simulated/floor/tiled/white,
-/area/survivalpod/superpose/Dinner)
-"wn" = (
-/obj/item/weapon/reagent_containers/food/snacks/chip/nacho/guac,
-/turf/simulated/floor,
-/area/survivalpod/superpose/Dinner)
-"KP" = (
-/obj/item/stack/cable_coil,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/hydro,
 /area/survivalpod/superpose/Dinner)
 "Lj" = (
 /turf/simulated/floor,
@@ -694,10 +631,10 @@
 "Rx" = (
 /obj/structure/simple_door/wood,
 /obj/structure/fans/tiny,
-/turf/simulated/floor/tiled,
+/turf/simulated/wall/concrete,
 /area/survivalpod/superpose/Dinner)
 "WB" = (
-/obj/structure/table/woodentable,
+/obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/Dinner)
@@ -766,13 +703,6 @@
 /obj/item/weapon/storage/briefcase/inflatable,
 /obj/structure/table/rack/shelf/steel,
 /turf/simulated/floor/plating,
-/area/survivalpod/superpose/Dinner)
-"Zv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/mopbucket,
-/obj/item/weapon/mop,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/turf/simulated/floor,
 /area/survivalpod/superpose/Dinner)
 "ZZ" = (
 /obj/structure/bookcase,
@@ -952,10 +882,10 @@ ab
 ab
 ab
 ab
-ad
+dQ
 da
 da
-ad
+dQ
 ab
 ab
 ab
@@ -974,23 +904,23 @@ aa
 ab
 ab
 ab
-ad
-ad
+dQ
+dQ
 ae
 ae
 ae
-ad
+dQ
 ap
 ap
-ad
+dQ
 ae
 ae
 ae
-ad
+dQ
 ae
 ae
 ae
-ad
+dQ
 ab
 ab
 ab
@@ -1000,16 +930,16 @@ aa
 aa
 ab
 ab
-ad
-ad
+dQ
+dQ
 af
 ao
 aC
 ax
-ad
+dQ
 ap
 aW
-ad
+dQ
 ao
 aC
 ax
@@ -1017,8 +947,8 @@ ao
 aC
 ax
 af
-ad
-ad
+dQ
+dQ
 ab
 ab
 aa
@@ -1026,17 +956,17 @@ aa
 (10,1,1) = {"
 aa
 ab
-ad
-ad
+dQ
+dQ
 aq
 af
 ao
 aD
 ax
-ad
+dQ
 az
 az
-ad
+dQ
 ao
 aD
 ax
@@ -1045,15 +975,16 @@ aD
 ax
 af
 bt
-ad
-ad
+dQ
+dQ
 ab
 aa
 "}
 (11,1,1) = {"
 aa
-ad
-ad
+dQ
+dQ
+af
 af
 af
 af
@@ -1061,7 +992,6 @@ af
 af
 af
 aT
-af
 af
 ba
 af
@@ -1073,8 +1003,8 @@ af
 af
 af
 af
-ad
-ad
+dQ
+dQ
 aa
 "}
 (12,1,1) = {"
@@ -1101,7 +1031,7 @@ af
 af
 af
 af
-ad
+dQ
 aa
 "}
 (13,1,1) = {"
@@ -1111,7 +1041,7 @@ af
 ao
 as
 ax
-af
+bu
 aE
 aE
 aE
@@ -1133,12 +1063,12 @@ aa
 "}
 (14,1,1) = {"
 aa
-ad
-ad
-ad
-ad
-ad
-ad
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
 aF
 aJ
 aO
@@ -1160,7 +1090,7 @@ aa
 "}
 (15,1,1) = {"
 aa
-ad
+dQ
 ag
 ap
 at
@@ -1177,7 +1107,7 @@ af
 af
 af
 af
-bu
+ah
 af
 af
 by
@@ -1187,14 +1117,14 @@ aa
 "}
 (16,1,1) = {"
 aa
-ad
+dQ
 WB
 ap
 ap
 ap
 az
 af
-qd
+aK
 aP
 aU
 aX
@@ -1209,39 +1139,39 @@ af
 af
 af
 af
-ad
+dQ
 aa
 "}
 (17,1,1) = {"
 aa
-ae
+dQ
 ai
 ap
 au
 ap
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
 bz
-ad
-ad
+dQ
+dQ
 aa
 "}
 (18,1,1) = {"
 aa
-ae
+dQ
 aj
 ap
 ah
@@ -1258,71 +1188,71 @@ bc
 aG
 aG
 aL
-KP
-ad
-bw
+aG
+dQ
+qd
 bv
 bA
-ad
+dQ
 aa
 "}
 (19,1,1) = {"
 aa
-ad
+dQ
 ak
 ap
 av
 ap
-ad
-ad
-ad
-ad
-ad
-ad
-lo
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+bc
 gw
-ad
-ad
-ad
+dQ
+dQ
+dQ
 bq
-ad
-ad
-bw
+dQ
+dQ
+bv
 bv
 bB
-ad
+dQ
 aa
 "}
 (20,1,1) = {"
 aa
-ad
+dQ
 al
 ap
 ap
 ap
-ad
+dQ
 Ql
 aM
 aQ
 aV
-ad
+dQ
 bd
-Zv
-ad
+bc
+dQ
 bi
 bm
 bl
-bl
 ad
+dQ
 bw
 bv
 bC
-ad
+dQ
 aa
 "}
 (21,1,1) = {"
 aa
-ad
+dQ
 am
 ap
 ap
@@ -1331,46 +1261,46 @@ aB
 aH
 aH
 aH
-ad
-ad
+dQ
+dQ
 aA
-ad
-ad
+dQ
+dQ
 bj
 bn
 bl
 lT
-ad
-ad
-ad
-ad
-ad
+dQ
+dQ
+dQ
+dQ
+dQ
 aa
 "}
 (22,1,1) = {"
 aa
 ab
-ad
-ad
+dQ
+dQ
 aw
 ap
-ad
+dQ
 aH
 aH
 aH
-ad
+dQ
 hm
 Lj
 XK
-ad
+dQ
 bk
 bo
 bl
 bs
-ad
-wn
-ad
-ad
+dQ
+dQ
+dQ
+dQ
 ab
 aa
 "}
@@ -1378,25 +1308,25 @@ aa
 aa
 ab
 ab
-ad
-ad
+dQ
+dQ
 ay
-ad
+dQ
 aI
 aN
 aR
-ad
+dQ
 Nb
 Lj
 bf
-ad
+dQ
 bp
 bl
 bl
 ZZ
-ad
-ad
-ad
+dQ
+dQ
+dQ
 ab
 ab
 aa
@@ -1406,23 +1336,23 @@ aa
 ab
 ab
 ab
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-Rx
-ad
-ad
-ad
 dQ
-eR
-ad
-ad
-ad
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+Rx
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
 ab
 ab
 ab

--- a/modular_chomp/maps/submaps/shelters/ExplorerHome-17x20.dmm
+++ b/modular_chomp/maps/submaps/shelters/ExplorerHome-17x20.dmm
@@ -416,7 +416,10 @@
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/ExplorerHome)
 "aX" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/ExplorerHome)
 "aY" = (
@@ -565,6 +568,47 @@
 /obj/item/clothing/accessory/poncho/thermal,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/ExplorerHome)
+"fb" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/ExplorerHome)
+"qU" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ExplorerHome)
+"sV" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ExplorerHome)
+"th" = (
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ExplorerHome)
+"zc" = (
+/obj/structure/grille/rustic,
+/obj/structure/window/reinforced/full,
+/obj/structure/cable/green,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/ExplorerHome)
+"Dg" = (
+/obj/machinery/power/smes/batteryrack/mapped,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/ExplorerHome)
 "GN" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/wood,
@@ -701,12 +745,12 @@ ax
 ap
 ap
 GN
-ap
-ap
-ap
-as
-ad
-ad
+qU
+sV
+sV
+zc
+Dg
+fb
 ag
 ag
 "}
@@ -835,7 +879,7 @@ ap
 ap
 ap
 ap
-ap
+th
 as
 ad
 ad

--- a/modular_chomp/maps/submaps/shelters/ExplorerHome-17x20.dmm
+++ b/modular_chomp/maps/submaps/shelters/ExplorerHome-17x20.dmm
@@ -607,6 +607,7 @@
 /area/survivalpod/superpose/ExplorerHome)
 "Dg" = (
 /obj/machinery/power/smes/batteryrack/mapped,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/ExplorerHome)
 "GN" = (

--- a/modular_chomp/maps/submaps/shelters/Farm-32x32.dmm
+++ b/modular_chomp/maps/submaps/shelters/Farm-32x32.dmm
@@ -45,7 +45,8 @@
 /turf/simulated/floor/outdoors/rocks,
 /area/survivalpod/superpose/Farm)
 "eb" = (
-/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable/green,
+/obj/machinery/power/smes/batteryrack/mapped,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/Farm)
 "ec" = (
@@ -65,6 +66,16 @@
 "eq" = (
 /turf/template_noop,
 /area/template_noop)
+"ff" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/Farm)
 "fp" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -144,6 +155,17 @@
 /obj/machinery/cell_charger,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/Farm)
+"sW" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/Farm)
 "te" = (
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/plating,
@@ -175,8 +197,8 @@
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/Farm)
 "Bb" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
-/turf/simulated/floor/wood,
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/Farm)
 "Bz" = (
 /obj/structure/reagent_dispensers/fueltank/high,
@@ -193,6 +215,90 @@
 "Eu" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/wood,
+/area/survivalpod/superpose/Farm)
+"EP" = (
+/obj/structure/closet/crate,
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/fiftyspawner/blucarpet,
+/obj/fiftyspawner/oracarpet,
+/obj/fiftyspawner/purcarpet,
+/obj/fiftyspawner/sblucarpet,
+/obj/fiftyspawner/tealcarpet,
+/obj/fiftyspawner/turcarpet,
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/algae{
+	amount = 50
+	},
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/lead{
+	amount = 30
+	},
+/obj/item/stack/material/plasteel{
+	amount = 30;
+	pixel_y = 5
+	},
+/obj/item/stack/material/resin{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/Farm)
 "Fe" = (
 /obj/structure/flora/tree/jungle,
@@ -377,6 +483,10 @@
 	dir = 1;
 	pixel_y = 20
 	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/Farm)
 "Mo" = (
@@ -402,6 +512,14 @@
 "OW" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/wood,
+/area/survivalpod/superpose/Farm)
+"Rn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/Farm)
 "Sr" = (
 /obj/structure/fence/corner{
@@ -508,6 +626,14 @@
 /obj/structure/bonfire/permanent/sifwood,
 /obj/item/weapon/reagent_containers/cooking_container/grill,
 /turf/simulated/floor/outdoors/grass/sif,
+/area/survivalpod/superpose/Farm)
+"Yq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/Farm)
 "Yz" = (
 /obj/structure/fence/corner{
@@ -838,7 +964,7 @@ or
 Gm
 Gm
 Gm
-Bb
+vN
 vN
 Gm
 cs
@@ -1119,7 +1245,7 @@ dJ
 dJ
 Oe
 Gm
-VN
+EP
 eb
 Iw
 Ip
@@ -1154,10 +1280,10 @@ dJ
 Oe
 Gm
 LM
-Ny
-Ny
-Ny
-Ny
+ff
+Yq
+Yq
+Rn
 Gm
 Oe
 Oe
@@ -1191,7 +1317,7 @@ Ny
 Ny
 Ny
 Ny
-qW
+sW
 Gm
 Oe
 Oe
@@ -1225,7 +1351,7 @@ Ny
 Ny
 WM
 Ny
-Ox
+qW
 Gm
 Oe
 Oe
@@ -1293,7 +1419,7 @@ Ny
 Ny
 Ny
 Ny
-Ny
+Bb
 Gm
 Oe
 Oe

--- a/modular_chomp/maps/submaps/shelters/FieldLab-20x20.dmm
+++ b/modular_chomp/maps/submaps/shelters/FieldLab-20x20.dmm
@@ -209,7 +209,6 @@
 	cell_type = /obj/item/weapon/cell/hyper;
 	dir = 8;
 	name = "Unknown APC";
-	operating = 0;
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -852,7 +851,7 @@ Wc
 fl
 IV
 bk
-mo
+ce
 xU
 xU
 xU

--- a/modular_chomp/maps/submaps/shelters/FieldLab-20x20.dmm
+++ b/modular_chomp/maps/submaps/shelters/FieldLab-20x20.dmm
@@ -5,6 +5,23 @@
 /obj/random/tool,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/FieldLab)
+"bk" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/FieldLab)
+"ce" = (
+/obj/machinery/door/airlock/external,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/FieldLab)
 "cq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -24,6 +41,14 @@
 "fl" = (
 /turf/template_noop,
 /area/survivalpod/superpose/FieldLab)
+"gR" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/FieldLab)
 "gS" = (
 /obj/structure/table/standard,
 /obj/item/device/multitool,
@@ -41,14 +66,30 @@
 /obj/structure/reagent_dispensers/fueltank/high,
 /turf/simulated/floor,
 /area/survivalpod/superpose/FieldLab)
+"iQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/FieldLab)
 "ja" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/FieldLab)
+"kZ" = (
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/FieldLab)
 "ll" = (
-/obj/machinery/floodlight,
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/FieldLab)
 "lI" = (
@@ -118,8 +159,24 @@
 /obj/machinery/cell_charger,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/FieldLab)
+"qy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/FieldLab)
 "qO" = (
 /obj/machinery/light/small,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/FieldLab)
+"si" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/FieldLab)
 "sx" = (
@@ -141,6 +198,10 @@
 /area/survivalpod/superpose/FieldLab)
 "xf" = (
 /obj/machinery/power/smes/buildable/point_of_interest,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/FieldLab)
 "xJ" = (
@@ -158,8 +219,11 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/FieldLab)
 "xU" = (
-/obj/structure/table/standard,
-/obj/random/tool,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/FieldLab)
 "yX" = (
@@ -167,6 +231,19 @@
 /obj/random/toolbox,
 /obj/item/weapon/cell/super,
 /turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/FieldLab)
+"zf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
 /area/survivalpod/superpose/FieldLab)
 "zX" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -191,6 +268,28 @@
 /area/survivalpod/superpose/FieldLab)
 "DW" = (
 /turf/simulated/wall/r_wall,
+/area/survivalpod/superpose/FieldLab)
+"El" = (
+/obj/machinery/door/airlock,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/FieldLab)
+"FA" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
 /area/survivalpod/superpose/FieldLab)
 "Gk" = (
 /obj/item/device/gps,
@@ -254,6 +353,14 @@
 /area/survivalpod/superpose/FieldLab)
 "Iq" = (
 /turf/simulated/floor,
+/area/survivalpod/superpose/FieldLab)
+"IJ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/FieldLab)
 "IO" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -400,6 +507,15 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/FieldLab)
+"Rl" = (
+/obj/machinery/light/small,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/FieldLab)
 "RT" = (
 /obj/structure/closet/crate,
 /obj/item/stack/material/plastic{
@@ -477,13 +593,19 @@
 "Wc" = (
 /turf/template_noop,
 /area/template_noop)
-"Xa" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
+"Wt" = (
 /obj/structure/cable{
+	d1 = 1;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/FieldLab)
+"Xa" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/FieldLab)
@@ -553,9 +675,9 @@ Wc
 Wc
 fl
 mm
-HQ
+kZ
 aG
-xU
+Pk
 yX
 xJ
 mm
@@ -575,10 +697,10 @@ Wc
 Wc
 fl
 IV
-HQ
-HQ
-HQ
-HQ
+IJ
+xU
+xU
+iQ
 Xa
 IV
 fl
@@ -597,10 +719,10 @@ Wc
 Wc
 fl
 mV
-HQ
+Xa
 XZ
 MD
-Pk
+gR
 xf
 mV
 fl
@@ -619,7 +741,7 @@ Wc
 Wc
 fl
 DW
-mb
+El
 DW
 DW
 DW
@@ -641,7 +763,7 @@ Wc
 Wc
 fl
 mm
-HQ
+Xa
 mm
 Vh
 Gt
@@ -663,7 +785,7 @@ Wc
 Wc
 fl
 IV
-HQ
+Xa
 mV
 Vh
 Gt
@@ -685,7 +807,7 @@ Wc
 Wc
 fl
 IV
-qO
+Rl
 DW
 DW
 DW
@@ -707,7 +829,7 @@ Wc
 Wc
 fl
 IV
-HQ
+Xa
 mo
 HQ
 cq
@@ -729,13 +851,13 @@ Wc
 Wc
 fl
 IV
-HQ
+bk
 mo
-HQ
-HQ
-HQ
-mo
-HQ
+xU
+xU
+xU
+ce
+iQ
 HQ
 mo
 lI
@@ -757,7 +879,7 @@ DW
 DW
 DW
 DW
-HQ
+Xa
 HQ
 DW
 DW
@@ -776,10 +898,10 @@ IV
 HQ
 mm
 ll
-ll
-Iq
-Iq
-HQ
+FA
+zf
+qy
+si
 HQ
 Iq
 Iq
@@ -798,8 +920,8 @@ mV
 HQ
 mV
 ll
-ll
-Iq
+FA
+Wt
 Iq
 HQ
 HQ

--- a/modular_chomp/maps/submaps/shelters/GrandLibrary-31x24.dmm
+++ b/modular_chomp/maps/submaps/shelters/GrandLibrary-31x24.dmm
@@ -63,6 +63,15 @@
 /obj/item/weapon/book/manual,
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/GrandLibrary)
+"bs" = (
+/obj/machinery/power/apc/hyper{
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -26
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/GrandLibrary)
 "bz" = (
 /obj/structure/bookcase,
 /obj/item/weapon/book/custom_library/nonfiction,
@@ -254,6 +263,11 @@
 /area/survivalpod/superpose/GrandLibrary)
 "nq" = (
 /obj/item/device/gps/computer,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/GrandLibrary)
 "nv" = (
@@ -288,10 +302,8 @@
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/GrandLibrary)
 "oD" = (
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 4;
-	pixel_x = 24
-	},
+/obj/structure/table/woodentable,
+/obj/machinery/librarycomp,
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/GrandLibrary)
 "oF" = (
@@ -1117,6 +1129,11 @@
 	anchored = 1;
 	pixel_y = 32
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/GrandLibrary)
 "QL" = (
@@ -1135,10 +1152,17 @@
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/GrandLibrary)
 "RE" = (
-/obj/machinery/librarycomp,
 /obj/item/weapon/flame/candle/candelabra/everburn{
 	anchored = 1;
 	pixel_y = 32
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/material/phoron{
+	material = 50
 	},
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/GrandLibrary)
@@ -1413,6 +1437,7 @@
 /obj/item/weapon/storage/box/flare,
 /obj/structure/closet/crate/wooden,
 /obj/item/weapon/gun/energy/locked/phasegun/pistol/unlocked,
+/obj/structure/cable/green,
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/GrandLibrary)
 "ZI" = (
@@ -1751,7 +1776,7 @@ Mx
 qd
 Qr
 ZA
-PH
+bs
 SU
 PH
 PH
@@ -1779,7 +1804,7 @@ nq
 PH
 Yu
 qd
-Sd
+oD
 PH
 NN
 jB
@@ -1806,7 +1831,7 @@ PH
 PH
 qd
 Nb
-oD
+PH
 PH
 CZ
 PH
@@ -1858,7 +1883,7 @@ cG
 DH
 PH
 dm
-PH
+Sd
 PH
 PH
 dm

--- a/modular_chomp/maps/submaps/shelters/HillOutpost-15x11.dmm
+++ b/modular_chomp/maps/submaps/shelters/HillOutpost-15x11.dmm
@@ -105,6 +105,10 @@
 /obj/item/ammo_magazine/m762svd,
 /turf/simulated/floor/wood/alt/tile,
 /area/survivalpod/superpose/HillOutpost)
+"w" = (
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/outdoors/rocks,
+/area/survivalpod/superpose/HillOutpost)
 "x" = (
 /obj/structure/cliff/automatic/corner{
 	dir = 10
@@ -135,6 +139,13 @@
 	dir = 8
 	},
 /turf/simulated/floor/outdoors/dirt,
+/area/survivalpod/superpose/HillOutpost)
+"B" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/turf/simulated/floor/outdoors/rocks,
 /area/survivalpod/superpose/HillOutpost)
 "D" = (
 /obj/structure/table/sifwooden_reinforced,
@@ -254,6 +265,14 @@
 /obj/random/soap,
 /obj/item/weapon/material/knife/machete/hatchet,
 /obj/item/weapon/storage/box/flare,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/circuitboard/batteryrack,
 /turf/simulated/floor/wood/alt/tile/broken,
 /area/survivalpod/superpose/HillOutpost)
 "W" = (
@@ -367,7 +386,7 @@ k
 a
 a
 a
-a
+w
 W
 c
 c
@@ -380,7 +399,7 @@ a
 a
 a
 a
-a
+B
 M
 c
 c

--- a/modular_chomp/maps/submaps/shelters/HydroCave-40x40.dmm
+++ b/modular_chomp/maps/submaps/shelters/HydroCave-40x40.dmm
@@ -305,6 +305,11 @@
 /obj/machinery/biogenerator,
 /turf/simulated/floor/tiled/hydro,
 /area/survivalpod/superpose/HydroCave)
+"jO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/tiled,
+/area/survivalpod/superpose/HydroCave)
 "jY" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -567,6 +572,16 @@
 /obj/item/weapon/storage/box/khcrystal,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/HydroCave)
+"ou" = (
+/obj/structure/table/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/wood,
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/item/weapon/storage/toolbox/electrical,
+/turf/simulated/floor/tiled,
+/area/survivalpod/superpose/HydroCave)
 "oQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock{
@@ -730,15 +745,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/survivalpod/superpose/HydroCave)
 "sR" = (
-/obj/structure/table/steel,
-/obj/item/stack/material/phoron{
-	amount = 5
+/obj/machinery/power/terminal{
+	dir = 1
 	},
-/obj/item/stack/material/phoron{
-	amount = 5
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/fiftyspawner/wood,
-/obj/fiftyspawner/steel,
 /turf/simulated/floor,
 /area/survivalpod/superpose/HydroCave)
 "sZ" = (
@@ -765,8 +778,8 @@
 /area/survivalpod/superpose/HydroCave)
 "up" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/port_gen/pacman,
-/obj/structure/cable,
+/obj/structure/cable/green,
+/obj/machinery/power/smes/buildable/offmap_spawn/empty,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/HydroCave)
 "uH" = (
@@ -1062,6 +1075,14 @@
 	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/HydroCave)
+"Et" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled,
 /area/survivalpod/superpose/HydroCave)
 "EB" = (
 /obj/machinery/alarm/monitor{
@@ -1795,6 +1816,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/HydroCave)
 "VB" = (
@@ -1812,6 +1837,14 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
+/area/survivalpod/superpose/HydroCave)
+"VP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
 /area/survivalpod/superpose/HydroCave)
 "Wd" = (
 /obj/structure/table/wooden_reinforced,
@@ -1967,6 +2000,15 @@
 "ZO" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
+/area/survivalpod/superpose/HydroCave)
+"ZU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
 /area/survivalpod/superpose/HydroCave)
 "ZW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2453,7 +2495,7 @@ JY
 JY
 Gy
 cY
-cY
+ZU
 AE
 xV
 xV
@@ -2495,7 +2537,7 @@ JY
 JY
 Gy
 cY
-xV
+VP
 mE
 Gy
 Ax
@@ -2537,7 +2579,7 @@ JY
 dh
 Gy
 xV
-xV
+Et
 Kb
 Ax
 fj
@@ -2579,7 +2621,7 @@ zz
 zz
 Gy
 xV
-xV
+ou
 TP
 Ax
 Fb
@@ -2621,7 +2663,7 @@ br
 br
 Gy
 xV
-cY
+jO
 TP
 Ax
 Wd

--- a/modular_chomp/maps/submaps/shelters/LargeAlienShip-57x25.dmm
+++ b/modular_chomp/maps/submaps/shelters/LargeAlienShip-57x25.dmm
@@ -1,7 +1,25 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aj" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/LargeAlienShip)
 "ao" = (
-/obj/machinery/atmospherics/binary/circulator,
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "as" = (
@@ -18,6 +36,14 @@
 	oxygen = 0;
 	temperature = 80
 	},
+/area/survivalpod/superpose/LargeAlienShip)
+"aA" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
 "aG" = (
 /obj/structure/grille/cult{
@@ -50,10 +76,14 @@
 /turf/simulated/shuttle/floor/alienplating,
 /area/survivalpod/superpose/LargeAlienShip)
 "bc" = (
-/obj/machinery/power/supermatter/shard,
-/turf/simulated/floor/reinforced/nitrogen{
-	nitrogen = 82.1472
+/obj/machinery/power/grounding_rod/pre_mapped,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
 	},
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "bi" = (
 /turf/simulated/floor,
@@ -74,6 +104,12 @@
 "bv" = (
 /obj/structure/particle_accelerator/power_box{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -103,17 +139,9 @@
 /turf/simulated/floor/wood/sif,
 /area/survivalpod/superpose/LargeAlienShip)
 "cp" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/power/emitter/gyrotron,
+/obj/structure/cable/yellow,
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "cB" = (
@@ -189,12 +217,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
 "dz" = (
-/obj/machinery/atmospherics/binary/circulator{
-	anchored = 1;
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "dB" = (
 /obj/effect/floor_decal/techfloor{
@@ -214,6 +242,12 @@
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -294,11 +328,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
 "fr" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/cyan{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -318,17 +348,17 @@
 	},
 /area/survivalpod/superpose/LargeAlienShip)
 "fK" = (
-/obj/structure/cable/cyan{
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "gc" = (
 /obj/effect/floor_decal/techfloor{
@@ -340,7 +370,10 @@
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "gt" = (
-/obj/structure/prop/statue/phoron,
+/obj/machinery/the_singularitygen/tesla{
+	anchored = 1;
+	pixel_y = 11
+	},
 /turf/simulated/floor/reinforced/nitrogen{
 	nitrogen = 82.1472
 	},
@@ -350,10 +383,24 @@
 /turf/simulated/floor/wood/sif,
 /area/survivalpod/superpose/LargeAlienShip)
 "gA" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/LargeAlienShip)
+"gS" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -404,12 +451,32 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
+"iP" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/LargeAlienShip)
 "iQ" = (
 /obj/structure/particle_accelerator/particle_emitter/center{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -539,17 +606,27 @@
 /turf/simulated/shuttle/wall/alien/blue/no_join,
 /area/survivalpod/superpose/LargeAlienShip)
 "lJ" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
 	},
-/turf/simulated/floor,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
 "mm" = (
-/obj/machinery/power/emitter/gyrotron,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/cyan,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "mv" = (
@@ -618,12 +695,29 @@
 /turf/simulated/shuttle/floor/alienplating,
 /area/survivalpod/superpose/LargeAlienShip)
 "mK" = (
-/obj/machinery/power/emitter/gyrotron,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/cyan,
 /turf/simulated/floor,
+/area/survivalpod/superpose/LargeAlienShip)
+"mO" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft,
 /area/survivalpod/superpose/LargeAlienShip)
 "mQ" = (
 /obj/structure/closet/alien,
@@ -652,9 +746,6 @@
 /area/survivalpod/superpose/LargeAlienShip)
 "nt" = (
 /obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -696,10 +787,18 @@
 /turf/simulated/shuttle/floor/yellow,
 /area/survivalpod/superpose/LargeAlienShip)
 "nC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8";
+	dir = 2
+	},
+/obj/machinery/power/terminal{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "oh" = (
 /obj/structure/prop/alien/pod/open,
@@ -712,15 +811,11 @@
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "oi" = (
+/obj/machinery/power/rad_collector,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/power/smes/buildable{
-	icon = 'icons/obj/alien_smes.dmi';
-	icon_state = "unit";
-	input_level = 950000;
-	name = "Alien Royal Capacitor";
-	output_level = 950000
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/structure/cable/cyan,
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "op" = (
@@ -746,12 +841,17 @@
 /turf/simulated/shuttle/floor/alienplating,
 /area/survivalpod/superpose/LargeAlienShip)
 "ph" = (
-/obj/machinery/power/generator{
-	anchored = 1;
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "pi" = (
 /obj/structure/grille/cult{
@@ -812,18 +912,19 @@
 /area/survivalpod/superpose/LargeAlienShip)
 "qe" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/power/smes/buildable{
-	icon = 'icons/obj/alien_smes.dmi';
-	icon_state = "unit";
-	input_level = 950000;
-	name = "Alien Royal Capacitor";
-	output_level = 950000
-	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "qC" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/LargeAlienShip)
+"qH" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "qQ" = (
 /turf/simulated/shuttle/floor/alien,
@@ -843,9 +944,6 @@
 /area/survivalpod/superpose/LargeAlienShip)
 "rx" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "rI" = (
@@ -914,15 +1012,11 @@
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "uQ" = (
-/obj/machinery/power/rad_collector,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/machinery/power/rad_collector,
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "uT" = (
@@ -932,10 +1026,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
 "uU" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/power/smes/buildable/point_of_interest,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8";
+	dir = 2
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8";
+	dir = 2
 	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -951,17 +1051,18 @@
 /turf/simulated/floor/carpet,
 /area/survivalpod/superpose/LargeAlienShip)
 "vH" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "0-4"
 	},
-/obj/structure/cable/cyan{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "vQ" = (
 /obj/structure/bed/chair/comfy/black{
@@ -987,10 +1088,31 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	dir = 4
 	},
 /turf/simulated/floor,
+/area/survivalpod/superpose/LargeAlienShip)
+"wt" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/shuttle/floor/alienplating,
+/area/survivalpod/superpose/LargeAlienShip)
+"wy" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "wD" = (
 /obj/structure/grille/cult{
@@ -1089,13 +1211,18 @@
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/LargeAlienShip)
 "xs" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/power/smes/buildable{
+	icon = 'icons/obj/alien_smes.dmi';
+	icon_state = "unit";
+	input_level = 950000;
+	name = "Alien Royal Capacitor";
+	output_level = 950000
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "xC" = (
 /obj/structure/grille/cult{
@@ -1123,6 +1250,14 @@
 "xT" = (
 /obj/structure/table/darkglass,
 /turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/LargeAlienShip)
+"xU" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "ya" = (
 /obj/effect/floor_decal/techfloor,
@@ -1182,8 +1317,10 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -1196,6 +1333,18 @@
 "Aj" = (
 /obj/structure/table/bench/glass,
 /turf/simulated/floor/carpet/blue,
+/area/survivalpod/superpose/LargeAlienShip)
+"Aw" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "AB" = (
 /obj/machinery/light/poi{
@@ -1286,6 +1435,14 @@
 	temperature = 80
 	},
 /area/survivalpod/superpose/LargeAlienShip)
+"Cp" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/LargeAlienShip)
 "Cy" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1315,6 +1472,11 @@
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -1486,6 +1648,20 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
+"Fd" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/LargeAlienShip)
 "Fm" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -1539,17 +1715,12 @@
 /turf/simulated/shuttle/wall/alien/blue/hard_corner,
 /area/survivalpod/superpose/LargeAlienShip)
 "HW" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
 "HX" = (
 /obj/structure/closet/alien,
@@ -1565,6 +1736,20 @@
 	dir = 1
 	},
 /turf/simulated/floor,
+/area/survivalpod/superpose/LargeAlienShip)
+"Ip" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
 "Ir" = (
 /obj/structure/table/alien/blue,
@@ -1591,9 +1776,12 @@
 /turf/simulated/shuttle/floor/alien,
 /area/survivalpod/superpose/LargeAlienShip)
 "Jt" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	dir = 8;
-	name = "Scrubber to Waste"
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -1634,9 +1822,6 @@
 /turf/simulated/floor/carpet/blue,
 /area/survivalpod/superpose/LargeAlienShip)
 "Ko" = (
-/obj/machinery/power/emitter/gyrotron{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -1664,9 +1849,11 @@
 /turf/simulated/shuttle/floor/alienplating,
 /area/survivalpod/superpose/LargeAlienShip)
 "KT" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
+/obj/machinery/power/terminal,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8";
+	dir = 2
 	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -1685,7 +1872,6 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "Md" = (
@@ -1705,6 +1891,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
+"ME" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/LargeAlienShip)
 "Nc" = (
 /obj/machinery/light/poi{
 	dir = 1
@@ -1714,9 +1912,6 @@
 "Nd" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
 	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -1755,8 +1950,10 @@
 /obj/machinery/light/poi{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/tank/phoron/full{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -1854,12 +2051,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "SK" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/machinery/meter,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
 "SO" = (
 /obj/structure/table/darkglass,
@@ -1908,10 +2105,17 @@
 /turf/simulated/shuttle/floor/alien,
 /area/survivalpod/superpose/LargeAlienShip)
 "Um" = (
-/obj/effect/fusion_em_field,
-/turf/simulated/floor/reinforced/nitrogen{
-	nitrogen = 82.1472
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
 "Un" = (
 /obj/structure/closet/alien,
@@ -1935,6 +2139,8 @@
 "US" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning,
+/obj/machinery/power/emitter/gyrotron,
+/obj/structure/cable/yellow,
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "Vk" = (
@@ -1997,16 +2203,31 @@
 /obj/machinery/power/rad_collector,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/cyan,
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
 "Vw" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/freezer,
 /area/survivalpod/superpose/LargeAlienShip)
+"VD" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/LargeAlienShip)
 "VF" = (
-/obj/machinery/atmospherics/pipe/tank/phoron/full{
-	dir = 8
+/obj/machinery/power/smes/buildable/point_of_interest,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
@@ -2028,6 +2249,22 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/LargeAlienShip)
+"Wv" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/hyper{
+	coverlocked = 0;
+	dir = 4;
+	environ = 1;
+	equipment = 1;
+	lighting = 1;
+	locked = 0;
+	pixel_x = 23
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "WJ" = (
 /obj/machinery/sleep_console{
@@ -2051,17 +2288,13 @@
 /turf/simulated/shuttle/floor/yellow,
 /area/survivalpod/superpose/LargeAlienShip)
 "Xc" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/cyan{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "4-8";
+	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/LargeAlienShip)
 "Xg" = (
 /obj/machinery/cryopod,
@@ -2144,6 +2377,12 @@
 /obj/structure/particle_accelerator/fuel_chamber{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/LargeAlienShip)
 "XC" = (
@@ -2222,23 +2461,29 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/cyan,
 /turf/simulated/floor,
 /area/survivalpod/superpose/LargeAlienShip)
-"ZN" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/power/smes/buildable{
-	icon = 'icons/obj/alien_smes.dmi';
-	icon_state = "unit";
-	input_level = 950000;
-	name = "Alien Royal Capacitor";
-	output_level = 950000
+"ZD" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/obj/structure/cable/cyan{
+/obj/machinery/power/emitter/gyrotron{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
+/area/survivalpod/superpose/LargeAlienShip)
+"ZN" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/shuttle/floor/alienplating,
 /area/survivalpod/superpose/LargeAlienShip)
 "ZQ" = (
 /obj/effect/floor_decal/techfloor{
@@ -2386,25 +2631,25 @@ CO
 CO
 GQ
 oh
-nC
+WT
 WT
 mK
 pi
 CS
-VR
-NP
-NP
-NP
-NP
-VR
-NP
-NP
-VR
+HW
+dz
+qH
+dz
+dz
+SK
+fK
+dz
+aA
 jr
 pi
 Ko
 WT
-nC
+WT
 uI
 GQ
 CO
@@ -2414,23 +2659,23 @@ CO
 GQ
 Bh
 nt
-WT
+Cp
 US
 GQ
 CS
-NP
-Vk
-NP
-NP
+Xc
+VR
 NP
 NP
 NP
-Vk
 NP
+NP
+VR
+Xc
 jr
 GQ
-hV
-WT
+ZD
+ao
 rx
 Py
 GQ
@@ -2440,12 +2685,12 @@ CO
 CO
 GQ
 qe
-xs
+hV
 gA
 Zq
 vV
 CS
-NP
+bc
 NP
 lp
 dZ
@@ -2453,12 +2698,12 @@ Lh
 pq
 lp
 NP
-NP
+bc
 jr
 vV
-uQ
-uU
-lJ
+oi
+gA
+qS
 qe
 GQ
 CO
@@ -2466,40 +2711,40 @@ CO
 (9,1,1) = {"
 CO
 GQ
-ao
-SK
-vH
+qe
+hV
+gA
 Vu
 jW
 CS
-VR
+lJ
 NP
 Yw
-bc
-Um
-bc
+PL
+PL
+PL
 Yw
 NP
-NP
+vH
 jr
 jW
-uQ
-Xc
-KT
-ao
+oi
+gA
+qS
+qe
 GQ
 CO
 "}
 (10,1,1) = {"
 CO
 GQ
-ph
-xs
-vH
+qe
+hV
+gA
 Vu
 jW
 CS
-NP
+Xc
 NP
 Gd
 PL
@@ -2507,53 +2752,53 @@ gt
 PL
 ds
 NP
-NP
+Xc
 jr
 jW
-uQ
-Xc
-lJ
-ph
+oi
+gA
+qS
+qe
 GQ
 CO
 "}
 (11,1,1) = {"
 CO
 GQ
-dz
-SK
-vH
+qe
+hV
+gA
 Vu
 jW
 CS
-NP
+VD
 NP
 AO
-bc
-Um
-bc
+PL
+PL
+PL
 AO
 NP
-VR
+iP
 jr
 jW
-uQ
-Xc
-KT
-dz
+oi
+gA
+qS
+qe
 GQ
 CO
 "}
 (12,1,1) = {"
 CO
 GQ
-ZN
-cp
-HW
+qe
+hV
+gA
 Vu
 DJ
 CS
-NP
+bc
 NP
 lp
 db
@@ -2561,13 +2806,13 @@ kG
 aG
 lp
 NP
-NP
+bc
 jr
 DJ
 uQ
-fK
-fr
-oi
+gA
+qS
+qe
 GQ
 CO
 "}
@@ -2576,23 +2821,23 @@ CO
 GQ
 Nd
 LM
-WT
-qS
+Fd
+cp
 GQ
 CS
-NP
-Vk
+Xc
+VR
 NP
 NP
 NP
 NP
 Mf
-Vk
-NP
+VR
+Xc
 jr
 GQ
-hV
-WT
+ZD
+gS
 zH
 wr
 GQ
@@ -2602,26 +2847,26 @@ CO
 CO
 GQ
 Jt
-Jt
-WT
+fr
+aj
 mm
 CY
-CS
-VR
-NP
-NP
-VR
-NP
-NP
-NP
-NP
-VR
-jr
+ZN
+Ip
+dz
+dz
+SK
+ph
+dz
+dz
+dz
+Um
+wt
 CY
-Ko
-WT
-Jt
-Jt
+ME
+fr
+ao
+gA
 GQ
 CO
 "}
@@ -2630,7 +2875,7 @@ CO
 GQ
 VF
 Pq
-WT
+xU
 qS
 GQ
 SS
@@ -2638,7 +2883,7 @@ FU
 FU
 FU
 rL
-NP
+Xc
 AS
 FU
 FU
@@ -2647,8 +2892,8 @@ SS
 GQ
 hV
 WT
-VF
-VF
+KT
+uU
 GQ
 CO
 "}
@@ -2665,7 +2910,7 @@ gW
 GQ
 jg
 fi
-PR
+mO
 nx
 jg
 GQ
@@ -2692,7 +2937,7 @@ bm
 CS
 kV
 Bf
-Bf
+Aw
 Bf
 KB
 jr
@@ -2794,7 +3039,7 @@ GQ
 WX
 cP
 cP
-Md
+wy
 DK
 bm
 CS
@@ -2827,7 +3072,7 @@ bm
 CS
 cX
 Qi
-Qi
+nC
 Qi
 iM
 jr
@@ -2853,8 +3098,8 @@ Qu
 bm
 CS
 NP
-NP
-NP
+Wv
+xs
 NP
 NP
 jr

--- a/modular_chomp/maps/submaps/shelters/LoneHome-18x22.dmm
+++ b/modular_chomp/maps/submaps/shelters/LoneHome-18x22.dmm
@@ -1094,6 +1094,9 @@
 /obj/item/weapon/storage/box/lights/mixed,
 /obj/item/weapon/extinguisher,
 /obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
 /turf/simulated/floor,
 /area/survivalpod/superpose/LoneHome)
 "cG" = (
@@ -1119,6 +1122,7 @@
 /area/survivalpod/superpose/LoneHome)
 "cK" = (
 /obj/item/weapon/material/minihoe,
+/obj/structure/closet/crate/solar,
 /turf/simulated/floor/outdoors/grass/heavy,
 /area/survivalpod/superpose/LoneHome)
 "cL" = (
@@ -1140,6 +1144,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/circuitboard/batteryrack,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
 /turf/simulated/floor,
 /area/survivalpod/superpose/LoneHome)
 "cP" = (

--- a/modular_chomp/maps/submaps/shelters/MechFabShip-27x24.dmm
+++ b/modular_chomp/maps/submaps/shelters/MechFabShip-27x24.dmm
@@ -13,7 +13,7 @@
 /area/survivalpod/superpose/MechFabShip)
 "aq" = (
 /obj/machinery/sleeper/survival_pod,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "at" = (
 /obj/structure/closet/walllocker_double/medical/west,
@@ -22,7 +22,7 @@
 /obj/item/weapon/storage/firstaid/toxin,
 /obj/item/weapon/storage/firstaid/o2,
 /obj/item/roller,
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor/tiled/red,
 /area/survivalpod/superpose/MechFabShip)
 "aF" = (
 /obj/structure/salvageable/console_os,
@@ -51,12 +51,9 @@
 /area/survivalpod/superpose/MechFabShip)
 "bk" = (
 /obj/item/device/gps/computer,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "bI" = (
-/obj/machinery/atmospherics/binary/circulator{
-	anchored = 1
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
@@ -87,7 +84,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "dh" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -118,7 +115,7 @@
 /obj/structure/cryofeed{
 	dir = 4
 	},
-/turf/simulated/floor/greengrid/nitrogen,
+/turf/simulated/floor/tiled/red,
 /area/survivalpod/superpose/MechFabShip)
 "eP" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -161,7 +158,7 @@
 /obj/item/device/kit/paint/durand/seraph,
 /obj/structure/table/rack/shelf/steel,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/shuttle/floor/voidcraft/light,
+/turf/simulated/floor/tiled/milspec,
 /area/survivalpod/superpose/MechFabShip)
 "hu" = (
 /obj/machinery/cryopod/robot{
@@ -184,13 +181,13 @@
 	dir = 4
 	},
 /obj/structure/closet/walllocker/emerglocker/east,
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "hH" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "hI" = (
 /obj/machinery/door/airlock/glass_centcom{
@@ -204,6 +201,7 @@
 /obj/effect/floor_decal/techfloor/orange/corner{
 	dir = 1
 	},
+/obj/structure/closet/crate/solar,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "it" = (
@@ -228,7 +226,7 @@
 	specialfunctions = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/shuttle/floor/voidcraft/light,
+/turf/simulated/floor/tiled/milspec,
 /area/survivalpod/superpose/MechFabShip)
 "iC" = (
 /turf/template_noop,
@@ -318,7 +316,7 @@
 /obj/machinery/light/poi{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "iI" = (
 /obj/structure/sign/warning/vacuum,
@@ -336,7 +334,7 @@
 /obj/machinery/light/poi{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "iU" = (
 /obj/structure/salvageable/computer_os,
@@ -367,9 +365,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "jE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -382,7 +377,7 @@
 	dir = 8
 	},
 /obj/structure/cryofeed,
-/turf/simulated/floor/greengrid/nitrogen,
+/turf/simulated/floor/tiled/red,
 /area/survivalpod/superpose/MechFabShip)
 "kz" = (
 /obj/structure/salvageable/console_broken_os,
@@ -410,7 +405,7 @@
 	id = "kalipsoshutters";
 	name = "Kalipso Blast Shielding"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "kJ" = (
 /obj/structure/closet/walllocker_double/kitchen/east{
@@ -437,7 +432,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor/tiled/red,
 /area/survivalpod/superpose/MechFabShip)
 "lC" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -456,15 +451,24 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "lZ" = (
-/obj/machinery/space_heater,
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/power/rtg/advanced,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "mf" = (
 /obj/structure/bed/chair/bay/comfy/captain{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor/tiled/red,
 /area/survivalpod/superpose/MechFabShip)
 "mG" = (
 /obj/structure/sign/kiddieplaque{
@@ -475,7 +479,7 @@
 /area/template_noop)
 "ny" = (
 /obj/effect/floor_decal/industrial/loading,
-/turf/simulated/shuttle/floor/voidcraft/light,
+/turf/simulated/floor/tiled/milspec,
 /area/survivalpod/superpose/MechFabShip)
 "nJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
@@ -489,7 +493,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "oS" = (
 /obj/structure/table/steel_reinforced,
@@ -502,7 +506,20 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/power/apc/hyper{
+	coverlocked = 0;
+	dir = 4;
+	environ = 1;
+	equipment = 1;
+	lighting = 1;
+	locked = 0;
+	pixel_x = 23
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "ph" = (
 /turf/simulated/wall/skipjack,
@@ -533,20 +550,17 @@
 	id = "kalipsoshutters";
 	name = "Kalipso Blast Shielding"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "qf" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "qk" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
-	},
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -554,6 +568,20 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 5
+	},
+/obj/structure/sign/atmos/air{
+	pixel_x = -32
+	},
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
@@ -563,9 +591,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "qU" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -577,7 +602,7 @@
 "qX" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/cell_charger,
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "qY" = (
 /obj/machinery/vending/robotics{
@@ -603,7 +628,7 @@
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "rZ" = (
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "sd" = (
 /obj/machinery/access_button{
@@ -630,18 +655,18 @@
 /obj/machinery/light/poi{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor/tiled/red,
 /area/survivalpod/superpose/MechFabShip)
 "te" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "tk" = (
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "tC" = (
 /obj/machinery/mech_recharger,
-/turf/simulated/shuttle/floor/voidcraft/light,
+/turf/simulated/floor/tiled/milspec,
 /area/survivalpod/superpose/MechFabShip)
 "uU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -667,37 +692,29 @@
 	dir = 8
 	},
 /obj/machinery/r_n_d/server/robotics,
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "vt" = (
-/obj/machinery/power/generator{
-	anchored = 1;
-	dir = 8
+/obj/effect/floor_decal/techfloor,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "vC" = (
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable/green,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "vO" = (
 /obj/effect/floor_decal/techfloor,
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "ws" = (
 /obj/machinery/airlock_sensor{
@@ -717,11 +734,16 @@
 "yh" = (
 /obj/structure/bed/pod,
 /obj/item/weapon/bedsheet/captain,
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "yH" = (
 /obj/effect/floor_decal/techfloor/corner,
-/turf/simulated/shuttle/plating,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "yN" = (
 /obj/structure/bed/chair/bay/shuttle{
@@ -731,7 +753,7 @@
 	dir = 8
 	},
 /obj/structure/closet/walllocker/emerglocker/west,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "yS" = (
 /obj/machinery/atmospherics/unary/engine/biggest{
@@ -742,7 +764,7 @@
 "zd" = (
 /obj/structure/bed/pod,
 /obj/item/weapon/bedsheet/ce,
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "zj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -772,7 +794,7 @@
 /obj/machinery/microwave{
 	pixel_y = 6
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "zU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -789,7 +811,7 @@
 	pixel_x = 4;
 	pixel_y = -30
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "Bf" = (
 /obj/machinery/meter,
@@ -797,6 +819,11 @@
 /obj/structure/closet/walllocker_double/hydrant/east,
 /obj/structure/closet/walllocker/emerglocker/south,
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/rtg/advanced,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Bk" = (
@@ -840,12 +867,12 @@
 /obj/item/trash/rkibble{
 	pixel_x = 8
 	},
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "BY" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/shipsensors,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Cu" = (
 /obj/machinery/door/airlock/multi_tile/metal/mait{
@@ -905,7 +932,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "DF" = (
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "DS" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -944,7 +971,7 @@
 	id = "kalipsoshutters";
 	name = "Kalipso Blast Shielding"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Gl" = (
 /obj/machinery/access_button{
@@ -962,7 +989,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/survivalpod/superpose/MechFabShip)
 "Gr" = (
-/obj/machinery/power/smes/buildable/hybrid,
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
@@ -972,24 +998,30 @@
 /obj/structure/sign/electricshock{
 	pixel_x = -32
 	},
+/obj/machinery/power/smes/buildable/point_of_interest,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "GQ" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light/small/emergency{
 	dir = 8
 	},
-/obj/structure/sign/atmos/air{
-	pixel_x = -32
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "GS" = (
 /obj/machinery/door/airlock/glass_centcom{
 	name = "Starboard Wing Atmos"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/survivalpod/superpose/MechFabShip)
@@ -998,7 +1030,7 @@
 	dir = 4
 	},
 /obj/structure/closet/walllocker/medical/west,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "HC" = (
 /obj/machinery/mecha_part_fabricator,
@@ -1006,11 +1038,11 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "HE" = (
 /obj/item/weapon/stool/padded,
-/turf/simulated/shuttle/floor/white,
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "HS" = (
 /obj/machinery/door/airlock/glass_centcom{
@@ -1024,19 +1056,16 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "IS" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/poi{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "Jv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
@@ -1069,18 +1098,20 @@
 	pixel_x = 4;
 	pixel_y = -30
 	},
-/turf/simulated/shuttle/floor/white,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "KC" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "KR" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -1106,7 +1137,7 @@
 /area/survivalpod/superpose/MechFabShip)
 "LN" = (
 /obj/structure/window/reinforced/survival_pod,
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor/tiled/red,
 /area/survivalpod/superpose/MechFabShip)
 "Ms" = (
 /obj/machinery/smartfridge/survival_pod,
@@ -1204,7 +1235,7 @@
 /obj/machinery/light/poi{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "Mv" = (
 /obj/machinery/door/blast/regular{
@@ -1241,12 +1272,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/survivalpod/superpose/MechFabShip)
 "ND" = (
 /obj/structure/sign/deck1,
@@ -1254,18 +1280,18 @@
 /area/survivalpod/superpose/MechFabShip)
 "Oo" = (
 /obj/item/weapon/stool/padded,
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "Ov" = (
 /obj/machinery/optable{
 	name = "Robotics Operating Table"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "OO" = (
 /obj/structure/bed/pod,
 /obj/item/weapon/bedsheet/hos,
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "Py" = (
 /obj/machinery/smartfridge/survival_pod{
@@ -1397,7 +1423,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "PH" = (
 /obj/structure/window/reinforced/survival_pod{
@@ -1407,20 +1433,7 @@
 /obj/structure/sign/department/rnd{
 	pixel_y = 32
 	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/survivalpod/superpose/MechFabShip)
-"PP" = (
-/obj/machinery/atmospherics/binary/circulator{
-	anchored = 1;
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/survivalpod/superpose/MechFabShip)
 "Qs" = (
 /obj/machinery/door/airlock/glass_centcom{
@@ -1436,7 +1449,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "QJ" = (
 /obj/machinery/disperser/middle{
@@ -1485,7 +1498,7 @@
 /obj/item/trash/rkibble{
 	pixel_x = 8
 	},
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "RE" = (
 /obj/machinery/recharge_station,
@@ -1496,7 +1509,7 @@
 /area/survivalpod/superpose/MechFabShip)
 "SE" = (
 /obj/item/weapon/stool/padded,
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "SW" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1508,9 +1521,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "Ta" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -1522,7 +1532,7 @@
 "Th" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/mecha_part_fabricator/pros,
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/milspec/sterile,
 /area/survivalpod/superpose/MechFabShip)
 "TI" = (
 /obj/structure/bed/chair/bay/shuttle{
@@ -1532,30 +1542,40 @@
 	dir = 4
 	},
 /obj/structure/closet/walllocker/emerglocker/east,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Ud" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
 	},
-/turf/simulated/shuttle/plating,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Uj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/structure/closet/crate/solar,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "UI" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/voidcraft/light,
+/turf/simulated/floor/tiled/milspec,
 /area/survivalpod/superpose/MechFabShip)
 "UL" = (
-/turf/simulated/shuttle/plating,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Vf" = (
 /obj/structure/closet/walllocker/emerglocker{
@@ -1576,7 +1596,7 @@
 	pixel_x = -28;
 	specialfunctions = 4
 	},
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor/tiled/red,
 /area/survivalpod/superpose/MechFabShip)
 "Vj" = (
 /obj/machinery/r_n_d/protolathe,
@@ -1584,19 +1604,19 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "VZ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/foodcart,
-/turf/simulated/shuttle/floor/voidcraft/light,
+/turf/simulated/floor/tiled/milspec,
 /area/survivalpod/superpose/MechFabShip)
 "Wl" = (
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
 	},
 /obj/structure/closet/walllocker/medical/east,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "WE" = (
 /obj/structure/sign/ironhammer,
@@ -1616,7 +1636,7 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/voidcraft,
+/turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "WY" = (
 /obj/structure/window/plastitanium/full,
@@ -1633,17 +1653,9 @@
 	id = "kalipsoshutters";
 	name = "Kalipso Blast Shielding"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Xe" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
@@ -1662,7 +1674,7 @@
 /obj/structure/sign/department/commander{
 	pixel_y = -32
 	},
-/turf/simulated/floor/greengrid/nitrogen,
+/turf/simulated/floor/tiled/red,
 /area/survivalpod/superpose/MechFabShip)
 "Xx" = (
 /obj/structure/window/plastitanium/full,
@@ -1684,7 +1696,7 @@
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Yb" = (
 /obj/machinery/door/airlock/glass_centcom{
@@ -1697,22 +1709,29 @@
 	dir = 8
 	},
 /obj/structure/closet/walllocker/emerglocker/west,
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "Yl" = (
 /obj/structure/fans,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Yo" = (
-/obj/machinery/power/port_gen/pacman{
-	anchored = 1
-	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/power/rtg/advanced,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Yt" = (
@@ -1724,7 +1743,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/turf/simulated/shuttle/floor/yellow,
+/turf/simulated/floor/tiled/yellow,
 /area/survivalpod/superpose/MechFabShip)
 "YP" = (
 /obj/machinery/disperser/front{
@@ -1733,17 +1752,17 @@
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Zg" = (
-/turf/simulated/shuttle/floor/voidcraft/light,
+/turf/simulated/floor/tiled/milspec,
 /area/survivalpod/superpose/MechFabShip)
 "Zm" = (
 /obj/effect/floor_decal/techfloor,
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Zs" = (
 /obj/structure/bed/chair/bay/comfy/black{
 	dir = 1
 	},
-/turf/simulated/shuttle/floor/voidcraft/light,
+/turf/simulated/floor/tiled/milspec,
 /area/survivalpod/superpose/MechFabShip)
 "Zt" = (
 /obj/structure/shuttle/engine/heater,
@@ -1758,7 +1777,7 @@
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "ZE" = (
-/turf/simulated/shuttle/floor/darkred,
+/turf/simulated/floor/tiled/red,
 /area/survivalpod/superpose/MechFabShip)
 "ZH" = (
 /obj/machinery/recharge_station,
@@ -1784,7 +1803,7 @@
 	id = "kalipsoshutters";
 	name = "Kalipso Blast Shielding"
 	},
-/turf/simulated/shuttle/plating,
+/turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 
 (1,1,1) = {"
@@ -1936,7 +1955,7 @@ ph
 sd
 ph
 Jv
-vt
+bI
 dh
 Zt
 dz
@@ -1962,7 +1981,7 @@ rZ
 rZ
 vO
 uU
-PP
+bI
 Uj
 Zt
 dz
@@ -2062,8 +2081,8 @@ DF
 DF
 DF
 hI
-UL
-UL
+dz
+dz
 Zm
 UI
 Cu
@@ -2089,7 +2108,7 @@ DF
 Yt
 ph
 RE
-UL
+dz
 Zm
 UI
 Mv
@@ -2115,7 +2134,7 @@ YM
 Dj
 ph
 hu
-UL
+dz
 Zm
 VZ
 ND
@@ -2141,7 +2160,7 @@ SE
 gv
 ph
 bL
-UL
+dz
 Zm
 iw
 ph
@@ -2167,7 +2186,7 @@ hH
 aG
 ph
 hu
-UL
+dz
 Zm
 gH
 ND
@@ -2193,7 +2212,7 @@ tk
 rr
 ph
 ZH
-UL
+dz
 Zm
 ny
 Cu
@@ -2216,11 +2235,11 @@ py
 HE
 tk
 tk
-tk
+KC
 hI
 UL
 UL
-Zm
+vt
 ny
 Mv
 CY
@@ -2326,7 +2345,7 @@ aq
 zN
 Zm
 Xe
-KC
+dz
 vC
 Zt
 dz

--- a/modular_chomp/maps/submaps/shelters/MechStorageFab-32x24.dmm
+++ b/modular_chomp/maps/submaps/shelters/MechStorageFab-32x24.dmm
@@ -8,6 +8,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechStorageFab)
+"aq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
 "av" = (
 /obj/structure/salvageable/computer,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -23,9 +31,29 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
+"aV" = (
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
 "ba" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"bh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"bu" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
 "bE" = (
@@ -92,6 +120,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MechStorageFab)
+"gz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
 /area/survivalpod/superpose/MechStorageFab)
 "gG" = (
 /obj/machinery/fusion_fuel_compressor,
@@ -174,6 +210,11 @@
 /area/survivalpod/superpose/MechStorageFab)
 "ly" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/MechStorageFab)
 "lA" = (
@@ -239,6 +280,16 @@
 /area/survivalpod/superpose/MechStorageFab)
 "nZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/survivalpod/superpose/MechStorageFab)
 "oh" = (
@@ -335,6 +386,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/survivalpod/superpose/MechStorageFab)
 "sk" = (
@@ -365,6 +421,16 @@
 "tH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/MechStorageFab)
@@ -413,9 +479,12 @@
 /turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
 "us" = (
-/obj/machinery/artifact_scanpad,
-/obj/effect/simple_portal/linked,
 /obj/effect/map_effect/interval/effect_emitter/sparks,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/rtg/advanced,
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechStorageFab)
 "uJ" = (
@@ -437,6 +506,11 @@
 "wg" = (
 /obj/random/junk,
 /obj/random/maintenance,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/survivalpod/superpose/MechStorageFab)
 "wU" = (
@@ -454,6 +528,11 @@
 "yH" = (
 /obj/machinery/door/airlock/maintenance/engi{
 	req_one_access = null
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
@@ -482,6 +561,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
 "Au" = (
@@ -493,6 +577,15 @@
 "AD" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MechStorageFab)
+"Bu" = (
+/obj/random/junk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
 /area/survivalpod/superpose/MechStorageFab)
 "BC" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -529,6 +622,14 @@
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/survivalpod/superpose/MechStorageFab)
+"DQ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
 "DV" = (
 /turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
@@ -552,7 +653,7 @@
 /turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
 "Go" = (
-/obj/machinery/power/smes/buildable/hybrid,
+/obj/machinery/power/smes/buildable/point_of_interest,
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
@@ -599,6 +700,11 @@
 /area/survivalpod/superpose/MechStorageFab)
 "IS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
 "IX" = (
@@ -706,6 +812,11 @@
 	dir = 9
 	},
 /obj/random/maintenance,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/survivalpod/superpose/MechStorageFab)
 "KN" = (
@@ -849,6 +960,11 @@
 	dir = 1
 	},
 /obj/random/junk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/MechStorageFab)
 "MB" = (
@@ -967,7 +1083,20 @@
 /area/template_noop)
 "Pt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Qd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
 "Qo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1005,6 +1134,11 @@
 /obj/machinery/door/window/survival_pod{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechStorageFab)
 "Sz" = (
@@ -1024,6 +1158,15 @@
 /area/survivalpod/superpose/MechStorageFab)
 "TK" = (
 /turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"Uq" = (
+/obj/random/junk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
 "Ut" = (
 /obj/structure/closet/secure_closet/engineering_welding{
@@ -1062,7 +1205,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/asteroid_steel,
+/area/survivalpod/superpose/MechStorageFab)
+"Wv" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
 "XH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1070,6 +1229,11 @@
 	},
 /obj/machinery/door/airlock/maintenance/rnd{
 	req_one_access = null
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
@@ -1107,6 +1271,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_dirty,
+/area/survivalpod/superpose/MechStorageFab)
+"Zf" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/asteroid_steel,
 /area/survivalpod/superpose/MechStorageFab)
 "Zj" = (
 /obj/structure/window/reinforced/survival_pod{
@@ -1591,7 +1763,7 @@ qY
 pA
 DV
 DV
-DV
+aV
 Ao
 tw
 tw
@@ -1712,14 +1884,14 @@ AD
 MA
 Pt
 IS
-Ib
+Wv
 Pt
 tH
 Pt
 ly
 nZ
 yH
-DV
+Qd
 Ar
 ba
 Ao
@@ -1784,21 +1956,21 @@ tw
 tw
 Ao
 pA
-pA
-pA
-sk
-TK
+DQ
+gz
+Uq
+aq
 AD
 pA
 TK
-DV
-pw
+bu
+Bu
 pA
 AD
-pA
+Zf
 wg
-pA
-DV
+gz
+bh
 TK
 Ao
 tw

--- a/modular_chomp/maps/submaps/shelters/MercShip-57x25.dmm
+++ b/modular_chomp/maps/submaps/shelters/MercShip-57x25.dmm
@@ -1,317 +1,4531 @@
-"aj" = (/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "fridge_sci"; icon_contents = "chem"; icon_state = "fridge_sci"; name = "Advanced storage"; pixel_y = 0},/obj/random/maintenance/clean,/obj/random/maintenance/cargo,/obj/random/maintenance/security,/obj/random/maintenance/security,/obj/random/maintenance/medical,/obj/random/maintenance/engineering,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"ao" = (/obj/machinery/atmospherics/binary/circulator,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"as" = (/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"at" = (/obj/structure/prop/alien/pod/hybrid,/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/MercShip)
-"aH" = (/obj/machinery/optable,/obj/machinery/light/poi,/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MercShip)
-"aJ" = (/obj/effect/floor_decal/techfloor{dir = 5},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"aL" = (/obj/structure/grille/cult{name = "Alien grille"},/obj/structure/window/phoronreinforced/full,/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{dir = 1},/obj/structure/window/phoronreinforced{dir = 8},/obj/structure/window/phoronreinforced{dir = 4},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"aM" = (/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "fridge_sci"; icon_contents = "chem"; icon_state = "fridge_sci"; name = "Advanced storage"; pixel_y = 0},/obj/random/maintenance/clean,/obj/random/maintenance/clean,/obj/random/maintenance/cargo,/obj/random/maintenance/cargo,/obj/random/maintenance/security,/obj/random/maintenance/security,/obj/random/maintenance/security,/obj/random/maintenance/security,/obj/random/maintenance/research,/obj/random/maintenance/medical,/obj/random/maintenance/medical,/obj/random/maintenance/engineering,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"aP" = (/obj/machinery/door/airlock/hatch{req_one_access = null},/obj/structure/fans/hardlight,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"bc" = (/turf/simulated/floor/airless,/area/survivalpod/superpose/MercShip)
-"bi" = (/turf/simulated/floor,/area/template_noop)
-"bp" = (/obj/effect/floor_decal/techfloor/corner{dir = 9},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"bv" = (/obj/structure/table/rack/shelf/steel,/obj/item/stack/cable_coil/blue,/obj/item/stack/cable_coil/blue,/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"bw" = (/obj/structure/window/reinforced/survival_pod,/obj/item/weapon/clipboard,/obj/structure/table/hardwoodtable,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"bH" = (/obj/structure/closet/emcloset/legacy,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"bN" = (/obj/machinery/light/poi,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"bO" = (/obj/effect/floor_decal/techfloor,/obj/structure/bed/chair/wood/wings,/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MercShip)
-"bZ" = (/obj/machinery/door/window/brigdoor/northright{req_access = null},/obj/structure/table/hardwoodtable,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"cp" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"cB" = (/obj/structure/prop/alien/pod/open,/obj/random/maintenance/morestuff,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"cH" = (/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "fridge_sci"; icon_contents = "chem"; icon_state = "fridge_sci"; name = "Advanced storage"; pixel_y = 0},/obj/random/maintenance/clean,/obj/random/maintenance/clean,/obj/random/maintenance/cargo,/obj/random/maintenance/cargo,/obj/random/maintenance/security,/obj/random/maintenance/security,/obj/random/maintenance/security,/obj/random/maintenance/research,/obj/random/maintenance/medical,/obj/random/maintenance/medical,/obj/random/maintenance/engineering,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"cL" = (/obj/machinery/atmospherics/binary/pump/on{dir = 1; target_pressure = 200},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"cP" = (/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MercShip)
-"cX" = (/obj/effect/floor_decal/techfloor/corner{dir = 10},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"de" = (/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MercShip)
-"dg" = (/obj/structure/table/rack/shelf/steel,/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"dr" = (/obj/machinery/recycling/sorter,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"dx" = (/obj/structure/closet/radiation,/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MercShip)
-"dz" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1; dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"dA" = (/obj/structure/window/reinforced/survival_pod,/obj/machinery/field_generator{anchored = 1; state = 1},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"dB" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"dC" = (/obj/machinery/autolathe{hacked = 1; name = "hacked autolathe"},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"dP" = (/obj/machinery/light/poi,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"dS" = (/obj/structure/cryofeed{dir = 2},/obj/machinery/light/small/emergency,/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/MercShip)
-"dW" = (/obj/structure/grille/cult{name = "Alien grille"},/obj/structure/window/phoronreinforced/full,/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{dir = 1},/obj/structure/window/phoronreinforced{dir = 4},/obj/structure/window/phoronreinforced{dir = 8},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"er" = (/obj/machinery/atmospherics/binary/pump/on{dir = 8; name = "Scrubber to Waste"},/obj/machinery/light/poi,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"ex" = (/obj/structure/table/rack/shelf/steel,/obj/item/stack/material/plasteel{amount = 30; pixel_y = 5},/obj/item/stack/material/plasteel{amount = 30; pixel_y = 5},/obj/item/stack/material/lead{amount = 30},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"eB" = (/obj/structure/closet/alien,/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MercShip)
-"fc" = (/turf/simulated/floor/carpet/tealcarpet,/area/survivalpod/superpose/MercShip)
-"ff" = (/obj/machinery/power/supermatter/shard,/turf/simulated/floor/greengrid/nitrogen,/area/survivalpod/superpose/MercShip)
-"fi" = (/obj/structure/grille/cult{name = "Alien grille"},/obj/structure/window/phoronreinforced/full,/obj/structure/window/phoronreinforced{dir = 4},/obj/structure/window/phoronreinforced{dir = 8},/obj/structure/window/phoronreinforced{dir = 1},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"fm" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/structure/table/marble,/obj/item/slime_extract/orange,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"fr" = (/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"fA" = (/obj/structure/cryofeed,/obj/structure/window/reinforced/survival_pod{dir = 5},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/MercShip)
-"fK" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 2; d2 = 8; icon_state = "2-8"},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"fN" = (/obj/machinery/light/poi{dir = 1},/turf/simulated/floor/carpet/gaycarpet,/area/survivalpod/superpose/MercShip)
-"gc" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 10},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"gt" = (/obj/structure/bed/double/padded,/obj/item/weapon/bedsheet/rddouble,/turf/simulated/floor/carpet,/area/survivalpod/superpose/MercShip)
-"gz" = (/obj/machinery/atmospherics/binary/pump/on{dir = 8; name = "Scrubber to Waste"},/obj/machinery/light/poi{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"gA" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"gS" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/light/poi{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"gW" = (/obj/machinery/door/airlock/hatch{req_one_access = null},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"hp" = (/obj/machinery/teleport/hub{dir = 8},/obj/effect/floor_decal/industrial/hatch/yellow,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"hw" = (/obj/machinery/vending/engivend{emagged = 1; req_access = list(777); req_log_access = null},/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MercShip)
-"hI" = (/obj/machinery/recycling/crusher,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"hR" = (/obj/machinery/cryopod{dir = 4},/obj/structure/cryofeed{pixel_x = -32},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"hV" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"ie" = (/obj/machinery/light/poi,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"iw" = (/obj/structure/bed/double/padded,/obj/item/weapon/bedsheet/rddouble,/turf/simulated/floor/carpet/blue,/area/survivalpod/superpose/MercShip)
-"iy" = (/obj/effect/floor_decal/techfloor,/obj/structure/table/hardwoodtable,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"iD" = (/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/machinery/ion_engine,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MercShip)
-"iJ" = (/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/fiftyspawner/blucarpet,/obj/fiftyspawner/oracarpet,/obj/fiftyspawner/purcarpet,/obj/fiftyspawner/sblucarpet,/obj/fiftyspawner/tealcarpet,/obj/fiftyspawner/turcarpet,/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/algae{amount = 50},/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/lead{amount = 30},/obj/item/stack/material/plasteel{amount = 30; pixel_y = 5},/obj/item/stack/material/resin{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/obj/structure/closet/alien,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"iM" = (/obj/effect/floor_decal/techfloor/corner{dir = 9},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"jc" = (/obj/effect/floor_decal/techfloor{dir = 4},/obj/machinery/light/poi{dir = 4},/obj/structure/salvageable/console_os{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"jd" = (/obj/machinery/atmospherics/pipe/tank/phoron/full,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"jg" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"},/turf/simulated/wall/skipjack,/area/survivalpod/superpose/MercShip)
-"jh" = (/obj/structure/table/rack/shelf/steel,/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"ji" = (/obj/structure/closet/alien,/obj/random/toolbox,/obj/random/toolbox,/obj/random/toolbox,/obj/item/weapon/storage/toolbox/syndicate/powertools,/obj/item/weapon/storage/toolbox/syndicate,/obj/fiftyspawner/phoronrglass,/obj/fiftyspawner/phoronrglass,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MercShip)
-"jm" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/structure/salvageable/bliss,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"jW" = (/obj/structure/grille/cult{name = "Alien grille"},/obj/structure/window/phoronreinforced/full,/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{dir = 1},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"jZ" = (/obj/machinery/cryopod,/obj/structure/cryofeed{dir = 4; pixel_x = 32},/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"kl" = (/obj/machinery/recharger/wallcharger{pixel_x = 4; pixel_y = -34},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"kD" = (/obj/machinery/atmospherics/binary/pump/on{target_pressure = 200},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"kO" = (/obj/structure/table/rack/shelf/steel,/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/algae{amount = 50},/obj/item/stack/material/algae{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"kS" = (/obj/structure/table/bench/glass,/turf/simulated/floor/carpet/tealcarpet,/area/survivalpod/superpose/MercShip)
-"kV" = (/obj/effect/floor_decal/techfloor/corner{dir = 6},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"lk" = (/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil/green,/obj/item/stack/cable_coil/blue,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/structure/closet/alien,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"lp" = (/obj/effect/floor_decal/industrial/warning,/obj/machinery/light/poi,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"lt" = (/obj/machinery/door/blast/multi_tile/four_tile_ver_sec,/turf/simulated/wall/skipjack,/area/survivalpod/superpose/MercShip)
-"lJ" = (/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"mm" = (/obj/machinery/power/emitter/gyrotron,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/industrial/warning,/obj/structure/cable/cyan,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"mv" = (/obj/structure/table/darkglass,/obj/item/weapon/reagent_containers/glass/beaker/bluespace,/obj/item/weapon/reagent_containers/glass/beaker/bluespace{pixel_x = -7},/obj/item/weapon/storage/belt/medical/alien,/obj/item/weapon/storage/belt/medical/alien{pixel_y = 6},/obj/item/weapon/storage/firstaid/surgery,/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MercShip)
-"my" = (/obj/machinery/oxygen_pump/anesthetic,/turf/simulated/wall/skipjack,/area/survivalpod/superpose/MercShip)
-"mK" = (/obj/machinery/power/emitter/gyrotron,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/industrial/warning,/obj/effect/floor_decal/industrial/warning,/obj/structure/cable/cyan,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"mQ" = (/obj/structure/closet/alien,/obj/item/clothing/suit/space/void/autolok,/obj/item/clothing/suit/space/void/autolok,/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/storage/toolbox/emergency,/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MercShip)
-"mT" = (/obj/machinery/cryopod,/obj/structure/cryofeed{dir = 4; pixel_x = 32},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"nj" = (/obj/item/weapon/tape_roll,/obj/item/sticky_pad/random,/obj/item/weapon/pen/blue,/obj/item/weapon/pen/blue,/obj/item/fulton_core,/obj/item/fulton_core,/obj/item/extraction_pack,/obj/item/extraction_pack,/obj/item/modular_computer/laptop/preset/custom_loadout/standard,/obj/item/weapon/pickaxe/hand,/obj/item/device/flashlight/color/yellow,/obj/item/device/flashlight/color/orange,/obj/item/device/threadneedle,/obj/item/device/radio,/obj/item/device/radio,/obj/item/device/radio,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/flame/lighter/zippo,/obj/item/weapon/flame/lighter/zippo,/obj/item/device/flashlight/lantern,/obj/random/soap,/obj/random/soap,/obj/item/weapon/towel/random,/obj/item/weapon/towel/random,/obj/item/bodybag/cryobag,/obj/item/bodybag/cryobag,/obj/item/weapon/storage/pill_bottle/spaceacillin,/obj/item/weapon/storage/pill_bottle/antitox,/obj/item/device/healthanalyzer,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/storage/firstaid/o2,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/stack/nanopaste,/obj/item/device/suit_cooling_unit/emergency,/obj/item/device/suit_cooling_unit/emergency,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,/obj/item/weapon/storage/toolbox/brass,/obj/item/weapon/storage/box/survival/space,/obj/item/weapon/storage/box/survival/space,/obj/item/weapon/storage/box/survival/space,/obj/item/weapon/storage/pill_bottle/dice_nerd,/obj/item/weapon/storage/box/flare,/obj/item/weapon/storage/box/khcrystal,/obj/item/weapon/storage/box/khcrystal,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/stack/marker_beacon/ten,/obj/item/device/starcaster_news,/obj/item/device/mapping_unit,/obj/item/weapon/storage/box/dosimeter,/obj/item/device/gps,/obj/item/device/gps,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/cell/device/hyper,/obj/item/device/pda,/obj/item/device/pda,/obj/item/weapon/card/id/external,/obj/item/weapon/card/id/external,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/gun/energy/locked/phasegun/pistol,/obj/item/weapon/gun/energy/locked/phasegun,/obj/item/weapon/cell/device/weapon{pixel_x = -2; pixel_y = -2},/obj/item/weapon/cell/device/weapon{pixel_x = -2; pixel_y = -2},/obj/item/clothing/accessory/permit/gun,/obj/item/clothing/accessory/permit/gun,/obj/item/weapon/material/knife/machete,/obj/item/weapon/material/fishing_net,/obj/item/weapon/storage/backpack/sport,/obj/item/weapon/storage/backpack/sport,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/weapon/storage/belt,/obj/item/clothing/accessory/poncho/thermal,/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "fridge_sci"; icon_contents = "chem"; icon_state = "fridge_sci"; name = "Advanced storage"; pixel_y = 0},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"ns" = (/obj/machinery/light/poi{dir = 1},/turf/simulated/floor/airless,/area/survivalpod/superpose/MercShip)
-"nt" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"nv" = (/obj/item/weapon/soap/deluxe,/obj/item/weapon/soap/deluxe,/obj/item/weapon/towel/random,/obj/item/weapon/towel/random,/obj/structure/table/hardwoodtable,/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/MercShip)
-"nx" = (/obj/structure/grille/cult{name = "Alien grille"},/obj/structure/window/phoronreinforced/full,/obj/structure/window/phoronreinforced{dir = 4},/obj/structure/window/phoronreinforced{dir = 8},/obj/structure/window/phoronreinforced,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"nB" = (/obj/structure/closet/alien,/obj/random/toolbox,/obj/random/toolbox,/obj/random/toolbox,/obj/item/weapon/storage/toolbox/syndicate/powertools,/obj/item/weapon/storage/toolbox/syndicate,/obj/fiftyspawner/plasteel,/obj/fiftyspawner/plasteel,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/machinery/light/poi{dir = 1},/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MercShip)
-"nC" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"nL" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/mecha/working/ripley/antique,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"oh" = (/obj/random/maintenance/medical,/obj/structure/table/hardwoodtable,/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MercShip)
-"oi" = (/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/machinery/door/window/brigdoor/eastright{name = "Laser Armor"},/obj/structure/table/rack/shelf/steel,/obj/item/weapon/gun/energy/netgun,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"op" = (/obj/structure/window/reinforced/survival_pod{dir = 10},/obj/machinery/light/poi,/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/MercShip)
-"oG" = (/obj/machinery/light/poi{dir = 4},/turf/simulated/floor/airless,/area/survivalpod/superpose/MercShip)
-"oI" = (/obj/effect/floor_decal/techfloor,/obj/machinery/vending/deluxe_dinner{req_access = null; req_log_access = null},/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MercShip)
-"oM" = (/obj/effect/floor_decal/techfloor,/obj/machinery/atmospherics/pipe/manifold/hidden,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"oR" = (/obj/effect/floor_decal/techfloor,/obj/structure/salvageable/machine{name = "Life Support Console"},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"ph" = (/obj/machinery/power/generator{anchored = 1; dir = 4},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"pi" = (/obj/structure/grille/cult{name = "Alien grille"},/obj/structure/window/phoronreinforced/full,/obj/structure/window/phoronreinforced{dir = 8},/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{dir = 1},/obj/structure/window/phoronreinforced{dir = 4},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"pu" = (/obj/machinery/sleeper{dir = 4; emagged = 1; initial_bin_rating = 4},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MercShip)
-"px" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/field_generator{anchored = 1; state = 1},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"pC" = (/obj/effect/floor_decal/techfloor,/obj/structure/prop/alien/dispenser,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"qa" = (/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/fiftyspawner/blucarpet,/obj/fiftyspawner/oracarpet,/obj/fiftyspawner/purcarpet,/obj/fiftyspawner/sblucarpet,/obj/fiftyspawner/tealcarpet,/obj/fiftyspawner/turcarpet,/obj/structure/table/rack/shelf/steel,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"qb" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/structure/salvageable/machine_os,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"qe" = (/obj/structure/table/hardwoodtable,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"qC" = (/obj/structure/bed/chair/comfy/black,/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MercShip)
-"qQ" = (/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"qS" = (/obj/effect/floor_decal/industrial/warning,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"qY" = (/obj/machinery/cryopod{dir = 4},/obj/structure/cryofeed{pixel_x = -32},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"rx" = (/obj/effect/floor_decal/industrial/warning/corner,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"rI" = (/obj/structure/bed/double/padded,/obj/item/weapon/bedsheet/rddouble,/turf/simulated/floor/carpet/tealcarpet,/area/survivalpod/superpose/MercShip)
-"rL" = (/obj/effect/floor_decal/techfloor{dir = 10},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"se" = (/obj/random/maintenance/engineering,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MercShip)
-"ss" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/machinery/door/window/brigdoor/westright{name = "Combat Armor"},/obj/structure/table/rack/shelf/steel,/obj/item/device/soulstone,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"sO" = (/turf/simulated/wall/r_lead,/area/survivalpod/superpose/MercShip)
-"td" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/structure/table/hardwoodtable,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"tr" = (/obj/machinery/air_sensor{frequency = 1438; id_tag = null; output = 63},/obj/effect/floor_decal/industrial/warning{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/survivalpod/superpose/MercShip)
-"tF" = (/obj/machinery/cryopod/robot,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"tK" = (/obj/structure/prop/alien/computer/hybrid,/obj/machinery/light/poi{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"uf" = (/obj/machinery/light/poi{dir = 1},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"ut" = (/obj/machinery/light/poi{dir = 4},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"uI" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/structure/table/marble,/obj/item/slime_extract/gold,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"uQ" = (/obj/machinery/power/rad_collector,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"uT" = (/obj/machinery/recycling/stamper,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"uU" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"ve" = (/obj/effect/floor_decal/techfloor,/obj/structure/salvageable/server_os,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"vg" = (/obj/structure/table/bench/glass,/turf/simulated/floor/carpet,/area/survivalpod/superpose/MercShip)
-"vH" = (/obj/structure/cable/cyan{d1 = 2; d2 = 4; icon_state = "2-4"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"vQ" = (/obj/structure/bed/chair/comfy/black{dir = 1},/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MercShip)
-"vU" = (/obj/item/device/gps/internal/poi{name = "#$(@@%$#"},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"vV" = (/obj/structure/grille/cult{name = "Alien grille"},/obj/structure/window/phoronreinforced/full,/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{dir = 1},/obj/structure/window/phoronreinforced{dir = 8},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"wr" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 5},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"wz" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/light/poi,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"wD" = (/obj/structure/grille/cult{name = "Alien grille"},/obj/structure/window/phoronreinforced/full,/obj/structure/window/phoronreinforced{dir = 4},/obj/structure/window/phoronreinforced{dir = 8},/obj/structure/window/phoronreinforced{dir = 1},/obj/structure/window/phoronreinforced,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"xn" = (/obj/effect/floor_decal/techfloor,/obj/machinery/light/poi{dir = 1},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"xs" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"xG" = (/obj/structure/prop/alien/computer/hybrid{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"xT" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/cryofeed{dir = 1},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MercShip)
-"xV" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/loot_pile/mecha/gygax/dark/adv,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"ya" = (/obj/structure/window/reinforced/survival_pod,/obj/item/weapon/tape_roll,/obj/structure/table/hardwoodtable,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"yi" = (/obj/effect/floor_decal/techfloor{dir = 4},/obj/structure/table/hardwoodtable,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"yv" = (/obj/structure/prop/fake_ai{name = "P0ps1ck13"},/obj/structure/window/reinforced/survival_pod{dir = 1},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"yD" = (/obj/effect/floor_decal/industrial/warning/cee{dir = 8},/obj/machinery/camera/network/engine{c_tag = "ENG - Engine Core 2"; dir = 1},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/survivalpod/superpose/MercShip)
-"yI" = (/obj/effect/floor_decal/techfloor,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"yP" = (/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"yY" = (/obj/machinery/recharger/wallcharger{pixel_x = 4; pixel_y = 26},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"zc" = (/obj/structure/sign/department/cargo_dock,/turf/simulated/wall/skipjack,/area/survivalpod/superpose/MercShip)
-"zu" = (/obj/random/maintenance/clean,/obj/structure/table/hardwoodtable,/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MercShip)
-"zz" = (/turf/simulated/floor/plating/external,/area/survivalpod/superpose/MercShip)
-"zH" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"zI" = (/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"Af" = (/obj/structure/bed/double/padded,/obj/item/weapon/bedsheet/rddouble,/obj/machinery/light/poi{dir = 4},/turf/simulated/floor/carpet,/area/survivalpod/superpose/MercShip)
-"Aj" = (/obj/structure/table/bench/glass,/turf/simulated/floor/carpet/blue,/area/survivalpod/superpose/MercShip)
-"AB" = (/obj/structure/sign/securearea{desc = "A warning sign which reads 'RADIOACTIVE AREA'"; icon_state = "radiation"; name = "RADIOACTIVE AREA"},/turf/simulated/wall/r_lead,/area/survivalpod/superpose/MercShip)
-"AL" = (/obj/machinery/door/window/brigdoor/northright{dir = 2; req_access = null},/obj/structure/table/hardwoodtable,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"AP" = (/obj/machinery/vending/medical{dir = 4; emagged = 1; pixel_x = 5; req_access = list(777)},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MercShip)
-"AS" = (/obj/effect/floor_decal/techfloor{dir = 9},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"Bd" = (/obj/machinery/vending/deluxe_boozeomat{req_access = null; req_log_access = null},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"Bf" = (/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Bh" = (/obj/structure/window/reinforced/survival_pod,/obj/item/weapon/hand_labeler,/obj/item/device/tape/random,/obj/structure/table/hardwoodtable,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"Bo" = (/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"BE" = (/obj/structure/prop/alien/pod/hybrid,/obj/structure/window/reinforced/survival_pod{dir = 8},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/MercShip)
-"BP" = (/obj/structure/closet/medical,/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MercShip)
-"BT" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/obj/mecha/combat/gygax/serenity,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Ca" = (/obj/random/maintenance/security,/obj/random/maintenance/security,/obj/structure/table/hardwoodtable,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"Cl" = (/obj/effect/floor_decal/techfloor,/obj/machinery/chemical_dispenser/ert/specialops/abductor{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Cy" = (/obj/effect/floor_decal/techfloor,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/meter,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"CO" = (/turf/template_noop,/area/template_noop)
-"CS" = (/obj/effect/floor_decal/techfloor,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"CY" = (/obj/structure/grille/cult{name = "Alien grille"},/obj/structure/window/phoronreinforced/full,/obj/structure/window/phoronreinforced{dir = 4},/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{dir = 1},/obj/structure/window/phoronreinforced{dir = 8},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"Dn" = (/obj/machinery/light/poi{dir = 8},/obj/structure/table/survival_pod,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"DF" = (/obj/structure/prop/alien/pod/hybrid,/obj/structure/window/reinforced/survival_pod{dir = 4},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/MercShip)
-"DJ" = (/obj/structure/grille/cult{name = "Alien grille"},/obj/structure/window/phoronreinforced/full,/obj/structure/window/phoronreinforced,/obj/structure/window/phoronreinforced{dir = 1},/obj/structure/window/phoronreinforced{dir = 4},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"DK" = (/obj/effect/floor_decal/industrial/warning{dir = 4},/obj/machinery/light/poi,/obj/structure/closet/emcloset/legacy,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"DM" = (/obj/effect/floor_decal/industrial/warning{dir = 6},/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/obj/machinery/atmospherics/unary/vent_pump/engine,/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/survivalpod/superpose/MercShip)
-"DX" = (/obj/machinery/vending/deluxe_dinner{req_access = null; req_log_access = null},/turf/simulated/wall/skipjack,/area/survivalpod/superpose/MercShip)
-"Ee" = (/obj/structure/table/bench/glass,/turf/simulated/floor/carpet/gaycarpet,/area/survivalpod/superpose/MercShip)
-"El" = (/obj/structure/toilet{dir = 1},/obj/structure/curtain/open/shower/security,/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/MercShip)
-"Em" = (/obj/machinery/atmospherics/pipe/tank/phoron/full{dir = 1},/obj/machinery/light/poi,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"Fm" = (/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"Fs" = (/obj/machinery/cablelayer,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"FU" = (/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"FZ" = (/obj/machinery/shower{pixel_y = 16},/obj/structure/curtain/open/shower/security,/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/MercShip)
-"Gd" = (/obj/machinery/door/blast/multi_tile/four_tile_ver_sec,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"GH" = (/obj/structure/window/reinforced/survival_pod{dir = 5},/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/MercShip)
-"GT" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/item/weapon/paper_bin,/obj/item/weapon/folder/yellow,/obj/item/weapon/pen/reagent/paralysis,/obj/structure/table/hardwoodtable,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"GU" = (/obj/structure/window/reinforced/survival_pod,/obj/machinery/teleport/station{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"Hc" = (/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "fridge_sci"; icon_contents = "chem"; icon_state = "fridge_sci"; name = "Advanced storage"; pixel_y = 0},/obj/random/maintenance/clean,/obj/random/maintenance/security,/obj/random/maintenance/security,/obj/random/maintenance/security,/obj/random/maintenance/research,/obj/random/maintenance/medical,/obj/random/maintenance/medical,/obj/random/maintenance/engineering,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"HW" = (/obj/structure/cable/cyan{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/structure/cable/cyan{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"HX" = (/obj/structure/closet/alien,/obj/item/clothing/suit/space/void/autolok,/obj/item/clothing/suit/space/void/autolok,/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/storage/toolbox/emergency,/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"Ib" = (/obj/machinery/atmospherics/pipe/tank/phoron/full{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"Ii" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/computer/teleporter{dir = 2},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"Ir" = (/obj/structure/table/rack/shelf/steel,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Jt" = (/obj/machinery/atmospherics/binary/pump/on{dir = 8; name = "Scrubber to Waste"},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"JB" = (/obj/effect/floor_decal/techfloor{dir = 6},/obj/structure/bed/chair/bay/comfy/captain{dir = 4},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"JD" = (/obj/structure/cryofeed{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 9},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/MercShip)
-"JW" = (/obj/structure/table/rack/shelf/steel,/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Kc" = (/turf/simulated/floor/carpet/blue,/area/survivalpod/superpose/MercShip)
-"Ke" = (/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "fridge_sci"; icon_contents = "chem"; icon_state = "fridge_sci"; name = "Advanced storage"; pixel_y = 0},/obj/random/maintenance/clean,/obj/random/maintenance/cargo,/obj/random/maintenance/security,/obj/random/maintenance/medical,/obj/random/maintenance/engineering,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Ko" = (/obj/machinery/power/emitter/gyrotron{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"Kq" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/structure/bed/chair/bay/comfy/teal,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Kw" = (/obj/machinery/light/poi{dir = 1},/turf/simulated/floor/carpet/tealcarpet,/area/survivalpod/superpose/MercShip)
-"KB" = (/obj/effect/floor_decal/techfloor/corner{dir = 5},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"KS" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/structure/prop/alien/dispenser,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"KT" = (/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"La" = (/obj/machinery/door/window/survival_pod,/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/MercShip)
-"LM" = (/obj/effect/floor_decal/industrial/warning/corner{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"Md" = (/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Mk" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/item/weapon/paper_bin,/obj/item/weapon/folder/yellow,/obj/item/weapon/pen/reagent/paralysis,/obj/structure/table/hardwoodtable,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"Mr" = (/obj/machinery/atmospherics/binary/circulator{anchored = 1; dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 8},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/MercShip)
-"Mz" = (/obj/effect/floor_decal/industrial/warning/cee{dir = 8},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/survivalpod/superpose/MercShip)
-"Nb" = (/obj/random/maintenance/clean,/obj/structure/table/hardwoodtable,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"Nc" = (/obj/machinery/light/poi{dir = 1},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"Nd" = (/obj/effect/floor_decal/industrial/warning{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 6},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"Nm" = (/obj/effect/floor_decal/techfloor{dir = 5},/obj/structure/bed/chair/bay/comfy/captain{dir = 4},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"NI" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/cable/cyan{d2 = 2; icon_state = "0-2"},/obj/machinery/power/smes/buildable/hybrid,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"NP" = (/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"NV" = (/obj/effect/floor_decal/industrial/warning,/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/survivalpod/superpose/MercShip)
-"NY" = (/obj/structure/closet/alien,/turf/simulated/floor/carpet,/area/survivalpod/superpose/MercShip)
-"Pi" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/machinery/door/window/brigdoor/eastleft{name = "Laser Armor"},/obj/structure/table/rack/shelf/steel,/obj/item/weapon/gun/energy/hooklauncher/ring,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"Pq" = (/obj/machinery/light/poi{dir = 4},/obj/machinery/atmospherics/pipe/tank/phoron/full{dir = 8},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"Py" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/cable/cyan,/obj/machinery/power/smes/buildable/hybrid,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"PB" = (/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/MercShip)
-"PF" = (/obj/machinery/cryopod{dir = 4},/obj/structure/cryofeed{pixel_x = -32},/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"PR" = (/obj/structure/grille/cult{name = "Alien grille"},/obj/structure/window/phoronreinforced/full,/obj/structure/window/phoronreinforced{dir = 4},/obj/structure/window/phoronreinforced{dir = 8},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"PT" = (/obj/effect/floor_decal/industrial/warning{dir = 4},/obj/machinery/light/poi{dir = 1},/obj/structure/closet/emcloset/legacy,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"Qe" = (/obj/machinery/door/window/survival_pod{dir = 2},/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/MercShip)
-"Qi" = (/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Qu" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/power/smes/buildable/hybrid,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"QH" = (/obj/structure/closet/crate/large,/obj/fiftyspawner/steel,/obj/item/stack/material/plasteel{amount = 30},/obj/item/stack/material/phoron{amount = 25},/obj/item/stack/material/glass/phoronrglass{amount = 20},/obj/fiftyspawner/steel,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"RL" = (/obj/effect/floor_decal/industrial/warning{dir = 5},/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/machinery/atmospherics/unary/outlet_injector{dir = 4},/turf/simulated/floor/reinforced/nitrogen{nitrogen = 82.1472},/area/survivalpod/superpose/MercShip)
-"Sd" = (/obj/machinery/door/airlock/hatch{req_one_access = null},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"SK" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden,/obj/machinery/meter,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"SO" = (/obj/machinery/light/poi,/turf/simulated/floor/carpet/blue,/area/survivalpod/superpose/MercShip)
-"SS" = (/turf/simulated/wall/skipjack,/area/survivalpod/superpose/MercShip)
-"SY" = (/obj/effect/floor_decal/techfloor/corner{dir = 10},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"Tg" = (/obj/machinery/light/poi{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Ti" = (/obj/effect/floor_decal/techfloor,/obj/structure/bed/chair/bay/comfy/teal{dir = 1},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Tk" = (/obj/machinery/light/poi,/turf/simulated/floor/airless,/area/survivalpod/superpose/MercShip)
-"Tr" = (/obj/structure/table/rack/shelf/steel,/obj/item/stack/material/smolebricks{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/obj/item/stack/material/resin{amount = 50},/obj/item/stack/material/resin{amount = 50},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Tw" = (/obj/structure/window/reinforced/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/machinery/door/window/brigdoor/westleft{name = "Combat Armor"},/obj/structure/table/rack/shelf/steel,/obj/item/weapon/rig/focalpoint,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"Tx" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/meter,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"TK" = (/turf/simulated/floor/carpet/gaycarpet,/area/survivalpod/superpose/MercShip)
-"TL" = (/obj/effect/floor_decal/techfloor,/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"Ui" = (/obj/effect/floor_decal/techfloor{dir = 5},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"Um" = (/obj/machinery/light/poi,/turf/simulated/floor/carpet/tealcarpet,/area/survivalpod/superpose/MercShip)
-"Un" = (/obj/structure/closet/alien,/obj/item/clothing/suit/space/void/autolok,/obj/item/clothing/suit/space/void/autolok,/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/storage/toolbox/emergency,/obj/effect/floor_decal/techfloor,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Uu" = (/obj/machinery/atmospherics/unary/engine/biggest{dir = 4},/turf/template_noop,/area/template_noop)
-"Uz" = (/obj/machinery/light/poi,/turf/simulated/floor/carpet,/area/survivalpod/superpose/MercShip)
-"UI" = (/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MercShip)
-"UJ" = (/obj/effect/floor_decal/techfloor{dir = 6},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"US" = (/obj/effect/floor_decal/industrial/warning,/obj/effect/floor_decal/industrial/warning,/obj/machinery/light/poi,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"Vk" = (/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"Vq" = (/obj/effect/floor_decal/techfloor,/turf/simulated/floor/wood/sif,/area/survivalpod/superpose/MercShip)
-"Vu" = (/obj/machinery/power/rad_collector,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/industrial/warning,/obj/structure/cable/cyan,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"Vw" = (/obj/machinery/recharge_station,/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/MercShip)
-"VF" = (/obj/machinery/atmospherics/pipe/tank/phoron/full{dir = 8},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"VP" = (/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"VQ" = (/obj/effect/floor_decal/industrial/warning{dir = 1},/obj/machinery/light/poi{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"VR" = (/obj/machinery/field_generator{anchored = 1; state = 1},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"VS" = (/obj/structure/table/reinforced,/obj/machinery/cell_charger,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"Wl" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/item/device/sleevemate,/obj/structure/table/hardwoodtable,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"Wu" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/techfloor{dir = 1},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"WJ" = (/obj/machinery/sleep_console{dir = 4},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MercShip)
-"WO" = (/obj/machinery/light/poi{dir = 4},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"WQ" = (/obj/structure/bed/double/padded,/obj/item/weapon/bedsheet/rddouble,/turf/simulated/floor/carpet/gaycarpet,/area/survivalpod/superpose/MercShip)
-"WT" = (/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"WX" = (/obj/machinery/vending/tool{emagged = 1; req_access = list(777); req_log_access = null},/turf/simulated/shuttle/floor/yellow,/area/survivalpod/superpose/MercShip)
-"Xc" = (/obj/structure/cable/cyan{d1 = 1; d2 = 4; icon_state = "1-4"},/obj/structure/cable/cyan{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"Xg" = (/obj/machinery/cryopod,/obj/structure/cryofeed{dir = 4; pixel_x = 32},/turf/simulated/shuttle/floor/darkred,/area/survivalpod/superpose/MercShip)
-"Xv" = (/turf/simulated/floor/carpet,/area/survivalpod/superpose/MercShip)
-"XA" = (/obj/machinery/light/poi{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"XC" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/item/weapon/hand_labeler,/obj/item/device/tape/random,/obj/structure/table/hardwoodtable,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/MercShip)
-"XY" = (/obj/effect/floor_decal/techfloor,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9},/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"Yi" = (/obj/machinery/door/blast/regular,/turf/simulated/floor/airless,/area/survivalpod/superpose/MercShip)
-"Yw" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"YA" = (/obj/structure/closet/alien,/obj/item/clothing/suit/space/void/autolok,/obj/item/clothing/suit/space/void/autolok,/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/tank/emergency/oxygen/double,/obj/item/weapon/storage/toolbox/emergency,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/MercShip)
-"YI" = (/turf/simulated/floor/greengrid/nitrogen,/area/survivalpod/superpose/MercShip)
-"YP" = (/obj/machinery/atmospherics/unary/engine/bigger{dir = 4; pixel_x = -3},/turf/template_noop,/area/template_noop)
-"Zh" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/structure/filingcabinet/medical,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"Zp" = (/obj/machinery/computer/operating{dir = 1},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/MercShip)
-"Zq" = (/obj/machinery/power/rad_collector,/obj/effect/floor_decal/industrial/outline/yellow,/obj/effect/floor_decal/industrial/warning,/obj/effect/floor_decal/industrial/warning,/obj/structure/cable/cyan,/turf/simulated/floor,/area/survivalpod/superpose/MercShip)
-"ZN" = (/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/structure/table/rack/shelf/steel,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
-"ZQ" = (/obj/effect/floor_decal/techfloor{dir = 6},/turf/simulated/shuttle/floor/black,/area/survivalpod/superpose/MercShip)
-"ZY" = (/obj/machinery/door/window/survival_pod{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/MercShip)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aj" = (
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "fridge_sci";
+	icon_contents = "chem";
+	icon_state = "fridge_sci";
+	name = "Advanced storage";
+	pixel_y = 0
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"ao" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "ReactorBlastAlien";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"as" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"at" = (
+/obj/structure/prop/alien/pod/hybrid,
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/MercShip)
+"aE" = (
+/obj/structure/particle_accelerator/particle_emitter/left{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"aH" = (
+/obj/machinery/optable,
+/obj/machinery/light/poi,
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MercShip)
+"aJ" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/survivalpod/superpose/MercShip)
+"aL" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"aM" = (
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "fridge_sci";
+	icon_contents = "chem";
+	icon_state = "fridge_sci";
+	name = "Advanced storage";
+	pixel_y = 0
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/obj/random/maintenance/research,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"aP" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"bc" = (
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the engine charging port.";
+	id = "reactorblastalien";
+	name = "Reactor Blast Doors";
+	pixel_x = -25;
+	pixel_y = 6;
+	req_access = null
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"bi" = (
+/turf/simulated/floor,
+/area/template_noop)
+"bp" = (
+/obj/structure/particle_accelerator/particle_emitter/center{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"bv" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/stack/cable_coil/blue,
+/obj/item/stack/cable_coil/blue,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"bw" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/item/weapon/clipboard,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"bH" = (
+/obj/structure/prop/alien/pod/open,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"bN" = (
+/obj/machinery/light/poi,
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"bO" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/bed/chair/wood/wings,
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MercShip)
+"bZ" = (
+/obj/machinery/door/window/brigdoor/northright{
+	req_access = null
+	},
+/obj/structure/table/hardwoodtable,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"ch" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"cp" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"cB" = (
+/obj/structure/prop/alien/pod/open,
+/obj/random/maintenance/morestuff,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"cH" = (
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "fridge_sci";
+	icon_contents = "chem";
+	icon_state = "fridge_sci";
+	name = "Advanced storage";
+	pixel_y = 0
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/obj/random/maintenance/research,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"cL" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 1;
+	target_pressure = 200
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"cP" = (
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MercShip)
+"cX" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"de" = (
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MercShip)
+"dg" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"dr" = (
+/obj/machinery/recycling/sorter,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"dx" = (
+/obj/structure/closet/radiation,
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MercShip)
+"dz" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"dA" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/machinery/field_generator{
+	anchored = 1;
+	state = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"dB" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"dC" = (
+/obj/machinery/autolathe{
+	hacked = 1;
+	name = "hacked autolathe"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"dP" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/light/poi,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"dS" = (
+/obj/structure/cryofeed{
+	dir = 2
+	},
+/obj/machinery/light/small/emergency,
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/MercShip)
+"dW" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"er" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "ReactorBlastAlien";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"ex" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/stack/material/plasteel{
+	amount = 30;
+	pixel_y = 5
+	},
+/obj/item/stack/material/plasteel{
+	amount = 30;
+	pixel_y = 5
+	},
+/obj/item/stack/material/lead{
+	amount = 30
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"eB" = (
+/obj/structure/closet/alien,
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MercShip)
+"eW" = (
+/obj/machinery/particle_accelerator/control_box,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"fc" = (
+/turf/simulated/floor/carpet/tealcarpet,
+/area/survivalpod/superpose/MercShip)
+"ff" = (
+/obj/machinery/the_singularitygen/tesla{
+	anchored = 1;
+	pixel_y = 11
+	},
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/survivalpod/superpose/MercShip)
+"fi" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"fm" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/table/marble,
+/obj/item/slime_extract/orange,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"fr" = (
+/turf/simulated/shuttle/wall/alien/blue/no_join,
+/area/survivalpod/superpose/MercShip)
+"fA" = (
+/obj/structure/cryofeed,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 5
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/MercShip)
+"fK" = (
+/obj/machinery/power/apc/hyper{
+	coverlocked = 0;
+	dir = 4;
+	environ = 1;
+	equipment = 1;
+	lighting = 1;
+	locked = 0;
+	pixel_x = 23
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"fN" = (
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/survivalpod/superpose/MercShip)
+"gc" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"gt" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/rddouble,
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/MercShip)
+"gz" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"gA" = (
+/turf/simulated/shuttle/wall/alien/blue/hard_corner,
+/area/survivalpod/superpose/MercShip)
+"gO" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	id = "reactorblastalien";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"gS" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light/poi{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"gW" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"hp" = (
+/obj/machinery/teleport/hub{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"hu" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"hw" = (
+/obj/machinery/vending/engivend{
+	emagged = 1;
+	req_access = list(777);
+	req_log_access = null
+	},
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MercShip)
+"hI" = (
+/obj/machinery/recycling/crusher,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"hR" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/structure/cryofeed{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"hV" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"ic" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "ReactorBlastAlien";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"ie" = (
+/obj/machinery/light/poi,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"iw" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/rddouble,
+/turf/simulated/floor/carpet/blue,
+/area/survivalpod/superpose/MercShip)
+"iy" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"iD" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/machinery/ion_engine,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MercShip)
+"iJ" = (
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/fiftyspawner/blucarpet,
+/obj/fiftyspawner/oracarpet,
+/obj/fiftyspawner/purcarpet,
+/obj/fiftyspawner/sblucarpet,
+/obj/fiftyspawner/tealcarpet,
+/obj/fiftyspawner/turcarpet,
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/algae{
+	amount = 50
+	},
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/lead{
+	amount = 30
+	},
+/obj/item/stack/material/plasteel{
+	amount = 30;
+	pixel_y = 5
+	},
+/obj/item/stack/material/resin{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/structure/closet/alien,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"iM" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"jc" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/light/poi{
+	dir = 4
+	},
+/obj/structure/salvageable/console_os{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"jd" = (
+/obj/machinery/atmospherics/pipe/tank/phoron/full,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"jg" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA"
+	},
+/turf/simulated/wall/skipjack,
+/area/survivalpod/superpose/MercShip)
+"jh" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"ji" = (
+/obj/structure/closet/alien,
+/obj/random/toolbox,
+/obj/random/toolbox,
+/obj/random/toolbox,
+/obj/item/weapon/storage/toolbox/syndicate/powertools,
+/obj/item/weapon/storage/toolbox/syndicate,
+/obj/fiftyspawner/phoronrglass,
+/obj/fiftyspawner/phoronrglass,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MercShip)
+"jm" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/salvageable/bliss,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"jz" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced,
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"jJ" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"jW" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"jZ" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed{
+	dir = 4;
+	pixel_x = 32
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"kl" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -34
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"kD" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	target_pressure = 200
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"kO" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/algae{
+	amount = 50
+	},
+/obj/item/stack/material/algae{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"kR" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"kS" = (
+/obj/structure/table/bench/glass,
+/turf/simulated/floor/carpet/tealcarpet,
+/area/survivalpod/superpose/MercShip)
+"kV" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"lk" = (
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/blue,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/structure/closet/alien,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"lp" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/power/emitter/gyrotron,
+/obj/structure/cable/yellow,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"lt" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/power/rad_collector,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"lJ" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"mm" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"mv" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/reagent_containers/glass/beaker/bluespace,
+/obj/item/weapon/reagent_containers/glass/beaker/bluespace{
+	pixel_x = -7
+	},
+/obj/item/weapon/storage/belt/medical/alien,
+/obj/item/weapon/storage/belt/medical/alien{
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/firstaid/surgery,
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MercShip)
+"my" = (
+/obj/machinery/oxygen_pump/anesthetic,
+/turf/simulated/wall/skipjack,
+/area/survivalpod/superpose/MercShip)
+"mK" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"mQ" = (
+/obj/structure/closet/alien,
+/obj/item/clothing/suit/space/void/autolok,
+/obj/item/clothing/suit/space/void/autolok,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/storage/toolbox/emergency,
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MercShip)
+"mT" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"nj" = (
+/obj/item/weapon/tape_roll,
+/obj/item/sticky_pad/random,
+/obj/item/weapon/pen/blue,
+/obj/item/weapon/pen/blue,
+/obj/item/fulton_core,
+/obj/item/fulton_core,
+/obj/item/extraction_pack,
+/obj/item/extraction_pack,
+/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
+/obj/item/weapon/pickaxe/hand,
+/obj/item/device/flashlight/color/yellow,
+/obj/item/device/flashlight/color/orange,
+/obj/item/device/threadneedle,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/flame/lighter/zippo,
+/obj/item/weapon/flame/lighter/zippo,
+/obj/item/device/flashlight/lantern,
+/obj/random/soap,
+/obj/random/soap,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/weapon/storage/pill_bottle/spaceacillin,
+/obj/item/weapon/storage/pill_bottle/antitox,
+/obj/item/device/healthanalyzer,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/stack/nanopaste,
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,
+/obj/item/weapon/storage/toolbox/brass,
+/obj/item/weapon/storage/box/survival/space,
+/obj/item/weapon/storage/box/survival/space,
+/obj/item/weapon/storage/box/survival/space,
+/obj/item/weapon/storage/pill_bottle/dice_nerd,
+/obj/item/weapon/storage/box/flare,
+/obj/item/weapon/storage/box/khcrystal,
+/obj/item/weapon/storage/box/khcrystal,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/stack/marker_beacon/ten,
+/obj/item/device/starcaster_news,
+/obj/item/device/mapping_unit,
+/obj/item/weapon/storage/box/dosimeter,
+/obj/item/device/gps,
+/obj/item/device/gps,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/device/pda,
+/obj/item/device/pda,
+/obj/item/weapon/card/id/external,
+/obj/item/weapon/card/id/external,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/gun/energy/locked/phasegun/pistol,
+/obj/item/weapon/gun/energy/locked/phasegun,
+/obj/item/weapon/cell/device/weapon{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/weapon/cell/device/weapon{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/weapon/material/knife/machete,
+/obj/item/weapon/material/fishing_net,
+/obj/item/weapon/storage/backpack/sport,
+/obj/item/weapon/storage/backpack/sport,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/weapon/storage/belt,
+/obj/item/clothing/accessory/poncho/thermal,
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "fridge_sci";
+	icon_contents = "chem";
+	icon_state = "fridge_sci";
+	name = "Advanced storage";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"ns" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	id = "reactorblastalien";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"nt" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"nv" = (
+/obj/item/weapon/soap/deluxe,
+/obj/item/weapon/soap/deluxe,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/MercShip)
+"nx" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"nB" = (
+/obj/structure/closet/alien,
+/obj/random/toolbox,
+/obj/random/toolbox,
+/obj/random/toolbox,
+/obj/item/weapon/storage/toolbox/syndicate/powertools,
+/obj/item/weapon/storage/toolbox/syndicate,
+/obj/fiftyspawner/plasteel,
+/obj/fiftyspawner/plasteel,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MercShip)
+"nC" = (
+/obj/machinery/light/poi,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"nL" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/mecha/working/ripley/antique,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"oh" = (
+/obj/random/maintenance/medical,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MercShip)
+"oi" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/machinery/door/window/brigdoor/eastright{
+	name = "Laser Armor"
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/gun/energy/netgun,
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"op" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 10
+	},
+/obj/machinery/light/poi,
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/MercShip)
+"ou" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"oG" = (
+/obj/structure/prop/alien/pod/open,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"oI" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/vending/deluxe_dinner{
+	req_access = null;
+	req_log_access = null
+	},
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MercShip)
+"oM" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"oR" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/salvageable/machine{
+	name = "Life Support Console"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"ph" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"pi" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"pu" = (
+/obj/machinery/sleeper{
+	dir = 4;
+	emagged = 1;
+	initial_bin_rating = 4
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MercShip)
+"px" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/field_generator{
+	anchored = 1;
+	state = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"pC" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/prop/alien/dispenser,
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"pD" = (
+/obj/structure/particle_accelerator/power_box{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"qa" = (
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/fiftyspawner/blucarpet,
+/obj/fiftyspawner/oracarpet,
+/obj/fiftyspawner/purcarpet,
+/obj/fiftyspawner/sblucarpet,
+/obj/fiftyspawner/tealcarpet,
+/obj/fiftyspawner/turcarpet,
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"qb" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/salvageable/machine_os,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"qe" = (
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"qC" = (
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MercShip)
+"qQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"qS" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"qY" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/structure/cryofeed{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"rx" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"rI" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/rddouble,
+/turf/simulated/floor/carpet/tealcarpet,
+/area/survivalpod/superpose/MercShip)
+"rL" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/turf/simulated/shuttle/floor/alienplating,
+/area/survivalpod/superpose/MercShip)
+"sc" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"se" = (
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MercShip)
+"ss" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/westright{
+	name = "Combat Armor"
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/device/soulstone,
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"sO" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"td" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"tj" = (
+/obj/machinery/power/apc/hyper{
+	coverlocked = 0;
+	dir = 4;
+	environ = 1;
+	equipment = 1;
+	lighting = 1;
+	locked = 0;
+	pixel_x = 23
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MercShip)
+"tr" = (
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"tF" = (
+/obj/machinery/cryopod/robot,
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"tK" = (
+/obj/structure/prop/alien/computer/hybrid,
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"tV" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/survivalpod/superpose/MercShip)
+"uf" = (
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"ut" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"uI" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/table/marble,
+/obj/item/slime_extract/gold,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"uQ" = (
+/obj/machinery/power/rad_collector,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"uT" = (
+/obj/machinery/recycling/stamper,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"uU" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -34
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"ve" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/salvageable/server_os,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"vg" = (
+/obj/structure/table/bench/glass,
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/MercShip)
+"vH" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"vP" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/survivalpod/superpose/MercShip)
+"vQ" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MercShip)
+"vU" = (
+/obj/item/device/gps/internal/poi{
+	name = "#$(@@%$#"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"vV" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"vW" = (
+/obj/structure/particle_accelerator/particle_emitter/right{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"wr" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"wz" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"wD" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"xn" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/yellow,
+/area/survivalpod/superpose/MercShip)
+"xs" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced,
+/obj/machinery/door/blast/regular{
+	id = "reactorblastalien";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"xG" = (
+/obj/structure/prop/alien/computer/hybrid{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"xT" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/cryofeed{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MercShip)
+"xV" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/loot_pile/mecha/gygax/dark/adv,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"ya" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/item/weapon/tape_roll,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"yi" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"yv" = (
+/obj/structure/prop/fake_ai{
+	name = "P0ps1ck13"
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"yD" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"yI" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"yP" = (
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"yY" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"zc" = (
+/obj/structure/sign/department/cargo_dock,
+/turf/simulated/wall/skipjack,
+/area/survivalpod/superpose/MercShip)
+"zu" = (
+/obj/random/maintenance/clean,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MercShip)
+"zz" = (
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/MercShip)
+"zH" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"zI" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/survivalpod/superpose/MercShip)
+"Af" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/rddouble,
+/obj/machinery/light/poi{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/MercShip)
+"Aj" = (
+/obj/structure/table/bench/glass,
+/turf/simulated/floor/carpet/blue,
+/area/survivalpod/superpose/MercShip)
+"AB" = (
+/obj/machinery/power/smes/buildable/point_of_interest,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8";
+	dir = 2
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8";
+	dir = 2
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"AL" = (
+/obj/machinery/door/window/brigdoor/northright{
+	dir = 2;
+	req_access = null
+	},
+/obj/structure/table/hardwoodtable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"AP" = (
+/obj/machinery/vending/medical{
+	dir = 4;
+	emagged = 1;
+	pixel_x = 5;
+	req_access = list(777)
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MercShip)
+"AS" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Bd" = (
+/obj/machinery/vending/deluxe_boozeomat{
+	req_access = null;
+	req_log_access = null
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"Bf" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Bh" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/item/weapon/hand_labeler,
+/obj/item/device/tape/random,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"Bo" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/survivalpod/superpose/MercShip)
+"Bs" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MercShip)
+"BE" = (
+/obj/structure/prop/alien/pod/hybrid,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/MercShip)
+"BM" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"BP" = (
+/obj/structure/closet/medical,
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MercShip)
+"BT" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/mecha/combat/gygax/serenity,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Ca" = (
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Cl" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/chemical_dispenser/ert/specialops/abductor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Cy" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"CD" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"CO" = (
+/turf/template_noop,
+/area/template_noop)
+"CS" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/survivalpod/superpose/MercShip)
+"CY" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"Dn" = (
+/obj/machinery/light/poi{
+	dir = 8
+	},
+/obj/structure/table/survival_pod,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"DF" = (
+/obj/structure/prop/alien/pod/hybrid,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/MercShip)
+"DJ" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"DK" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/prop/alien/pod/open,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"DM" = (
+/obj/machinery/power/smes/buildable,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"DX" = (
+/obj/machinery/vending/deluxe_dinner{
+	req_access = null;
+	req_log_access = null
+	},
+/turf/simulated/wall/skipjack,
+/area/survivalpod/superpose/MercShip)
+"Ee" = (
+/obj/structure/table/bench/glass,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/survivalpod/superpose/MercShip)
+"El" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower/security,
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/MercShip)
+"Em" = (
+/obj/machinery/atmospherics/pipe/tank/phoron/full{
+	dir = 1
+	},
+/obj/machinery/light/poi,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"EF" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Fm" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"Fq" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Fs" = (
+/obj/machinery/cablelayer,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"FL" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"FU" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/survivalpod/superpose/MercShip)
+"FZ" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/structure/curtain/open/shower/security,
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/MercShip)
+"Gd" = (
+/obj/structure/particle_accelerator/fuel_chamber{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"Gn" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"GH" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/MercShip)
+"GT" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/pen/reagent/paralysis,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"GU" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/machinery/teleport/station{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"Hc" = (
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "fridge_sci";
+	icon_contents = "chem";
+	icon_state = "fridge_sci";
+	name = "Advanced storage";
+	pixel_y = 0
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/obj/random/maintenance/security,
+/obj/random/maintenance/research,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"HW" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"HX" = (
+/obj/structure/closet/alien,
+/obj/item/clothing/suit/space/void/autolok,
+/obj/item/clothing/suit/space/void/autolok,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/storage/toolbox/emergency,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Ib" = (
+/obj/machinery/atmospherics/pipe/tank/phoron/full{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Ii" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/computer/teleporter{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"Ir" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Iz" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Jt" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Jv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MercShip)
+"JB" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/obj/structure/bed/chair/bay/comfy/captain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"JD" = (
+/obj/structure/cryofeed{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 9
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/MercShip)
+"JW" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Kc" = (
+/turf/simulated/floor/carpet/blue,
+/area/survivalpod/superpose/MercShip)
+"Ke" = (
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "fridge_sci";
+	icon_contents = "chem";
+	icon_state = "fridge_sci";
+	name = "Advanced storage";
+	pixel_y = 0
+	},
+/obj/random/maintenance/clean,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/security,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Ko" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Kq" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/bed/chair/bay/comfy/teal,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Kw" = (
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/tealcarpet,
+/area/survivalpod/superpose/MercShip)
+"KB" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"KS" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/prop/alien/dispenser,
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"KT" = (
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8";
+	dir = 2
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"La" = (
+/obj/machinery/door/window/survival_pod,
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/MercShip)
+"LM" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Md" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Mk" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/pen/reagent/paralysis,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"Mr" = (
+/obj/machinery/atmospherics/binary/circulator{
+	anchored = 1;
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MercShip)
+"Mz" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Nb" = (
+/obj/random/maintenance/clean,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"Nc" = (
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Nd" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Nm" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/obj/structure/bed/chair/bay/comfy/captain{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"NI" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"NP" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"NV" = (
+/obj/machinery/power/grounding_rod/pre_mapped,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"NY" = (
+/obj/structure/closet/alien,
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/MercShip)
+"Pi" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/machinery/door/window/brigdoor/eastleft{
+	name = "Laser Armor"
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/gun/energy/hooklauncher/ring,
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"Pq" = (
+/obj/machinery/light/poi{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Py" = (
+/obj/machinery/door/airlock/alien{
+	req_one_access = null
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"PB" = (
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/MercShip)
+"PF" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/structure/cryofeed{
+	pixel_x = -32
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"PR" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"PT" = (
+/obj/structure/prop/alien/pod/open,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Qe" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/MercShip)
+"Qi" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Qu" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"QH" = (
+/obj/structure/closet/crate/large,
+/obj/fiftyspawner/steel,
+/obj/item/stack/material/plasteel{
+	amount = 30
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/item/stack/material/glass/phoronrglass{
+	amount = 20
+	},
+/obj/fiftyspawner/steel,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"RL" = (
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/survivalpod/superpose/MercShip)
+"Sd" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"SK" = (
+/obj/machinery/power/smes/buildable/point_of_interest,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"SO" = (
+/obj/machinery/light/poi,
+/turf/simulated/floor/carpet/blue,
+/area/survivalpod/superpose/MercShip)
+"SS" = (
+/turf/simulated/wall/skipjack,
+/area/survivalpod/superpose/MercShip)
+"SU" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"SY" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"Tf" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"Tg" = (
+/obj/machinery/light/poi{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Ti" = (
+/obj/effect/floor_decal/techfloor,
+/obj/structure/bed/chair/bay/comfy/teal{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Tk" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"Tr" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/item/stack/material/resin{
+	amount = 50
+	},
+/obj/item/stack/material/resin{
+	amount = 50
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Tw" = (
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/westleft{
+	name = "Combat Armor"
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/rig/focalpoint,
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"Tx" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"TK" = (
+/turf/simulated/floor/carpet/gaycarpet,
+/area/survivalpod/superpose/MercShip)
+"TL" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"Ui" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"Um" = (
+/obj/machinery/light/poi,
+/turf/simulated/floor/carpet/tealcarpet,
+/area/survivalpod/superpose/MercShip)
+"Un" = (
+/obj/structure/closet/alien,
+/obj/item/clothing/suit/space/void/autolok,
+/obj/item/clothing/suit/space/void/autolok,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Uu" = (
+/obj/machinery/atmospherics/unary/engine/biggest{
+	dir = 4
+	},
+/turf/template_noop,
+/area/template_noop)
+"Uz" = (
+/obj/machinery/light/poi,
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/MercShip)
+"UI" = (
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MercShip)
+"UJ" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"UR" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"US" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/power/emitter/gyrotron,
+/obj/structure/cable/yellow,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Vk" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"Vq" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/wood/sif,
+/area/survivalpod/superpose/MercShip)
+"Vu" = (
+/obj/machinery/power/rad_collector,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Vw" = (
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/MercShip)
+"VD" = (
+/obj/structure/particle_accelerator/end_cap{
+	dir = 8
+	},
+/obj/effect/floor_decal/techfloor/hole{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"VF" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8";
+	dir = 2
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"VP" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"VQ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/power/emitter/gyrotron{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"VR" = (
+/obj/machinery/field_generator{
+	anchored = 1;
+	state = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"VS" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"Wl" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/item/device/sleevemate,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"Wu" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"WH" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"WJ" = (
+/obj/machinery/sleep_console{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MercShip)
+"WO" = (
+/obj/machinery/light/poi{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"WQ" = (
+/obj/structure/bed/double/padded,
+/obj/item/weapon/bedsheet/rddouble,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/survivalpod/superpose/MercShip)
+"WT" = (
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"WX" = (
+/obj/machinery/vending/tool{
+	emagged = 1;
+	req_access = list(777);
+	req_log_access = null
+	},
+/turf/simulated/shuttle/floor/yellow,
+/area/survivalpod/superpose/MercShip)
+"WZ" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Xc" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"Xg" = (
+/obj/machinery/cryopod,
+/obj/structure/cryofeed{
+	dir = 4;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/red,
+/area/survivalpod/superpose/MercShip)
+"Xv" = (
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/MercShip)
+"XA" = (
+/obj/machinery/light/poi{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"XC" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/item/weapon/hand_labeler,
+/obj/item/device/tape/random,
+/obj/structure/table/hardwoodtable,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"XY" = (
+/obj/effect/floor_decal/techfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"Yi" = (
+/obj/machinery/door/airlock/vault,
+/obj/structure/fans/hardlight,
+/turf/simulated/floor/reinforced/nitrogen{
+	nitrogen = 82.1472
+	},
+/area/survivalpod/superpose/MercShip)
+"Yw" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"YA" = (
+/obj/structure/closet/alien,
+/obj/item/clothing/suit/space/void/autolok,
+/obj/item/clothing/suit/space/void/autolok,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/tank/emergency/oxygen/double,
+/obj/item/weapon/storage/toolbox/emergency,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/MercShip)
+"YI" = (
+/obj/structure/grille/cult{
+	name = "Alien grille"
+	},
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id = "reactorblastalien";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/obj/structure/fans/hardlight,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/MercShip)
+"YP" = (
+/obj/machinery/atmospherics/unary/engine/bigger{
+	dir = 4;
+	pixel_x = -3
+	},
+/turf/template_noop,
+/area/template_noop)
+"Zh" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/filingcabinet/medical,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"Zp" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/MercShip)
+"Zq" = (
+/obj/machinery/power/rad_collector,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor,
+/area/survivalpod/superpose/MercShip)
+"ZN" = (
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
+"ZQ" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/yellow,
+/area/survivalpod/superpose/MercShip)
+"ZY" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/MercShip)
 
 (1,1,1) = {"
-COCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOSSSSSSSSSSSSSSSSSSaLaPaPdWSSSSCOCOCOCOCOCOCOCOCOCOCOCOCO
-COCOCOSSSSSSSSSSSSSSSSSSSSSSSSSSSSCOCOCOCOCOCOCOCOCOCOCOCOWTSSjdjdtKjdjdSSUIUIUIUIUIUISSSSCOCOCOCOCOCOCOCOCOCOCOCO
-COCOCOWTSSbHPTQuaophdzNINdgzVFSSSSSSCOSSSSwDSSSSSSCOCOCOYPWTSSkDkDWTkDkDSSUIUIUIUIUIUIUISSSSCOCOCOCOCOCOCOCOCOCOCO
-COCOCOWTSSnCntxsSKxsSKcpLMJtPqSSHXSSSSSSWXjinBhwSSSSCOCOCOSSSSoMoMCyoMXYSSVqVqbObObObOVqoISSCOCOCOCOCOCOCOCOCOCOCO
-COUuCOWTSSWTWTgAvHvHvHHWWTWTWTgWqQqQSSmQcPcPcPcPSSSSSSCOCOCOSScBcBiJVkYASSieVkNbqeNbqeieBdSSSSCOCOCOCOCOCOCOCOCOCO
-COCObiSSSSmKUSZqVuVuVuVulpmmqSjgqQqQgWcPcPcPcPcPdxSSSSSSwDSSSSSSSSSSgWSSSSSSgWSSSSSSSSSSSSSSSSSSCOCOCOCOCOCOCOCOCO
-COWTWTSSSSpisOvVjWjWjWDJsOCYsOsOqQutSSGTMdMdKqMdZhSSSSHXqQqQNcqQqQqQqQqQNcqQqQqQqQqQqQNcqQHXSSSSSSSSSSSSCOCOCOCOCO
-UuWTWTSSSSCSxnCSCSCSCSCSxnCSsOsOqQqQSSSSyaBhALbwSSSSqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQSSCaXvNYSSSSCOCOCOCO
-COWTWTSSzIVRNPsOsOsOsOsONPVRFUgWqQqQyYNcqQqQqQqQNcyYqQqQzcSSgWSSSSSSgWSSSSSSgWSSSSSSgWSSSSqQqQgWqQXvAfSSSSwDSSSSCO
-COWTWTSSzINPbcbcbcnsbcbcbcNPFUsOTLTLTLTLTLTLTLTLTLTLTLSYSSDFyPBESSUIUIeBSSUIUIeBSSUIUIeBSSqQqQSSqQXvvgSSqbtdjmSSSS
-COWTWTWTzINPbcSSvVjWDJSSbcsOFUABkVyIyIyIyIcXZNNPqaNPKeFUSSfAyvJDSSqCKcAjSSqCfckSSSqCXvvgSSqQqQDXqQqQqQSSKSFmNmjcSS
-COWTWTGdZQNPbcSSMzNVRLfibcsOrLfiBfVSVSdCQHQidgNPJWNPcHrLSSatdSatSSohSOiwSSzuUmrISSzuUzgtSSCSCSSSCSCSCSgWTLTLUJyifi
-COWTWOSSXANPbcYiYIfftrPRoGsOXAPRBfVkVkVkVkQijhNPkONPaMTgSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSXANPSSXAvUnjSSDnNPNPVPPR
-COWTWTWTaJNPbcSSyDNVDMnxbcsOASnxBfhIdruTFsQibvNPexNPHcASSSPiufssSSzuKwrISSohfNWQSSxTpxIiwDBoBoSSasasasgWFmFmUiyinx
-COWTWTWTzINPbcSSvVjWDJSSbcsOFUABKBWuWuWuWuiMIrNPTrNPajFUSSoiyPTwSSvQfckSSSvQTKEeSSMrhpVkZYqQqQSSYwseYwSSpCTLJBjcSS
-COWTWTSSzINPbcbcbcTkbcbcbcNPFUsOFmFmFmFmFmFmFmFmFmFmFmbpSSuIBofmSSUIUIeBSSUIUIeBSSiDdAGUwDqQqQSSYwzzxVSSveiyoRSSSS
-COWTWTltzIVRNPsOsOsOsOsONPVRFUgWqQqQkldPqQqQqQqQdPklqQqQzcwDgWwDSSSSgWSSSSSSgWSSSSSSSSSSSSqQqQSSBTsegSSSSSwDSSSSCO
-COWTWTSSSSBowzBoBoBoBoBowzBosOsOqQqQSSSSMkXCbZWlSSSSqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQqQSSYwzznLSSSSCOCOCOCO
-COWTWTSSSSpisOvVjWjWjWDJsOCYsOsOqQutSSClyIyITiyIUnSSSSHXqQqQdPqQqQqQqQqQdPqQqQqQqQqQqQdPqQHXSSSSSSSSSSSSCOCOCOCOCO
-UuCObiSSSSKoVQuQuQuQuQuQVQKohVjgqQqQgWdedededededemvSSSSwDSSSSSSSSSSgWSSSSSSgWSSSSSSSdSSSSSSSSSSCOCOCOCOCOCOCOCOCO
-COCOCOWTSSWTWTuUXcXcXcfKWTWTWTgWqQqQSSBPdedededeAPSSSSCOCOCOSScBcBlkVkYASSqYVkmTSSnvPBLaFZSSSSCOCOCOCOCOCOCOCOCOCO
-COCOCOWTSSnCrxlJKTlJKTfrzHJtVFSSHXSSSSSSWJpuaHZpSSSSCOCOCOSSSSdBdBTxdBgcSSPFFmjZSSPBPBGHSSSSCOCOCOCOCOCOCOCOCOCOCO
-COUuCOWTSSbHDKQuaophdzPywrerVFSSSSSSCOSSSSwDmySSSSCOCOCOCOWTSScLcLWTcLcLSShRyPXgSSQeopVwSSSSCOCOCOCOCOCOCOCOCOCOCO
-COCOCOSSSSSSSSSSSSSSSSSSSSSSSSSSSSCOCOCOCOCOCOCOCOCOCOCOYPWTSSIbEmxGIbIbSStFbNtFSSElSSSSSSCOCOCOCOCOCOCOCOCOCOCOCO
-COCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOCOSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSCOCOCOCOCOCOCOCOCOCOCOCOCO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+Uu
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+Uu
+CO
+CO
+CO
+CO
+CO
+"}
+(2,1,1) = {"
+CO
+CO
+CO
+CO
+Uu
+CO
+WT
+WT
+WT
+WT
+WT
+WT
+WT
+WT
+WT
+WT
+WT
+WT
+WT
+CO
+CO
+CO
+Uu
+CO
+CO
+"}
+(3,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+bi
+WT
+WT
+WT
+WT
+WT
+WT
+WO
+WT
+WT
+WT
+WT
+WT
+WT
+bi
+CO
+CO
+CO
+CO
+CO
+"}
+(4,1,1) = {"
+CO
+SS
+WT
+WT
+WT
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+WT
+WT
+WT
+SS
+CO
+"}
+(5,1,1) = {"
+CO
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+zI
+zI
+zI
+ZQ
+NP
+aJ
+zI
+zI
+zI
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+CO
+"}
+(6,1,1) = {"
+CO
+SS
+oG
+WT
+WT
+mK
+pi
+xn
+NI
+ph
+EF
+ph
+ph
+yD
+Iz
+ph
+ou
+Bo
+pi
+HW
+WT
+WT
+bH
+SS
+CO
+"}
+(7,1,1) = {"
+CO
+SS
+PT
+nt
+WZ
+US
+SS
+xn
+Qu
+VR
+NP
+NP
+NP
+NP
+NP
+VR
+Qu
+Bo
+gA
+VQ
+Mz
+rx
+DK
+SS
+CO
+"}
+(8,1,1) = {"
+CO
+SS
+dz
+hV
+vH
+Zq
+vV
+xn
+NV
+NP
+fr
+jz
+Yi
+Tf
+fr
+NP
+NV
+Bo
+vV
+uQ
+vH
+qS
+dz
+SS
+CO
+"}
+(9,1,1) = {"
+CO
+SS
+dz
+hV
+vH
+Vu
+jW
+xn
+Xc
+NP
+er
+RL
+RL
+RL
+er
+NP
+sc
+Bo
+jW
+uQ
+vH
+qS
+dz
+SS
+CO
+"}
+(10,1,1) = {"
+CO
+SS
+dz
+hV
+vH
+Vu
+jW
+xn
+Qu
+NP
+YI
+RL
+ff
+RL
+ao
+NP
+Qu
+Bo
+jW
+uQ
+vH
+qS
+dz
+SS
+CO
+"}
+(11,1,1) = {"
+CO
+SS
+dz
+hV
+vH
+Vu
+jW
+xn
+sO
+NP
+ic
+RL
+RL
+RL
+ic
+NP
+Gn
+Bo
+jW
+uQ
+vH
+qS
+dz
+SS
+CO
+"}
+(12,1,1) = {"
+CO
+SS
+dz
+hV
+vH
+Vu
+DJ
+xn
+NV
+NP
+fr
+ns
+gO
+xs
+fr
+NP
+NV
+Bo
+DJ
+lt
+vH
+qS
+dz
+SS
+CO
+"}
+(13,1,1) = {"
+CO
+SS
+Nd
+LM
+BM
+lp
+SS
+xn
+Qu
+VR
+NP
+NP
+NP
+NP
+bc
+VR
+Qu
+Bo
+SS
+VQ
+hu
+zH
+wr
+SS
+CO
+"}
+(14,1,1) = {"
+CO
+SS
+gz
+Jt
+UR
+mm
+CY
+CS
+FL
+ph
+ph
+yD
+Fq
+ph
+ph
+ph
+wz
+vP
+CY
+Ko
+Jt
+Mz
+vH
+SS
+CO
+"}
+(15,1,1) = {"
+CO
+SS
+SK
+Pq
+WH
+qS
+SS
+SS
+FU
+FU
+FU
+rL
+Qu
+tV
+FU
+FU
+FU
+SS
+SS
+hV
+WT
+VF
+AB
+SS
+CO
+"}
+(16,1,1) = {"
+CO
+SS
+SS
+SS
+gW
+jg
+SS
+SS
+gW
+SS
+jg
+fi
+lJ
+nx
+jg
+SS
+Py
+SS
+SS
+jg
+gW
+SS
+SS
+SS
+CO
+"}
+(17,1,1) = {"
+CO
+SS
+SS
+HX
+NP
+NP
+NP
+NP
+kV
+Bf
+Bf
+Bf
+jJ
+Bf
+Bf
+Bf
+KB
+NP
+NP
+NP
+NP
+HX
+SS
+SS
+CO
+"}
+(18,1,1) = {"
+CO
+CO
+SS
+SS
+NP
+NP
+Tg
+NP
+yI
+VS
+Vk
+aE
+bp
+vW
+Vk
+hI
+Wu
+NP
+Tg
+NP
+NP
+SS
+SS
+CO
+CO
+"}
+(19,1,1) = {"
+CO
+CO
+CO
+SS
+SS
+gW
+SS
+SS
+yY
+VS
+Vk
+SY
+pD
+tr
+Vk
+dr
+uU
+SS
+SS
+gW
+SS
+SS
+CO
+CO
+CO
+"}
+(20,1,1) = {"
+CO
+CO
+SS
+SS
+mQ
+cP
+GT
+SS
+kR
+dC
+Vk
+eW
+Gd
+tr
+Vk
+uT
+dP
+SS
+Cl
+de
+BP
+SS
+SS
+CO
+CO
+"}
+(21,1,1) = {"
+CO
+CO
+SS
+WX
+cP
+cP
+cp
+ya
+yI
+QH
+Vk
+Tk
+VD
+CD
+Vk
+Fs
+Wu
+Mk
+yI
+de
+de
+WJ
+SS
+CO
+CO
+"}
+(22,1,1) = {"
+CO
+CO
+wD
+ji
+cP
+cP
+Md
+Bh
+cX
+ut
+NP
+NP
+KT
+NP
+NP
+AS
+iM
+XC
+yI
+de
+de
+pu
+wD
+CO
+CO
+"}
+(23,1,1) = {"
+CO
+CO
+SS
+nB
+Bs
+Jv
+Kq
+AL
+qQ
+SU
+qQ
+fK
+DM
+NP
+NP
+Fm
+NP
+bZ
+Ti
+de
+de
+aH
+my
+CO
+CO
+"}
+(24,1,1) = {"
+CO
+CO
+SS
+hw
+tj
+cP
+Md
+bw
+NP
+TL
+ZN
+dg
+jh
+bv
+Ir
+Fm
+NP
+Wl
+yI
+de
+de
+Zp
+SS
+CO
+CO
+"}
+(25,1,1) = {"
+CO
+CO
+SS
+SS
+SS
+dx
+Zh
+SS
+Nc
+TL
+qa
+JW
+kO
+ex
+Tr
+Fm
+nC
+SS
+Un
+de
+AP
+SS
+SS
+CO
+CO
+"}
+(26,1,1) = {"
+CO
+CO
+CO
+SS
+SS
+SS
+SS
+SS
+ch
+TL
+NP
+NP
+NP
+NP
+NP
+Fm
+kl
+SS
+SS
+mv
+SS
+SS
+CO
+CO
+CO
+"}
+(27,1,1) = {"
+CO
+CO
+CO
+CO
+SS
+SS
+SS
+NP
+NP
+TL
+Ke
+cH
+aM
+Hc
+aj
+Fm
+NP
+NP
+SS
+SS
+SS
+CO
+CO
+CO
+CO
+"}
+(28,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+SS
+HX
+NP
+NP
+cX
+Qi
+ut
+Tg
+AS
+Qi
+iM
+NP
+NP
+HX
+SS
+CO
+CO
+CO
+CO
+CO
+"}
+(29,1,1) = {"
+CO
+CO
+YP
+CO
+CO
+wD
+NP
+NP
+zc
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+zc
+NP
+NP
+wD
+CO
+CO
+CO
+YP
+CO
+"}
+(30,1,1) = {"
+SS
+WT
+WT
+SS
+CO
+SS
+NP
+NP
+SS
+DF
+fA
+at
+SS
+Pi
+oi
+uI
+wD
+NP
+NP
+SS
+CO
+SS
+WT
+WT
+SS
+"}
+(31,1,1) = {"
+SS
+SS
+SS
+SS
+SS
+SS
+Nc
+NP
+gW
+yP
+yv
+dS
+SS
+uf
+yP
+Md
+gW
+NP
+nC
+SS
+SS
+SS
+SS
+SS
+SS
+"}
+(32,1,1) = {"
+SS
+jd
+kD
+oM
+cB
+SS
+NP
+NP
+SS
+BE
+JD
+at
+SS
+ss
+Tw
+fm
+wD
+NP
+NP
+SS
+cB
+dB
+cL
+Ib
+SS
+"}
+(33,1,1) = {"
+SS
+jd
+kD
+oM
+cB
+SS
+NP
+NP
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+NP
+NP
+SS
+cB
+dB
+cL
+Em
+SS
+"}
+(34,1,1) = {"
+SS
+tK
+WT
+Cy
+iJ
+SS
+NP
+NP
+SS
+UI
+qC
+oh
+SS
+zu
+vQ
+UI
+SS
+NP
+NP
+SS
+lk
+Tx
+WT
+xG
+SS
+"}
+(35,1,1) = {"
+SS
+jd
+kD
+oM
+Vk
+gW
+NP
+NP
+gW
+UI
+Kc
+SO
+SS
+Kw
+fc
+UI
+gW
+NP
+NP
+gW
+Vk
+dB
+cL
+Ib
+SS
+"}
+(36,1,1) = {"
+SS
+jd
+kD
+XY
+YA
+SS
+NP
+NP
+SS
+eB
+Aj
+iw
+SS
+rI
+kS
+eB
+SS
+NP
+NP
+SS
+YA
+gc
+cL
+Ib
+SS
+"}
+(37,1,1) = {"
+SS
+SS
+SS
+SS
+SS
+SS
+Nc
+NP
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+NP
+nC
+SS
+SS
+SS
+SS
+SS
+SS
+"}
+(38,1,1) = {"
+SS
+UI
+UI
+Vq
+ie
+SS
+NP
+NP
+SS
+UI
+qC
+zu
+SS
+oh
+vQ
+UI
+SS
+NP
+NP
+SS
+qY
+PF
+hR
+tF
+SS
+"}
+(39,1,1) = {"
+aL
+UI
+UI
+Vq
+Vk
+gW
+NP
+NP
+gW
+UI
+fc
+Um
+SS
+fN
+TK
+UI
+gW
+NP
+NP
+gW
+Vk
+Fm
+yP
+bN
+SS
+"}
+(40,1,1) = {"
+aP
+UI
+UI
+bO
+Nb
+SS
+NP
+NP
+SS
+eB
+kS
+rI
+SS
+WQ
+Ee
+eB
+SS
+NP
+NP
+SS
+mT
+jZ
+Xg
+tF
+SS
+"}
+(41,1,1) = {"
+aP
+UI
+UI
+bO
+qe
+SS
+NP
+NP
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+NP
+NP
+SS
+SS
+SS
+SS
+SS
+SS
+"}
+(42,1,1) = {"
+dW
+UI
+UI
+bO
+Nb
+SS
+NP
+NP
+SS
+UI
+qC
+zu
+SS
+xT
+Mr
+iD
+SS
+NP
+NP
+SS
+nv
+PB
+Qe
+El
+SS
+"}
+(43,1,1) = {"
+SS
+UI
+UI
+bO
+qe
+SS
+NP
+NP
+gW
+UI
+Xv
+Uz
+SS
+px
+hp
+dA
+SS
+NP
+NP
+Sd
+PB
+PB
+op
+SS
+SS
+"}
+(44,1,1) = {"
+SS
+SS
+UI
+Vq
+ie
+SS
+Nc
+NP
+SS
+eB
+vg
+gt
+SS
+Ii
+Vk
+GU
+SS
+NP
+nC
+SS
+La
+GH
+Vw
+SS
+SS
+"}
+(45,1,1) = {"
+CO
+SS
+SS
+oI
+Bd
+SS
+NP
+NP
+SS
+SS
+SS
+SS
+SS
+wD
+ZY
+wD
+SS
+NP
+NP
+SS
+FZ
+SS
+SS
+SS
+CO
+"}
+(46,1,1) = {"
+CO
+CO
+SS
+SS
+SS
+SS
+HX
+NP
+NP
+NP
+NP
+yI
+XA
+Md
+NP
+NP
+NP
+NP
+HX
+SS
+SS
+SS
+SS
+CO
+CO
+"}
+(47,1,1) = {"
+CO
+CO
+CO
+CO
+SS
+SS
+SS
+NP
+NP
+NP
+NP
+yI
+NP
+Md
+NP
+NP
+NP
+NP
+SS
+SS
+SS
+CO
+CO
+CO
+CO
+"}
+(48,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+SS
+SS
+SS
+gW
+SS
+DX
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+SS
+CO
+CO
+CO
+CO
+CO
+"}
+(49,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+CO
+SS
+Ca
+NP
+NP
+NP
+yI
+XA
+as
+Yw
+Yw
+BT
+Yw
+SS
+CO
+CO
+CO
+CO
+CO
+CO
+"}
+(50,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+CO
+SS
+Xv
+Xv
+Xv
+NP
+yI
+vU
+as
+se
+zz
+se
+zz
+SS
+CO
+CO
+CO
+CO
+CO
+CO
+"}
+(51,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+CO
+SS
+NY
+Af
+vg
+NP
+yI
+nj
+as
+Yw
+xV
+gS
+nL
+SS
+CO
+CO
+CO
+CO
+CO
+CO
+"}
+(52,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+CO
+SS
+SS
+SS
+SS
+SS
+gW
+SS
+gW
+SS
+SS
+SS
+SS
+SS
+CO
+CO
+CO
+CO
+CO
+CO
+"}
+(53,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+SS
+SS
+qb
+KS
+TL
+Dn
+Fm
+pC
+ve
+SS
+SS
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+"}
+(54,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+wD
+td
+Fm
+TL
+NP
+Fm
+TL
+iy
+wD
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+"}
+(55,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+SS
+jm
+Nm
+UJ
+NP
+Ui
+JB
+oR
+SS
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+"}
+(56,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+SS
+SS
+jc
+yi
+VP
+yi
+jc
+SS
+SS
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+"}
+(57,1,1) = {"
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+SS
+SS
+fi
+PR
+nx
+SS
+SS
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
+CO
 "}

--- a/modular_chomp/maps/submaps/shelters/MethLab-20x20.dmm
+++ b/modular_chomp/maps/submaps/shelters/MethLab-20x20.dmm
@@ -460,6 +460,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/chemical_dispenser/full,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/survivalpod/superpose/MethLab)
 "GP" = (
@@ -846,6 +847,14 @@
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/extinguisher,
 /obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/circuitboard/batteryrack,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
 /turf/simulated/floor,
 /area/survivalpod/superpose/MethLab)
 "Yz" = (

--- a/modular_chomp/maps/submaps/shelters/OldHotel-25x25.dmm
+++ b/modular_chomp/maps/submaps/shelters/OldHotel-25x25.dmm
@@ -169,6 +169,12 @@
 /obj/random/junk,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/survivalpod/superpose/OldHotel)
+"hO" = (
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/OldHotel)
 "hQ" = (
 /turf/simulated/wall/wood,
 /area/survivalpod/superpose/OldHotel)
@@ -468,6 +474,10 @@
 /obj/item/weapon/material/knife/butch,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/survivalpod/superpose/OldHotel)
+"Ag" = (
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/OldHotel)
 "AO" = (
 /obj/structure/railing,
 /turf/simulated/floor/outdoors/dirt,
@@ -475,6 +485,7 @@
 "AU" = (
 /obj/structure/table/woodentable,
 /obj/item/device/tape,
+/obj/item/weapon/circuitboard/batteryrack,
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/OldHotel)
 "Bt" = (
@@ -667,6 +678,10 @@
 "PO" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/wood/broken,
+/area/survivalpod/superpose/OldHotel)
+"Qh" = (
+/obj/item/weapon/stock_parts/matter_bin,
+/turf/simulated/floor/wood,
 /area/survivalpod/superpose/OldHotel)
 "Qv" = (
 /obj/structure/table/woodentable,
@@ -1032,7 +1047,7 @@ bW
 wK
 JT
 AU
-qg
+hO
 nD
 rK
 tz
@@ -1059,7 +1074,7 @@ ZG
 hQ
 zP
 TU
-qg
+Qh
 hQ
 hQ
 hQ
@@ -1084,7 +1099,7 @@ gA
 MU
 nD
 hQ
-qg
+Ag
 qg
 SZ
 qg

--- a/modular_chomp/maps/submaps/shelters/PirateShip-13x30.dmm
+++ b/modular_chomp/maps/submaps/shelters/PirateShip-13x30.dmm
@@ -1,6 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ao" = (
-/turf/simulated/shuttle/wall/dark/hard_corner,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood,
 /area/survivalpod/superpose/PirateShip)
 "aH" = (
 /obj/effect/floor_decal/industrial/danger/corner{
@@ -19,7 +24,7 @@
 /area/survivalpod/superpose/PirateShip)
 "bZ" = (
 /obj/structure/sign/flag/pirate,
-/turf/simulated/shuttle/wall/dark/hard_corner,
+/turf/simulated/wall/rplastihull,
 /area/survivalpod/superpose/PirateShip)
 "cc" = (
 /obj/machinery/light{
@@ -35,6 +40,10 @@
 /obj/machinery/power/apc/alarms_hidden{
 	pixel_y = -28
 	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/PirateShip)
 "dc" = (
@@ -44,18 +53,18 @@
 /turf/simulated/floor/tiled,
 /area/survivalpod/superpose/PirateShip)
 "dr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/door/airlock/glass_external/public,
 /turf/simulated/floor/tiled/dark,
 /area/survivalpod/superpose/PirateShip)
 "eb" = (
 /obj/machinery/disperser/middle{
 	dir = 4
 	},
-/turf/simulated/shuttle/wall/dark,
+/turf/simulated/wall/rplastihull,
 /area/survivalpod/superpose/PirateShip)
 "fd" = (
 /obj/structure/bed,
@@ -84,16 +93,19 @@
 /turf/template_noop,
 /area/template_noop)
 "ha" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
+/obj/machinery/power/port_gen/pacman/super,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
+/obj/fiftyspawner/uranium,
 /turf/simulated/floor/tiled/dark,
 /area/survivalpod/superpose/PirateShip)
 "hM" = (
 /obj/machinery/disperser/middle{
 	dir = 8
 	},
-/turf/simulated/shuttle/wall/dark,
+/turf/simulated/wall/rplastihull,
 /area/survivalpod/superpose/PirateShip)
 "iP" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -111,6 +123,11 @@
 "js" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/survivalpod/superpose/PirateShip)
 "jW" = (
@@ -162,8 +179,14 @@
 /turf/simulated/shuttle/plating,
 /area/survivalpod/superpose/PirateShip)
 "mv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_external/public,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/power/smes,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/survivalpod/superpose/PirateShip)
 "mR" = (
@@ -233,14 +256,15 @@
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/PirateShip)
-"sh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/shuttle/wall/dark,
-/area/survivalpod/superpose/PirateShip)
 "tq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	id_tag = "pshiproom3"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/PirateShip)
@@ -330,11 +354,17 @@
 /obj/structure/sign/flag/pirate{
 	pixel_y = 29
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/machinery/power/terminal{
+	dir = 4
 	},
-/obj/machinery/door/airlock/glass_external/public,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/survivalpod/superpose/PirateShip)
 "Ey" = (
@@ -391,8 +421,12 @@
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/PirateShip)
 "Kc" = (
-/obj/structure/sign/flag/pirate,
-/turf/simulated/shuttle/wall/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood,
 /area/survivalpod/superpose/PirateShip)
 "Ki" = (
 /obj/structure/closet/crate/wooden,
@@ -446,11 +480,12 @@
 /turf/simulated/shuttle/plating/skipjack,
 /area/survivalpod/superpose/PirateShip)
 "MA" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/survivalpod/superpose/PirateShip)
 "MH" = (
 /obj/structure/table/woodentable,
@@ -475,7 +510,7 @@
 /turf/simulated/floor/wood,
 /area/survivalpod/superpose/PirateShip)
 "NN" = (
-/turf/simulated/shuttle/wall/dark,
+/turf/simulated/wall/rplastihull,
 /area/survivalpod/superpose/PirateShip)
 "PQ" = (
 /obj/structure/fans,
@@ -488,7 +523,7 @@
 /area/survivalpod/superpose/PirateShip)
 "Qd" = (
 /obj/item/device/gps/computer,
-/turf/simulated/shuttle/wall/dark,
+/turf/simulated/wall/rplastihull,
 /area/survivalpod/superpose/PirateShip)
 "Qw" = (
 /obj/machinery/light{
@@ -566,7 +601,7 @@ cf
 cf
 cf
 cf
-ao
+NN
 NN
 NN
 cf
@@ -626,18 +661,18 @@ cf
 (3,1,1) = {"
 cf
 cf
-ao
 NN
 NN
 NN
 NN
-Kc
+NN
+bZ
 NN
 NN
-ao
-mv
-mv
-ao
+NN
+NN
+NN
+NN
 hM
 NN
 kJ
@@ -701,8 +736,8 @@ Ki
 NN
 Ev
 dr
-sh
-MA
+NN
+zL
 zL
 zL
 Ap
@@ -712,7 +747,7 @@ zL
 zm
 Xl
 Kk
-ao
+NN
 kJ
 NN
 cf
@@ -726,12 +761,12 @@ NN
 KK
 To
 cB
-ao
+NN
 NN
 Ym
 NN
-ao
-Qw
+NN
+mv
 Mr
 Xy
 zL
@@ -757,13 +792,13 @@ NN
 PQ
 To
 To
-To
+ao
 tq
-To
-To
-To
+Kc
+Kc
+Kc
 js
-Mr
+MA
 Mr
 Xy
 zL
@@ -790,11 +825,11 @@ Qd
 To
 To
 kM
-ao
+NN
 NN
 iY
 NN
-ao
+NN
 Qw
 Mr
 Xy
@@ -840,7 +875,7 @@ zL
 aH
 Fg
 Kk
-ao
+NN
 kJ
 NN
 cf
@@ -882,18 +917,18 @@ cf
 (11,1,1) = {"
 cf
 cf
-ao
 NN
 NN
 NN
 NN
-Kc
+NN
+bZ
 NN
 NN
-ao
+NN
 lU
 lU
-ao
+NN
 eb
 NN
 kJ
@@ -950,7 +985,7 @@ cf
 cf
 cf
 cf
-ao
+NN
 NN
 NN
 cf

--- a/modular_chomp/maps/submaps/shelters/PizzaParlor-18x19.dmm
+++ b/modular_chomp/maps/submaps/shelters/PizzaParlor-18x19.dmm
@@ -248,6 +248,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/PizzaParlor)
 "iq" = (
@@ -1102,6 +1107,15 @@
 	name = "Pizza Delivery ID"
 	},
 /obj/machinery/recharger,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/high{
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/survivalpod/superpose/PizzaParlor)
 "VK" = (

--- a/modular_chomp/maps/submaps/shelters/PizzaParlor-18x19.dmm
+++ b/modular_chomp/maps/submaps/shelters/PizzaParlor-18x19.dmm
@@ -1171,6 +1171,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/closet/crate/solar,
 /turf/simulated/floor/outdoors/sidewalk/slab{
 	movement_cost = 0;
 	temperature = 293.15

--- a/modular_chomp/maps/submaps/shelters/ScienceShip-25x33.dmm
+++ b/modular_chomp/maps/submaps/shelters/ScienceShip-25x33.dmm
@@ -1,257 +1,3075 @@
-"ae" = (/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod,/obj/machinery/shower{pixel_y = 20},/obj/structure/curtain/open/shower,/obj/random/soap,/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/ScienceShip)
-"ap" = (/obj/structure/sign/science{pixel_y = -32},/turf/template_noop,/area/template_noop)
-"bc" = (/obj/structure/sign/science{pixel_y = 32},/turf/template_noop,/area/template_noop)
-"be" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 8},/obj/structure/shuttle/engine/heater{dir = 4},/turf/simulated/shuttle/wall,/area/survivalpod/superpose/ScienceShip)
-"bm" = (/turf/template_noop,/area/survivalpod/superpose/ScienceShip)
-"bP" = (/obj/structure/grille/rustic{health = 25; name = "reinforced grille"},/obj/structure/shuttle/window,/obj/structure/curtain/black{icon_state = "open"; layer = 2; name = "privacy curtain"; opacity = 0},/obj/machinery/door/firedoor/border_only,/obj/machinery/door/blast/regular/open{id = "estrella_blast"; name = "window blast shield"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"ch" = (/obj/machinery/door/airlock/maintenance/common,/obj/item/tape/engineering,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/steel_grid,/area/survivalpod/superpose/ScienceShip)
-"cm" = (/obj/machinery/atmospherics/unary/engine/bigger{dir = 4; pixel_x = -3},/turf/template_noop,/area/survivalpod/superpose/ScienceShip)
-"cu" = (/obj/item/weapon/towel/random,/obj/item/weapon/towel/random,/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"cw" = (/obj/structure/closet/walllocker/emerglocker{dir = 1; pixel_y = -32},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"da" = (/obj/machinery/atmospherics/pipe/simple/visible,/obj/machinery/access_button{command = "cycle_interior"; frequency = 1380; master_tag = "estrella"; name = "interior access button"; pixel_y = 26},/obj/machinery/door/firedoor/border_only,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"df" = (/obj/structure/closet/walllocker_double/medical/west,/obj/item/weapon/storage/firstaid,/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/toxin,/obj/item/weapon/storage/firstaid/o2,/obj/item/roller,/obj/item/device/defib_kit/loaded,/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"dh" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 5},/obj/structure/table/bench/standard,/obj/machinery/light{dir = 8},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"dp" = (/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 8},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"dB" = (/obj/structure/closet/secure_closet/engineering_electrical{req_access = null},/obj/machinery/light{dir = 1},/obj/item/weapon/storage/belt/utility,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"dS" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/ScienceShip)
-"eu" = (/turf/simulated/floor/carpet,/area/survivalpod/superpose/ScienceShip)
-"ez" = (/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"fe" = (/obj/structure/shuttle/engine/router,/turf/simulated/shuttle/wall,/area/survivalpod/superpose/ScienceShip)
-"fg" = (/obj/screen/alert/highpressure,/turf/simulated/shuttle/wall,/area/survivalpod/superpose/ScienceShip)
-"fs" = (/obj/machinery/door/airlock/maintenance/common,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/steel_grid,/area/survivalpod/superpose/ScienceShip)
-"fD" = (/obj/machinery/door/window/survival_pod{dir = 8},/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"ge" = (/obj/machinery/atmospherics/pipe/tank/phoron{dir = 4},/obj/effect/floor_decal/industrial/outline/red,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"gf" = (/obj/structure/table/rack/shelf/steel,/obj/fiftyspawner/glass,/obj/fiftyspawner/glass,/obj/fiftyspawner/steel,/obj/fiftyspawner/steel,/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 8},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"hb" = (/obj/machinery/r_n_d/protolathe,/obj/screen/alert/highpressure,/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"hB" = (/obj/effect/floor_decal/industrial/warning{dir = 10},/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 1; frequency = 1380; id_tag = "estrella_pump"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"hQ" = (/obj/machinery/firealarm{dir = 1; pixel_y = -24},/obj/structure/bed/chair/wood{dir = 8},/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"hR" = (/obj/structure/extinguisher_cabinet{pixel_y = -30},/obj/effect/floor_decal/industrial/warning/corner{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"iv" = (/obj/structure/bed/chair/office/dark{dir = 1},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"iQ" = (/obj/structure/table/wooden_reinforced,/obj/structure/flora/pottedplant/smallcactus{pixel_y = 13},/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"je" = (/obj/machinery/atmospherics/unary/vent_pump{dir = 1; icon_state = "map_vent_out"; use_power = 1},/obj/structure/cryofeed,/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/ScienceShip)
-"ju" = (/obj/structure/closet/walllocker/emerglocker{pixel_y = 32},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"kl" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/turf/simulated/shuttle/wall,/area/survivalpod/superpose/ScienceShip)
-"kw" = (/obj/structure/table,/obj/machinery/light{layer = 3},/obj/item/weapon/gun/projectile/revolver/toy/crossbow,/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"kV" = (/obj/structure/table/rack/shelf/steel,/obj/fiftyspawner/rods,/obj/fiftyspawner/rods,/obj/item/stack/material/plasteel{amount = 30},/obj/item/stack/material/plasteel{amount = 30},/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 8},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"ll" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{frequency = 1380; id_tag = "estrella_pump"},/obj/machinery/embedded_controller/radio/airlock/docking_port{frequency = 1380; id_tag = "estrella"; pixel_y = 26; tag_airpump = "estrella_pump"; tag_chamber_sensor = "estrella_sensor"; tag_exterior_door = "estrella_outer"; tag_interior_door = "estrella_inner"},/obj/effect/floor_decal/industrial/warning{dir = 5},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"lu" = (/obj/machinery/r_n_d/circuit_imprinter,/obj/item/weapon/reagent_containers/glass/beaker{pixel_x = 9; pixel_y = 8},/obj/machinery/light,/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"lB" = (/obj/machinery/alarm/alarms_hidden{dir = 8; pixel_x = 22},/obj/structure/sink{dir = 4; pixel_x = 11},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"lH" = (/obj/machinery/door/airlock/maintenance/command{req_one_access = null},/obj/machinery/door/firedoor/glass,/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled/steel_grid,/area/survivalpod/superpose/ScienceShip)
-"lK" = (/obj/item/weapon/gun/projectile/colt,/obj/item/weapon/gun/projectile/garand,/obj/item/ammo_magazine/m45,/obj/item/ammo_magazine/m45,/obj/structure/closet/secure_closet/guncabinet{req_one_access = null},/obj/item/ammo_magazine/ammo_box/b12g/beanbag,/obj/item/ammo_magazine/ammo_box/b12g/beanbag,/obj/item/ammo_magazine/ammo_box/b12g/flechette,/obj/item/ammo_magazine/ammo_box/b12g/flechette,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"lM" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"lW" = (/obj/structure/shuttle/window,/obj/machinery/door/firedoor/glass,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"mg" = (/obj/structure/shuttle/window,/obj/structure/curtain/black{icon_state = "open"; layer = 2; name = "privacy curtain"; opacity = 0},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"nb" = (/obj/structure/bed/chair/office/dark{dir = 8},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"nq" = (/obj/structure/fuel_port{pixel_x = -32},/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/machinery/light{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"nM" = (/obj/structure/closet/walllocker_double/kitchen/north{dir = 8; name = "Ration Cabinet"; pixel_x = -32; pixel_y = 0},/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/device/radio{pixel_x = -5; pixel_y = 5},/obj/item/device/radio{pixel_x = 5; pixel_y = 5},/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"nQ" = (/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"nV" = (/obj/machinery/alarm/alarms_hidden{dir = 8; pixel_x = 22},/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"os" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 8},/obj/structure/extinguisher_cabinet{pixel_x = -27},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"oJ" = (/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/bed/chair/wood{dir = 4},/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"oS" = (/obj/structure/table/rack/shelf/steel,/obj/item/weapon/storage/toolbox/electrical,/obj/item/weapon/storage/toolbox/mechanical{pixel_y = 5},/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 6},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"oX" = (/turf/simulated/shuttle/wall,/area/survivalpod/superpose/ScienceShip)
-"pk" = (/obj/machinery/atmospherics/binary/pump,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"pm" = (/obj/machinery/atmospherics/unary/cryo_cell,/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"pG" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"pL" = (/obj/machinery/light{dir = 8},/obj/item/device/radio/intercom{desc = "Talk... listen through this."; name = "Station Intercom (Brig Radio)"; pixel_y = -21; wires = 7},/obj/structure/salvageable/console_os{dir = 4},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/ScienceShip)
-"qb" = (/obj/machinery/door/window/northright{name = "Server Room"; req_access = null},/obj/machinery/door/window/southleft{name = "Server Room"; req_access = null},/obj/effect/floor_decal/industrial/warning/full,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"qe" = (/obj/structure/table/rack/shelf/steel,/obj/item/stack/material/phoron{amount = 25},/obj/item/stack/material/phoron{amount = 25},/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 8},/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"qh" = (/obj/structure/sign/science{pixel_x = 32},/turf/template_noop,/area/template_noop)
-"ql" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/ScienceShip)
-"ri" = (/obj/machinery/portable_atmospherics/canister/phoron,/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/outline/red,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"rs" = (/obj/machinery/atmospherics/pipe/manifold/hidden,/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"rP" = (/obj/machinery/light{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"se" = (/obj/machinery/atmospherics/pipe/simple/hidden,/obj/structure/shuttle/window,/obj/machinery/door/firedoor/glass,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"sv" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"sz" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/door/airlock/maintenance/engi{req_one_access = null},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/steel_grid,/area/survivalpod/superpose/ScienceShip)
-"sH" = (/turf/simulated/shuttle/wall/no_join{base_state = "orange"; icon = 'icons/turf/shuttle_orange.dmi'; icon_state = "orange"},/area/survivalpod/superpose/ScienceShip)
-"sI" = (/obj/structure/salvageable/console_os{dir = 1},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/ScienceShip)
-"sJ" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"sK" = (/obj/machinery/door/airlock/maintenance/engi{req_one_access = null},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/steel_grid,/area/survivalpod/superpose/ScienceShip)
-"sT" = (/obj/machinery/door/airlock/maintenance/rnd{req_one_access = null},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/steel_grid,/area/survivalpod/superpose/ScienceShip)
-"sY" = (/obj/structure/table/rack/shelf/steel,/obj/item/clothing/suit/bio_suit/anomaly,/obj/item/clothing/mask/breath,/obj/item/clothing/head/bio_hood/anomaly,/obj/item/clothing/gloves/sterile/latex,/obj/item/weapon/storage/excavation,/obj/item/stack/flag/yellow,/obj/item/device/measuring_tape,/obj/item/weapon/pickaxe/drill,/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 8},/obj/item/weapon/material/knife/machete/hatchet,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"tb" = (/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 8},/obj/machinery/space_heater,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"te" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"tg" = (/obj/machinery/light/small,/obj/structure/prop/fake_ai{name = "C0n71nu17y"},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/ScienceShip)
-"tu" = (/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,/obj/structure/table/rack/shelf/steel,/obj/item/stack/material/glass/phoronrglass{amount = 20},/obj/item/stack/material/glass/phoronrglass{amount = 20},/obj/fiftyspawner/rods,/obj/fiftyspawner/rods,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"tN" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 8},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/ScienceShip)
-"tR" = (/obj/machinery/door/firedoor/glass,/obj/structure/table/reinforced,/obj/machinery/door/window/northright{dir = 4; name = "Medical booth"},/obj/structure/curtain/black{icon_state = "open"; layer = 2; name = "privacy curtain"; opacity = 0},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"um" = (/obj/structure/closet/cabinet{pixel_y = 20},/obj/item/toy/plushie/kitten,/obj/item/toy/plushie/grey_cat,/obj/item/toy/plushie/orange_cat,/obj/item/toy/plushie/borgplushie/scrubpuppy,/obj/item/toy/plushie/black_fox,/obj/item/toy/plushie,/obj/item/toy/plushie/corgi,/obj/item/toy/plushie/crimson_fox,/obj/item/clothing/shoes/sandal,/obj/item/clothing/shoes/sandal,/obj/machinery/computer/security/telescreen/entertainment{icon_state = "frame"; pixel_x = -32},/obj/item/weapon/towel/random,/obj/item/weapon/towel/random,/turf/simulated/floor/carpet/turcarpet,/area/survivalpod/superpose/ScienceShip)
-"uu" = (/obj/machinery/door/airlock/multi_tile/metal/mait,/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/steel_grid,/area/survivalpod/superpose/ScienceShip)
-"uX" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 10},/obj/structure/closet/walllocker/emerglocker{pixel_x = -25; pixel_y = 32},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"vl" = (/obj/structure/closet/cabinet{pixel_y = 20},/obj/item/weapon/ore/diamond,/obj/item/weapon/ore/gold,/obj/item/weapon/ore/osmium,/obj/item/weapon/ore/silver,/obj/item/weapon/ore/uranium,/obj/item/weapon/bluespace_crystal,/obj/item/clothing/head/sombrero,/obj/item/clothing/head/sombrero,/obj/item/clothing/suit/poncho,/obj/item/clothing/accessory/poncho/thermal/red,/obj/item/clothing/accessory/poncho/thermal/security,/obj/item/clothing/accessory/poncho/thermal/green,/obj/item/clothing/shoes/footwraps,/obj/item/clothing/shoes/footwraps,/obj/item/clothing/shoes/footwraps,/obj/item/clothing/shoes/footwraps,/obj/item/toy/bosunwhistle/fluff/strix,/obj/item/weapon/blobcore_chunk,/obj/item/weapon/towel/random,/obj/item/weapon/towel/random,/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"wp" = (/obj/machinery/atmospherics/pipe/simple/hidden,/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/steel_grid,/area/survivalpod/superpose/ScienceShip)
-"xk" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"xw" = (/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"xy" = (/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/ScienceShip)
-"xF" = (/obj/effect/floor_decal/industrial/outline/blue,/obj/structure/closet/jcloset,/obj/item/weapon/mop,/obj/structure/mopbucket,/obj/item/weapon/reagent_containers/glass/bucket,/obj/item/weapon/reagent_containers/spray/cleaner,/obj/item/weapon/reagent_containers/spray/cleaner,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"yb" = (/obj/machinery/vending/wallmed1{name = "NanoMed Wall"; pixel_x = 25},/obj/structure/table/reinforced,/obj/item/weapon/storage/quickdraw/syringe_case,/obj/item/weapon/storage/quickdraw/syringe_case,/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"yn" = (/obj/machinery/power/terminal{dir = 8},/obj/structure/cable{d2 = 2; icon_state = "0-2"},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"yt" = (/obj/machinery/smartfridge/survival_pod{name = "food storage"},/obj/item/weapon/reagent_containers/food/snacks/burrito_spicy,/obj/item/weapon/reagent_containers/food/snacks/burrito_spicy,/obj/item/weapon/reagent_containers/food/snacks/burrito_spicy,/obj/item/weapon/reagent_containers/food/snacks/burrito_vegan,/obj/item/weapon/reagent_containers/food/snacks/burrito_vegan,/obj/item/weapon/reagent_containers/food/snacks/burrito_vegan,/obj/item/weapon/reagent_containers/food/snacks/burrito_mystery,/obj/item/weapon/reagent_containers/food/snacks/burrito_mystery,/obj/item/weapon/reagent_containers/food/snacks/burrito_mystery,/obj/item/weapon/reagent_containers/food/snacks/burrito_hell,/obj/item/weapon/reagent_containers/food/snacks/burrito_hell,/obj/item/weapon/reagent_containers/food/snacks/burrito_hell,/obj/item/weapon/reagent_containers/food/snacks/burrito_hell,/obj/item/weapon/reagent_containers/food/snacks/burrito_cheese,/obj/item/weapon/reagent_containers/food/snacks/burrito_cheese,/obj/item/weapon/reagent_containers/food/snacks/burrito_cheese,/obj/item/weapon/reagent_containers/food/snacks/burrito,/obj/item/weapon/reagent_containers/food/snacks/burrito,/obj/item/weapon/reagent_containers/food/snacks/burrito,/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito,/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito,/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito,/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito/filled,/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito/filled,/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito/filled,/obj/item/weapon/reagent_containers/food/snacks/sliceable/supremoburrito,/obj/item/weapon/reagent_containers/food/snacks/enchiladas,/obj/item/weapon/reagent_containers/food/snacks/enchiladas,/obj/item/weapon/reagent_containers/food/snacks/enchiladas,/obj/item/weapon/reagent_containers/food/snacks/cheesenachos,/obj/item/weapon/reagent_containers/food/snacks/cheesenachos,/obj/item/weapon/reagent_containers/food/snacks/cheesenachos,/obj/item/weapon/reagent_containers/food/snacks/chipplate/nachos,/obj/item/weapon/reagent_containers/food/snacks/chipplate/nachos,/obj/item/weapon/reagent_containers/food/snacks/chipplate/nachos,/obj/item/weapon/reagent_containers/food/snacks/cubannachos,/obj/item/weapon/reagent_containers/food/snacks/cubannachos,/obj/item/weapon/reagent_containers/food/snacks/cubannachos,/obj/item/weapon/reagent_containers/food/snacks/cubannachos,/obj/item/weapon/reagent_containers/food/snacks/nachos,/obj/item/weapon/reagent_containers/food/snacks/nachos,/obj/item/weapon/reagent_containers/food/snacks/nachos,/obj/item/weapon/reagent_containers/food/snacks/nachos,/obj/item/weapon/reagent_containers/food/snacks/pandenata,/obj/item/weapon/reagent_containers/food/snacks/pandenata,/obj/item/weapon/reagent_containers/food/snacks/pandenata,/obj/item/weapon/reagent_containers/food/snacks/tocino,/obj/item/weapon/reagent_containers/food/snacks/tocino,/obj/item/weapon/reagent_containers/food/snacks/tocino,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"yy" = (/obj/machinery/recharger/wallcharger{pixel_x = 4; pixel_y = 26},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"yB" = (/obj/machinery/alarm/alarms_hidden{dir = 8; pixel_x = 22},/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"yJ" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/firealarm{dir = 8; pixel_x = -24},/obj/machinery/mech_recharger,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"zp" = (/obj/machinery/atmospherics/unary/vent_pump/on,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"zV" = (/obj/structure/table/rack/shelf/steel,/obj/item/stack/material/uranium,/obj/item/stack/material/phoron{amount = 5; pixel_x = -1; pixel_y = -3},/obj/item/stack/material/silver{amount = 5; pixel_x = 2; pixel_y = 4},/obj/item/stack/material/copper{amount = 25},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"Az" = (/obj/machinery/door/airlock/maintenance/medical{req_one_access = null},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/steel_grid,/area/survivalpod/superpose/ScienceShip)
-"AN" = (/obj/structure/bed/chair/wood,/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"AO" = (/obj/structure/closet/walllocker/emerglocker{pixel_x = -25; pixel_y = 32},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"AP" = (/obj/machinery/atmospherics/pipe/simple/visible{dir = 6},/turf/simulated/shuttle/wall/hard_corner,/area/survivalpod/superpose/ScienceShip)
-"AQ" = (/obj/structure/bed/double/padded,/obj/structure/closet/walllocker/emerglocker{pixel_y = 32},/obj/item/weapon/bedsheet/rainbowdouble,/turf/simulated/floor/carpet/turcarpet,/area/survivalpod/superpose/ScienceShip)
-"Bn" = (/obj/structure/grille/rustic{health = 25; name = "reinforced grille"},/obj/structure/shuttle/window,/obj/machinery/door/firedoor/border_only,/obj/machinery/door/blast/regular/open{dir = 4; id = "estrella_blast"; name = "window blast shield"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"Bz" = (/obj/structure/toilet{dir = 8; pixel_x = 9},/obj/machinery/door/window/survival_pod{dir = 1},/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/ScienceShip)
-"BR" = (/obj/structure/salvageable/computer,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/ScienceShip)
-"BS" = (/obj/effect/catwalk_plated/white,/obj/machinery/light/small{dir = 1},/turf/template_noop,/area/template_noop)
-"Cm" = (/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/effect/floor_decal/industrial/warning{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"Cn" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4},/obj/machinery/firealarm{dir = 4; pixel_x = 24},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"Cq" = (/obj/machinery/portable_atmospherics/canister/air,/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/outline/blue,/obj/machinery/firealarm{dir = 8; pixel_x = -24},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"Cz" = (/obj/screen/alert/highpressure,/obj/machinery/r_n_d/destructive_analyzer,/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"CW" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 10},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/ScienceShip)
-"CX" = (/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/machinery/portable_atmospherics/canister/air/airlock,/obj/machinery/light/small{dir = 1},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"Dp" = (/obj/screen/alert/highpressure,/turf/simulated/shuttle/wall/hard_corner,/area/survivalpod/superpose/ScienceShip)
-"Ds" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"DK" = (/obj/structure/closet/crate,/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/fiftyspawner/blucarpet,/obj/fiftyspawner/oracarpet,/obj/fiftyspawner/purcarpet,/obj/fiftyspawner/sblucarpet,/obj/fiftyspawner/tealcarpet,/obj/fiftyspawner/turcarpet,/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/algae{amount = 50},/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/lead{amount = 30},/obj/item/stack/material/plasteel{amount = 30; pixel_y = 5},/obj/item/stack/material/resin{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/obj/machinery/light{layer = 3},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"DM" = (/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 1},/obj/structure/reagent_dispensers/fueltank/high,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"DV" = (/obj/machinery/alarm/alarms_hidden{dir = 8; pixel_x = 22},/obj/structure/bed/chair/office/dark,/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"DW" = (/obj/effect/catwalk_plated/dark,/obj/machinery/shipsensors{dir = 8},/obj/structure/sign/science{pixel_x = 32},/turf/template_noop,/area/survivalpod/superpose/ScienceShip)
-"Eg" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 8},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"Eq" = (/turf/template_noop,/area/template_noop)
-"Ew" = (/obj/machinery/sleeper{dir = 4},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"EH" = (/obj/machinery/recharger/wallcharger{pixel_x = 4; pixel_y = -34},/obj/machinery/space_heater,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"EN" = (/obj/structure/cable/green{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"ER" = (/obj/structure/bed/chair/bay/comfy/red{dir = 8},/obj/structure/closet/walllocker/emerglocker{pixel_x = -25; pixel_y = 32},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/ScienceShip)
-"Fb" = (/obj/structure/table/reinforced,/obj/item/weapon/reagent_containers/glass/beaker/large,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/glass/beaker,/obj/machinery/reagentgrinder,/obj/machinery/firealarm{dir = 4; pixel_x = 24},/obj/item/weapon/reagent_containers/spray/cleaner{desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'"; name = "Chemistry Cleaner"},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"Fe" = (/obj/structure/table/wooden_reinforced,/obj/item/weapon/coin/diamond,/obj/machinery/light{layer = 3},/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"Ft" = (/obj/machinery/access_button{command = "cycle_exterior"; frequency = 1380; master_tag = "estrella"; name = "exterior access button"; pixel_y = 26},/obj/machinery/door/firedoor/border_only,/obj/machinery/door/blast/regular/open{dir = 4; id = "estrella_blast"; layer = 2; name = "window blast shield"; open_layer = 2},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"FR" = (/obj/machinery/door/airlock/hatch{icon_state = "door_locked"; id_tag = "estrella_side_hatch"; locked = 1; req_access = null; req_one_access = null},/obj/machinery/button/remote/airlock{dir = 8; id = "estrella_side_hatch"; name = "Side Hatch Control"; pixel_x = -27; specialfunctions = 4},/obj/machinery/door/firedoor/border_only,/obj/machinery/door/blast/regular/open{id = "estrella_blast"; layer = 2; name = "window blast shield"; open_layer = 2},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"FV" = (/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/closet/crate/engineering,/obj/fiftyspawner/steel,/obj/fiftyspawner/glass,/obj/item/weapon/tank/phoron,/obj/item/weapon/tank/phoron,/obj/item/weapon/storage/toolbox/mechanical,/obj/item/weapon/storage/toolbox/electrical,/obj/item/device/multitool,/obj/item/device/geiger,/obj/item/clothing/glasses/goggles,/obj/item/clothing/glasses/goggles,/obj/item/device/t_scanner,/obj/item/clothing/glasses/welding,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"Gi" = (/obj/effect/catwalk_plated/white,/turf/template_noop,/area/survivalpod/superpose/ScienceShip)
-"Gl" = (/obj/effect/floor_decal/industrial/warning{dir = 9},/obj/machinery/atmospherics/unary/vent_pump/high_volume{frequency = 1380; id_tag = "estrella_pump"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"GM" = (/obj/structure/table/bench/wooden,/obj/machinery/light{dir = 4},/obj/machinery/alarm/alarms_hidden{dir = 8; pixel_x = 22},/obj/item/device/flash,/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"GP" = (/obj/machinery/atmospherics/pipe/simple/hidden,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"GU" = (/obj/machinery/sleep_console{dir = 4},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"HX" = (/obj/machinery/chem_master{pixel_x = -7},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"Ij" = (/obj/machinery/power/smes/buildable/hybrid,/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/structure/cable/green,/obj/machinery/light{dir = 8},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"In" = (/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 8},/obj/structure/extinguisher_cabinet{pixel_x = -27},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"Io" = (/obj/machinery/atmospherics/unary/freezer{icon_state = "freezer"},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"Ip" = (/obj/structure/bed/chair/office/dark{dir = 8},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"Iz" = (/obj/structure/table/reinforced,/obj/item/weapon/folder/blue,/obj/item/weapon/paper_bin,/obj/item/weapon/pen/blue{pixel_x = -5; pixel_y = -1},/obj/item/weapon/pen/red,/obj/item/weapon/pen{pixel_x = 4; pixel_y = 4},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"IB" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/shower{dir = 1},/obj/structure/curtain/open/shower,/obj/random/soap,/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/ScienceShip)
-"IE" = (/obj/structure/closet/walllocker/emerglocker{dir = 1; pixel_x = -24; pixel_y = -32},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"II" = (/obj/machinery/power/port_gen/pacman,/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/structure/cable{d2 = 4; icon_state = "0-4"},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"IM" = (/obj/machinery/portable_atmospherics/canister/phoron,/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/effect/floor_decal/industrial/outline/red,/obj/machinery/firealarm{dir = 8; pixel_x = -24},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"IQ" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"Jd" = (/obj/machinery/atmospherics/pipe/manifold/visible{dir = 4},/obj/effect/floor_decal/industrial/warning{dir = 4},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"Jm" = (/obj/machinery/door/airlock/multi_tile/metal/mait{dir = 1; frequency = 1380; icon_state = "door_locked"; id_tag = "estrella_outer"; locked = 1; name = "External Access"},/obj/machinery/door/firedoor/border_only,/obj/machinery/door/blast/regular/open{dir = 4; id = "estrella_blast"; layer = 2; name = "window blast shield"; open_layer = 2},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"JG" = (/obj/structure/reagent_dispensers/acid{density = 0; pixel_x = -30},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"JJ" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/structure/closet/walllocker/emerglocker{dir = 1; pixel_y = -32},/obj/machinery/alarm/alarms_hidden{pixel_y = 22},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"Kh" = (/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"Kq" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/shower{dir = 1},/obj/structure/curtain/open/shower,/obj/random/soap,/turf/simulated/floor/plating,/area/survivalpod/superpose/ScienceShip)
-"Kx" = (/obj/screen/alert/highpressure,/turf/template_noop,/area/template_noop)
-"KD" = (/obj/machinery/atmospherics/unary/vent_pump{dir = 1; external_pressure_bound = 0; external_pressure_bound_default = 0; icon_state = "map_vent_in"; initialize_directions = 1; internal_pressure_bound = 4000; internal_pressure_bound_default = 4000; pressure_checks = 2; pressure_checks_default = 2; pump_direction = 0; use_power = 1},/obj/structure/cryofeed{dir = 4},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/ScienceShip)
-"Lj" = (/obj/structure/closet/walllocker_double/kitchen/north{dir = 8; name = "Ration Cabinet"; pixel_x = -32; pixel_y = 0},/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/device/radio{pixel_x = -5; pixel_y = 5},/obj/item/device/radio{pixel_x = 5; pixel_y = 5},/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/structure/cable/green{d1 = 2; d2 = 4; icon_state = "2-4"},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"Lx" = (/obj/structure/extinguisher_cabinet{pixel_x = 28},/obj/machinery/light{dir = 4},/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 4},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"LC" = (/obj/machinery/door/firedoor/glass,/obj/structure/shuttle/window,/obj/structure/curtain/black{icon_state = "open"; layer = 2; name = "privacy curtain"; opacity = 0},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"LP" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 5},/obj/structure/closet/secure_closet/guncabinet{req_one_access = null},/obj/item/clothing/head/helmet/combat/USDF,/obj/item/clothing/head/helmet/combat/USDF,/obj/item/clothing/suit/armor/combat/USDF,/obj/item/clothing/suit/armor/combat/USDF,/obj/item/device/flash,/obj/item/device/flash,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"Mc" = (/obj/machinery/atmospherics/pipe/simple/hidden,/obj/structure/fireaxecabinet{pixel_x = 32},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"Mg" = (/obj/machinery/atmospherics/pipe/manifold4w/visible,/obj/machinery/meter,/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"MR" = (/obj/machinery/shuttle_sensor,/turf/simulated/shuttle/wall/hard_corner,/area/survivalpod/superpose/ScienceShip)
-"Ng" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/alarm/alarms_hidden{pixel_y = 22},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"Nm" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/machinery/light{dir = 8},/obj/effect/floor_decal/industrial/outline/yellow,/obj/structure/cable/green{d2 = 4; icon_state = "0-4"},/obj/machinery/power/shield_generator/charged{field_radius = 8; initial_shield_modes = 2153; target_radius = 8},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"NV" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"Oh" = (/obj/effect/catwalk_plated/white,/obj/machinery/light/small{dir = 8},/turf/template_noop,/area/survivalpod/superpose/ScienceShip)
-"Oi" = (/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"Ou" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"OG" = (/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"Pk" = (/obj/structure/closet/walllocker/emerglocker{pixel_y = 32},/turf/simulated/floor/plating,/area/survivalpod/superpose/ScienceShip)
-"Pv" = (/obj/machinery/atmospherics/unary/freezer{icon_state = "freezer_1"; power_setting = 20; set_temperature = 73; use_power = 1},/obj/item/device/radio/intercom{dir = 1; name = "Station Intercom (General)"; pixel_y = 21},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/ScienceShip)
-"Pz" = (/obj/structure/cable/green{d1 = 2; d2 = 8; icon_state = "2-8"},/obj/effect/floor_decal/industrial/warning/corner,/obj/machinery/gear_dispenser/suit/ert{req_one_access = null},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"PB" = (/turf/simulated/floor/wood/broken,/area/survivalpod/superpose/ScienceShip)
-"PS" = (/obj/structure/cable{d1 = 1; d2 = 8; icon_state = "1-8"},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"Qp" = (/obj/item/device/radio/intercom{dir = 4; name = "Station Intercom (General)"; pixel_x = 21},/obj/structure/table/reinforced,/obj/item/weapon/stock_parts/console_screen,/obj/item/weapon/stock_parts/console_screen,/obj/item/stack/cable_coil,/obj/item/stack/cable_coil,/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"QA" = (/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 8},/obj/machinery/suspension_gen,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"QC" = (/obj/structure/table/wooden_reinforced,/obj/item/weapon/paper_bin,/obj/item/weapon/pen/fountain,/obj/item/weapon/pen/chameleon,/obj/item/device/gps/advanced/science,/obj/machinery/button/remote/blast_door{id = "estrella_blast"; name = "remote blast shielding control"; pixel_x = -1; pixel_y = -26},/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"QH" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/item/device/radio/intercom{dir = 8; name = "Station Intercom (General)"; pixel_x = -21},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"QR" = (/obj/machinery/meter,/obj/structure/closet/walllocker/emerglocker{pixel_x = -25; pixel_y = 32},/obj/machinery/alarm/alarms_hidden{dir = 4; pixel_x = -22},/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 8},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/ScienceShip)
-"QT" = (/obj/structure/bed/chair/office/dark{dir = 4},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"Ro" = (/obj/structure/extinguisher_cabinet{pixel_y = 30},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"Rp" = (/obj/machinery/alarm/alarms_hidden{dir = 8; pixel_x = 22},/turf/simulated/floor/wood/broken,/area/survivalpod/superpose/ScienceShip)
-"RI" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow,/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/recharge_station,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"RU" = (/obj/structure/closet/cabinet{pixel_y = 20},/obj/machinery/computer/security/telescreen/entertainment{icon_state = "frame"; pixel_x = -32},/obj/item/weapon/handcuffs/legcuffs/fuzzy,/obj/item/weapon/handcuffs/fuzzy,/obj/item/clothing/mask/muzzle/ballgag,/obj/item/clothing/suit/iasexy,/obj/item/clothing/under/sexybunny_white/sexybunny_black,/obj/item/clothing/under/dress/maid/sexy,/obj/item/clothing/head/collectable/rabbitears,/turf/simulated/floor/wood/broken,/area/survivalpod/superpose/ScienceShip)
-"RV" = (/obj/structure/table/steel_reinforced,/obj/machinery/power/apc/alarms_hidden{dir = 4; pixel_x = 24},/obj/structure/cable/green,/obj/random/maintenance,/obj/random/maintenance,/obj/random/maintenance,/obj/random/maintenance/research,/obj/random/maintenance/research,/obj/random/maintenance/research,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"St" = (/obj/effect/floor_decal/industrial/warning,/obj/machinery/atmospherics/pipe/simple/hidden{dir = 5},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"SC" = (/obj/machinery/atmospherics/valve,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"SE" = (/obj/structure/closet/emcloset,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"SU" = (/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 8},/obj/structure/reagent_dispensers/watertank/high,/turf/simulated/floor/tiled/techfloor/grid,/area/survivalpod/superpose/ScienceShip)
-"Te" = (/obj/structure/bed/chair/office/dark{dir = 4},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"Tp" = (/obj/structure/bed/double/padded,/obj/structure/curtain/bed,/obj/item/weapon/bedsheet/hosdouble,/obj/machinery/computer/security/telescreen/entertainment{icon_state = "frame"; pixel_y = 32},/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"Tr" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/door/airlock/maintenance/rnd{req_one_access = null},/obj/machinery/door/firedoor/glass,/turf/simulated/floor/tiled/steel_grid,/area/survivalpod/superpose/ScienceShip)
-"TB" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 4},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/ScienceShip)
-"TF" = (/obj/screen/alert/highpressure,/obj/machinery/computer/rdconsole/core{dir = 4},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"Ug" = (/obj/machinery/atmospherics/pipe/simple/hidden,/obj/structure/extinguisher_cabinet{pixel_x = -27},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"Ul" = (/turf/simulated/shuttle/wall/hard_corner,/area/survivalpod/superpose/ScienceShip)
-"Ur" = (/obj/machinery/atmospherics/pipe/tank/air{dir = 4},/obj/effect/floor_decal/industrial/outline/blue,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"Uz" = (/obj/structure/salvageable/server,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/ScienceShip)
-"UG" = (/obj/structure/table/reinforced,/obj/item/device/gps/advanced/science,/obj/item/weapon/reagent_containers/spray/cleaner{desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'"; name = "Chemistry Cleaner"},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"UN" = (/obj/structure/table/reinforced,/obj/fiftyspawner/steel,/obj/fiftyspawner/glass,/obj/machinery/light{dir = 1},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"UP" = (/obj/machinery/firealarm{dir = 4; pixel_x = 24},/obj/structure/table/reinforced,/obj/item/weapon/disk/design_disk,/obj/item/weapon/disk/design_disk,/obj/item/weapon/disk/tech_disk,/obj/item/weapon/disk/tech_disk,/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"UZ" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 1; frequency = 1380; id_tag = "estrella_pump"},/obj/effect/floor_decal/industrial/warning{dir = 6},/obj/machinery/airlock_sensor{frequency = 1380; id_tag = "estrella_sensor"; pixel_y = -28},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"VB" = (/obj/item/device/radio/intercom{dir = 4; name = "Station Intercom (General)"; pixel_x = 21},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"VE" = (/obj/machinery/atmospherics/portables_connector,/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/light/small{dir = 1},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/ScienceShip)
-"VH" = (/obj/machinery/firealarm{dir = 4; pixel_x = 24},/obj/machinery/computer/crew,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/ScienceShip)
-"VJ" = (/obj/structure/table/steel_reinforced,/obj/structure/cable/green{d1 = 1; d2 = 2; icon_state = "1-2"},/obj/random/maintenance,/obj/random/maintenance,/obj/random/maintenance,/obj/effect/floor_decal/industrial/warning/corner{dir = 4},/obj/random/maintenance/research,/obj/random/maintenance/research,/obj/random/maintenance/research,/obj/machinery/alarm/alarms_hidden{dir = 8; pixel_x = 22},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"VS" = (/obj/machinery/light{dir = 8},/obj/machinery/atmospherics/binary/passive_gate{dir = 1; regulate_mode = 0; unlocked = 1},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"VT" = (/obj/machinery/door/airlock/multi_tile/metal/mait{dir = 1; frequency = 1380; icon_state = "door_locked"; id_tag = "estrella_inner"; locked = 1; name = "Internal Access"},/obj/machinery/atmospherics/pipe/simple/visible{dir = 5},/obj/machinery/door/firedoor/border_only,/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"VY" = (/obj/structure/cable/green{d1 = 4; d2 = 8; icon_state = "4-8"},/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"Wc" = (/obj/structure/table/reinforced,/obj/machinery/chemical_dispenser/full{pixel_y = 5},/obj/item/device/radio/intercom{desc = "Talk... listen through this."; name = "Station Intercom (Brig Radio)"; pixel_y = -21; wires = 7},/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"Wj" = (/obj/structure/grille/rustic{health = 25; name = "reinforced grille"},/obj/structure/shuttle/window,/obj/machinery/door/firedoor/border_only,/obj/machinery/door/blast/regular/open{id = "estrella_blast"; name = "window blast shield"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"Wu" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 8},/turf/simulated/floor/plating,/area/survivalpod/superpose/ScienceShip)
-"WL" = (/obj/effect/floor_decal/industrial/warning{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"Xh" = (/obj/structure/toilet{pixel_y = 12},/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/machinery/door/window/survival_pod{dir = 2; req_one_access = null},/turf/simulated/floor/tiled/freezer,/area/survivalpod/superpose/ScienceShip)
-"Xz" = (/obj/machinery/door/airlock/hatch{icon_state = "door_locked"; id_tag = "estrella_back_hatch"; locked = 1; req_one_access = null},/obj/machinery/button/remote/airlock{desiredstate = 1; id = "estrella_back_hatch"; name = "Rear Hatch Control"; pixel_y = 27; req_access = null; specialfunctions = 4},/obj/machinery/door/firedoor/border_only,/obj/machinery/door/blast/regular/open{dir = 4; id = "estrella_blast"; layer = 2; name = "window blast shield"; open_layer = 2},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/ScienceShip)
-"XQ" = (/obj/structure/closet/cabinet{pixel_y = 20},/obj/item/weapon/implanter/sizecontrol,/obj/item/weapon/ore/uranium,/obj/item/weapon/ore/uranium,/obj/item/weapon/ore/phoron,/obj/item/weapon/ore/phoron,/obj/item/weapon/ore/osmium,/obj/item/weapon/ore/osmium,/obj/item/weapon/ore/gold,/obj/item/weapon/ore/diamond,/obj/item/weapon/ore/marble,/obj/item/weapon/ore/osmium,/obj/item/weapon/ore/rutile,/obj/item/toy/bosunwhistle/fluff/strix,/obj/item/toy/character/wizard,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/mindbreaker/unidentified,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/mindbreaker/unidentified,/obj/item/weapon/fluff/squeezetoy,/obj/item/weapon/fluff/zekewatch,/obj/item/weapon/fluff/fidgetspinner/red,/obj/item/weapon/storage/pill_bottle/dice_nerd,/turf/simulated/floor/wood,/area/survivalpod/superpose/ScienceShip)
-"Yi" = (/obj/structure/closet/secure_closet/engineering_welding{req_access = null},/obj/item/weapon/storage/belt/utility,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"YH" = (/obj/machinery/atmospherics/pipe/simple/hidden/yellow{dir = 5},/obj/structure/extinguisher_cabinet{pixel_x = -27},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"YN" = (/obj/machinery/atmospherics/portables_connector,/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/shuttle/floor/white,/area/survivalpod/superpose/ScienceShip)
-"YX" = (/obj/machinery/autolathe{hacked = 1},/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"Za" = (/obj/structure/table/reinforced,/obj/item/weapon/stock_parts/scanning_module/adv{pixel_x = 5; pixel_y = 6},/obj/item/weapon/stock_parts/scanning_module/adv{pixel_x = 5; pixel_y = 6},/obj/item/weapon/stock_parts/micro_laser/high,/obj/item/weapon/stock_parts/micro_laser/high,/obj/item/weapon/stock_parts/matter_bin/adv,/obj/item/weapon/stock_parts/matter_bin/adv,/obj/item/weapon/stock_parts/manipulator/hyper,/obj/item/weapon/stock_parts/manipulator/hyper,/obj/item/weapon/stock_parts/capacitor/adv,/obj/item/weapon/stock_parts/capacitor/adv,/turf/simulated/shuttle/floor/purple,/area/survivalpod/superpose/ScienceShip)
-"Zc" = (/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
-"Zd" = (/turf/simulated/floor/plating,/area/survivalpod/superpose/ScienceShip)
-"Zg" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 4},/obj/machinery/alarm/alarms_hidden{dir = 1; pixel_y = -22},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/ScienceShip)
-"ZJ" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/obj/machinery/alarm/alarms_hidden{dir = 8; pixel_x = 22},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/ScienceShip)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ae" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/obj/structure/curtain/open/shower,
+/obj/random/soap,
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/ScienceShip)
+"ap" = (
+/obj/structure/sign/science{
+	pixel_y = -32
+	},
+/turf/template_noop,
+/area/template_noop)
+"bc" = (
+/obj/structure/sign/science{
+	pixel_y = 32
+	},
+/turf/template_noop,
+/area/template_noop)
+"be" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 4
+	},
+/turf/simulated/shuttle/wall,
+/area/survivalpod/superpose/ScienceShip)
+"bm" = (
+/turf/template_noop,
+/area/survivalpod/superpose/ScienceShip)
+"bP" = (
+/obj/structure/grille/rustic{
+	health = 25;
+	name = "reinforced grille"
+	},
+/obj/structure/shuttle/window,
+/obj/structure/curtain/black{
+	icon_state = "open";
+	layer = 2;
+	name = "privacy curtain";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	id = "estrella_blast";
+	name = "window blast shield"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"ch" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/item/tape/engineering,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/survivalpod/superpose/ScienceShip)
+"cm" = (
+/obj/machinery/atmospherics/unary/engine/bigger{
+	dir = 4;
+	pixel_x = -3
+	},
+/turf/template_noop,
+/area/survivalpod/superpose/ScienceShip)
+"cu" = (
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"cw" = (
+/obj/structure/closet/walllocker/emerglocker{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"da" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1380;
+	master_tag = "estrella";
+	name = "interior access button";
+	pixel_y = 26
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"df" = (
+/obj/structure/closet/walllocker_double/medical/west,
+/obj/item/weapon/storage/firstaid,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/roller,
+/obj/item/device/defib_kit/loaded,
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"dh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/structure/table/bench/standard,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"dp" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"dB" = (
+/obj/structure/closet/secure_closet/engineering_electrical{
+	req_access = null
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/weapon/storage/belt/utility,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"dS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/ScienceShip)
+"eu" = (
+/turf/simulated/floor/carpet,
+/area/survivalpod/superpose/ScienceShip)
+"ez" = (
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"fe" = (
+/obj/structure/shuttle/engine/router,
+/turf/simulated/shuttle/wall,
+/area/survivalpod/superpose/ScienceShip)
+"fg" = (
+/obj/screen/alert/highpressure,
+/turf/simulated/shuttle/wall,
+/area/survivalpod/superpose/ScienceShip)
+"fs" = (
+/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/survivalpod/superpose/ScienceShip)
+"fD" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"ge" = (
+/obj/machinery/atmospherics/pipe/tank/phoron{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"gf" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"hb" = (
+/obj/machinery/r_n_d/protolathe,
+/obj/screen/alert/highpressure,
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"hB" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1380;
+	id_tag = "estrella_pump"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"hQ" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"hR" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"iv" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"iQ" = (
+/obj/structure/table/wooden_reinforced,
+/obj/structure/flora/pottedplant/smallcactus{
+	pixel_y = 13
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"je" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	icon_state = "map_vent_out";
+	use_power = 1
+	},
+/obj/structure/cryofeed,
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/ScienceShip)
+"ju" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"kl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/shuttle/wall,
+/area/survivalpod/superpose/ScienceShip)
+"kw" = (
+/obj/structure/table,
+/obj/machinery/light{
+	layer = 3
+	},
+/obj/item/weapon/gun/projectile/revolver/toy/crossbow,
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"kV" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/rods,
+/obj/item/stack/material/plasteel{
+	amount = 30
+	},
+/obj/item/stack/material/plasteel{
+	amount = 30
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"ll" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1380;
+	id_tag = "estrella_pump"
+	},
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "estrella";
+	pixel_y = 26;
+	tag_airpump = "estrella_pump";
+	tag_chamber_sensor = "estrella_sensor";
+	tag_exterior_door = "estrella_outer";
+	tag_interior_door = "estrella_inner"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"lu" = (
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/item/weapon/reagent_containers/glass/beaker{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/machinery/light,
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"lB" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"lH" = (
+/obj/machinery/door/airlock/maintenance/command{
+	req_one_access = null
+	},
+/obj/machinery/door/firedoor/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/steel_grid,
+/area/survivalpod/superpose/ScienceShip)
+"lK" = (
+/obj/item/weapon/gun/projectile/colt,
+/obj/item/weapon/gun/projectile/garand,
+/obj/item/ammo_magazine/m45,
+/obj/item/ammo_magazine/m45,
+/obj/structure/closet/secure_closet/guncabinet{
+	req_one_access = null
+	},
+/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
+/obj/item/ammo_magazine/ammo_box/b12g/beanbag,
+/obj/item/ammo_magazine/ammo_box/b12g/flechette,
+/obj/item/ammo_magazine/ammo_box/b12g/flechette,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"lM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"lW" = (
+/obj/structure/shuttle/window,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"mg" = (
+/obj/structure/shuttle/window,
+/obj/structure/curtain/black{
+	icon_state = "open";
+	layer = 2;
+	name = "privacy curtain";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"nb" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"nq" = (
+/obj/structure/fuel_port{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"nM" = (
+/obj/structure/closet/walllocker_double/kitchen/north{
+	dir = 8;
+	name = "Ration Cabinet";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"nQ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"nV" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"os" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"oJ" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/bed/chair/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"oS" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"oX" = (
+/turf/simulated/shuttle/wall,
+/area/survivalpod/superpose/ScienceShip)
+"pk" = (
+/obj/machinery/atmospherics/binary/pump,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"pm" = (
+/obj/machinery/atmospherics/unary/cryo_cell,
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"pG" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"pL" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	desc = "Talk... listen through this.";
+	name = "Station Intercom (Brig Radio)";
+	pixel_y = -21;
+	wires = 7
+	},
+/obj/structure/salvageable/console_os{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/ScienceShip)
+"qb" = (
+/obj/machinery/door/window/northright{
+	name = "Server Room";
+	req_access = null
+	},
+/obj/machinery/door/window/southleft{
+	name = "Server Room";
+	req_access = null
+	},
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"qe" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"qh" = (
+/obj/structure/sign/science{
+	pixel_x = 32
+	},
+/turf/template_noop,
+/area/template_noop)
+"ql" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/ScienceShip)
+"ri" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"rs" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"rP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"se" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/shuttle/window,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"sv" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"sz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/survivalpod/superpose/ScienceShip)
+"sH" = (
+/turf/simulated/shuttle/wall/no_join{
+	base_state = "orange";
+	icon = 'icons/turf/shuttle_orange.dmi';
+	icon_state = "orange"
+	},
+/area/survivalpod/superpose/ScienceShip)
+"sI" = (
+/obj/structure/salvageable/console_os{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/ScienceShip)
+"sJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"sK" = (
+/obj/machinery/door/airlock/maintenance/engi{
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/survivalpod/superpose/ScienceShip)
+"sT" = (
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/survivalpod/superpose/ScienceShip)
+"sY" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/clothing/suit/bio_suit/anomaly,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/bio_hood/anomaly,
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/weapon/storage/excavation,
+/obj/item/stack/flag/yellow,
+/obj/item/device/measuring_tape,
+/obj/item/weapon/pickaxe/drill,
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/obj/item/weapon/material/knife/machete/hatchet,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"tb" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"te" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"tg" = (
+/obj/machinery/light/small,
+/obj/structure/prop/fake_ai{
+	name = "C0n71nu17y"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/ScienceShip)
+"tu" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/stack/material/glass/phoronrglass{
+	amount = 20
+	},
+/obj/item/stack/material/glass/phoronrglass{
+	amount = 20
+	},
+/obj/fiftyspawner/rods,
+/obj/fiftyspawner/rods,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"tN" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/ScienceShip)
+"tR" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northright{
+	dir = 4;
+	name = "Medical booth"
+	},
+/obj/structure/curtain/black{
+	icon_state = "open";
+	layer = 2;
+	name = "privacy curtain";
+	opacity = 0
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"um" = (
+/obj/structure/closet/cabinet{
+	pixel_y = 20
+	},
+/obj/item/toy/plushie/kitten,
+/obj/item/toy/plushie/grey_cat,
+/obj/item/toy/plushie/orange_cat,
+/obj/item/toy/plushie/borgplushie/scrubpuppy,
+/obj/item/toy/plushie/black_fox,
+/obj/item/toy/plushie,
+/obj/item/toy/plushie/corgi,
+/obj/item/toy/plushie/crimson_fox,
+/obj/item/clothing/shoes/sandal,
+/obj/item/clothing/shoes/sandal,
+/obj/machinery/computer/security/telescreen/entertainment{
+	icon_state = "frame";
+	pixel_x = -32
+	},
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/turf/simulated/floor/carpet/turcarpet,
+/area/survivalpod/superpose/ScienceShip)
+"uu" = (
+/obj/machinery/door/airlock/multi_tile/metal/mait,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/survivalpod/superpose/ScienceShip)
+"uX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 10
+	},
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -25;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"vl" = (
+/obj/structure/closet/cabinet{
+	pixel_y = 20
+	},
+/obj/item/weapon/ore/diamond,
+/obj/item/weapon/ore/gold,
+/obj/item/weapon/ore/osmium,
+/obj/item/weapon/ore/silver,
+/obj/item/weapon/ore/uranium,
+/obj/item/weapon/bluespace_crystal,
+/obj/item/clothing/head/sombrero,
+/obj/item/clothing/head/sombrero,
+/obj/item/clothing/suit/poncho,
+/obj/item/clothing/accessory/poncho/thermal/red,
+/obj/item/clothing/accessory/poncho/thermal/security,
+/obj/item/clothing/accessory/poncho/thermal/green,
+/obj/item/clothing/shoes/footwraps,
+/obj/item/clothing/shoes/footwraps,
+/obj/item/clothing/shoes/footwraps,
+/obj/item/clothing/shoes/footwraps,
+/obj/item/toy/bosunwhistle/fluff/strix,
+/obj/item/weapon/blobcore_chunk,
+/obj/item/weapon/towel/random,
+/obj/item/weapon/towel/random,
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"wp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/survivalpod/superpose/ScienceShip)
+"xk" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"xw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"xy" = (
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/ScienceShip)
+"xF" = (
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/closet/jcloset,
+/obj/item/weapon/mop,
+/obj/structure/mopbucket,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"yb" = (
+/obj/machinery/vending/wallmed1{
+	name = "NanoMed Wall";
+	pixel_x = 25
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/obj/item/weapon/storage/quickdraw/syringe_case,
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"yn" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"yt" = (
+/obj/machinery/smartfridge/survival_pod{
+	name = "food storage"
+	},
+/obj/item/weapon/reagent_containers/food/snacks/burrito_spicy,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_spicy,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_spicy,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_vegan,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_vegan,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_vegan,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_mystery,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_mystery,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_mystery,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_hell,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_hell,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_hell,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_hell,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_cheese,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_cheese,
+/obj/item/weapon/reagent_containers/food/snacks/burrito_cheese,
+/obj/item/weapon/reagent_containers/food/snacks/burrito,
+/obj/item/weapon/reagent_containers/food/snacks/burrito,
+/obj/item/weapon/reagent_containers/food/snacks/burrito,
+/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito,
+/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito,
+/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito,
+/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito/filled,
+/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito/filled,
+/obj/item/weapon/reagent_containers/food/snacks/slice/bigbeanburrito/filled,
+/obj/item/weapon/reagent_containers/food/snacks/sliceable/supremoburrito,
+/obj/item/weapon/reagent_containers/food/snacks/enchiladas,
+/obj/item/weapon/reagent_containers/food/snacks/enchiladas,
+/obj/item/weapon/reagent_containers/food/snacks/enchiladas,
+/obj/item/weapon/reagent_containers/food/snacks/cheesenachos,
+/obj/item/weapon/reagent_containers/food/snacks/cheesenachos,
+/obj/item/weapon/reagent_containers/food/snacks/cheesenachos,
+/obj/item/weapon/reagent_containers/food/snacks/chipplate/nachos,
+/obj/item/weapon/reagent_containers/food/snacks/chipplate/nachos,
+/obj/item/weapon/reagent_containers/food/snacks/chipplate/nachos,
+/obj/item/weapon/reagent_containers/food/snacks/cubannachos,
+/obj/item/weapon/reagent_containers/food/snacks/cubannachos,
+/obj/item/weapon/reagent_containers/food/snacks/cubannachos,
+/obj/item/weapon/reagent_containers/food/snacks/cubannachos,
+/obj/item/weapon/reagent_containers/food/snacks/nachos,
+/obj/item/weapon/reagent_containers/food/snacks/nachos,
+/obj/item/weapon/reagent_containers/food/snacks/nachos,
+/obj/item/weapon/reagent_containers/food/snacks/nachos,
+/obj/item/weapon/reagent_containers/food/snacks/pandenata,
+/obj/item/weapon/reagent_containers/food/snacks/pandenata,
+/obj/item/weapon/reagent_containers/food/snacks/pandenata,
+/obj/item/weapon/reagent_containers/food/snacks/tocino,
+/obj/item/weapon/reagent_containers/food/snacks/tocino,
+/obj/item/weapon/reagent_containers/food/snacks/tocino,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"yy" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"yB" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"yJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/mech_recharger,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"zp" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"zV" = (
+/obj/structure/table/rack/shelf/steel,
+/obj/item/stack/material/uranium,
+/obj/item/stack/material/phoron{
+	amount = 5;
+	pixel_x = -1;
+	pixel_y = -3
+	},
+/obj/item/stack/material/silver{
+	amount = 5;
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/stack/material/copper{
+	amount = 25
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"Az" = (
+/obj/machinery/door/airlock/maintenance/medical{
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/survivalpod/superpose/ScienceShip)
+"AN" = (
+/obj/structure/bed/chair/wood,
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"AO" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -25;
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"AP" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/turf/simulated/shuttle/wall/hard_corner,
+/area/survivalpod/superpose/ScienceShip)
+"AQ" = (
+/obj/structure/bed/double/padded,
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_y = 32
+	},
+/obj/item/weapon/bedsheet/rainbowdouble,
+/turf/simulated/floor/carpet/turcarpet,
+/area/survivalpod/superpose/ScienceShip)
+"Bn" = (
+/obj/structure/grille/rustic{
+	health = 25;
+	name = "reinforced grille"
+	},
+/obj/structure/shuttle/window,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "estrella_blast";
+	name = "window blast shield"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"Bz" = (
+/obj/structure/toilet{
+	dir = 8;
+	pixel_x = 9
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/ScienceShip)
+"BR" = (
+/obj/structure/salvageable/computer,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/ScienceShip)
+"BS" = (
+/obj/effect/catwalk_plated/white,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"Cm" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"Cn" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"Cq" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"Cz" = (
+/obj/screen/alert/highpressure,
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"CW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/ScienceShip)
+"CX" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"Dp" = (
+/obj/screen/alert/highpressure,
+/turf/simulated/shuttle/wall/hard_corner,
+/area/survivalpod/superpose/ScienceShip)
+"Ds" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"DK" = (
+/obj/structure/closet/crate,
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/fiftyspawner/blucarpet,
+/obj/fiftyspawner/oracarpet,
+/obj/fiftyspawner/purcarpet,
+/obj/fiftyspawner/sblucarpet,
+/obj/fiftyspawner/tealcarpet,
+/obj/fiftyspawner/turcarpet,
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/algae{
+	amount = 50
+	},
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/lead{
+	amount = 30
+	},
+/obj/item/stack/material/plasteel{
+	amount = 30;
+	pixel_y = 5
+	},
+/obj/item/stack/material/resin{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/machinery/light{
+	layer = 3
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"DM" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/fueltank/high,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"DV" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"DW" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/shipsensors{
+	dir = 8
+	},
+/obj/structure/sign/science{
+	pixel_x = 32
+	},
+/turf/template_noop,
+/area/survivalpod/superpose/ScienceShip)
+"Eg" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"Eq" = (
+/turf/template_noop,
+/area/template_noop)
+"Ew" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"EH" = (
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -34
+	},
+/obj/machinery/space_heater,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"EN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"ER" = (
+/obj/structure/bed/chair/bay/comfy/red{
+	dir = 8
+	},
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -25;
+	pixel_y = 32
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/ScienceShip)
+"Fb" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/obj/machinery/reagentgrinder,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"Fe" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/coin/diamond,
+/obj/machinery/light{
+	layer = 3
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"Ft" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1380;
+	master_tag = "estrella";
+	name = "exterior access button";
+	pixel_y = 26
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "estrella_blast";
+	layer = 2;
+	name = "window blast shield";
+	open_layer = 2
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"FR" = (
+/obj/machinery/door/airlock/hatch{
+	icon_state = "door_locked";
+	id_tag = "estrella_side_hatch";
+	locked = 1;
+	req_access = null;
+	req_one_access = null
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "estrella_side_hatch";
+	name = "Side Hatch Control";
+	pixel_x = -27;
+	specialfunctions = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	id = "estrella_blast";
+	layer = 2;
+	name = "window blast shield";
+	open_layer = 2
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"FV" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/crate/engineering,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/glass,
+/obj/item/weapon/tank/phoron,
+/obj/item/weapon/tank/phoron,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/storage/toolbox/electrical,
+/obj/item/device/multitool,
+/obj/item/device/geiger,
+/obj/item/clothing/glasses/goggles,
+/obj/item/clothing/glasses/goggles,
+/obj/item/device/t_scanner,
+/obj/item/clothing/glasses/welding,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"Gi" = (
+/obj/effect/catwalk_plated/white,
+/turf/template_noop,
+/area/survivalpod/superpose/ScienceShip)
+"Gl" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1380;
+	id_tag = "estrella_pump"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"GM" = (
+/obj/structure/table/bench/wooden,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/item/device/flash,
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"GP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"GU" = (
+/obj/machinery/sleep_console{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"HX" = (
+/obj/machinery/chem_master{
+	pixel_x = -7
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"Ij" = (
+/obj/machinery/power/smes/buildable/point_of_interest,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/cable/green,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"In" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"Io" = (
+/obj/machinery/atmospherics/unary/freezer{
+	icon_state = "freezer"
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"Ip" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"Iz" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/blue{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/weapon/pen/red,
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"IB" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower,
+/obj/random/soap,
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/ScienceShip)
+"IE" = (
+/obj/structure/closet/walllocker/emerglocker{
+	dir = 1;
+	pixel_x = -24;
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"II" = (
+/obj/machinery/power/port_gen/pacman/mrs,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/fiftyspawner/tritium,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"IM" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"IQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"Jd" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"Jm" = (
+/obj/machinery/door/airlock/multi_tile/metal/mait{
+	dir = 1;
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "estrella_outer";
+	locked = 1;
+	name = "External Access"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "estrella_blast";
+	layer = 2;
+	name = "window blast shield";
+	open_layer = 2
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"JG" = (
+/obj/structure/reagent_dispensers/acid{
+	density = 0;
+	pixel_x = -30
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"JJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/emerglocker{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 22
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"Kh" = (
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"Kq" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower,
+/obj/random/soap,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/ScienceShip)
+"Kx" = (
+/obj/screen/alert/highpressure,
+/turf/template_noop,
+/area/template_noop)
+"KD" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 1;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/obj/structure/cryofeed{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/ScienceShip)
+"Lj" = (
+/obj/structure/closet/walllocker_double/kitchen/north{
+	dir = 8;
+	name = "Ration Cabinet";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"Lx" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"LC" = (
+/obj/machinery/door/firedoor/glass,
+/obj/structure/shuttle/window,
+/obj/structure/curtain/black{
+	icon_state = "open";
+	layer = 2;
+	name = "privacy curtain";
+	opacity = 0
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"LP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/guncabinet{
+	req_one_access = null
+	},
+/obj/item/clothing/head/helmet/combat/USDF,
+/obj/item/clothing/head/helmet/combat/USDF,
+/obj/item/clothing/suit/armor/combat/USDF,
+/obj/item/clothing/suit/armor/combat/USDF,
+/obj/item/device/flash,
+/obj/item/device/flash,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"Mc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/fireaxecabinet{
+	pixel_x = 32
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"Mg" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/obj/machinery/meter,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"MR" = (
+/obj/machinery/shuttle_sensor,
+/turf/simulated/shuttle/wall/hard_corner,
+/area/survivalpod/superpose/ScienceShip)
+"Ng" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/alarm/alarms_hidden{
+	pixel_y = 22
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"Nm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/shield_generator/charged{
+	field_radius = 8;
+	initial_shield_modes = 2153;
+	target_radius = 8
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"NV" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"Oh" = (
+/obj/effect/catwalk_plated/white,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/template_noop,
+/area/survivalpod/superpose/ScienceShip)
+"Oi" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"Ou" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"OG" = (
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"Pk" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/ScienceShip)
+"Pv" = (
+/obj/machinery/atmospherics/unary/freezer{
+	icon_state = "freezer_1";
+	power_setting = 20;
+	set_temperature = 73;
+	use_power = 1
+	},
+/obj/item/device/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/ScienceShip)
+"Pz" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/gear_dispenser/suit/ert{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"PB" = (
+/turf/simulated/floor/wood/broken,
+/area/survivalpod/superpose/ScienceShip)
+"PS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"Qp" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 21
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"QA" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/obj/machinery/suspension_gen,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"QC" = (
+/obj/structure/table/wooden_reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/fountain,
+/obj/item/weapon/pen/chameleon,
+/obj/item/device/gps/advanced/science,
+/obj/machinery/button/remote/blast_door{
+	id = "estrella_blast";
+	name = "remote blast shielding control";
+	pixel_x = -1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"QH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/item/device/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -21
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"QR" = (
+/obj/machinery/meter,
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_x = -25;
+	pixel_y = 32
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/ScienceShip)
+"QT" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"Ro" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"Rp" = (
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/wood/broken,
+/area/survivalpod/superpose/ScienceShip)
+"RI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/recharge_station,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"RU" = (
+/obj/structure/closet/cabinet{
+	pixel_y = 20
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	icon_state = "frame";
+	pixel_x = -32
+	},
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/obj/item/weapon/handcuffs/fuzzy,
+/obj/item/clothing/mask/muzzle/ballgag,
+/obj/item/clothing/suit/iasexy,
+/obj/item/clothing/under/sexybunny_white/sexybunny_black,
+/obj/item/clothing/under/dress/maid/sexy,
+/obj/item/clothing/head/collectable/rabbitears,
+/turf/simulated/floor/wood/broken,
+/area/survivalpod/superpose/ScienceShip)
+"RV" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/power/apc/alarms_hidden{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/cable/green,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"St" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"SC" = (
+/obj/machinery/atmospherics/valve,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"SE" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"SU" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/ScienceShip)
+"Te" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"Tp" = (
+/obj/structure/bed/double/padded,
+/obj/structure/curtain/bed,
+/obj/item/weapon/bedsheet/hosdouble,
+/obj/machinery/computer/security/telescreen/entertainment{
+	icon_state = "frame";
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"Tr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/rnd{
+	req_one_access = null
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/steel_grid,
+/area/survivalpod/superpose/ScienceShip)
+"TB" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/ScienceShip)
+"TF" = (
+/obj/screen/alert/highpressure,
+/obj/machinery/computer/rdconsole/core{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"Ug" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"Ul" = (
+/turf/simulated/shuttle/wall/hard_corner,
+/area/survivalpod/superpose/ScienceShip)
+"Ur" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"Uz" = (
+/obj/structure/salvageable/server,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/ScienceShip)
+"UG" = (
+/obj/structure/table/reinforced,
+/obj/item/device/gps/advanced/science,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the 'Space' from Space Cleaner and written in Chemistry. Scrawled on the back is, 'Okay, whoever filled this with polytrinic acid, it was only funny the first time. It was hard enough replacing the CMO's first cat!'";
+	name = "Chemistry Cleaner"
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"UN" = (
+/obj/structure/table/reinforced,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/glass,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"UP" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/disk/tech_disk,
+/obj/item/weapon/disk/tech_disk,
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"UZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1380;
+	id_tag = "estrella_pump"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
+	},
+/obj/machinery/airlock_sensor{
+	frequency = 1380;
+	id_tag = "estrella_sensor";
+	pixel_y = -28
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"VB" = (
+/obj/item/device/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"VE" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/ScienceShip)
+"VH" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/computer/crew,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/ScienceShip)
+"VJ" = (
+/obj/structure/table/steel_reinforced,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/random/maintenance,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"VS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 1;
+	regulate_mode = 0;
+	unlocked = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"VT" = (
+/obj/machinery/door/airlock/multi_tile/metal/mait{
+	dir = 1;
+	frequency = 1380;
+	icon_state = "door_locked";
+	id_tag = "estrella_inner";
+	locked = 1;
+	name = "Internal Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"VY" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"Wc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/chemical_dispenser/full{
+	pixel_y = 5
+	},
+/obj/item/device/radio/intercom{
+	desc = "Talk... listen through this.";
+	name = "Station Intercom (Brig Radio)";
+	pixel_y = -21;
+	wires = 7
+	},
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"Wj" = (
+/obj/structure/grille/rustic{
+	health = 25;
+	name = "reinforced grille"
+	},
+/obj/structure/shuttle/window,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	id = "estrella_blast";
+	name = "window blast shield"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"Wu" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/ScienceShip)
+"WL" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"Xh" = (
+/obj/structure/toilet{
+	pixel_y = 12
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 2;
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/survivalpod/superpose/ScienceShip)
+"Xz" = (
+/obj/machinery/door/airlock/hatch{
+	icon_state = "door_locked";
+	id_tag = "estrella_back_hatch";
+	locked = 1;
+	req_one_access = null
+	},
+/obj/machinery/button/remote/airlock{
+	desiredstate = 1;
+	id = "estrella_back_hatch";
+	name = "Rear Hatch Control";
+	pixel_y = 27;
+	req_access = null;
+	specialfunctions = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "estrella_blast";
+	layer = 2;
+	name = "window blast shield";
+	open_layer = 2
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/ScienceShip)
+"XQ" = (
+/obj/structure/closet/cabinet{
+	pixel_y = 20
+	},
+/obj/item/weapon/implanter/sizecontrol,
+/obj/item/weapon/ore/uranium,
+/obj/item/weapon/ore/uranium,
+/obj/item/weapon/ore/phoron,
+/obj/item/weapon/ore/phoron,
+/obj/item/weapon/ore/osmium,
+/obj/item/weapon/ore/osmium,
+/obj/item/weapon/ore/gold,
+/obj/item/weapon/ore/diamond,
+/obj/item/weapon/ore/marble,
+/obj/item/weapon/ore/osmium,
+/obj/item/weapon/ore/rutile,
+/obj/item/toy/bosunwhistle/fluff/strix,
+/obj/item/toy/character/wizard,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/mindbreaker/unidentified,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/mindbreaker/unidentified,
+/obj/item/weapon/fluff/squeezetoy,
+/obj/item/weapon/fluff/zekewatch,
+/obj/item/weapon/fluff/fidgetspinner/red,
+/obj/item/weapon/storage/pill_bottle/dice_nerd,
+/turf/simulated/floor/wood,
+/area/survivalpod/superpose/ScienceShip)
+"Yi" = (
+/obj/structure/closet/secure_closet/engineering_welding{
+	req_access = null
+	},
+/obj/item/weapon/storage/belt/utility,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"YH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"YN" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/shuttle/floor/white,
+/area/survivalpod/superpose/ScienceShip)
+"YX" = (
+/obj/machinery/autolathe{
+	hacked = 1
+	},
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"Za" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/stock_parts/scanning_module/adv{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/weapon/stock_parts/scanning_module/adv{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/micro_laser/high,
+/obj/item/weapon/stock_parts/matter_bin/adv,
+/obj/item/weapon/stock_parts/matter_bin/adv,
+/obj/item/weapon/stock_parts/manipulator/hyper,
+/obj/item/weapon/stock_parts/manipulator/hyper,
+/obj/item/weapon/stock_parts/capacitor/adv,
+/obj/item/weapon/stock_parts/capacitor/adv,
+/turf/simulated/shuttle/floor/purple,
+/area/survivalpod/superpose/ScienceShip)
+"Zc" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
+"Zd" = (
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/ScienceShip)
+"Zg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/ScienceShip)
+"ZJ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/alarm/alarms_hidden{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/ScienceShip)
 
 (1,1,1) = {"
-EqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEq
-EqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqapoXoXoXoXEqEqEq
-EqEqEqEqEqEqEqEqEqEqEqEqEqEqEqoXoXsHUloXoXEqEqEqEq
-EqEqEqEqEqEqEqEqEqapEqEqEqEqoXUldBYioSbebmbmEqEqEq
-EqEqEqEqEqoXWjWjoXsHoXoXbPoXoXriuXOitbbecmbmEqEqEq
-EqEqEqEqoXUlBRUzaeXhXQvlKhTpoXIMZcVBklfeoXEqEqEqEq
-EqEqEqEqBnpLERxyfDeueueueuGMoXgeZcOigfbebmbmEqEqEq
-EqEqEqEqoXUlsIsIoJQChQnQKhiQoXgeZcOikVbecmbmEqEqEq
-EqEqEqEqEqoXoXoXoXoXUllHmgoXoXUlnqnVklfeoXEqEqEqEq
-EqEqEqEqEqDWsHYNpmIooXEgIQjuNgsKpkpGqebebmbmEqEqEq
-EqEqEqEqEqoXUldhrslBoXrPoXoXoXUlInsJtubecmbmEqEqEq
-EqEqEqEqEqBnWcIpOGQTtRGPoXumAQoXuuwpUloXoXEqEqEqEq
-EqEqoXoXWjoXUlHXOGybUlosfsxkyBoXQHxwytoXoXoXEqEqEq
-EqKxBnUNYXzVoXdfOGDsAzCnoXANKhoXLjVYPzAPCXUlUlEqEq
-EqfgDpivezDVoXGUEwFbUlGPLCFeKhoXIjynCmdaGlllFtGiEq
-EqBnhbAOezIzUloXoXoXoXMcoXIBBzoXIIPSCmVTMgJdJmGiEq
-EqBnCznbezNVsTIQJJIQIQLxoXoXoXoXyJOiVJUlhBUZMROhEq
-EqBnTFezezQpUloXoXoXoXGPoXRUPkoXRIOiRVUloXoXUlGiEq
-EqfgDpJGTeUPoXPvVEVHUlEgchWuRpoXNmteENsvRoWLXzGiEq
-EqKxBnluUGZaoXQRqlTBTrCnoXPBcuoXnMzpOiOiSEUloXEqEq
-EqKxfgoXWjoXUlseqblWUlUgLCkwZdoXQHxwFVSEUloXEqEqEq
-EqEqKxKxEqoXoXtNdSCWoXGPoXKqBzoXuuwpUloXoXEqEqEqEq
-EqEqEqEqEqoXUljetgKDoXrPoXoXoXUlYHsJDMbebmbmEqEqEq
-EqEqEqEqEqEqoXoXoXoXoXSthRcwZgszOupGSUbecmbmEqEqEq
-EqEqEqEqEqEqEqEqoXoXUlFRUloXoXUlVSZJklfeoXEqEqEqEq
-EqEqEqEqEqEqEqEqEqEqBSGiUlUlxFyySCOisYbebmbmEqEqEq
-EqEqEqEqEqEqEqEqEqEqEqEqqhsHCqOulMOiQAbecmbmEqEqEq
-EqEqEqEqEqEqEqEqEqEqEqEqEqoXUrIEOiOiklfeoXEqEqEqEq
-EqEqEqEqEqEqEqEqEqEqEqEqEqoXUlEHOiOidpbebmbmEqEqEq
-EqEqEqEqEqEqEqEqEqEqEqEqEqEqoXUlDKlKLPbecmbmEqEqEq
-EqEqEqEqEqEqEqEqEqEqEqEqEqEqEqoXoXsHUloXoXEqEqEqEq
-EqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqbcoXoXoXoXEqEqEq
-EqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEqEq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(2,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Kx
+fg
+Bn
+Bn
+Bn
+fg
+Kx
+Kx
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(3,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+oX
+Bn
+Dp
+hb
+Cz
+TF
+Dp
+Bn
+fg
+Kx
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(4,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+oX
+UN
+iv
+AO
+nb
+ez
+JG
+lu
+oX
+Kx
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(5,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+Eq
+oX
+Bn
+oX
+Eq
+Eq
+Eq
+Eq
+Wj
+YX
+ez
+ez
+ez
+ez
+Te
+UG
+Wj
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(6,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+oX
+Ul
+pL
+Ul
+oX
+DW
+oX
+Bn
+oX
+zV
+DV
+Iz
+NV
+Qp
+UP
+Za
+oX
+oX
+oX
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(7,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+Wj
+BR
+ER
+sI
+oX
+sH
+Ul
+Wc
+Ul
+oX
+oX
+Ul
+sT
+Ul
+oX
+oX
+Ul
+oX
+Ul
+oX
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(8,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+Wj
+Uz
+xy
+sI
+oX
+YN
+dh
+Ip
+HX
+df
+GU
+oX
+IQ
+oX
+Pv
+QR
+se
+tN
+je
+oX
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(9,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+oX
+ae
+fD
+oJ
+oX
+pm
+rs
+OG
+OG
+OG
+Ew
+oX
+JJ
+oX
+VE
+ql
+qb
+dS
+tg
+oX
+oX
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(10,1,1) = {"
+Eq
+Eq
+Eq
+ap
+sH
+Xh
+eu
+QC
+oX
+Io
+lB
+QT
+yb
+Ds
+Fb
+oX
+IQ
+oX
+VH
+TB
+lW
+CW
+KD
+oX
+oX
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(11,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+oX
+XQ
+eu
+hQ
+Ul
+oX
+oX
+tR
+Ul
+Az
+Ul
+oX
+IQ
+oX
+Ul
+Tr
+Ul
+oX
+oX
+oX
+Ul
+BS
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(12,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+oX
+vl
+eu
+nQ
+lH
+Eg
+rP
+GP
+os
+Cn
+GP
+Mc
+Lx
+GP
+Eg
+Cn
+Ug
+GP
+rP
+St
+FR
+Gi
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(13,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+bP
+Kh
+eu
+Kh
+mg
+IQ
+oX
+oX
+fs
+oX
+LC
+oX
+oX
+oX
+ch
+oX
+LC
+oX
+oX
+hR
+Ul
+Ul
+qh
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(14,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+oX
+Tp
+GM
+iQ
+oX
+ju
+oX
+um
+xk
+AN
+Fe
+IB
+oX
+RU
+Wu
+PB
+kw
+Kq
+oX
+cw
+oX
+Ul
+sH
+oX
+oX
+Eq
+Eq
+Eq
+Eq
+"}
+(15,1,1) = {"
+Eq
+Eq
+Eq
+oX
+oX
+oX
+oX
+oX
+oX
+Ng
+oX
+AQ
+yB
+Kh
+Kh
+Bz
+oX
+Pk
+Rp
+cu
+Zd
+Bz
+oX
+Zg
+oX
+xF
+Cq
+Ur
+Ul
+oX
+Eq
+Eq
+Eq
+"}
+(16,1,1) = {"
+Eq
+Eq
+oX
+Ul
+ri
+IM
+ge
+ge
+Ul
+sK
+Ul
+oX
+oX
+oX
+oX
+oX
+oX
+oX
+oX
+oX
+oX
+oX
+Ul
+sz
+Ul
+yy
+Ou
+IE
+EH
+Ul
+oX
+Eq
+Eq
+"}
+(17,1,1) = {"
+Eq
+Eq
+oX
+dB
+uX
+Zc
+Zc
+Zc
+nq
+pk
+In
+uu
+QH
+Lj
+Ij
+II
+yJ
+RI
+Nm
+nM
+QH
+uu
+YH
+Ou
+VS
+SC
+lM
+Oi
+Oi
+DK
+oX
+Eq
+Eq
+"}
+(18,1,1) = {"
+Eq
+ap
+sH
+Yi
+Oi
+VB
+Oi
+Oi
+nV
+pG
+sJ
+wp
+xw
+VY
+yn
+PS
+Oi
+Oi
+te
+zp
+xw
+wp
+sJ
+pG
+ZJ
+Oi
+Oi
+Oi
+Oi
+lK
+sH
+bc
+Eq
+"}
+(19,1,1) = {"
+Eq
+oX
+Ul
+oS
+tb
+kl
+gf
+kV
+kl
+qe
+tu
+Ul
+yt
+Pz
+Cm
+Cm
+VJ
+RV
+EN
+Oi
+FV
+Ul
+DM
+SU
+kl
+sY
+QA
+kl
+dp
+LP
+Ul
+oX
+Eq
+"}
+(20,1,1) = {"
+Eq
+oX
+oX
+be
+be
+fe
+be
+be
+fe
+be
+be
+oX
+oX
+AP
+da
+VT
+Ul
+Ul
+sv
+Oi
+SE
+oX
+be
+be
+fe
+be
+be
+fe
+be
+be
+oX
+oX
+Eq
+"}
+(21,1,1) = {"
+Eq
+oX
+oX
+bm
+cm
+oX
+bm
+cm
+oX
+bm
+cm
+oX
+oX
+CX
+Gl
+Mg
+hB
+oX
+Ro
+SE
+Ul
+oX
+bm
+cm
+oX
+bm
+cm
+oX
+bm
+cm
+oX
+oX
+Eq
+"}
+(22,1,1) = {"
+Eq
+oX
+Eq
+bm
+bm
+Eq
+bm
+bm
+Eq
+bm
+bm
+Eq
+oX
+Ul
+ll
+Jd
+UZ
+oX
+WL
+Ul
+oX
+Eq
+bm
+bm
+Eq
+bm
+bm
+Eq
+bm
+bm
+Eq
+oX
+Eq
+"}
+(23,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Ul
+Ft
+Jm
+MR
+Ul
+Xz
+oX
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(24,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Gi
+Gi
+Oh
+Gi
+Gi
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+"}
+(25,1,1) = {"
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
 "}

--- a/modular_chomp/maps/submaps/shelters/SmallCombatShip-9x11.dmm
+++ b/modular_chomp/maps/submaps/shelters/SmallCombatShip-9x11.dmm
@@ -1,43 +1,390 @@
-"a" = (/turf/simulated/wall/shull,/area/survivalpod/superpose/SmallCombatShip)
-"d" = (/obj/machinery/disperser/front{dir = 1},/turf/template_noop,/area/template_noop)
-"f" = (/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/SmallCombatShip)
-"g" = (/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/SmallCombatShip)
-"h" = (/obj/effect/catwalk_plated/dark,/turf/template_noop,/area/survivalpod/superpose/SmallCombatShip)
-"l" = (/obj/structure/bed/chair/bay/comfy/red{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/SmallCombatShip)
-"m" = (/turf/simulated/wall/rshull,/area/survivalpod/superpose/SmallCombatShip)
-"o" = (/obj/structure/salvageable/machine,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/SmallCombatShip)
-"s" = (/obj/structure/closet/walllocker_double/medical/west,/obj/item/weapon/storage/firstaid,/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/toxin,/obj/item/weapon/storage/firstaid/o2,/obj/item/roller,/obj/effect/floor_decal/techfloor{dir = 4},/obj/structure/window/reinforced/survival_pod,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/SmallCombatShip)
-"t" = (/obj/effect/catwalk_plated/dark,/obj/effect/catwalk_plated/dark,/turf/template_noop,/area/survivalpod/superpose/SmallCombatShip)
-"u" = (/obj/machinery/porta_turret/stationary/syndie{faction = "neutral"},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/SmallCombatShip)
-"w" = (/obj/item/device/gps,/obj/item/sticky_pad/random,/obj/item/device/starcaster_news,/obj/item/weapon/pen/blue,/obj/item/device/pda,/obj/item/weapon/card/id/external,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/gun/energy/locked/phasegun/pistol,/obj/item/weapon/material/knife/tacknife/survival,/obj/item/clothing/accessory/permit/gun,/obj/item/device/camera,/obj/item/device/binoculars,/obj/item/device/threadneedle,/obj/random/soap,/obj/item/weapon/towel/random,/obj/item/bodybag/cryobag,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/color/yellow,/obj/item/device/radio,/obj/item/device/radio,/obj/item/weapon/flame/lighter/random,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/device/suit_cooling_unit/emergency,/obj/item/stack/nanopaste,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,/obj/item/weapon/storage/backpack/messenger,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/clothing/accessory/poncho/thermal,/obj/item/weapon/storage/box/survival/comp,/obj/item/weapon/storage/toolbox/brass,/obj/item/weapon/storage/box/khcrystal,/obj/structure/closet/walllocker_double/east,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/SmallCombatShip)
-"z" = (/obj/structure/salvageable/server,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/SmallCombatShip)
-"A" = (/obj/structure/shuttle/engine/heater,/turf/simulated/wall/shull,/area/survivalpod/superpose/SmallCombatShip)
-"C" = (/obj/structure/closet/walllocker_double/kitchen/east{name = "Ration Cabinet"},/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/device/radio{pixel_x = -5; pixel_y = 5},/obj/item/device/radio{pixel_x = -5; pixel_y = 5},/obj/item/device/radio{pixel_x = 5; pixel_y = 5},/obj/item/device/radio{pixel_x = 5; pixel_y = 5},/obj/effect/floor_decal/techfloor{dir = 8},/obj/structure/window/reinforced/survival_pod,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/SmallCombatShip)
-"D" = (/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/SmallCombatShip)
-"H" = (/obj/machinery/portable_atmospherics/canister/phoron,/obj/machinery/atmospherics/portables_connector{dir = 1},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/SmallCombatShip)
-"I" = (/obj/machinery/disperser/middle{dir = 1},/turf/template_noop,/area/template_noop)
-"J" = (/obj/structure/salvageable/computer,/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/SmallCombatShip)
-"L" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/shuttle/engine/heater,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/SmallCombatShip)
-"M" = (/obj/structure/bed/chair/bay/comfy/red{dir = 8},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/SmallCombatShip)
-"N" = (/turf/template_noop,/area/template_noop)
-"O" = (/obj/machinery/atmospherics/unary/engine{dir = 1},/turf/template_noop,/area/survivalpod/superpose/SmallCombatShip)
-"Q" = (/obj/machinery/disperser/back{dir = 1},/obj/structure/ship_munition/disperser_charge/explosive,/turf/simulated/wall/rshull,/area/survivalpod/superpose/SmallCombatShip)
-"U" = (/obj/structure/bed/chair/bay/comfy/red{dir = 1},/obj/machinery/door/window/survival_pod{dir = 2},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/SmallCombatShip)
-"W" = (/obj/structure/window/plastitanium/full,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod,/obj/structure/grille/rustic{health = 25; name = "reinforced grille"},/obj/machinery/door/blast/regular/open{dir = 4; id = "stargazer_blast"; name = "window blast shield"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/SmallCombatShip)
-"X" = (/obj/structure/fans/hardlight/colorable{color = "red"},/obj/machinery/door/airlock/hatch{req_one_access = null},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/SmallCombatShip)
-"Y" = (/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/SmallCombatShip)
-"Z" = (/obj/fiftyspawner/glass,/obj/fiftyspawner/glass,/obj/fiftyspawner/glass,/obj/fiftyspawner/glass,/obj/fiftyspawner/glass,/obj/fiftyspawner/steel,/obj/fiftyspawner/steel,/obj/fiftyspawner/steel,/obj/fiftyspawner/steel,/obj/fiftyspawner/steel,/obj/fiftyspawner/plastic,/obj/fiftyspawner/plastic,/obj/fiftyspawner/plastic,/obj/fiftyspawner/plastic,/obj/fiftyspawner/plastic,/obj/structure/table/rack/shelf/steel,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/SmallCombatShip)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/simulated/wall/shull,
+/area/survivalpod/superpose/SmallCombatShip)
+"d" = (
+/obj/machinery/disperser/front{
+	dir = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"f" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/SmallCombatShip)
+"g" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/SmallCombatShip)
+"h" = (
+/obj/effect/catwalk_plated/dark,
+/turf/template_noop,
+/area/survivalpod/superpose/SmallCombatShip)
+"l" = (
+/obj/structure/bed/chair/bay/comfy/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/SmallCombatShip)
+"m" = (
+/turf/simulated/wall/rshull,
+/area/survivalpod/superpose/SmallCombatShip)
+"o" = (
+/obj/structure/salvageable/machine,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/SmallCombatShip)
+"q" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/machinery/power/apc/hyper{
+	pixel_y = -24
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/SmallCombatShip)
+"s" = (
+/obj/structure/closet/walllocker_double/medical/west,
+/obj/item/weapon/storage/firstaid,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/roller,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/SmallCombatShip)
+"t" = (
+/obj/effect/catwalk_plated/dark,
+/obj/effect/catwalk_plated/dark,
+/turf/template_noop,
+/area/survivalpod/superpose/SmallCombatShip)
+"u" = (
+/obj/machinery/porta_turret/stationary/syndie{
+	faction = "neutral"
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/SmallCombatShip)
+"w" = (
+/obj/item/device/gps,
+/obj/item/sticky_pad/random,
+/obj/item/device/starcaster_news,
+/obj/item/weapon/pen/blue,
+/obj/item/device/pda,
+/obj/item/weapon/card/id/external,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/gun/energy/locked/phasegun/pistol,
+/obj/item/weapon/material/knife/tacknife/survival,
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/device/camera,
+/obj/item/device/binoculars,
+/obj/item/device/threadneedle,
+/obj/random/soap,
+/obj/item/weapon/towel/random,
+/obj/item/bodybag/cryobag,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/color/yellow,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/weapon/flame/lighter/random,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/stack/nanopaste,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,
+/obj/item/weapon/storage/backpack/messenger,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/clothing/accessory/poncho/thermal,
+/obj/item/weapon/storage/box/survival/comp,
+/obj/item/weapon/storage/toolbox/brass,
+/obj/item/weapon/storage/box/khcrystal,
+/obj/structure/closet/walllocker_double/east,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/SmallCombatShip)
+"z" = (
+/obj/structure/salvageable/server,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/SmallCombatShip)
+"A" = (
+/obj/structure/shuttle/engine/heater,
+/turf/simulated/wall/shull,
+/area/survivalpod/superpose/SmallCombatShip)
+"C" = (
+/obj/structure/closet/walllocker_double/kitchen/east{
+	name = "Ration Cabinet"
+	},
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/SmallCombatShip)
+"D" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/SmallCombatShip)
+"H" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/SmallCombatShip)
+"I" = (
+/obj/machinery/disperser/middle{
+	dir = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"J" = (
+/obj/structure/salvageable/computer,
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/SmallCombatShip)
+"L" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/SmallCombatShip)
+"M" = (
+/obj/structure/bed/chair/bay/comfy/red{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/SmallCombatShip)
+"N" = (
+/turf/template_noop,
+/area/template_noop)
+"O" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/template_noop,
+/area/survivalpod/superpose/SmallCombatShip)
+"Q" = (
+/obj/machinery/disperser/back{
+	dir = 1
+	},
+/obj/structure/ship_munition/disperser_charge/explosive,
+/turf/simulated/wall/rshull,
+/area/survivalpod/superpose/SmallCombatShip)
+"U" = (
+/obj/structure/bed/chair/bay/comfy/red{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/SmallCombatShip)
+"W" = (
+/obj/structure/window/plastitanium/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/grille/rustic{
+	health = 25;
+	name = "reinforced grille"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "stargazer_blast";
+	name = "window blast shield"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/SmallCombatShip)
+"X" = (
+/obj/structure/fans/hardlight/colorable{
+	color = "red"
+	},
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/SmallCombatShip)
+"Y" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/SmallCombatShip)
+"Z" = (
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/plastic,
+/obj/structure/table/rack/shelf/steel,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/SmallCombatShip)
 
 (1,1,1) = {"
-NNNmNmNNN
-NdmmWmmdN
-mIWJozWIm
-mQmsUCmQm
-mmlYfDMmm
-NWgYZDgWN
-uawaaagau
-NaHahXgaN
-aaLahaLaa
-aAOhthOAa
-aONNNNNOa
+N
+N
+m
+m
+m
+N
+u
+N
+a
+a
+a
+"}
+(2,1,1) = {"
+N
+d
+I
+Q
+m
+W
+a
+a
+a
+A
+O
+"}
+(3,1,1) = {"
+N
+m
+W
+m
+l
+g
+w
+H
+L
+O
+N
+"}
+(4,1,1) = {"
+m
+m
+J
+s
+Y
+Y
+a
+a
+a
+h
+N
+"}
+(5,1,1) = {"
+N
+W
+o
+U
+f
+Z
+a
+h
+h
+t
+N
+"}
+(6,1,1) = {"
+m
+m
+z
+C
+D
+q
+a
+X
+a
+h
+N
+"}
+(7,1,1) = {"
+N
+m
+W
+m
+M
+g
+g
+g
+L
+O
+N
+"}
+(8,1,1) = {"
+N
+d
+I
+Q
+m
+W
+a
+a
+a
+A
+O
+"}
+(9,1,1) = {"
+N
+N
+m
+m
+m
+N
+u
+N
+a
+a
+a
 "}

--- a/modular_chomp/maps/submaps/shelters/SurvivalDIY-11x11.dmm
+++ b/modular_chomp/maps/submaps/shelters/SurvivalDIY-11x11.dmm
@@ -354,6 +354,9 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_11x11)
+"C" = (
+/turf/simulated/wall,
+/area/survivalpod/superpose/SurvivalDIY_11x11)
 "F" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
@@ -369,7 +372,9 @@
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_11x11)
 "O" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/closet/secure_closet/engineering_electrical{
+	locked = 0
+	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_11x11)
 "P" = (
@@ -407,6 +412,15 @@
 /area/survivalpod/superpose/SurvivalDIY_11x11)
 "S" = (
 /obj/vehicle/train/engine,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_11x11)
+"T" = (
+/obj/machinery/power/apc/alarms_hidden{
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -24;
+	req_access = null
+	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_11x11)
 "U" = (
@@ -448,7 +462,7 @@ X
 a
 a
 w
-a
+C
 e
 "}
 (3,1,1) = {"
@@ -461,7 +475,7 @@ b
 a
 a
 v
-a
+T
 e
 "}
 (4,1,1) = {"

--- a/modular_chomp/maps/submaps/shelters/SurvivalDIY-11x11.dmm
+++ b/modular_chomp/maps/submaps/shelters/SurvivalDIY-11x11.dmm
@@ -408,6 +408,10 @@
 /obj/vehicle/train/engine,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_11x11)
+"U" = (
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_11x11)
 "X" = (
 /obj/machinery/vending/tool{
 	emagged = 1;
@@ -468,7 +472,7 @@ q
 O
 a
 a
-a
+U
 a
 e
 "}

--- a/modular_chomp/maps/submaps/shelters/SurvivalDIY-11x11.dmm
+++ b/modular_chomp/maps/submaps/shelters/SurvivalDIY-11x11.dmm
@@ -238,6 +238,7 @@
 	},
 /obj/item/weapon/rcd_ammo/large,
 /obj/item/weapon/rcd_ammo/large,
+/obj/item/areaeditor/blueprints/engineers,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_11x11)
 "w" = (

--- a/modular_chomp/maps/submaps/shelters/SurvivalDIY-7x7.dmm
+++ b/modular_chomp/maps/submaps/shelters/SurvivalDIY-7x7.dmm
@@ -125,12 +125,27 @@
 /obj/item/areaeditor/blueprints/engineers,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_7x7)
+"e" = (
+/obj/machinery/power/apc/alarms_hidden{
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -24;
+	req_access = null
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
 "g" = (
 /obj/structure/inflatable/door,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_7x7)
 "h" = (
 /obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"k" = (
+/obj/structure/closet/secure_closet/engineering_electrical{
+	locked = 0
+	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_7x7)
 "q" = (
@@ -283,13 +298,16 @@
 /obj/item/device/mapping_unit,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_7x7)
+"X" = (
+/turf/simulated/wall,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
 
 (1,1,1) = {"
 A
 A
 A
 A
-A
+X
 A
 A
 "}
@@ -298,7 +316,7 @@ A
 T
 G
 d
-G
+e
 a
 A
 "}
@@ -313,7 +331,7 @@ A
 "}
 (4,1,1) = {"
 A
-G
+k
 G
 w
 C

--- a/modular_chomp/maps/submaps/shelters/SurvivalDIY-7x7.dmm
+++ b/modular_chomp/maps/submaps/shelters/SurvivalDIY-7x7.dmm
@@ -122,6 +122,7 @@
 	},
 /obj/item/weapon/rcd_ammo,
 /obj/item/weapon/rcd_ammo,
+/obj/item/areaeditor/blueprints/engineers,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_7x7)
 "g" = (

--- a/modular_chomp/maps/submaps/shelters/SurvivalDIY-7x7.dmm
+++ b/modular_chomp/maps/submaps/shelters/SurvivalDIY-7x7.dmm
@@ -1,25 +1,348 @@
-"a" = (/obj/structure/closet/crate,/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil/green,/obj/item/stack/cable_coil/blue,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"c" = (/obj/item/device/gps,/obj/item/sticky_pad/random,/obj/item/device/starcaster_news,/obj/item/weapon/pen/blue,/obj/item/device/pda,/obj/item/weapon/card/id/external,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/gun/energy/locked/phasegun/pistol,/obj/item/weapon/material/knife/tacknife/survival,/obj/item/clothing/accessory/permit/gun,/obj/item/device/camera,/obj/item/device/binoculars,/obj/item/device/threadneedle,/obj/random/soap,/obj/item/weapon/towel/random,/obj/item/bodybag/cryobag,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/color/yellow,/obj/item/device/radio,/obj/item/device/radio,/obj/item/weapon/flame/lighter/random,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/device/suit_cooling_unit/emergency,/obj/item/stack/nanopaste,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,/obj/item/weapon/storage/backpack/messenger,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/clothing/accessory/poncho/thermal,/obj/item/weapon/storage/box/survival/comp,/obj/item/weapon/storage/toolbox/brass,/obj/item/weapon/storage/box/khcrystal,/obj/structure/closet/crate,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"d" = (/obj/machinery/autolathe,/obj/item/weapon/rcd/loaded{pixel_x = -4; pixel_y = 10},/obj/item/weapon/rcd_ammo,/obj/item/weapon/rcd_ammo,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"g" = (/obj/structure/inflatable/door,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"h" = (/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"u" = (/obj/structure/reagent_dispensers/fueltank,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"w" = (/obj/machinery/power/port_gen/pacman,/obj/item/stack/material/phoron{amount = 25},/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"A" = (/obj/structure/inflatable,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"C" = (/obj/machinery/portable_atmospherics/powered/pump/filled,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"D" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"G" = (/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"H" = (/obj/machinery/space_heater,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"M" = (/obj/structure/closet/crate,/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/fiftyspawner/blucarpet,/obj/fiftyspawner/oracarpet,/obj/fiftyspawner/purcarpet,/obj/fiftyspawner/sblucarpet,/obj/fiftyspawner/tealcarpet,/obj/fiftyspawner/turcarpet,/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/algae{amount = 50},/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/lead{amount = 30},/obj/item/stack/material/plasteel{amount = 30; pixel_y = 5},/obj/item/stack/material/resin{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"S" = (/obj/machinery/floodlight,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
-"T" = (/obj/structure/closet/toolcloset,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/toxin,/obj/item/weapon/storage/firstaid/o2,/obj/item/weapon/module/id_auth,/obj/item/weapon/module/card_reader,/obj/item/weapon/module/cell_power,/obj/item/weapon/module/power_control,/obj/item/weapon/circuitboard/microwave,/obj/item/weapon/circuitboard/mass_driver,/obj/item/weapon/circuitboard/jukebox,/obj/item/weapon/circuitboard/intercom,/obj/item/weapon/circuitboard/firealarm,/obj/item/weapon/circuitboard/airalarm,/obj/item/weapon/cell/high,/obj/item/weapon/cell/high,/obj/item/device/flashlight,/obj/item/device/flashlight,/obj/item/weapon/tape_roll,/obj/item/weapon/tape_roll,/obj/item/weapon/reagent_containers/spray/cleaner,/obj/item/weapon/storage/box/lights/mixed,/obj/item/weapon/storage/box/lights/mixed,/obj/item/weapon/storage/belt/utility/full/multitool,/obj/item/weapon/storage/bag/trash,/obj/item/weapon/storage/bag/trash,/obj/item/weapon/storage/backpack/dufflebag/eng,/obj/item/device/geiger,/obj/item/device/mapping_unit,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_7x7)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/closet/crate,
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/blue,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"c" = (
+/obj/item/device/gps,
+/obj/item/sticky_pad/random,
+/obj/item/device/starcaster_news,
+/obj/item/weapon/pen/blue,
+/obj/item/device/pda,
+/obj/item/weapon/card/id/external,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/gun/energy/locked/phasegun/pistol,
+/obj/item/weapon/material/knife/tacknife/survival,
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/device/camera,
+/obj/item/device/binoculars,
+/obj/item/device/threadneedle,
+/obj/random/soap,
+/obj/item/weapon/towel/random,
+/obj/item/bodybag/cryobag,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/color/yellow,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/weapon/flame/lighter/random,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/stack/nanopaste,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,
+/obj/item/weapon/storage/backpack/messenger,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/clothing/accessory/poncho/thermal,
+/obj/item/weapon/storage/box/survival/comp,
+/obj/item/weapon/storage/toolbox/brass,
+/obj/item/weapon/storage/box/khcrystal,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"d" = (
+/obj/machinery/autolathe,
+/obj/item/weapon/rcd/loaded{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"g" = (
+/obj/structure/inflatable/door,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"h" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"q" = (
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"u" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"w" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"A" = (
+/obj/structure/inflatable,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"C" = (
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"D" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"G" = (
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"H" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"M" = (
+/obj/structure/closet/crate,
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/fiftyspawner/blucarpet,
+/obj/fiftyspawner/oracarpet,
+/obj/fiftyspawner/purcarpet,
+/obj/fiftyspawner/sblucarpet,
+/obj/fiftyspawner/tealcarpet,
+/obj/fiftyspawner/turcarpet,
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/algae{
+	amount = 50
+	},
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/lead{
+	amount = 30
+	},
+/obj/item/stack/material/plasteel{
+	amount = 30;
+	pixel_y = 5
+	},
+/obj/item/stack/material/resin{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"S" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
+"T" = (
+/obj/structure/closet/toolcloset,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/module/id_auth,
+/obj/item/weapon/module/card_reader,
+/obj/item/weapon/module/cell_power,
+/obj/item/weapon/module/power_control,
+/obj/item/weapon/circuitboard/microwave,
+/obj/item/weapon/circuitboard/mass_driver,
+/obj/item/weapon/circuitboard/jukebox,
+/obj/item/weapon/circuitboard/intercom,
+/obj/item/weapon/circuitboard/firealarm,
+/obj/item/weapon/circuitboard/airalarm,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/belt/utility/full/multitool,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/weapon/storage/backpack/dufflebag/eng,
+/obj/item/device/geiger,
+/obj/item/device/mapping_unit,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_7x7)
 
 (1,1,1) = {"
-AAAAAAA
-ATcGgGg
-AGGGgGg
-AdGwAAA
-AGGCShA
-AaMDHuA
-AAAAAAA
+A
+A
+A
+A
+A
+A
+A
+"}
+(2,1,1) = {"
+A
+T
+G
+d
+G
+a
+A
+"}
+(3,1,1) = {"
+A
+c
+G
+q
+G
+M
+A
+"}
+(4,1,1) = {"
+A
+G
+G
+w
+C
+D
+A
+"}
+(5,1,1) = {"
+A
+g
+g
+A
+S
+H
+A
+"}
+(6,1,1) = {"
+A
+G
+G
+A
+h
+u
+A
+"}
+(7,1,1) = {"
+A
+g
+g
+A
+A
+A
+A
 "}

--- a/modular_chomp/maps/submaps/shelters/SurvivalDIY-9x9.dmm
+++ b/modular_chomp/maps/submaps/shelters/SurvivalDIY-9x9.dmm
@@ -77,6 +77,7 @@
 	},
 /obj/item/weapon/rcd_ammo,
 /obj/item/weapon/rcd_ammo,
+/obj/item/areaeditor/blueprints/engineers,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_9x9)
 "h" = (

--- a/modular_chomp/maps/submaps/shelters/SurvivalDIY-9x9.dmm
+++ b/modular_chomp/maps/submaps/shelters/SurvivalDIY-9x9.dmm
@@ -278,12 +278,17 @@
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_9x9)
 "I" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/closet/secure_closet/engineering_electrical{
+	locked = 0
+	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_9x9)
 "M" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"N" = (
+/turf/simulated/wall,
 /area/survivalpod/superpose/SurvivalDIY_9x9)
 "Q" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -297,6 +302,15 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/SurvivalDIY_9x9)
+"X" = (
+/obj/machinery/power/apc/alarms_hidden{
+	dir = 8;
+	pixel_y = 0;
+	pixel_x = -24;
+	req_access = null
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
 
 (1,1,1) = {"
 h
@@ -306,7 +320,7 @@ h
 h
 h
 h
-h
+N
 h
 "}
 (2,1,1) = {"
@@ -317,7 +331,7 @@ F
 u
 u
 u
-u
+X
 h
 "}
 (3,1,1) = {"

--- a/modular_chomp/maps/submaps/shelters/SurvivalDIY-9x9.dmm
+++ b/modular_chomp/maps/submaps/shelters/SurvivalDIY-9x9.dmm
@@ -1,30 +1,398 @@
-"a" = (/obj/machinery/floodlight,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"f" = (/obj/structure/closet/crate,/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil/green,/obj/item/stack/cable_coil/blue,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"g" = (/obj/machinery/autolathe,/obj/item/weapon/rcd/loaded{pixel_x = -4; pixel_y = 10},/obj/item/weapon/rcd_ammo,/obj/item/weapon/rcd_ammo,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"h" = (/obj/structure/inflatable,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"i" = (/obj/structure/closet/secure_closet/engineering_welding{locked = 0},/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"o" = (/obj/item/device/gps,/obj/item/sticky_pad/random,/obj/item/device/starcaster_news,/obj/item/weapon/pen/blue,/obj/item/device/pda,/obj/item/weapon/card/id/external,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/gun/energy/locked/phasegun/pistol,/obj/item/weapon/material/knife/tacknife/survival,/obj/item/clothing/accessory/permit/gun,/obj/item/device/camera,/obj/item/device/binoculars,/obj/item/device/threadneedle,/obj/random/soap,/obj/item/weapon/towel/random,/obj/item/bodybag/cryobag,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/color/yellow,/obj/item/device/radio,/obj/item/device/radio,/obj/item/weapon/flame/lighter/random,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/device/suit_cooling_unit/emergency,/obj/item/stack/nanopaste,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,/obj/item/weapon/storage/backpack/messenger,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/clothing/accessory/poncho/thermal,/obj/item/weapon/storage/box/survival/comp,/obj/item/weapon/storage/toolbox/brass,/obj/item/weapon/storage/box/khcrystal,/obj/structure/closet/crate,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"q" = (/obj/vehicle/train/engine/quadbike/built,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"u" = (/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"y" = (/obj/machinery/space_heater,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"z" = (/obj/structure/closet/toolcloset,/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/toxin,/obj/item/weapon/storage/firstaid/o2,/obj/item/weapon/module/id_auth,/obj/item/weapon/module/card_reader,/obj/item/weapon/module/cell_power,/obj/item/weapon/module/power_control,/obj/item/weapon/circuitboard/microwave,/obj/item/weapon/circuitboard/mass_driver,/obj/item/weapon/circuitboard/jukebox,/obj/item/weapon/circuitboard/intercom,/obj/item/weapon/circuitboard/firealarm,/obj/item/weapon/circuitboard/airalarm,/obj/item/weapon/cell/high,/obj/item/weapon/cell/high,/obj/item/device/flashlight,/obj/item/device/flashlight,/obj/item/weapon/tape_roll,/obj/item/weapon/tape_roll,/obj/item/weapon/reagent_containers/spray/cleaner,/obj/item/weapon/storage/box/lights/mixed,/obj/item/weapon/storage/box/lights/mixed,/obj/item/weapon/storage/belt/utility/full/multitool,/obj/item/weapon/storage/bag/trash,/obj/item/weapon/storage/bag/trash,/obj/item/weapon/storage/backpack/dufflebag/eng,/obj/item/device/geiger,/obj/item/device/mapping_unit,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"C" = (/obj/structure/closet/crate,/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/item/stack/material/cardboard{amount = 50},/obj/fiftyspawner/blucarpet,/obj/fiftyspawner/oracarpet,/obj/fiftyspawner/purcarpet,/obj/fiftyspawner/sblucarpet,/obj/fiftyspawner/tealcarpet,/obj/fiftyspawner/turcarpet,/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood{amount = 50; color = "#824B28"},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/hard{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/wood/sif{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/marble{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/cloth{amount = 50},/obj/item/stack/material/algae{amount = 50},/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/sandstone,/obj/item/stack/material/lead{amount = 30},/obj/item/stack/material/plasteel{amount = 30; pixel_y = 5},/obj/item/stack/material/resin{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/obj/item/stack/material/smolebricks{amount = 50},/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"F" = (/obj/machinery/power/port_gen/pacman,/obj/item/stack/material/phoron{amount = 25},/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"H" = (/obj/structure/inflatable/door,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"I" = (/obj/structure/closet/secure_closet/engineering_electrical,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"M" = (/obj/machinery/portable_atmospherics/powered/pump/filled,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"Q" = (/obj/structure/reagent_dispensers/watertank,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"T" = (/obj/structure/reagent_dispensers/fueltank,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
-"V" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalDIY_9x9)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"f" = (
+/obj/structure/closet/crate,
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/blue,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"g" = (
+/obj/machinery/autolathe,
+/obj/item/weapon/rcd/loaded{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"h" = (
+/obj/structure/inflatable,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"i" = (
+/obj/structure/closet/secure_closet/engineering_welding{
+	locked = 0
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"o" = (
+/obj/item/device/gps,
+/obj/item/sticky_pad/random,
+/obj/item/device/starcaster_news,
+/obj/item/weapon/pen/blue,
+/obj/item/device/pda,
+/obj/item/weapon/card/id/external,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/gun/energy/locked/phasegun/pistol,
+/obj/item/weapon/material/knife/tacknife/survival,
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/device/camera,
+/obj/item/device/binoculars,
+/obj/item/device/threadneedle,
+/obj/random/soap,
+/obj/item/weapon/towel/random,
+/obj/item/bodybag/cryobag,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/color/yellow,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/weapon/flame/lighter/random,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/stack/nanopaste,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,
+/obj/item/weapon/storage/backpack/messenger,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/clothing/accessory/poncho/thermal,
+/obj/item/weapon/storage/box/survival/comp,
+/obj/item/weapon/storage/toolbox/brass,
+/obj/item/weapon/storage/box/khcrystal,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"q" = (
+/obj/vehicle/train/engine/quadbike/built,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"u" = (
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"x" = (
+/obj/structure/closet/crate/solar,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"y" = (
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"z" = (
+/obj/structure/closet/toolcloset,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/weapon/module/id_auth,
+/obj/item/weapon/module/card_reader,
+/obj/item/weapon/module/cell_power,
+/obj/item/weapon/module/power_control,
+/obj/item/weapon/circuitboard/microwave,
+/obj/item/weapon/circuitboard/mass_driver,
+/obj/item/weapon/circuitboard/jukebox,
+/obj/item/weapon/circuitboard/intercom,
+/obj/item/weapon/circuitboard/firealarm,
+/obj/item/weapon/circuitboard/airalarm,
+/obj/item/weapon/cell/high,
+/obj/item/weapon/cell/high,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/tape_roll,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/belt/utility/full/multitool,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/weapon/storage/backpack/dufflebag/eng,
+/obj/item/device/geiger,
+/obj/item/device/mapping_unit,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"C" = (
+/obj/structure/closet/crate,
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/item/stack/material/cardboard{
+	amount = 50
+	},
+/obj/fiftyspawner/blucarpet,
+/obj/fiftyspawner/oracarpet,
+/obj/fiftyspawner/purcarpet,
+/obj/fiftyspawner/sblucarpet,
+/obj/fiftyspawner/tealcarpet,
+/obj/fiftyspawner/turcarpet,
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood{
+	amount = 50;
+	color = "#824B28"
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/hard{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/wood/sif{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/marble{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/cloth{
+	amount = 50
+	},
+/obj/item/stack/material/algae{
+	amount = 50
+	},
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/sandstone,
+/obj/item/stack/material/lead{
+	amount = 30
+	},
+/obj/item/stack/material/plasteel{
+	amount = 30;
+	pixel_y = 5
+	},
+/obj/item/stack/material/resin{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/obj/item/stack/material/smolebricks{
+	amount = 50
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"F" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"H" = (
+/obj/structure/inflatable/door,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"I" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"M" = (
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"Q" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"T" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
+"V" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalDIY_9x9)
 
 (1,1,1) = {"
-hhhhhhhhh
-hziIqHuuH
-huuuuHuuH
-hFguuhhhh
-huuuuuuuh
-hufCuVTuh
-hufCuaauh
-huoMuQyuh
-hhhhhhhhh
+h
+h
+h
+h
+h
+h
+h
+h
+h
+"}
+(2,1,1) = {"
+h
+z
+u
+F
+u
+u
+u
+u
+h
+"}
+(3,1,1) = {"
+h
+i
+u
+g
+u
+f
+f
+o
+h
+"}
+(4,1,1) = {"
+h
+I
+u
+u
+u
+C
+C
+M
+h
+"}
+(5,1,1) = {"
+h
+q
+u
+u
+u
+u
+u
+x
+h
+"}
+(6,1,1) = {"
+h
+H
+H
+h
+u
+V
+a
+Q
+h
+"}
+(7,1,1) = {"
+h
+u
+u
+h
+u
+T
+a
+y
+h
+"}
+(8,1,1) = {"
+h
+u
+u
+h
+u
+u
+u
+u
+h
+"}
+(9,1,1) = {"
+h
+H
+H
+h
+h
+h
+h
+h
+h
 "}

--- a/modular_chomp/maps/submaps/shelters/SurvivalScience-9x9.dmm
+++ b/modular_chomp/maps/submaps/shelters/SurvivalScience-9x9.dmm
@@ -1,65 +1,758 @@
-"ax" = (/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,/area/survivalpod/superpose/SurvivalScience)
-"cv" = (/obj/structure/fans/tiny,/obj/effect/floor_decal/industrial/danger/full,/obj/machinery/door/airlock/voidcraft/survival_pod,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/SurvivalScience)
-"eI" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/atmospherics/unary/vent_pump{dir = 8; external_pressure_bound = 0; external_pressure_bound_default = 0; icon_state = "map_vent_in"; initialize_directions = 8; internal_pressure_bound = 4000; internal_pressure_bound_default = 4000; pressure_checks = 2; pressure_checks_default = 2; pump_direction = 0; use_power = 1},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/SurvivalScience)
-"eX" = (/obj/machinery/r_n_d/server/robotics,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/machinery/atmospherics/pipe/simple/hidden{dir = 5},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/SurvivalScience)
-"fo" = (/obj/structure/tubes,/obj/machinery/computer/rdservercontrol{dir = 8},/obj/structure/window/reinforced/survival_pod{opacity = 1},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"fS" = (/turf/simulated/shuttle/wall/voidcraft/survival,/area/survivalpod/superpose/SurvivalScience)
-"gC" = (/obj/structure/table/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 8; opacity = 1},/obj/machinery/cell_charger{pixel_x = 1; pixel_y = -2},/obj/machinery/recharger{pixel_x = -3; pixel_y = 9},/obj/structure/window/reinforced/survival_pod{opacity = 1},/obj/item/weapon/reagent_containers/food/drinks/jar{pixel_x = 10; pixel_y = 12},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"gN" = (/obj/machinery/light{dir = 1},/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScience)
-"gW" = (/obj/machinery/r_n_d/destructive_analyzer,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"gY" = (/obj/structure/fans/tiny,/obj/effect/floor_decal/industrial/danger/full,/obj/machinery/door/airlock/voidcraft/vertical,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScience)
-"hp" = (/obj/machinery/computer/rdconsole/core{dir = 4},/obj/machinery/light{dir = 8; layer = 3},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"hW" = (/obj/machinery/r_n_d/protolathe,/obj/structure/sign/periodic{pixel_y = 29},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"ku" = (/obj/structure/sign/science,/turf/simulated/shuttle/wall/voidcraft/lightblue,/area/survivalpod/superpose/SurvivalScience)
-"mB" = (/obj/structure/reagent_dispensers/fueltank/high,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"mY" = (/obj/effect/floor_decal/techfloor{dir = 1},/obj/effect/floor_decal/industrial/warning{dir = 1},/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScience)
-"nQ" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 8},/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/meter,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScience)
-"oQ" = (/obj/machinery/autolathe,/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/light,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"ph" = (/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScience)
-"pw" = (/obj/effect/floor_decal/industrial/loading{dir = 1},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"pK" = (/obj/machinery/door/window/survival_pod{dir = 2; req_one_access = null},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"sk" = (/obj/effect/floor_decal/techfloor,/obj/effect/floor_decal/industrial/warning,/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScience)
-"uq" = (/obj/machinery/mecha_part_fabricator,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"va" = (/obj/machinery/sleeper/survival_pod,/obj/structure/window/reinforced/survival_pod{dir = 8; opacity = 1},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"vt" = (/obj/structure/sign/mining/survival{dir = 8},/turf/simulated/shuttle/wall/voidcraft/lightblue,/area/survivalpod/superpose/SurvivalScience)
-"wq" = (/obj/machinery/smartfridge/survival_pod,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/menu9,/obj/item/weapon/storage/mre/menu9,/obj/item/weapon/storage/mre/menu10,/obj/item/weapon/storage/mre/menu10,/obj/item/weapon/storage/mre/menu11,/obj/item/weapon/storage/mre/menu11,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/weapon/storage/pill_bottle/antitox,/obj/item/weapon/storage/box/survival/space,/obj/item/device/healthanalyzer,/obj/item/weapon/storage/pill_bottle/dice_nerd,/obj/machinery/light{dir = 1},/obj/item/weapon/storage/firstaid/regular,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/storage/box/survival/space,/obj/item/weapon/storage/box/survival/space,/obj/item/device/radio,/obj/item/device/radio,/obj/item/device/radio,/obj/item/device/starcaster_news,/obj/item/device/starcaster_news,/obj/item/device/threadneedle,/obj/item/device/flashlight,/obj/item/device/flashlight,/obj/item/weapon/storage/toolbox/emergency,/obj/item/weapon/storage/pill_bottle/spaceacillin,/obj/random/soap,/obj/item/weapon/material/knife/machete/hatchet,/obj/item/weapon/storage/box/flare,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"wY" = (/obj/effect/floor_decal/industrial/hatch/yellow,/obj/machinery/recharge_station,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/SurvivalScience)
-"xx" = (/obj/structure/window/reinforced/survival_pod{opacity = 1},/obj/machinery/r_n_d/circuit_imprinter,/obj/item/weapon/reagent_containers/glass/beaker{pixel_x = 9; pixel_y = 8},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"zw" = (/obj/item/device/gps/computer,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"zR" = (/obj/structure/sign/mining,/turf/simulated/shuttle/wall/voidcraft/lightblue,/area/survivalpod/superpose/SurvivalScience)
-"AA" = (/obj/structure/bed/pod,/obj/item/weapon/bedsheet/purple,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"AB" = (/obj/structure/bed/chair/office/dark{dir = 8},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"AH" = (/obj/structure/window/reinforced/survival_pod{opacity = 1},/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "smartfridge"; icon_contents = "boxes"; icon_state = "smartfridge"; name = "Advanced storage"; pixel_y = -1},/obj/item/weapon/stock_parts/micro_laser,/obj/item/weapon/stock_parts/micro_laser,/obj/item/weapon/stock_parts/matter_bin,/obj/item/weapon/stock_parts/matter_bin,/obj/item/weapon/stock_parts/console_screen,/obj/item/weapon/stock_parts/console_screen,/obj/item/weapon/storage/toolbox/mechanical{pixel_x = -2; pixel_y = -1},/obj/item/weapon/storage/toolbox/mechanical{pixel_x = -2; pixel_y = -1},/obj/item/clothing/gloves/sterile/latex,/obj/item/clothing/gloves/sterile/latex,/obj/item/weapon/storage/belt/utility,/obj/item/weapon/storage/belt/utility,/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/item/stack/material/copper{amount = 25},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/glass{amount = 50; pixel_x = 3; pixel_y = 3},/obj/item/clothing/mask/gas,/obj/item/clothing/mask/gas,/obj/item/weapon/disk/design_disk,/obj/item/weapon/disk/design_disk,/obj/item/weapon/disk/tech_disk,/obj/item/weapon/disk/tech_disk,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"Ct" = (/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"Cz" = (/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScience)
-"CX" = (/turf/simulated/shuttle/wall/voidcraft/lightblue,/area/survivalpod/superpose/SurvivalScience)
-"EO" = (/obj/structure/sign/mining/survival,/turf/simulated/shuttle/wall/voidcraft/lightblue,/area/survivalpod/superpose/SurvivalScience)
-"Gd" = (/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod,/obj/structure/grille,/obj/structure/curtain/black,/turf/simulated/floor/plating,/area/survivalpod/superpose/SurvivalScience)
-"Gt" = (/obj/machinery/r_n_d/server/core,/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 8},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/SurvivalScience)
-"Gx" = (/obj/structure/sign/mining/survival{dir = 4},/turf/simulated/shuttle/wall/voidcraft/lightblue,/area/survivalpod/superpose/SurvivalScience)
-"HB" = (/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "smartfridge"; icon_contents = "boxes"; icon_state = "smartfridge"; name = "Advanced storage"; pixel_y = -1},/obj/item/weapon/storage/toolbox/mechanical{pixel_x = -2; pixel_y = -1},/obj/item/weapon/storage/toolbox/mechanical{pixel_x = -2; pixel_y = -1},/obj/item/weapon/storage/toolbox/electrical{pixel_x = 1; pixel_y = 6},/obj/item/weapon/storage/toolbox/electrical{pixel_x = 1; pixel_y = 6},/obj/item/weapon/storage/belt/utility,/obj/item/weapon/storage/belt/utility,/obj/item/device/multitool{pixel_x = 3},/obj/item/device/multitool{pixel_x = 3},/obj/item/weapon/tool/crowbar,/obj/item/weapon/tool/crowbar,/obj/item/weapon/tool/crowbar,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/item/device/mmi,/obj/item/device/mmi,/obj/item/device/mmi,/obj/item/clothing/head/welding{pixel_x = -3; pixel_y = 5},/obj/item/clothing/head/welding{pixel_x = -3; pixel_y = 5},/obj/item/clothing/head/welding/demon,/obj/item/clothing/glasses/welding,/obj/item/clothing/glasses/welding,/obj/item/stack/cable_coil,/obj/item/stack/cable_coil,/obj/item/stack/cable_coil,/obj/item/device/healthanalyzer,/obj/item/device/healthanalyzer,/obj/item/device/flash/synthetic,/obj/item/device/flash/synthetic,/obj/item/device/flash/synthetic,/obj/item/weapon/storage/firstaid/regular{empty = 1; name = "First-Aid (empty)"},/obj/item/weapon/storage/firstaid/regular{empty = 1; name = "First-Aid (empty)"},/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000; pixel_x = 5; pixel_y = -5},/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000; pixel_x = 5; pixel_y = -5},/obj/item/device/assembly/prox_sensor{pixel_x = -8; pixel_y = 4},/obj/item/device/assembly/prox_sensor{pixel_x = -8; pixel_y = 4},/obj/item/stack/material/copper{amount = 25},/obj/item/stack/material/plastic{max_amount = 25},/obj/item/stack/material/plastic{max_amount = 25},/obj/item/stack/material/plasteel{amount = 10},/obj/item/stack/material/plasteel{amount = 10},/obj/item/stack/material/glass{amount = 50; pixel_x = -2; pixel_y = 2},/obj/item/stack/material/glass{amount = 50; pixel_x = -2; pixel_y = 2},/obj/item/stack/material/glass{amount = 50; pixel_x = -2; pixel_y = 2},/obj/item/stack/material/glass{amount = 50; pixel_x = -2; pixel_y = 2},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/device/flash,/obj/item/device/flash,/obj/effect/floor_decal/industrial/outline/yellow,/obj/item/clothing/mask/gas,/obj/item/clothing/mask/gas,/obj/item/weapon/implanter,/obj/item/weapon/implanter,/obj/item/weapon/implanter,/obj/item/weapon/storage/backpack/dufflebag/sci,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"IJ" = (/obj/structure/fans,/obj/structure/window/reinforced/survival_pod{dir = 8; opacity = 1},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"Ko" = (/obj/structure/table/reinforced,/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"Mf" = (/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/atmospherics/portables_connector{dir = 8},/obj/machinery/power/apc/alarms_hidden{dir = 4; pixel_x = 20},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScience)
-"Nt" = (/obj/machinery/mech_recharger,/obj/machinery/newscaster{layer = 3.3; pixel_y = -27},/obj/mecha/medical/odysseus/old,/obj/effect/floor_decal/industrial/warning/full,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/SurvivalScience)
-"NV" = (/obj/structure/reagent_dispensers/acid{pixel_x = -30},/obj/structure/sink/kitchen{dir = 8; pixel_x = -13},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"PD" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 6},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScience)
-"Qx" = (/obj/machinery/mecha_part_fabricator/pros,/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"TK" = (/obj/effect/floor_decal/techfloor{dir = 8},/obj/effect/floor_decal/industrial/warning{dir = 8},/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScience)
-"TY" = (/obj/structure/closet/secure_closet/guncabinet/phase{pixel_y = -32},/obj/item/weapon/gun/energy/locked/phasegun/pistol,/obj/item/weapon/gun/energy/locked/phasegun/pistol,/obj/item/clothing/accessory/permit/gun/planetside,/obj/item/clothing/accessory/permit/gun/planetside,/obj/item/clothing/accessory/holster/waist,/obj/item/clothing/accessory/holster/waist,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScience)
-"Vp" = (/obj/structure/window/reinforced/survival_pod{opacity = 1},/obj/structure/table/reinforced,/obj/item/weapon/paper_bin{pixel_x = -3; pixel_y = 7},/obj/item/weapon/clipboard,/obj/item/weapon/folder/white,/obj/item/weapon/pen,/obj/item/weapon/reagent_containers/dropper{pixel_y = -4},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScience)
-"VG" = (/obj/machinery/atmospherics/unary/vent_pump{dir = 8; icon_state = "map_vent_out"; use_power = 1},/obj/machinery/light/small{dir = 4},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/SurvivalScience)
-"Yk" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/warning/full,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/SurvivalScience)
-"Zq" = (/obj/machinery/atmospherics/unary/freezer{dir = 8; icon_state = "freezer_1"; power_setting = 20; set_temperature = 73; use_power = 1},/obj/machinery/light{dir = 4},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScience)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ax" = (
+/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,
+/area/survivalpod/superpose/SurvivalScience)
+"cv" = (
+/obj/structure/fans/tiny,
+/obj/effect/floor_decal/industrial/danger/full,
+/obj/machinery/door/airlock/voidcraft/survival_pod,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/SurvivalScience)
+"eI" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 8;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/SurvivalScience)
+"eX" = (
+/obj/machinery/r_n_d/server/robotics,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/SurvivalScience)
+"fo" = (
+/obj/structure/tubes,
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"fS" = (
+/turf/simulated/shuttle/wall/voidcraft/survival,
+/area/survivalpod/superpose/SurvivalScience)
+"gC" = (
+/obj/structure/table/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8;
+	opacity = 1
+	},
+/obj/machinery/cell_charger{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/machinery/recharger{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/obj/item/weapon/reagent_containers/food/drinks/jar{
+	pixel_x = 10;
+	pixel_y = 12
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"gN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScience)
+"gW" = (
+/obj/machinery/r_n_d/destructive_analyzer,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"gY" = (
+/obj/structure/fans/tiny,
+/obj/effect/floor_decal/industrial/danger/full,
+/obj/machinery/door/airlock/voidcraft/vertical,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScience)
+"hp" = (
+/obj/machinery/computer/rdconsole/core{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 3
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"hW" = (
+/obj/machinery/r_n_d/protolathe,
+/obj/structure/sign/periodic{
+	pixel_y = 29
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"ku" = (
+/obj/structure/sign/science,
+/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/area/survivalpod/superpose/SurvivalScience)
+"mB" = (
+/obj/structure/reagent_dispensers/fueltank/high,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"mY" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScience)
+"nQ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/meter,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScience)
+"oQ" = (
+/obj/machinery/autolathe,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"ph" = (
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScience)
+"pw" = (
+/obj/effect/floor_decal/industrial/loading{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"pK" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 2;
+	req_one_access = null
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"sk" = (
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScience)
+"uq" = (
+/obj/machinery/mecha_part_fabricator,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"va" = (
+/obj/machinery/sleeper/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8;
+	opacity = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"vt" = (
+/obj/structure/sign/mining/survival{
+	dir = 8
+	},
+/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/area/survivalpod/superpose/SurvivalScience)
+"wq" = (
+/obj/machinery/smartfridge/survival_pod,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/menu9,
+/obj/item/weapon/storage/mre/menu9,
+/obj/item/weapon/storage/mre/menu10,
+/obj/item/weapon/storage/mre/menu10,
+/obj/item/weapon/storage/mre/menu11,
+/obj/item/weapon/storage/mre/menu11,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/weapon/storage/pill_bottle/antitox,
+/obj/item/weapon/storage/box/survival/space,
+/obj/item/device/healthanalyzer,
+/obj/item/weapon/storage/pill_bottle/dice_nerd,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/storage/box/survival/space,
+/obj/item/weapon/storage/box/survival/space,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/starcaster_news,
+/obj/item/device/starcaster_news,
+/obj/item/device/threadneedle,
+/obj/item/device/flashlight,
+/obj/item/device/flashlight,
+/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/weapon/storage/pill_bottle/spaceacillin,
+/obj/random/soap,
+/obj/item/weapon/material/knife/machete/hatchet,
+/obj/item/weapon/storage/box/flare,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"wY" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/SurvivalScience)
+"xx" = (
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/item/weapon/reagent_containers/glass/beaker{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"zw" = (
+/obj/item/device/gps/computer,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"zR" = (
+/obj/structure/sign/mining,
+/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/area/survivalpod/superpose/SurvivalScience)
+"AA" = (
+/obj/structure/bed/pod,
+/obj/item/weapon/bedsheet/purple,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"AB" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"AH" = (
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "smartfridge";
+	icon_contents = "boxes";
+	icon_state = "smartfridge";
+	name = "Advanced storage";
+	pixel_y = -1
+	},
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/weapon/storage/belt/utility,
+/obj/item/weapon/storage/belt/utility,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/stack/material/copper{
+	amount = 25
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/disk/tech_disk,
+/obj/item/weapon/disk/tech_disk,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"Ct" = (
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"Cz" = (
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScience)
+"CX" = (
+/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/area/survivalpod/superpose/SurvivalScience)
+"EO" = (
+/obj/structure/sign/mining/survival,
+/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/area/survivalpod/superpose/SurvivalScience)
+"Gd" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/grille,
+/obj/structure/curtain/black,
+/turf/simulated/floor/plating,
+/area/survivalpod/superpose/SurvivalScience)
+"Gt" = (
+/obj/machinery/r_n_d/server/core,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/SurvivalScience)
+"Gx" = (
+/obj/structure/sign/mining/survival{
+	dir = 4
+	},
+/turf/simulated/shuttle/wall/voidcraft/lightblue,
+/area/survivalpod/superpose/SurvivalScience)
+"HB" = (
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "smartfridge";
+	icon_contents = "boxes";
+	icon_state = "smartfridge";
+	name = "Advanced storage";
+	pixel_y = -1
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/belt/utility,
+/obj/item/weapon/storage/belt/utility,
+/obj/item/device/multitool{
+	pixel_x = 3
+	},
+/obj/item/device/multitool{
+	pixel_x = 3
+	},
+/obj/item/weapon/tool/crowbar,
+/obj/item/weapon/tool/crowbar,
+/obj/item/weapon/tool/crowbar,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/item/device/mmi,
+/obj/item/device/mmi,
+/obj/item/device/mmi,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/welding/demon,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/device/healthanalyzer,
+/obj/item/device/healthanalyzer,
+/obj/item/device/flash/synthetic,
+/obj/item/device/flash/synthetic,
+/obj/item/device/flash/synthetic,
+/obj/item/weapon/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/stack/material/copper{
+	amount = 25
+	},
+/obj/item/stack/material/plastic{
+	max_amount = 25
+	},
+/obj/item/stack/material/plastic{
+	max_amount = 25
+	},
+/obj/item/stack/material/plasteel{
+	amount = 10
+	},
+/obj/item/stack/material/plasteel{
+	amount = 10
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/weapon/implanter,
+/obj/item/weapon/implanter,
+/obj/item/weapon/implanter,
+/obj/item/weapon/storage/backpack/dufflebag/sci,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"IJ" = (
+/obj/structure/fans,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8;
+	opacity = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"Ko" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"Mf" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/power/apc/alarms_hidden{
+	dir = 4;
+	pixel_x = 20
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScience)
+"Nt" = (
+/obj/machinery/mech_recharger,
+/obj/machinery/newscaster{
+	layer = 3.3;
+	pixel_y = -27
+	},
+/obj/mecha/medical/odysseus/old,
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/SurvivalScience)
+"NV" = (
+/obj/structure/reagent_dispensers/acid{
+	pixel_x = -30
+	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = -13
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"PD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScience)
+"Qx" = (
+/obj/machinery/mecha_part_fabricator/pros,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"TK" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScience)
+"TY" = (
+/obj/structure/closet/secure_closet/guncabinet/phase{
+	pixel_y = -32
+	},
+/obj/item/weapon/gun/energy/locked/phasegun/pistol,
+/obj/item/weapon/gun/energy/locked/phasegun/pistol,
+/obj/item/clothing/accessory/permit/gun/planetside,
+/obj/item/clothing/accessory/permit/gun/planetside,
+/obj/item/clothing/accessory/holster/waist,
+/obj/item/clothing/accessory/holster/waist,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScience)
+"Vp" = (
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/clipboard,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/pen,
+/obj/item/weapon/reagent_containers/dropper{
+	pixel_y = -4
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScience)
+"VG" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	icon_state = "map_vent_out";
+	use_power = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/SurvivalScience)
+"Yk" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/SurvivalScience)
+"Zq" = (
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 8;
+	icon_state = "freezer_1";
+	power_setting = 20;
+	set_temperature = 73;
+	use_power = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScience)
 
 (1,1,1) = {"
-fSaxGdkucvCXzRaxfS
-axhWKogWmYIJwqzwax
-vthpABCtCzvapwAAGd
-CXAHVpxxCzgCpKfoCX
-gYTKCzgNCzphPDMfax
-CXQxHBuqCzwYnQZqCX
-vtNVCtCtCzYkGteIGx
-axmBoQTYskNteXVGax
-fSaxzRCXcvCXEOaxfS
+fS
+ax
+vt
+CX
+gY
+CX
+vt
+ax
+fS
+"}
+(2,1,1) = {"
+ax
+hW
+hp
+AH
+TK
+Qx
+NV
+mB
+ax
+"}
+(3,1,1) = {"
+Gd
+Ko
+AB
+Vp
+Cz
+HB
+Ct
+oQ
+zR
+"}
+(4,1,1) = {"
+ku
+gW
+Ct
+xx
+gN
+uq
+Ct
+TY
+CX
+"}
+(5,1,1) = {"
+cv
+mY
+Cz
+Cz
+Cz
+Cz
+Cz
+sk
+cv
+"}
+(6,1,1) = {"
+CX
+IJ
+va
+gC
+ph
+wY
+Yk
+Nt
+CX
+"}
+(7,1,1) = {"
+zR
+wq
+pw
+pK
+PD
+nQ
+Gt
+eX
+EO
+"}
+(8,1,1) = {"
+ax
+zw
+AA
+fo
+Mf
+Zq
+eI
+VG
+ax
+"}
+(9,1,1) = {"
+fS
+ax
+Gd
+CX
+ax
+CX
+Gx
+ax
+fS
 "}

--- a/modular_chomp/maps/submaps/shelters/SurvivalScience2-9x9.dmm
+++ b/modular_chomp/maps/submaps/shelters/SurvivalScience2-9x9.dmm
@@ -1,56 +1,660 @@
-"a" = (/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,/area/survivalpod/superpose/SurvivalScienceV2)
-"b" = (/obj/machinery/mecha_part_fabricator{req_access = null},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"c" = (/obj/structure/window/reinforced/survival_pod{opacity = 1},/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "smartfridge"; icon_contents = "boxes"; icon_state = "smartfridge"; name = "Advanced storage"; pixel_y = -1},/obj/item/weapon/stock_parts/micro_laser,/obj/item/weapon/stock_parts/micro_laser,/obj/item/weapon/stock_parts/matter_bin,/obj/item/weapon/stock_parts/matter_bin,/obj/item/weapon/stock_parts/console_screen,/obj/item/weapon/stock_parts/console_screen,/obj/item/weapon/storage/toolbox/mechanical{pixel_x = -2; pixel_y = -1},/obj/item/weapon/storage/toolbox/mechanical{pixel_x = -2; pixel_y = -1},/obj/item/clothing/gloves/sterile/latex,/obj/item/clothing/gloves/sterile/latex,/obj/item/weapon/storage/belt/utility,/obj/item/weapon/storage/belt/utility,/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/item/stack/material/copper{amount = 25},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/glass{amount = 50; pixel_x = 3; pixel_y = 3},/obj/item/clothing/mask/gas,/obj/item/clothing/mask/gas,/obj/item/weapon/disk/design_disk,/obj/item/weapon/disk/design_disk,/obj/item/weapon/disk/tech_disk,/obj/item/weapon/disk/tech_disk,/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScienceV2)
-"e" = (/obj/machinery/atmospherics/unary/freezer{dir = 4; icon_state = "freezer_1"; power_setting = 20; set_temperature = 73; use_power = 1},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 1},/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"f" = (/obj/item/device/gps/computer,/obj/structure/window/reinforced/survival_pod{dir = 4},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"g" = (/obj/structure/window/reinforced/survival_pod{dir = 10},/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"h" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/r_n_d/server/core,/obj/machinery/light{dir = 4},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/SurvivalScienceV2)
-"i" = (/obj/effect/floor_decal/industrial/hatch/yellow,/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"j" = (/obj/machinery/r_n_d/circuit_imprinter,/obj/item/weapon/reagent_containers/glass/beaker{pixel_x = 9; pixel_y = 8},/obj/structure/window/reinforced/survival_pod{opacity = 1},/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"k" = (/obj/structure/window/reinforced/survival_pod{opacity = 1},/obj/structure/table/reinforced,/obj/item/weapon/paper_bin{pixel_x = -3; pixel_y = 7},/obj/item/weapon/clipboard,/obj/item/weapon/folder/white,/obj/item/weapon/pen,/obj/item/weapon/reagent_containers/dropper{pixel_y = -4},/obj/machinery/light{dir = 8},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScienceV2)
-"m" = (/obj/machinery/computer/rdconsole/core{dir = 4; req_access = null},/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/light{dir = 8},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"n" = (/obj/structure/sign/mining/survival{dir = 8},/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,/area/survivalpod/superpose/SurvivalScienceV2)
-"o" = (/obj/machinery/r_n_d/protolathe,/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"p" = (/obj/machinery/atmospherics/pipe/manifold/hidden,/obj/machinery/power/apc/alarms_hidden{pixel_y = -20},/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"q" = (/obj/structure/sign/mining/survival{dir = 1},/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,/area/survivalpod/superpose/SurvivalScienceV2)
-"s" = (/obj/structure/sink/kitchen{dir = 8; pixel_x = -10},/obj/machinery/light{dir = 8},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"t" = (/obj/machinery/door/window/survival_pod,/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"u" = (/obj/structure/window/reinforced/survival_pod{dir = 4},/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"v" = (/obj/machinery/smartfridge/survival_pod{icon = 'icons/obj/vending.dmi'; icon_base = "smartfridge"; icon_contents = "boxes"; icon_state = "smartfridge"; name = "Advanced storage"; pixel_y = -1},/obj/item/weapon/storage/toolbox/mechanical{pixel_x = -2; pixel_y = -1},/obj/item/weapon/storage/toolbox/mechanical{pixel_x = -2; pixel_y = -1},/obj/item/weapon/storage/toolbox/electrical{pixel_x = 1; pixel_y = 6},/obj/item/weapon/storage/toolbox/electrical{pixel_x = 1; pixel_y = 6},/obj/item/weapon/storage/belt/utility,/obj/item/weapon/storage/belt/utility,/obj/item/device/multitool{pixel_x = 3},/obj/item/device/multitool{pixel_x = 3},/obj/item/weapon/tool/crowbar,/obj/item/weapon/tool/crowbar,/obj/item/weapon/tool/crowbar,/obj/item/device/mmi,/obj/item/device/mmi,/obj/item/device/mmi,/obj/item/clothing/head/welding{pixel_x = -3; pixel_y = 5},/obj/item/clothing/head/welding{pixel_x = -3; pixel_y = 5},/obj/item/clothing/head/welding/demon,/obj/item/clothing/glasses/welding,/obj/item/clothing/glasses/welding,/obj/item/stack/cable_coil,/obj/item/stack/cable_coil,/obj/item/stack/cable_coil,/obj/item/device/healthanalyzer,/obj/item/device/healthanalyzer,/obj/item/device/flash/synthetic,/obj/item/device/flash/synthetic,/obj/item/device/flash/synthetic,/obj/item/weapon/storage/firstaid/regular{empty = 1; name = "First-Aid (empty)"},/obj/item/weapon/storage/firstaid/regular{empty = 1; name = "First-Aid (empty)"},/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000; pixel_x = 5; pixel_y = -5},/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000; pixel_x = 5; pixel_y = -5},/obj/item/device/assembly/prox_sensor{pixel_x = -8; pixel_y = 4},/obj/item/device/assembly/prox_sensor{pixel_x = -8; pixel_y = 4},/obj/item/stack/material/copper{amount = 25},/obj/item/stack/material/plastic{max_amount = 25},/obj/item/stack/material/plastic{max_amount = 25},/obj/item/stack/material/plasteel{amount = 10},/obj/item/stack/material/plasteel{amount = 10},/obj/item/stack/material/glass{amount = 50; pixel_x = -2; pixel_y = 2},/obj/item/stack/material/glass{amount = 50; pixel_x = -2; pixel_y = 2},/obj/item/stack/material/glass{amount = 50; pixel_x = -2; pixel_y = 2},/obj/item/stack/material/glass{amount = 50; pixel_x = -2; pixel_y = 2},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/device/flash,/obj/item/device/flash,/obj/effect/floor_decal/industrial/outline/yellow,/obj/item/clothing/mask/gas,/obj/item/clothing/mask/gas,/obj/item/weapon/implanter,/obj/item/weapon/implanter,/obj/item/weapon/implanter,/obj/item/weapon/storage/backpack/dufflebag/sci,/obj/machinery/light{dir = 1},/turf/simulated/shuttle/floor/voidcraft/light,/area/survivalpod/superpose/SurvivalScienceV2)
-"w" = (/obj/machinery/r_n_d/destructive_analyzer,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"x" = (/obj/structure/window/reinforced/survival_pod{dir = 8},/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"y" = (/obj/structure/table/reinforced,/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,/obj/machinery/recharger/wallcharger{pixel_y = 22},/obj/machinery/recharger/wallcharger{pixel_x = 8; pixel_y = 32},/obj/machinery/light{dir = 1},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"z" = (/obj/machinery/recharge_station,/obj/effect/floor_decal/industrial/outline/yellow,/obj/machinery/light{dir = 4},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"A" = (/obj/machinery/mech_recharger,/obj/mecha/medical/odysseus/old,/obj/effect/floor_decal/industrial/warning/full,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"B" = (/obj/machinery/mecha_part_fabricator/pros{req_access = null},/obj/effect/floor_decal/industrial/outline/yellow,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"D" = (/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/machinery/atmospherics/unary/vent_pump{dir = 8; external_pressure_bound = 0; external_pressure_bound_default = 0; icon_state = "map_vent_in"; initialize_directions = 8; internal_pressure_bound = 4000; internal_pressure_bound_default = 4000; pressure_checks = 2; pressure_checks_default = 2; pump_direction = 0; use_power = 1},/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/SurvivalScienceV2)
-"E" = (/obj/structure/sign/mining/survival,/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,/area/survivalpod/superpose/SurvivalScienceV2)
-"F" = (/obj/machinery/mech_recharger,/obj/effect/floor_decal/industrial/warning/full,/obj/structure/closet/walllocker_double/survival/west,/obj/machinery/light{dir = 8},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"G" = (/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"I" = (/obj/structure/table/reinforced,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"J" = (/obj/machinery/autolathe,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"K" = (/obj/machinery/atmospherics/portables_connector{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/machinery/portable_atmospherics/canister/nitrogen,/obj/machinery/light,/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"L" = (/obj/structure/sign/mining/survival{dir = 4},/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,/area/survivalpod/superpose/SurvivalScienceV2)
-"M" = (/obj/machinery/r_n_d/server/robotics,/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/SurvivalScienceV2)
-"N" = (/obj/structure/window/reinforced/survival_pod{opacity = 1},/obj/machinery/computer/rdservercontrol{dir = 4},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"O" = (/obj/structure/closet/secure_closet/guncabinet/phase{req_one_access = null},/obj/item/clothing/accessory/holster/waist,/obj/item/clothing/accessory/holster/waist,/obj/item/clothing/accessory/permit/gun/planetside,/obj/item/clothing/accessory/permit/gun/planetside,/obj/item/weapon/gun/energy/locked/frontier/holdout,/obj/item/weapon/gun/energy/locked/frontier/holdout,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"Q" = (/obj/machinery/door/airlock/voidcraft/survival_pod,/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"R" = (/obj/structure/reagent_dispensers/acid{pixel_x = 30},/obj/effect/floor_decal/industrial/hatch/yellow,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"S" = (/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/machinery/atmospherics/unary/vent_pump{dir = 8; icon_state = "map_vent_out"; use_power = 1},/obj/machinery/light,/turf/simulated/floor/bluegrid{name = "Server Base"; nitrogen = 500; oxygen = 0; temperature = 80},/area/survivalpod/superpose/SurvivalScienceV2)
-"U" = (/obj/machinery/door/window/survival_pod{dir = 2},/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"V" = (/obj/structure/fans,/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"X" = (/obj/machinery/atmospherics/pipe/manifold/hidden{dir = 1},/obj/machinery/meter,/obj/machinery/door/window/survival_pod{dir = 1},/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
-"Y" = (/obj/structure/reagent_dispensers/fueltank/high,/obj/machinery/light{dir = 1},/turf/simulated/shuttle/floor/voidcraft/dark,/area/survivalpod/superpose/SurvivalScienceV2)
-"Z" = (/obj/machinery/newscaster{layer = 3.3; pixel_y = -27},/turf/simulated/shuttle/plating/skipjack,/area/survivalpod/superpose/SurvivalScienceV2)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"b" = (
+/obj/machinery/mecha_part_fabricator{
+	req_access = null
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"c" = (
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "smartfridge";
+	icon_contents = "boxes";
+	icon_state = "smartfridge";
+	name = "Advanced storage";
+	pixel_y = -1
+	},
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/clothing/gloves/sterile/latex,
+/obj/item/weapon/storage/belt/utility,
+/obj/item/weapon/storage/belt/utility,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/stack/material/copper{
+	amount = 25
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/disk/design_disk,
+/obj/item/weapon/disk/tech_disk,
+/obj/item/weapon/disk/tech_disk,
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"e" = (
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 4;
+	icon_state = "freezer_1";
+	power_setting = 20;
+	set_temperature = 73;
+	use_power = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"f" = (
+/obj/item/device/gps/computer,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"g" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 10
+	},
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"h" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/r_n_d/server/core,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/SurvivalScienceV2)
+"i" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"j" = (
+/obj/machinery/r_n_d/circuit_imprinter,
+/obj/item/weapon/reagent_containers/glass/beaker{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"k" = (
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/weapon/clipboard,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/pen,
+/obj/item/weapon/reagent_containers/dropper{
+	pixel_y = -4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"m" = (
+/obj/machinery/computer/rdconsole/core{
+	dir = 4;
+	req_access = null
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"n" = (
+/obj/structure/sign/mining/survival{
+	dir = 8
+	},
+/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"o" = (
+/obj/machinery/r_n_d/protolathe,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"p" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/obj/machinery/power/apc/alarms_hidden{
+	pixel_y = -20
+	},
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"q" = (
+/obj/structure/sign/mining/survival{
+	dir = 1
+	},
+/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"s" = (
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = -10
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"t" = (
+/obj/machinery/door/window/survival_pod,
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"u" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"v" = (
+/obj/machinery/smartfridge/survival_pod{
+	icon = 'icons/obj/vending.dmi';
+	icon_base = "smartfridge";
+	icon_contents = "boxes";
+	icon_state = "smartfridge";
+	name = "Advanced storage";
+	pixel_y = -1
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/belt/utility,
+/obj/item/weapon/storage/belt/utility,
+/obj/item/device/multitool{
+	pixel_x = 3
+	},
+/obj/item/device/multitool{
+	pixel_x = 3
+	},
+/obj/item/weapon/tool/crowbar,
+/obj/item/weapon/tool/crowbar,
+/obj/item/weapon/tool/crowbar,
+/obj/item/device/mmi,
+/obj/item/device/mmi,
+/obj/item/device/mmi,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/clothing/head/welding/demon,
+/obj/item/clothing/glasses/welding,
+/obj/item/clothing/glasses/welding,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/device/healthanalyzer,
+/obj/item/device/healthanalyzer,
+/obj/item/device/flash/synthetic,
+/obj/item/device/flash/synthetic,
+/obj/item/device/flash/synthetic,
+/obj/item/weapon/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	empty = 1;
+	name = "First-Aid (empty)"
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/stack/material/copper{
+	amount = 25
+	},
+/obj/item/stack/material/plastic{
+	max_amount = 25
+	},
+/obj/item/stack/material/plastic{
+	max_amount = 25
+	},
+/obj/item/stack/material/plasteel{
+	amount = 10
+	},
+/obj/item/stack/material/plasteel{
+	amount = 10
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/device/flash,
+/obj/item/device/flash,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/weapon/implanter,
+/obj/item/weapon/implanter,
+/obj/item/weapon/implanter,
+/obj/item/weapon/storage/backpack/dufflebag/sci,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft/light,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"w" = (
+/obj/machinery/r_n_d/destructive_analyzer,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"x" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"y" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 22
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 8;
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"z" = (
+/obj/machinery/recharge_station,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"A" = (
+/obj/machinery/mech_recharger,
+/obj/mecha/medical/odysseus/old,
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"B" = (
+/obj/machinery/mecha_part_fabricator/pros{
+	req_access = null
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"D" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 8;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/SurvivalScienceV2)
+"E" = (
+/obj/structure/sign/mining/survival,
+/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"F" = (
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/structure/closet/walllocker_double/survival/west,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"G" = (
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"I" = (
+/obj/structure/table/reinforced,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"J" = (
+/obj/machinery/autolathe,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"K" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/light,
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"L" = (
+/obj/structure/sign/mining/survival{
+	dir = 4
+	},
+/turf/simulated/shuttle/wall/voidcraft/survival/hard_corner,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"M" = (
+/obj/machinery/r_n_d/server/robotics,
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/SurvivalScienceV2)
+"N" = (
+/obj/structure/window/reinforced/survival_pod{
+	opacity = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"O" = (
+/obj/structure/closet/secure_closet/guncabinet/phase{
+	req_one_access = null
+	},
+/obj/item/clothing/accessory/holster/waist,
+/obj/item/clothing/accessory/holster/waist,
+/obj/item/clothing/accessory/permit/gun/planetside,
+/obj/item/clothing/accessory/permit/gun/planetside,
+/obj/item/weapon/gun/energy/locked/frontier/holdout,
+/obj/item/weapon/gun/energy/locked/frontier/holdout,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"Q" = (
+/obj/machinery/door/airlock/voidcraft/survival_pod,
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"R" = (
+/obj/structure/reagent_dispensers/acid{
+	pixel_x = 30
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"S" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump{
+	dir = 8;
+	icon_state = "map_vent_out";
+	use_power = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/survivalpod/superpose/SurvivalScienceV2)
+"U" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 2
+	},
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"V" = (
+/obj/structure/fans,
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"X" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/machinery/meter,
+/obj/machinery/door/window/survival_pod{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"Y" = (
+/obj/structure/reagent_dispensers/fueltank/high,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/SurvivalScienceV2)
+"Z" = (
+/obj/machinery/newscaster{
+	layer = 3.3;
+	pixel_y = -27
+	},
+/turf/simulated/shuttle/plating/skipjack,
+/area/survivalpod/superpose/SurvivalScienceV2)
 
 (1,1,1) = {"
-aqaqaqaqa
-nIywYBvbL
-amGtGiGRa
-noGusGGzL
-akcjNUgJa
-nVfGGGxOL
-aFGGeXDha
-nAGZKpSML
-aEQEaEaEa
+a
+n
+a
+n
+a
+n
+a
+n
+a
+"}
+(2,1,1) = {"
+q
+I
+m
+o
+k
+V
+F
+A
+E
+"}
+(3,1,1) = {"
+a
+y
+G
+G
+c
+f
+G
+G
+Q
+"}
+(4,1,1) = {"
+q
+w
+t
+u
+j
+G
+G
+Z
+E
+"}
+(5,1,1) = {"
+a
+Y
+G
+s
+N
+G
+e
+K
+a
+"}
+(6,1,1) = {"
+q
+B
+i
+G
+U
+G
+X
+p
+E
+"}
+(7,1,1) = {"
+a
+v
+G
+G
+g
+x
+D
+S
+a
+"}
+(8,1,1) = {"
+q
+b
+R
+z
+J
+O
+h
+M
+E
+"}
+(9,1,1) = {"
+a
+L
+a
+L
+a
+L
+a
+L
+a
 "}

--- a/modular_chomp/maps/submaps/shelters/TinyCombatShip-9x7.dmm
+++ b/modular_chomp/maps/submaps/shelters/TinyCombatShip-9x7.dmm
@@ -1,33 +1,357 @@
-"a" = (/turf/template_noop,/area/template_noop)
-"b" = (/obj/machinery/disperser/front{dir = 1},/turf/template_noop,/area/template_noop)
-"c" = (/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/TinyCombatShip)
-"f" = (/obj/structure/fans/hardlight/colorable{color = "red"},/obj/machinery/door/airlock/hatch{req_one_access = null},/turf/simulated/floor/plating/external,/area/survivalpod/superpose/TinyCombatShip)
-"h" = (/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/shuttle/engine/heater,/turf/simulated/floor/plating/external,/area/survivalpod/superpose/TinyCombatShip)
-"j" = (/obj/structure/salvageable/machine,/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/TinyCombatShip)
-"k" = (/turf/simulated/wall/rshull,/area/survivalpod/superpose/TinyCombatShip)
-"l" = (/obj/machinery/disperser/back{dir = 1},/obj/structure/ship_munition/disperser_charge/explosive,/turf/simulated/wall/shull,/area/survivalpod/superpose/TinyCombatShip)
-"n" = (/obj/structure/closet/walllocker_double/medical/west,/obj/item/weapon/storage/firstaid,/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/toxin,/obj/item/weapon/storage/firstaid/o2,/obj/item/roller,/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/TinyCombatShip)
-"q" = (/obj/effect/floor_decal/techfloor{dir = 8},/obj/structure/window/reinforced/survival_pod,/obj/machinery/light/poi{dir = 1},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/TinyCombatShip)
-"s" = (/obj/structure/window/plastitanium/full,/obj/structure/window/reinforced/survival_pod{dir = 4},/obj/structure/window/reinforced/survival_pod{dir = 8},/obj/structure/window/reinforced/survival_pod{dir = 1},/obj/structure/window/reinforced/survival_pod,/obj/structure/grille/rustic{health = 25; name = "reinforced grille"},/obj/machinery/door/blast/regular/open{dir = 4; id = "stargazer_blast"; name = "window blast shield"},/turf/simulated/shuttle/plating,/area/survivalpod/superpose/TinyCombatShip)
-"t" = (/obj/effect/catwalk_plated/dark,/turf/template_noop,/area/survivalpod/superpose/TinyCombatShip)
-"u" = (/obj/machinery/disperser/middle{dir = 1},/turf/template_noop,/area/template_noop)
-"x" = (/obj/item/device/gps,/obj/item/sticky_pad/random,/obj/item/device/starcaster_news,/obj/item/weapon/pen/blue,/obj/item/device/pda,/obj/item/weapon/card/id/external,/obj/item/weapon/storage/mre/random,/obj/item/weapon/storage/mre/random,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/reagent_containers/food/snacks/sosjerky,/obj/item/weapon/gun/energy/locked/phasegun/pistol,/obj/item/weapon/material/knife/tacknife/survival,/obj/item/clothing/accessory/permit/gun,/obj/item/device/camera,/obj/item/device/binoculars,/obj/item/device/threadneedle,/obj/random/soap,/obj/item/weapon/towel/random,/obj/item/bodybag/cryobag,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/flare,/obj/item/device/flashlight/color/yellow,/obj/item/device/radio,/obj/item/device/radio,/obj/item/weapon/flame/lighter/random,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/cell/device/hyper,/obj/item/weapon/extinguisher/mini,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/weapon/reagent_containers/pill/spaceacillin,/obj/item/device/fbp_backup_cell,/obj/item/device/fbp_backup_cell,/obj/item/device/suit_cooling_unit/emergency,/obj/item/stack/nanopaste,/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,/obj/item/weapon/storage/backpack/messenger,/obj/item/clothing/accessory/storage/black_drop_pouches,/obj/item/clothing/accessory/poncho/thermal,/obj/item/weapon/storage/box/survival/comp,/obj/item/weapon/storage/toolbox/brass,/obj/item/weapon/storage/box/khcrystal,/obj/structure/closet/walllocker_double/kitchen/east{name = "Ration Cabinet"},/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/TinyCombatShip)
-"D" = (/obj/effect/floor_decal/techfloor{dir = 4},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/TinyCombatShip)
-"F" = (/obj/machinery/portable_atmospherics/canister/phoron,/obj/machinery/atmospherics/portables_connector{dir = 4},/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/TinyCombatShip)
-"H" = (/obj/structure/bed/chair/bay/comfy/red{dir = 1},/obj/machinery/door/window/survival_pod{dir = 2},/turf/simulated/floor/tiled/techmaint,/area/survivalpod/superpose/TinyCombatShip)
-"L" = (/obj/machinery/atmospherics/unary/engine{dir = 1},/turf/template_noop,/area/survivalpod/superpose/TinyCombatShip)
-"M" = (/obj/effect/catwalk_plated/dark,/obj/machinery/light/poi{dir = 1},/turf/template_noop,/area/survivalpod/superpose/TinyCombatShip)
-"P" = (/obj/effect/floor_decal/techfloor{dir = 8},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/TinyCombatShip)
-"S" = (/turf/simulated/wall/shull,/area/survivalpod/superpose/TinyCombatShip)
-"U" = (/obj/effect/floor_decal/techfloor{dir = 4},/obj/structure/window/reinforced/survival_pod,/obj/machinery/light/poi{dir = 1},/turf/simulated/shuttle/floor/voidcraft,/area/survivalpod/superpose/TinyCombatShip)
-"X" = (/obj/structure/closet/crate,/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/plastic{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/steel{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/material/glass{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/rods{amount = 50},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil{pixel_x = 3; pixel_y = 3},/obj/item/stack/cable_coil/green,/obj/item/stack/cable_coil/blue,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/obj/item/weapon/storage/briefcase/inflatable,/turf/simulated/floor/tiled/techfloor,/area/survivalpod/superpose/TinyCombatShip)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"b" = (
+/obj/machinery/disperser/front{
+	dir = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"c" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/TinyCombatShip)
+"f" = (
+/obj/structure/fans/hardlight/colorable{
+	color = "red"
+	},
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/TinyCombatShip)
+"h" = (
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/shuttle/engine/heater,
+/turf/simulated/floor/plating/external,
+/area/survivalpod/superpose/TinyCombatShip)
+"j" = (
+/obj/structure/salvageable/machine,
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/TinyCombatShip)
+"k" = (
+/turf/simulated/wall/rshull,
+/area/survivalpod/superpose/TinyCombatShip)
+"l" = (
+/obj/machinery/disperser/back{
+	dir = 1
+	},
+/obj/structure/ship_munition/disperser_charge/explosive,
+/turf/simulated/wall/shull,
+/area/survivalpod/superpose/TinyCombatShip)
+"n" = (
+/obj/structure/closet/walllocker_double/medical/west,
+/obj/item/weapon/storage/firstaid,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/toxin,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/item/roller,
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/TinyCombatShip)
+"q" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/TinyCombatShip)
+"s" = (
+/obj/structure/window/plastitanium/full,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/grille/rustic{
+	health = 25;
+	name = "reinforced grille"
+	},
+/obj/machinery/door/blast/regular/open{
+	dir = 4;
+	id = "stargazer_blast";
+	name = "window blast shield"
+	},
+/turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TinyCombatShip)
+"t" = (
+/obj/effect/catwalk_plated/dark,
+/turf/template_noop,
+/area/survivalpod/superpose/TinyCombatShip)
+"u" = (
+/obj/machinery/disperser/middle{
+	dir = 1
+	},
+/turf/template_noop,
+/area/template_noop)
+"x" = (
+/obj/item/device/gps,
+/obj/item/sticky_pad/random,
+/obj/item/device/starcaster_news,
+/obj/item/weapon/pen/blue,
+/obj/item/device/pda,
+/obj/item/weapon/card/id/external,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/storage/mre/random,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/reagent_containers/food/snacks/sosjerky,
+/obj/item/weapon/gun/energy/locked/phasegun/pistol,
+/obj/item/weapon/material/knife/tacknife/survival,
+/obj/item/clothing/accessory/permit/gun,
+/obj/item/device/camera,
+/obj/item/device/binoculars,
+/obj/item/device/threadneedle,
+/obj/random/soap,
+/obj/item/weapon/towel/random,
+/obj/item/bodybag/cryobag,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/flare,
+/obj/item/device/flashlight/color/yellow,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/weapon/flame/lighter/random,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/cell/device/hyper,
+/obj/item/weapon/extinguisher/mini,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/glass/beaker/vial/tricordrazine,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/weapon/reagent_containers/pill/spaceacillin,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/fbp_backup_cell,
+/obj/item/device/suit_cooling_unit/emergency,
+/obj/item/stack/nanopaste,
+/obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/clotting,
+/obj/item/weapon/storage/backpack/messenger,
+/obj/item/clothing/accessory/storage/black_drop_pouches,
+/obj/item/clothing/accessory/poncho/thermal,
+/obj/item/weapon/storage/box/survival/comp,
+/obj/item/weapon/storage/toolbox/brass,
+/obj/item/weapon/storage/box/khcrystal,
+/obj/structure/closet/walllocker_double/kitchen/east{
+	name = "Ration Cabinet"
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/TinyCombatShip)
+"D" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/power/apc/hyper{
+	pixel_y = -24
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/TinyCombatShip)
+"F" = (
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/TinyCombatShip)
+"H" = (
+/obj/structure/bed/chair/bay/comfy/red{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/survivalpod/superpose/TinyCombatShip)
+"L" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/template_noop,
+/area/survivalpod/superpose/TinyCombatShip)
+"M" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/template_noop,
+/area/survivalpod/superpose/TinyCombatShip)
+"P" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/TinyCombatShip)
+"S" = (
+/turf/simulated/wall/shull,
+/area/survivalpod/superpose/TinyCombatShip)
+"U" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod,
+/obj/machinery/light/poi{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/voidcraft,
+/area/survivalpod/superpose/TinyCombatShip)
+"X" = (
+/obj/structure/closet/crate,
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/plastic{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/steel{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/material/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/blue,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/obj/item/weapon/storage/briefcase/inflatable,
+/turf/simulated/floor/tiled/techfloor,
+/area/survivalpod/superpose/TinyCombatShip)
 
 (1,1,1) = {"
-aaakskaaa
-abkkjkkba
-SusUHqsuS
-SlSncxSlS
-SSFDcPXSS
-aShSfShSa
-aSLMtMLSa
+a
+a
+S
+S
+S
+a
+a
+"}
+(2,1,1) = {"
+a
+b
+u
+l
+S
+S
+S
+"}
+(3,1,1) = {"
+a
+k
+s
+S
+F
+h
+L
+"}
+(4,1,1) = {"
+k
+k
+U
+n
+D
+S
+M
+"}
+(5,1,1) = {"
+s
+j
+H
+c
+c
+f
+t
+"}
+(6,1,1) = {"
+k
+k
+q
+x
+P
+S
+M
+"}
+(7,1,1) = {"
+a
+k
+s
+S
+X
+h
+L
+"}
+(8,1,1) = {"
+a
+b
+u
+l
+S
+S
+S
+"}
+(9,1,1) = {"
+a
+a
+S
+S
+S
+a
+a
 "}

--- a/modular_chomp/maps/submaps/shelters/TradingShip-40x22.dmm
+++ b/modular_chomp/maps/submaps/shelters/TradingShip-40x22.dmm
@@ -131,6 +131,13 @@
 	},
 /turf/simulated/shuttle/plating/airless/carry,
 /area/survivalpod/superpose/TradingShip)
+"dx" = (
+/obj/structure/closet/walllocker/emerglocker{
+	pixel_y = 32
+	},
+/obj/structure/closet/crate/solar,
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
 "dy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -170,6 +177,9 @@
 	},
 /obj/item/stack/material/glass{
 	amount = 15
+	},
+/obj/item/stack/material/phoron{
+	amount = 25
 	},
 /turf/simulated/shuttle/floor/black,
 /area/survivalpod/superpose/TradingShip)
@@ -294,10 +304,26 @@
 /obj/machinery/optable,
 /turf/simulated/shuttle/floor/black,
 /area/survivalpod/superpose/TradingShip)
+"jn" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
 "jA" = (
 /obj/structure/fans/hardlight,
 /obj/machinery/door/airlock/multi_tile/metal/mait,
 /turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
+"jD" = (
+/obj/machinery/power/smes/batteryrack/mapped,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/shuttle/floor/black,
 /area/survivalpod/superpose/TradingShip)
 "jH" = (
 /obj/structure/table/standard,
@@ -633,6 +659,11 @@
 	req_access = null;
 	req_one_access = null
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/survivalpod/superpose/TradingShip)
 "pr" = (
@@ -809,6 +840,14 @@
 "th" = (
 /obj/machinery/iv_drip,
 /turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"to" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/shuttle/floor/darkred,
 /area/survivalpod/superpose/TradingShip)
 "tu" = (
 /obj/structure/sink{
@@ -993,6 +1032,16 @@
 	icon_state = "plant-22"
 	},
 /turf/simulated/floor/carpet,
+/area/survivalpod/superpose/TradingShip)
+"wt" = (
+/obj/machinery/power/apc/hyper{
+	pixel_y = -24
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/shuttle/floor/black,
 /area/survivalpod/superpose/TradingShip)
 "wz" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -1262,6 +1311,14 @@
 /obj/machinery/light,
 /turf/simulated/shuttle/floor/black,
 /area/survivalpod/superpose/TradingShip)
+"DU" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
 "DX" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/tool,
@@ -1384,6 +1441,14 @@
 /obj/structure/table/standard,
 /obj/machinery/chemical_dispenser/bar_alc/full,
 /turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Gw" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/shuttle/floor/darkred,
 /area/survivalpod/superpose/TradingShip)
 "GN" = (
 /obj/machinery/light/small{
@@ -1619,7 +1684,7 @@
 /turf/simulated/shuttle/floor/black,
 /area/survivalpod/superpose/TradingShip)
 "MT" = (
-/turf/simulated/shuttle/wall/dark,
+/turf/simulated/wall/rplastihull,
 /area/survivalpod/superpose/TradingShip)
 "No" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -1774,6 +1839,15 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/survivalpod/superpose/TradingShip)
+"Rb" = (
+/obj/machinery/door/airlock/multi_tile/glass,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/shuttle/floor/voidcraft/dark,
+/area/survivalpod/superpose/TradingShip)
 "Ry" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/paper_bin{
@@ -1785,17 +1859,30 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/survivalpod/superpose/TradingShip)
+"RU" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/shuttle/floor/darkred,
+/area/survivalpod/superpose/TradingShip)
 "Sp" = (
 /turf/simulated/shuttle/floor/black,
+/area/survivalpod/superpose/TradingShip)
+"Su" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/shuttle/floor/darkred,
 /area/survivalpod/superpose/TradingShip)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	start_pressure = 740.5
 	},
 /turf/simulated/shuttle/floor/black,
-/area/survivalpod/superpose/TradingShip)
-"SE" = (
-/turf/simulated/shuttle/wall/dark/hard_corner,
 /area/survivalpod/superpose/TradingShip)
 "SI" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1901,6 +1988,16 @@
 	},
 /obj/structure/window/reinforced/full,
 /turf/simulated/shuttle/plating,
+/area/survivalpod/superpose/TradingShip)
+"VC" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/machinery/power/port_gen/pacman,
+/turf/simulated/shuttle/floor/black,
 /area/survivalpod/superpose/TradingShip)
 "VL" = (
 /obj/machinery/vending/engivend{
@@ -2286,7 +2383,7 @@ MT
 Mc
 MT
 MT
-SE
+MT
 Sp
 Uy
 MT
@@ -2303,7 +2400,7 @@ Mc
 Mc
 Mc
 MT
-SE
+MT
 Qp
 xF
 MT
@@ -2318,7 +2415,7 @@ Mc
 MT
 Qm
 Sp
-SE
+MT
 MT
 Mc
 Mc
@@ -2381,7 +2478,7 @@ MT
 MT
 MT
 MT
-SE
+MT
 ET
 Sp
 Sp
@@ -2409,7 +2506,7 @@ MT
 MT
 rf
 eE
-SE
+MT
 MT
 Sp
 Sp
@@ -2523,14 +2620,14 @@ MT
 MT
 MT
 MT
-SE
+MT
 Sp
 CV
 Km
 qz
 CV
 Sp
-SE
+MT
 MT
 MT
 MT
@@ -2685,9 +2782,9 @@ Mc
 "}
 (26,1,1) = {"
 Mc
-SE
 MT
-SE
+MT
+MT
 Pv
 fP
 NE
@@ -2696,15 +2793,15 @@ MT
 Sp
 CV
 CV
-Sp
+wt
 MT
 Sy
 kd
 HB
 No
-SE
 MT
-SE
+MT
+MT
 Mc
 "}
 (27,1,1) = {"
@@ -2720,11 +2817,11 @@ TK
 CV
 CV
 CV
-CV
-TK
-CV
-CV
-CV
+to
+Rb
+Su
+Su
+Gw
 dy
 wz
 AL
@@ -2748,7 +2845,7 @@ Sp
 rf
 Sp
 CV
-CV
+RU
 dy
 nh
 GN
@@ -2757,26 +2854,26 @@ Mc
 "}
 (29,1,1) = {"
 Mc
-SE
 MT
-SE
+MT
+MT
 VY
 Sp
 Sp
 AR
-SE
+MT
 hx
 rx
 FL
 WL
-SE
-HP
-Sp
-Sp
-cC
-SE
 MT
-SE
+dx
+Sp
+jn
+cC
+MT
+MT
+MT
 Mc
 "}
 (30,1,1) = {"
@@ -2787,15 +2884,15 @@ MT
 MT
 VP
 VP
-SE
+MT
 MT
 gA
 tN
 CV
 Sp
 MT
-SE
-pl
+MT
+MT
 pl
 MT
 MT
@@ -2819,8 +2916,8 @@ CV
 zN
 jH
 MT
-Sp
-Sp
+jD
+DU
 bm
 cX
 Mc
@@ -2843,7 +2940,7 @@ CV
 CV
 lW
 MT
-zh
+VC
 Sp
 bf
 JI
@@ -2855,11 +2952,11 @@ Mc
 Mc
 Mc
 MT
-SE
+MT
 Od
 Sp
 cM
-SE
+MT
 MT
 fe
 LX


### PR DESCRIPTION

## About The Pull Request
This PR aims to make most of the outsider pods require power now, all of the pods have been supplied with their own power generation methods depending on the pod to make it self sustaining, every pod at the very least has a pacman and battery rack mapped in, or if it doesn't, it has the methods of building one.

Some pods do have RTGs for power generation but those create low amounts of power passively, most pods also have a solars crate thrown in for building solar panels.

DIY pods now have engineers blueprints included in them for custom buildings.

Most of the "Survival Pods" still have infinite power for the consistency with other non-superposed pods. This might need adjusting with stuff like the science pods.

My aim for this PR was to.
1. Fix a bug where you were unable to place ANY wall mounted machinery due to requires_power being set to true.
2. Make pods less set and forget.
3. Encourage multiple outsiders or outsiders to interact with the station for things like power.

This PR also removes some broken pods because I was unable to get them working, those pods were not practical for outsider use anyway.
## Changelog
:cl:
del: Removed the Crashed Alien Ship, Large Alien Ship, Merc ship outsider pods due to them not properly spawning.
balance: Outsider pods now require power, but all outsider pods now have the means to generate their own power.
maptweak: All outsider pods rewired and now with power generation options.
maptweak: Removal of restricted head consoles from science pods.
maptweak: Indestructible walls removed off certain outsider pods like the trade ship.
maptweak: DIY outsider pods now have non-CE blueprints for off-station construction projects.
/:cl:
