### PR TITLE
Fixing the prefabs (aka repenting for my mapping sins)

### DIFF
--- a/1mapping_palette.dmm
+++ b/1mapping_palette.dmm
@@ -148,7 +148,7 @@
 /area/space)
 "afA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -483,21 +483,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/space)
-"aqk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "aqC" = (
 /obj/machinery/flasher{
 	id = "atriumflash";
@@ -621,15 +606,14 @@
 /turf/simulated/wall/rdshull,
 /area/space)
 "awv" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	dir = 1
-	},
 /obj/machinery/door/airlock/angled_bay/hatch/engineering{
 	dir = 4;
 	name = "Auxiliary Storage"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/space)
@@ -943,7 +927,7 @@
 	},
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/space)
@@ -1137,9 +1121,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/space)
@@ -2004,7 +1986,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2668,7 +2650,7 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2815,9 +2797,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/space)
@@ -2873,9 +2853,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/space)
@@ -3031,7 +3009,7 @@
 /area/space)
 "bYE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/alarm/angled{
 	pixel_y = 18
@@ -4047,9 +4025,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/angled_bay/double/glass/medical{
 	name = "Triage Center"
 	},
@@ -4445,12 +4421,11 @@
 /obj/structure/railing/grey{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8";
-	dir = 1
-	},
 /obj/structure/frame,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/bluegrid,
 /area/space)
 "cRJ" = (
@@ -5550,7 +5525,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5981,9 +5956,7 @@
 /area/space)
 "dUD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/space)
 "dUN" = (
@@ -5992,9 +5965,7 @@
 /area/space)
 "dUT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/space)
 "dVg" = (
@@ -6624,12 +6595,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/space)
-"esv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/space)
 "esW" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -6758,7 +6723,7 @@
 	},
 /obj/machinery/door/firedoor/glass/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8256,10 +8221,9 @@
 /area/space)
 "fxI" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	dir = 1
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/airless,
 /area/space)
@@ -8486,9 +8450,7 @@
 /turf/simulated/wall/rshull,
 /area/space)
 "fHu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8520,9 +8482,7 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "fIZ" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2
-	},
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor/plating,
 /area/space)
 "fJa" = (
@@ -8956,14 +8916,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/space)
@@ -8976,7 +8935,7 @@
 /area/space)
 "geV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10159,24 +10118,6 @@
 /obj/effect/meteor/big,
 /turf/template_noop,
 /area/space)
-"gNP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass/hidden{
-	dir = 1
-	},
-/obj/machinery/door/airlock/angled_bay/standard/glass/common{
-	name = "Hallway Airlock"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "gNZ" = (
 /obj/machinery/vending/cola{
 	dir = 1
@@ -10248,7 +10189,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -10576,16 +10517,6 @@
 /obj/structure/flora/pottedplant/mysterious,
 /turf/simulated/floor/wood/sif,
 /area/space)
-"haW" = (
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor/corner,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "hbc" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -10755,9 +10686,7 @@
 /obj/machinery/door/firedoor/glass/hidden{
 	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/angled_bay/hatch/engineering{
 	name = "Atmospherics"
 	},
@@ -10816,9 +10745,7 @@
 /obj/machinery/door/firedoor/glass/hidden{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/angled_bay/hatch/common{
 	name = "Starboard Lower Thruster Two"
@@ -11092,9 +11019,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/space)
 "hqH" = (
@@ -11160,7 +11085,7 @@
 /area/space)
 "hty" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11249,9 +11174,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/space)
 "hwQ" = (
@@ -11678,8 +11601,7 @@
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
-	icon_state = "0-8";
-	dir = 2
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless,
 /area/space)
@@ -11983,9 +11905,7 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "hSP" = (
-/obj/structure/disposalpipe/tagger{
-	dir = 1
-	},
+/obj/structure/disposalpipe/tagger,
 /turf/simulated/floor/plating,
 /area/space)
 "hSS" = (
@@ -12220,9 +12140,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/space)
@@ -12460,9 +12378,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/techfloor/corner,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -12743,7 +12659,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14064,7 +13980,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14129,9 +14045,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/space)
 "jjg" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2
-	},
+/obj/structure/disposalpipe/sortjunction,
 /turf/simulated/floor/plating,
 /area/space)
 "jjA" = (
@@ -14197,9 +14111,7 @@
 /turf/simulated/shuttle/floor/white,
 /area/space)
 "jlB" = (
-/obj/structure/disposalpipe/tagger/partial{
-	dir = 1
-	},
+/obj/structure/disposalpipe/tagger/partial,
 /turf/simulated/floor/plating,
 /area/space)
 "jlD" = (
@@ -14807,9 +14719,7 @@
 /turf/simulated/shuttle/floor/alienplating/external,
 /area/space)
 "jGZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14871,9 +14781,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/space)
 "jKi" = (
@@ -14945,7 +14853,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15512,9 +15420,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/space)
@@ -15985,12 +15891,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/space)
 "krO" = (
@@ -17036,9 +16938,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/milspec/stripe,
 /turf/simulated/floor/tiled/dark,
@@ -17550,9 +17450,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/space)
 "lup" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plating,
 /area/space)
 "luC" = (
@@ -18628,9 +18526,7 @@
 /turf/simulated/floor/outdoors/dirt,
 /area/space)
 "mgN" = (
-/obj/structure/disposalpipe/up{
-	dir = 2
-	},
+/obj/structure/disposalpipe/up,
 /turf/simulated/floor/plating,
 /area/space)
 "mgQ" = (
@@ -19116,9 +19012,7 @@
 /obj/machinery/door/firedoor/glass/hidden{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/angled_bay/hatch/common{
 	name = "Portside Lower Thruster One"
@@ -20450,9 +20344,7 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/space)
@@ -20521,9 +20413,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/space)
@@ -20563,9 +20453,7 @@
 /turf/simulated/shuttle/floor/voidcraft,
 /area/survivalpod)
 "nfZ" = (
-/obj/structure/disposalpipe/down{
-	dir = 2
-	},
+/obj/structure/disposalpipe/down,
 /turf/simulated/floor/plating,
 /area/space)
 "ngF" = (
@@ -20717,9 +20605,7 @@
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/space)
 "nod" = (
-/obj/structure/disposalpipe/sortjunction/wildcard/flipped{
-	dir = 2
-	},
+/obj/structure/disposalpipe/sortjunction/wildcard/flipped,
 /turf/simulated/floor/plating,
 /area/space)
 "noS" = (
@@ -21373,9 +21259,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/space)
 "nLJ" = (
@@ -21410,20 +21294,6 @@
 	oxygen = 0;
 	temperature = 80
 	},
-/area/space)
-"nNj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
 /area/space)
 "nNl" = (
 /obj/structure/fence/corner{
@@ -21474,9 +21344,7 @@
 /obj/machinery/door/firedoor/glass/hidden{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/angled_bay/hatch/common{
 	name = "Starboard Lower Thruster One"
@@ -21800,10 +21668,9 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	dir = 1
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/airless,
 /area/space)
@@ -22070,8 +21937,7 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	dir = 1
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/space)
@@ -22875,9 +22741,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet/blue,
 /area/space)
 "oKd" = (
@@ -23466,9 +23330,7 @@
 /turf/simulated/floor/plating,
 /area/space)
 "pfL" = (
-/obj/structure/disposalpipe/sortjunction/untagged/flipped{
-	dir = 2
-	},
+/obj/structure/disposalpipe/sortjunction/untagged/flipped,
 /turf/simulated/floor/plating,
 /area/space)
 "pfQ" = (
@@ -23845,7 +23707,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -24199,12 +24061,10 @@
 /turf/simulated/shuttle/floor/darkred,
 /area/space)
 "pzZ" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/sortjunction/untagged/flipped{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/space)
 "pAr" = (
 /turf/simulated/floor/plating/external,
@@ -24246,7 +24106,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24274,21 +24134,6 @@
 	pixel_y = 13
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
-/area/space)
-"pCs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
 /area/space)
 "pCz" = (
 /obj/effect/resonance,
@@ -24828,9 +24673,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/space)
 "pYO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25317,12 +25160,6 @@
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/purple,
-/area/space)
-"qpT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
 /area/space)
 "qpZ" = (
 /obj/structure/closet/alien,
@@ -26069,7 +25906,7 @@
 /area/space)
 "qNQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26193,16 +26030,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/space)
@@ -27008,9 +26844,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/space)
 "rnW" = (
-/obj/structure/disposalpipe/broken{
-	dir = 2
-	},
+/obj/structure/disposalpipe/broken,
 /turf/simulated/floor/plating,
 /area/space)
 "roD" = (
@@ -27237,8 +27071,7 @@
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
-	icon_state = "0-8";
-	dir = 2
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/bluegrid,
 /area/space)
@@ -27552,7 +27385,6 @@
 /obj/item/weapon/ore/osmium,
 /obj/item/weapon/ore/silver,
 /obj/item/weapon/ore/uranium,
-/obj/item/weapon/ore/bluespace_crystal,
 /obj/item/clothing/head/sombrero,
 /obj/item/clothing/head/sombrero,
 /obj/item/clothing/suit/poncho,
@@ -27608,8 +27440,7 @@
 /obj/machinery/power/tesla_coil,
 /obj/structure/cable/yellow{
 	d2 = 8;
-	icon_state = "0-8";
-	dir = 2
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/airless,
 /area/space)
@@ -27626,7 +27457,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/space)
@@ -27841,9 +27672,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/space)
@@ -27916,7 +27745,7 @@
 	},
 /obj/machinery/door/firedoor/glass/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28542,14 +28371,13 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "skT" = (
+/obj/machinery/light{
+	layer = 3
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	dir = 1
-	},
-/obj/machinery/light{
-	layer = 3
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless,
 /area/space)
@@ -29170,7 +28998,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -29291,7 +29119,7 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29496,9 +29324,7 @@
 /obj/machinery/door/firedoor/glass/hidden{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/angled_bay/hatch/common{
 	name = "Portside Lower Thruster Two"
@@ -29939,9 +29765,7 @@
 /turf/simulated/floor/wood/sif,
 /area/space)
 "tfy" = (
-/obj/structure/disposalpipe/sortjunction/untagged{
-	dir = 2
-	},
+/obj/structure/disposalpipe/sortjunction/untagged,
 /turf/simulated/floor/plating,
 /area/space)
 "tfz" = (
@@ -30171,17 +29995,16 @@
 	},
 /obj/structure/cable/yellow,
 /obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	dir = 1
-	},
-/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/machinery/power/smes/buildable,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/bluegrid,
 /area/space)
 "trU" = (
@@ -30510,9 +30333,7 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/space)
 "tBU" = (
@@ -31655,7 +31476,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31819,7 +31640,7 @@
 /area/space)
 "uop" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31871,12 +31692,9 @@
 /area/space)
 "upR" = (
 /obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/airless,
 /area/space)
@@ -32267,13 +32085,6 @@
 	},
 /turf/simulated/floor/gorefloor,
 /area/space)
-"uEA" = (
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "uEJ" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/structure/table/marble,
@@ -32443,9 +32254,7 @@
 /turf/simulated/shuttle/floor/alienplating,
 /area/space)
 "uLN" = (
-/obj/structure/disposalpipe/sortjunction/wildcard{
-	dir = 2
-	},
+/obj/structure/disposalpipe/sortjunction/wildcard,
 /turf/simulated/floor/plating,
 /area/space)
 "uMv" = (
@@ -32680,9 +32489,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/space)
 "uSU" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 2
-	},
+/obj/structure/disposalpipe/sortjunction/flipped,
 /turf/simulated/floor/plating,
 /area/space)
 "uTd" = (
@@ -34070,44 +33877,6 @@
 /area/space)
 "vPK" = (
 /obj/structure/closet/alien,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
-/obj/item/weapon/ore/bluespace_crystal,
 /obj/item/weapon/tool/screwdriver/alien,
 /obj/item/device/multitool/alien,
 /obj/item/device/gps/syndie,
@@ -34204,7 +33973,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -34863,29 +34632,13 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor,
-/area/space)
-"wqK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor,
 /area/space)
 "wqO" = (
 /turf/simulated/shuttle/wall/voidcraft/no_join,
@@ -34974,9 +34727,7 @@
 /area/space)
 "wsC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/space)
 "wsJ" = (
@@ -35182,9 +34933,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/button/remote/airlock{
 	desiredstate = 1;
 	dir = 8;
@@ -35402,7 +35151,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -36661,18 +36410,6 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/shuttle/floor/alien/blue,
 /area/space)
-"xzg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/space)
 "xzP" = (
 /obj/structure/prop/alien/computer/hybrid,
 /obj/effect/floor_decal/techfloor{
@@ -37238,7 +36975,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -37783,21 +37520,18 @@
 /area/space)
 "yhk" = (
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/space)
 "yhY" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 2
-	},
+/obj/structure/disposalpipe/junction/yjunction,
 /turf/simulated/floor/plating,
 /area/space)
 "yik" = (
@@ -39195,7 +38929,7 @@ xcs
 qMX
 ucE
 mDJ
-xWB
+pzZ
 ucE
 wWl
 qDB
@@ -39701,7 +39435,7 @@ ucE
 ucE
 ucE
 ucE
-qpT
+usi
 ucE
 cFJ
 ucE
@@ -80912,7 +80646,7 @@ hBF
 bMm
 uha
 bMm
-esv
+qZn
 cPQ
 xdM
 xdM
@@ -81158,13 +80892,13 @@ xdM
 txL
 bMm
 jbu
-wqK
+gov
 pYO
 ssE
-wqK
-aqk
-gNP
-pCs
+gov
+kiB
+cpi
+wrU
 jGZ
 fHu
 pYO
@@ -82152,9 +81886,9 @@ sNj
 xdM
 oyE
 nXM
-xzg
-xzg
-xzg
+wvE
+wvE
+wvE
 xTt
 psP
 mcg
@@ -82922,7 +82656,7 @@ twa
 twa
 sCm
 fCI
-pzZ
+gjU
 xdM
 eCg
 dxY
@@ -83180,7 +82914,7 @@ bRU
 kua
 lqj
 pPz
-haW
+bfX
 mzk
 fVe
 dxY
@@ -83219,7 +82953,7 @@ wiN
 bvi
 olM
 aWP
-nNj
+dkf
 itL
 jNB
 eyY
@@ -83438,7 +83172,7 @@ uaW
 hWR
 rTB
 npK
-uEA
+kDq
 xdM
 xqf
 djF

--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -7317,7 +7317,7 @@
 	id_tag = "spacebus_south"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable/blue{
 	d1 = 1;
@@ -13982,7 +13982,7 @@
 /area/rnd/xenobiology/xenoflora)
 "dYF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable/green{
@@ -13994,7 +13994,7 @@
 /area/rnd/xenobiology/xenoflora)
 "dYG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14248,7 +14248,7 @@
 /area/hallway/primary/firstdeck/aft)
 "dZd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -14280,7 +14280,7 @@
 "dZf" = (
 /obj/machinery/biogenerator,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14291,7 +14291,7 @@
 /area/rnd/xenobiology/xenoflora)
 "dZg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -14316,7 +14316,7 @@
 /area/rnd/xenobiology/xenoflora)
 "dZi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/cable/green{
@@ -14332,7 +14332,7 @@
 /area/rnd/xenobiology/xenoflora)
 "dZj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14348,7 +14348,7 @@
 /area/rnd/xenobiology/xenoflora)
 "dZk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -14365,7 +14365,7 @@
 /area/rnd/xenobiology/xenoflora_isolation)
 "dZl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/hydro,
@@ -14391,7 +14391,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/rnd/xenobiology/xenoflora_isolation)
@@ -16436,7 +16436,7 @@
 /area/rnd/xenobiology)
 "fHQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -16495,7 +16495,7 @@
 "fKK" = (
 /obj/structure/closet/crate/hydroponics/prespawned,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -16531,7 +16531,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
@@ -16593,7 +16593,7 @@
 /area/shuttle/large_escape_pod2/station)
 "fQn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/camera/network/research{
 	c_tag = "SCI - Xenoflora Starboard";
@@ -16802,7 +16802,7 @@
 	req_access = list(47)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/light,
 /obj/item/weapon/gun/energy/floragun,
@@ -16820,7 +16820,7 @@
 	req_access = list(47)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/item/device/multitool,
 /turf/simulated/floor/tiled/white,
@@ -21462,7 +21462,7 @@
 /obj/item/device/t_scanner,
 /obj/item/clothing/glasses/welding,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/power/apc/super{
 	pixel_y = 24;
@@ -25911,7 +25911,7 @@
 	},
 /obj/machinery/atmospheric_field_generator/perma/underdoors,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/spacebus)
@@ -27130,7 +27130,7 @@
 /area/hallway/primary/firstdeck/vaultlobby)
 "rJn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/wall/rthull,
 /area/shuttle/spacebus)

--- a/maps/southern_cross/southern_cross-12.dmm
+++ b/maps/southern_cross/southern_cross-12.dmm
@@ -3,11 +3,9 @@
 /obj/structure/flora/grass/both,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "aE" = (
-/turf/simulated/wall/solidrock,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/wall/solidrock)
 "aK" = (
 /obj/effect/catwalk_plated,
 /obj/structure/railing/grey{
@@ -27,32 +25,26 @@
 /turf/simulated/floor/plating/external,
 /area/surface/outpost/shelter/exterior)
 "bj" = (
-/turf/simulated/mineral/sif,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/mineral/sif)
 "bw" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "bx" = (
 /obj/effect/zone_divider,
-/turf/simulated/wall/solidrock,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/wall/solidrock)
 "bV" = (
 /obj/effect/zone_divider,
-/turf/simulated/mineral/sif,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/mineral/sif)
 "bY" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/light,
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
 "bZ" = (
-/turf/simulated/floor/outdoors/ice,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/ice)
 "cg" = (
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "ck" = (
 /obj/machinery/light{
 	layer = 3
@@ -109,44 +101,35 @@
 /obj/effect/zone_divider,
 /turf/simulated/open/sif{
 	temperature = 243.15
-	},
-/area/surface/outside/wilderness/skylands/empty)
+	})
 "do" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "dD" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "dI" = (
 /obj/structure/flora/rocks1,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "dS" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "dT" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "dX" = (
 /obj/structure/flora/grass/brown,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "eb" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "ef" = (
 /obj/structure/flora/smallbould,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "em" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -157,8 +140,7 @@
 /area/surface/outpost/shelter/dorms)
 "et" = (
 /obj/structure/flora/grass/green,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "eP" = (
 /obj/structure/coatrack,
 /obj/structure/cable{
@@ -170,12 +152,10 @@
 /area/surface/outpost/shelter/dorms)
 "fa" = (
 /obj/structure/flora/grass/both,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "fq" = (
 /obj/structure/flora/tree/pine,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "fy" = (
 /obj/effect/catwalk_plated,
 /obj/structure/railing/grey{
@@ -195,31 +175,25 @@
 /obj/structure/flora/grass/green,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "fT" = (
 /obj/structure/flora/rocks2,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "fW" = (
 /obj/structure/flora/log2,
-/turf/simulated/floor/outdoors/ice,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/ice)
 "gk" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/log1,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "gn" = (
 /obj/structure/outcrop,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "gH" = (
 /obj/structure/flora/bush,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "hs" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -246,29 +220,23 @@
 /area/surface/outpost/shelter)
 "hy" = (
 /obj/structure/flora/rocks1,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "hz" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "hA" = (
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "hB" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "hI" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "hP" = (
 /obj/structure/flora/smallbould,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "hR" = (
 /obj/effect/catwalk_plated,
 /obj/structure/railing/grey{
@@ -285,8 +253,7 @@
 /area/surface/outpost/shelter/exterior)
 "hU" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "ie" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor/wood/sif,
@@ -294,8 +261,7 @@
 "ih" = (
 /obj/structure/flora/ausbushes,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "in" = (
 /obj/structure/table/standard,
 /obj/fiftyspawner/steel,
@@ -308,18 +274,15 @@
 "io" = (
 /obj/structure/flora/smallbould,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "iu" = (
 /obj/effect/zone_divider,
 /turf/simulated/mineral/floor/light{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "iP" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "jb" = (
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "Wilderness Shelter defibrillator closet";
@@ -338,35 +301,28 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "jq" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/palebush,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "js" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "jA" = (
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "jC" = (
 /obj/structure/flora/smallbould,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "jM" = (
 /obj/effect/zone_divider,
 /turf/simulated/open/sif{
 	temperature = 243.15
-	},
-/area/surface/outside/wilderness/skylands/empty)
+	})
 "jU" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "ka" = (
 /obj/machinery/light/small,
 /obj/structure/closet/secure_closet/guncabinet{
@@ -396,8 +352,7 @@
 "kc" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "kg" = (
 /obj/structure/table/sifwooden_reinforced,
 /obj/item/weapon/deck/cards{
@@ -420,12 +375,10 @@
 /area/surface/outpost/shelter/dorms)
 "km" = (
 /obj/structure/flora/rocks1,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "kn" = (
 /obj/structure/flora/rocks2,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "kB" = (
 /obj/structure/cable{
 	d1 = 32;
@@ -454,8 +407,7 @@
 /area/surface/outpost/shelter/utilityroom)
 "kG" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "kJ" = (
 /obj/structure/curtain/open/bed,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -469,20 +421,16 @@
 /area/surface/outpost/shelter/exterior)
 "kZ" = (
 /obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "le" = (
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "lo" = (
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "lK" = (
 /obj/structure/flora/rocks2,
 /obj/structure/flora/log1,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "lP" = (
 /obj/machinery/light{
 	dir = 4
@@ -497,30 +445,24 @@
 /area/surface/outpost/shelter/utilityroom)
 "me" = (
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "ml" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "mt" = (
 /obj/structure/flora/log2,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "mu" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "mv" = (
 /obj/structure/flora/smallbould,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "my" = (
 /obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "mG" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
@@ -532,25 +474,21 @@
 /area/surface/outpost/shelter/dorms)
 "mI" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "mL" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fernybush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "mP" = (
 /turf/simulated/wall/log_sif,
 /area/surface/outpost/shelter)
 "mV" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "nf" = (
 /obj/structure/flora/rocks2,
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "nj" = (
 /obj/structure/closet/walllocker_double/survival/north{
 	name = "Wilderness Shelter Emergency Survival Wall Cabinet";
@@ -560,84 +498,67 @@
 /area/surface/outpost/shelter)
 "ns" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "ny" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "nC" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "nE" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/log2,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "nF" = (
 /obj/structure/flora/rocks2,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "nR" = (
 /obj/structure/flora/lily1,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "nX" = (
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "nY" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "od" = (
 /obj/structure/flora/rocks2,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "oe" = (
 /obj/structure/flora/log2,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "og" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/ice,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/ice)
 "oq" = (
 /obj/structure/flora/rocks2,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "ou" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "oF" = (
 /obj/structure/flora/ausbushes,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "oM" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "oT" = (
 /obj/structure/flora/log1,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "pa" = (
 /obj/structure/flora/grass/brown,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "ph" = (
 /obj/structure/closet,
 /obj/item/weapon/storage/box/lights/bulbs,
@@ -652,47 +573,37 @@
 "pl" = (
 /obj/structure/flora/grass/brown,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "pr" = (
 /obj/structure/flora/tree/jungle_small,
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "pu" = (
 /obj/structure/flora/lily1,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "pO" = (
 /obj/structure/flora/tree/jungle_small,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "qf" = (
 /obj/structure/flora/rocks2,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "ql" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "qn" = (
 /obj/structure/flora/lily2,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "qF" = (
 /obj/structure/flora/lily2,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "qG" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "qJ" = (
-/turf/simulated/mineral/floor/light,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/mineral/floor/light)
 "qK" = (
 /obj/machinery/alarm/sifwilderness{
 	dir = 8;
@@ -705,53 +616,42 @@
 /obj/effect/zone_divider,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "ra" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/lily1,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "rj" = (
 /obj/structure/flora/ausbushes,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "rn" = (
 /obj/effect/zone_divider,
 /obj/effect/zone_divider,
-/turf/simulated/mineral,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/mineral)
 "rw" = (
 /obj/structure/flora/bboulder1,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "rx" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "rH" = (
 /obj/structure/flora/lily3,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "rM" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "rY" = (
 /obj/structure/flora/bush,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "sc" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "sf" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "sk" = (
 /obj/structure/coatrack,
 /turf/simulated/floor/wood/sif,
@@ -761,19 +661,16 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/rocks2,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "sW" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "tb" = (
 /obj/effect/zone_divider,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "ti" = (
 /obj/effect/catwalk_plated,
 /obj/structure/railing/grey{
@@ -790,8 +687,7 @@
 /obj/effect/zone_divider,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "tm" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/light{
@@ -807,22 +703,18 @@
 /obj/structure/flora/rocks1,
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "tv" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "tx" = (
 /obj/structure/flora/tree/jungle_small,
 /obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "tB" = (
 /obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "tI" = (
 /obj/effect/catwalk_plated,
 /obj/structure/railing/grey{
@@ -839,33 +731,27 @@
 /area/surface/outpost/shelter/exterior)
 "tJ" = (
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "tL" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "tR" = (
 /obj/structure/flora/tree/jungle_small,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "tT" = (
 /obj/structure/flora/smallbould,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "tZ" = (
 /obj/structure/flora/tree/jungle_small,
 /obj/structure/flora/rocks1,
 /obj/structure/flora/ausbushes/leafybush,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "up" = (
 /obj/structure/flora/lily3,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "uq" = (
 /obj/structure/sink{
 	dir = 8;
@@ -880,8 +766,7 @@
 /obj/effect/landmark/map_data{
 	height = 2
 	},
-/turf/simulated/wall/solidrock,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/wall/solidrock)
 "uC" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -903,8 +788,7 @@
 /obj/effect/zone_divider,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "uW" = (
 /obj/effect/catwalk_plated,
 /obj/structure/railing/grey{
@@ -919,35 +803,28 @@
 "uX" = (
 /obj/structure/flora/log1,
 /obj/structure/flora/lily3,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "uZ" = (
 /obj/structure/flora/bush,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "vd" = (
 /obj/structure/flora/rocks1,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "vk" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/smallbould,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "vp" = (
 /obj/structure/outcrop,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "vv" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/rocks,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/rocks)
 "vy" = (
 /obj/structure/flora/lily2,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "vS" = (
 /obj/structure/table/rack/shelf,
 /obj/item/weapon/soap/nanotrasen,
@@ -968,30 +845,24 @@
 /obj/structure/flora/rocks1,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "wz" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "wO" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "wY" = (
 /obj/structure/flora/log1,
 /obj/structure/flora/ausbushes/fernybush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "xj" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "xl" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "xv" = (
 /obj/structure/table/sifwooden_reinforced,
 /obj/item/weapon/storage/toolbox/emergency{
@@ -1025,23 +896,18 @@
 "xG" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "xN" = (
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "xO" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "xV" = (
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "xY" = (
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "ye" = (
 /turf/simulated/open/sif{
 	temperature = 243.15
@@ -1050,31 +916,22 @@
 "yf" = (
 /obj/structure/outcrop,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
-"yn" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "yu" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "yB" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "yD" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/tree/palm,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "yG" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "yJ" = (
 /obj/structure/table/sifwooden_reinforced,
 /obj/item/device/flashlight/lamp/green,
@@ -1087,28 +944,23 @@
 "yK" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "zs" = (
 /obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "zx" = (
 /obj/structure/flora/lily2,
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "zE" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "zM" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "zN" = (
 /obj/effect/catwalk_plated,
 /obj/structure/railing/grey{
@@ -1155,8 +1007,7 @@
 "Ah" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/ausbushes/fernybush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "Ai" = (
 /obj/structure/ladder,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1168,21 +1019,17 @@
 "Aj" = (
 /obj/structure/flora/lily3,
 /obj/structure/flora/log2,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "AL" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "AM" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "Bi" = (
 /obj/structure/flora/rocks2,
 /obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "Bo" = (
 /obj/effect/catwalk_plated,
 /obj/structure/railing/grey{
@@ -1199,8 +1046,7 @@
 /area/surface/outpost/shelter/exterior)
 "BC" = (
 /obj/structure/flora/lily3,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "BG" = (
 /obj/structure/undies_wardrobe,
 /obj/machinery/light{
@@ -1212,8 +1058,7 @@
 "BM" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "BU" = (
 /obj/effect/catwalk_plated,
 /obj/structure/ladder,
@@ -1230,8 +1075,7 @@
 "BZ" = (
 /obj/structure/flora/log2,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "Cc" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -1242,13 +1086,11 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "Cp" = (
 /obj/structure/flora/log1,
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "Ct" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -1263,25 +1105,20 @@
 "Cz" = (
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "CK" = (
 /obj/structure/flora/ausbushes,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "CL" = (
 /obj/structure/flora/log1,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "CO" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "CS" = (
 /obj/structure/flora/ausbushes,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "CT" = (
 /turf/simulated/wall/log_sif,
 /area/surface/outpost/shelter/utilityroom)
@@ -1296,18 +1133,15 @@
 "Db" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "Dh" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "Dy" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "DA" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/button/remote/blast_door{
@@ -1319,16 +1153,10 @@
 	},
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outpost/shelter/exterior)
-"DD" = (
-/turf/simulated/open/sif{
-	temperature = 243.15
-	},
-/area/surface/outside/wilderness/skylands)
 "DE" = (
 /obj/structure/flora/rocks2,
 /obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "DM" = (
 /obj/effect/catwalk_plated,
 /obj/structure/railing/grey{
@@ -1345,74 +1173,59 @@
 /area/surface/outpost/shelter/exterior)
 "DN" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "DY" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Ec" = (
 /obj/structure/simple_door/sifwood,
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter)
 "Es" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands/empty)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Et" = (
 /obj/structure/outcrop,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "EF" = (
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "EJ" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fernybush,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "EK" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "EM" = (
 /obj/structure/flora/tree/palm,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "Fs" = (
 /obj/structure/flora/rocks2,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Fx" = (
 /obj/structure/flora/tree/palm,
 /obj/effect/overlay/coconut,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "FD" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "FK" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "FO" = (
 /obj/structure/outcrop,
-/turf/simulated/floor/outdoors/rocks,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/rocks)
 "FP" = (
 /obj/structure/flora/log1,
 /obj/structure/flora/rocks1,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "FS" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/smallbould,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Gg" = (
 /obj/structure/closet/medical_wall{
 	name = "Wilderness Shelter first-aid closet";
@@ -1424,43 +1237,34 @@
 "Gp" = (
 /obj/structure/flora/tree/dead,
 /obj/structure/flora/log2,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "GD" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "GK" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "GN" = (
 /turf/simulated/wall/log_sif,
 /area/surface/outpost/shelter/dorms)
 "GS" = (
-/turf/simulated/wall/rsifwood,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/wall/rsifwood)
 "Hb" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Hm" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Hn" = (
 /obj/structure/flora/rocks2,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Hr" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "Hw" = (
 /obj/structure/flora/bboulder1,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "HI" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -1468,14 +1272,12 @@
 /area/surface/outpost/shelter/dorms)
 "HJ" = (
 /obj/structure/flora/rocks1,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "HP" = (
 /obj/structure/outcrop,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "Ii" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -1490,25 +1292,20 @@
 /area/surface/outpost/shelter/dorms)
 "Ip" = (
 /obj/structure/flora/smallbould,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "Is" = (
 /obj/structure/flora/rocks1,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "ID" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "IH" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "JP" = (
 /obj/structure/flora/log1,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "JU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1527,13 +1324,11 @@
 /area/surface/outpost/shelter)
 "Kf" = (
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "Km" = (
 /obj/effect/zone_divider,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "Kq" = (
 /obj/machinery/camera/network/carrier{
 	c_tag = "WILD - Shelter Second Floor";
@@ -1544,17 +1339,14 @@
 "Kr" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Kv" = (
 /obj/structure/flora/log2,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "KA" = (
 /obj/structure/flora/tree/dead,
 /obj/structure/flora/grass/brown,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "KF" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1
@@ -1563,48 +1355,38 @@
 /area/surface/outpost/shelter/dorms)
 "KS" = (
 /obj/structure/flora/ausbushes/reedbush,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "La" = (
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "Ll" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "Lq" = (
 /obj/structure/outcrop,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "Lt" = (
 /obj/structure/flora/rocks2,
 /obj/effect/zone_divider,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "LB" = (
 /obj/structure/flora/log2,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "LC" = (
 /obj/structure/flora/rocks2,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "LK" = (
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "LP" = (
 /obj/structure/flora/tree/dead,
-/turf/simulated/floor/outdoors/rocks,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/rocks)
 "LT" = (
 /obj/structure/flora/grass/both,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "LU" = (
 /turf/simulated/floor/wood/sif,
 /area/surface/outpost/shelter/dorms)
@@ -1613,8 +1395,7 @@
 /area/surface/outpost/shelter/dorms)
 "Me" = (
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Mr" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -1638,24 +1419,20 @@
 "MB" = (
 /obj/structure/flora/tree/palm,
 /obj/effect/overlay/coconut,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "MF" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "MM" = (
 /obj/structure/flora/tree/jungle_small,
 /obj/structure/flora/ausbushes/grassybush,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "MQ" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/rocks2,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "MY" = (
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/wood/sif{
@@ -1666,8 +1443,7 @@
 /area/surface/outpost/shelter/exterior)
 "MZ" = (
 /obj/structure/flora/rocks2,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "Nq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/full,
@@ -1693,18 +1469,15 @@
 /obj/structure/flora/rocks1,
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "NH" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "Of" = (
 /obj/structure/flora/tree/jungle_small,
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "Oj" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/structure/cable{
@@ -1716,33 +1489,27 @@
 /area/surface/outpost/shelter/dorms)
 "Ol" = (
 /obj/structure/flora/bush,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "On" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Ow" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "OM" = (
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "ON" = (
 /obj/structure/flora/log1,
 /obj/structure/flora/bboulder1{
 	pixel_x = -10
 	},
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "OO" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "OQ" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/power/apc{
@@ -1763,47 +1530,37 @@
 "OW" = (
 /obj/structure/flora/tree/jungle_small,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Pd" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Pm" = (
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Pt" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/log2,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "PP" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "PV" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "Qc" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "QJ" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "QQ" = (
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "QY" = (
 /obj/structure/flora/tree/jungle,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "Rb" = (
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -1816,8 +1573,7 @@
 "Rh" = (
 /turf/simulated/mineral/floor/light{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "Rl" = (
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
@@ -1830,15 +1586,13 @@
 /area/surface/outpost/shelter/dorms)
 "Rm" = (
 /obj/structure/flora/log1,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "Rn" = (
 /obj/structure/flora/tree/dead,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/mineral/floor/light{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "Ru" = (
 /obj/structure/simple_door/sifwood,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -1864,13 +1618,11 @@
 /obj/structure/flora/grass/brown,
 /turf/simulated/mineral/floor/light{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "RJ" = (
 /obj/structure/flora/rocks2,
 /obj/structure/flora/bboulder1,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "RO" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -1890,20 +1642,17 @@
 /obj/structure/flora/grass/green,
 /turf/simulated/mineral/floor/light{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "RZ" = (
 /obj/structure/flora/rocks2,
 /turf/simulated/mineral/floor/light{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "Sb" = (
 /obj/structure/flora/log2,
 /turf/simulated/mineral/floor/light{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "Sd" = (
 /obj/structure/bed/chair/comfy/blue,
 /turf/simulated/floor/carpet/turcarpet,
@@ -1935,17 +1684,14 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/effect/zone_divider,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "Sr" = (
-/turf/simulated/floor/outdoors/rocks,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/rocks)
 "SO" = (
 /obj/structure/flora/tree/winter,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "ST" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/camera/network/carrier{
@@ -1961,22 +1707,18 @@
 /obj/structure/flora/log1,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "Th" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "To" = (
 /obj/structure/flora/tree/dead,
 /turf/simulated/mineral/floor/light{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "Tz" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "TC" = (
 /obj/structure/closet/hydrant{
 	pixel_y = -26
@@ -1987,59 +1729,47 @@
 "TD" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "TE" = (
 /obj/structure/flora/tree/winter1,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "TG" = (
 /obj/structure/flora/grass/brown,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "TH" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 "TO" = (
-/turf/simulated/mineral,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/mineral)
 "Uo" = (
 /obj/structure/flora/rocks1,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "Uv" = (
 /obj/structure/flora/log2,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "UW" = (
 /obj/structure/flora/rocks2,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "Vb" = (
 /obj/structure/flora/grass/brown,
-/turf/simulated/floor/outdoors/ice,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/ice)
 "Vi" = (
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/outdoors/grass,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass)
 "Vl" = (
 /obj/structure/flora/log1,
 /turf/simulated/mineral/floor/light{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "Vp" = (
 /obj/effect/zone_divider,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "VD" = (
 /obj/structure/bed/chair/bay/comfy/blue{
 	dir = 8
@@ -2049,22 +1779,18 @@
 "VE" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "VJ" = (
 /obj/structure/flora/rocks1,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "VT" = (
 /obj/structure/flora/lily1,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "Wb" = (
 /obj/effect/zone_divider,
-/turf/simulated/mineral,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/mineral)
 "Wi" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
@@ -2076,8 +1802,7 @@
 /obj/structure/flora/rocks2,
 /obj/structure/flora/grass/green,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "Wv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2089,13 +1814,11 @@
 "WB" = (
 /obj/structure/flora/lily2,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water/deep,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water/deep)
 "WF" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "WH" = (
 /obj/structure/table/sifwooden_reinforced,
 /obj/machinery/cell_charger,
@@ -2146,54 +1869,44 @@
 /obj/structure/flora/rocks1,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "WJ" = (
-/turf/simulated/floor/outdoors/dirt,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/dirt)
 "WO" = (
 /turf/simulated/open/sif{
 	temperature = 243.15
-	},
-/area/surface/outside/wilderness/skylands/empty)
+	})
 "WQ" = (
 /obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "WX" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/grass/brown,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "Xo" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "Xu" = (
 /obj/structure/flora/rocks2,
 /obj/structure/flora/grass/brown,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "Xw" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/mud,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/mud)
 "Xx" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "XF" = (
 /obj/structure/flora/rocks1,
 /obj/structure/flora/tree/winter,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "XJ" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/yellowdouble,
@@ -2202,8 +1915,7 @@
 "XK" = (
 /obj/structure/flora/lily3,
 /obj/effect/zone_divider,
-/turf/simulated/floor/water,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/water)
 "XU" = (
 /obj/effect/catwalk_plated,
 /obj/structure/railing/grey{
@@ -2225,8 +1937,7 @@
 "Yb" = (
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "Ym" = (
 /obj/machinery/light{
 	layer = 3
@@ -2238,8 +1949,7 @@
 /obj/structure/flora/ausbushes,
 /turf/simulated/mineral/floor{
 	outdoors = 1
-	},
-/area/surface/outside/wilderness/skylands)
+	})
 "Yu" = (
 /obj/structure/simple_door/sifwood,
 /turf/simulated/floor/wood/sif,
@@ -2262,16 +1972,13 @@
 /area/surface/outpost/shelter/utilityroom)
 "YA" = (
 /obj/structure/flora/tree/winter1,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "YK" = (
 /obj/structure/flora/rocks1,
-/turf/simulated/floor/outdoors/ice,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/ice)
 "YL" = (
 /obj/structure/flora/rocks2,
-/turf/simulated/floor/outdoors/snow,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/snow)
 "Zr" = (
 /obj/machinery/bluespace_beacon{
 	alpha = 0;
@@ -2283,8 +1990,7 @@
 "ZQ" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/zone_divider,
-/turf/simulated/floor/outdoors/grass/heavy,
-/area/surface/outside/wilderness/skylands)
+/turf/simulated/floor/outdoors/grass/heavy)
 
 (1,1,1) = {"
 aE
@@ -32093,7 +31799,7 @@ EF
 EF
 EF
 jA
-yn
+Es
 xV
 xl
 xY
@@ -37042,7 +36748,7 @@ TO
 TO
 Ow
 WO
-DD
+WO
 xV
 xY
 WJ
@@ -37480,7 +37186,7 @@ WJ
 WJ
 xY
 WJ
-yn
+Es
 xV
 TO
 TO
@@ -37738,8 +37444,8 @@ WJ
 xY
 WJ
 xV
-DD
-DD
+WO
+WO
 TO
 TO
 TO
@@ -37995,10 +37701,10 @@ WJ
 WJ
 xY
 WJ
-DD
-DD
-DD
-DD
+WO
+WO
+WO
+WO
 TO
 TO
 TO
@@ -38252,11 +37958,11 @@ TO
 WJ
 WJ
 xY
-yn
-DD
-DD
-DD
-DD
+Es
+WO
+WO
+WO
+WO
 TO
 TO
 TO
@@ -38511,10 +38217,10 @@ WJ
 WJ
 xY
 xV
-DD
-DD
-DD
-DD
+WO
+WO
+WO
+WO
 TO
 TO
 TO
@@ -38768,11 +38474,11 @@ TO
 WJ
 WJ
 xY
-DD
-DD
-DD
-DD
-DD
+WO
+WO
+WO
+WO
+WO
 TO
 TO
 TO
@@ -39025,12 +38731,12 @@ TO
 TO
 WJ
 WJ
-DD
-DD
-DD
-DD
-DD
-DD
+WO
+WO
+WO
+WO
+WO
+WO
 TO
 TO
 TO
@@ -39283,11 +38989,11 @@ TO
 TO
 WJ
 WJ
-DD
-DD
-DD
-DD
-DD
+WO
+WO
+WO
+WO
+WO
 TO
 TO
 TO
@@ -39541,11 +39247,11 @@ TO
 TO
 WJ
 WJ
-DD
-DD
-DD
-DD
-DD
+WO
+WO
+WO
+WO
+WO
 TO
 TO
 TO
@@ -39801,8 +39507,8 @@ WJ
 hz
 xY
 iP
-DD
-DD
+WO
+WO
 js
 TO
 TO
@@ -43215,7 +42921,7 @@ Wb
 TO
 xY
 xV
-yn
+Es
 La
 WO
 WO
@@ -43225,7 +42931,7 @@ WO
 WO
 WO
 CK
-yn
+Es
 xl
 xY
 TO
@@ -45019,7 +44725,7 @@ TO
 TO
 Hr
 xY
-yn
+Es
 WO
 WO
 WO
@@ -45031,7 +44737,7 @@ WO
 WO
 WO
 WO
-yn
+Es
 xY
 TO
 TO
@@ -45537,7 +45243,7 @@ Hr
 xY
 xY
 MB
-yn
+Es
 CK
 DY
 WO
@@ -45546,7 +45252,7 @@ WO
 WO
 WO
 WO
-yn
+Es
 La
 TO
 TO
@@ -45801,7 +45507,7 @@ yD
 xV
 Hm
 La
-yn
+Es
 CK
 La
 La
@@ -46035,7 +45741,7 @@ TO
 TO
 TO
 TO
-yn
+Es
 CL
 FD
 jA

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -48879,10 +48879,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 1;
 	d2 = 4;
-	dir = 4;
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)
@@ -53842,15 +53841,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	dir = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D3)

--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -589,7 +589,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsaft{
@@ -1023,7 +1023,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsaft{
@@ -1064,7 +1064,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsaft{
@@ -2386,7 +2386,7 @@
 	name = "Particle Accelerator Shroud"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/research/particleaccelerator)
@@ -2780,7 +2780,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsaft{
@@ -15609,7 +15609,7 @@
 	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/research/particleaccelerator)
@@ -16046,7 +16046,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsaft{
@@ -18538,7 +18538,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsaft{
@@ -23839,7 +23839,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsaft{

--- a/maps/southern_cross/southern_cross-5.dmm
+++ b/maps/southern_cross/southern_cross-5.dmm
@@ -4285,12 +4285,8 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/main/corridor)
 "io" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/auxiliary_storage)
 "ip" = (
@@ -6021,9 +6017,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/auxiliary_storage)
 "lp" = (
@@ -8643,9 +8637,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/main/gym)
 "qf" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/unary/heat_exchanger{
 	dir = 8
 	},
@@ -10768,9 +10760,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/outpost/main/airlock/right_two)
 "tN" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/overlay/snow/floor,
 /obj/effect/overlay/snow/floor/edges{
 	dir = 4
@@ -11055,9 +11045,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/main/corridor)
 "ul" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/plating/sif/planetuse,
 /area/surface/outside/plains/outpost)
@@ -11341,9 +11329,7 @@
 	id = "EngineReactor";
 	rad_resistance = 150
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/reactor_smes)
 "uP" = (
@@ -11480,9 +11466,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
@@ -15799,9 +15783,7 @@
 /obj/structure/fence{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/overlay/snow/floor,
 /obj/effect/overlay/snow/floor/edges{
 	dir = 4
@@ -16293,9 +16275,7 @@
 	},
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/auxiliary_storage)
 "Ek" = (
@@ -16447,9 +16427,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/main/corridor)
 "ED" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/overlay/snow/floor,
 /obj/effect/overlay/snow/floor/edges{
 	dir = 8
@@ -18068,7 +18046,7 @@
 /area/surface/outpost/main/airlock/left_one)
 "HF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 6;
@@ -21232,9 +21210,7 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/mining_main/storage)
 "Nq" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -22330,23 +22306,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/black,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/auxiliary_storage)
 "PA" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	dir = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/cable/cyan{
 	d1 = 2;
 	d2 = 8;
@@ -22911,15 +22874,11 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/smes)
 "Qy" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/auxiliary_storage)
 "Qz" = (
@@ -23791,7 +23750,7 @@
 /area/surface/outpost/main/airlock/landing_north)
 "RY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	d1 = 6;
@@ -24491,9 +24450,7 @@
 /obj/structure/fence{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/effect/overlay/snow/floor,
 /turf/simulated/floor/plating/sif/planetuse,
 /area/surface/outside/plains/outpost)
@@ -25495,9 +25452,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/auxiliary_storage)
 "Vz" = (

--- a/maps/southern_cross/southern_cross-6.dmm
+++ b/maps/southern_cross/southern_cross-6.dmm
@@ -1136,7 +1136,7 @@
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "cq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/research{
@@ -1418,7 +1418,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable/blue{
 	d1 = 4;
@@ -1458,7 +1458,7 @@
 /area/surface/outpost/research/xenoarcheology/isolation_a)
 "cU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/research/xenoarcheology/isolation_a)
@@ -2196,7 +2196,7 @@
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "er" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/cable/blue{
 	d1 = 1;
@@ -2214,7 +2214,7 @@
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "et" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/research{
@@ -2225,7 +2225,7 @@
 /area/surface/outpost/research/xenoarcheology/isolation_b)
 "eu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/research/xenoarcheology/isolation_b)
@@ -2949,7 +2949,7 @@
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "fQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -2961,7 +2961,7 @@
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "fR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/research{
@@ -2972,7 +2972,7 @@
 /area/surface/outpost/research/xenoarcheology/isolation_c)
 "fS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/reinforced,
 /area/surface/outpost/research/xenoarcheology/isolation_c)

--- a/maps/southern_cross/southern_cross-7.dmm
+++ b/maps/southern_cross/southern_cross-7.dmm
@@ -260,9 +260,6 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
 "akv" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -272,6 +269,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/janitorial)
@@ -390,6 +392,8 @@
 /area/expoutpost/techstorage)
 "apA" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -591,9 +595,7 @@
 /turf/simulated/floor,
 /area/expoutpost/portfuelstorage)
 "aAP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -699,9 +701,7 @@
 /turf/simulated/floor,
 /area/expoutpost/portqpadjunction)
 "aFp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/carpet,
 /area/expoutpost/explodorm1)
@@ -739,15 +739,20 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
@@ -1028,9 +1033,7 @@
 /turf/simulated/floor,
 /area/expoutpost/atmospherics)
 "aQF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/closet/walllocker{
 	dir = 4;
 	pixel_x = 32
@@ -1096,9 +1099,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
 "aVF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1150,6 +1151,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -1258,13 +1261,14 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/item/device/radio/intercom{
 	dir = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 21
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/medbaylobby)
@@ -1344,15 +1348,17 @@
 /turf/simulated/floor/reinforced,
 /area/expoutpost/portfuelstorage)
 "bep" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/firedoor/multi_tile/glass,
 /obj/machinery/door/airlock/security{
 	name = "Aegis Security Office"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/expoutpost/secoffice)
@@ -1973,31 +1979,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/lowersternhallway)
-"bIm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/lowersternhallway)
 "bIu" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -2096,18 +2077,12 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	dir = 1;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor,
@@ -2160,11 +2135,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/uppersternhallway)
@@ -2192,9 +2169,7 @@
 /turf/simulated/floor,
 /area/expoutpost/uppersternhallway)
 "bOy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/disposal/wall{
 	dir = 4;
 	pixel_x = -35
@@ -2475,9 +2450,7 @@
 /turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "cbF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2741,9 +2714,7 @@
 /turf/simulated/floor,
 /area/expoutpost/lowersternhallway)
 "cjN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3123,7 +3094,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
@@ -3526,14 +3497,16 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/starqpadjunction)
@@ -3598,13 +3571,14 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/machinery/light_switch{
 	dir = 8;
 	pixel_x = -24;
 	pixel_y = -12
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/suite2)
@@ -3935,19 +3909,6 @@
 "dks" = (
 /turf/simulated/wall/r_wall,
 /area/expoutpost/janitorial)
-"dkW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
-/area/expoutpost/portuppermaint)
 "dln" = (
 /obj/effect/floor_decal/grass_edge{
 	dir = 1
@@ -3972,7 +3933,7 @@
 /area/expoutpost/portbowhallway)
 "dnj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4068,9 +4029,7 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
 "dqX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
@@ -4079,9 +4038,7 @@
 /turf/simulated/floor/carpet,
 /area/expoutpost/explodorm2)
 "drS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -4198,12 +4155,14 @@
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "dxV" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "dya" = (
@@ -4308,9 +4267,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/washroom)
 "dzZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4698,9 +4655,6 @@
 /area/expoutpost/hangarthree)
 "dQz" = (
 /obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -4710,6 +4664,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
@@ -5051,14 +5010,15 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
@@ -5159,7 +5119,7 @@
 /area/expoutpost/hangarsix)
 "emF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5194,9 +5154,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
 "eof" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -5570,14 +5528,15 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarthree)
@@ -5726,7 +5685,7 @@
 /area/expoutpost/reactorroom)
 "eHK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5897,6 +5856,7 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/milspec/raised,
@@ -5934,9 +5894,6 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/surgical1)
 "eNI" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -5945,6 +5902,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/suite2)
@@ -6066,7 +6028,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/techstorage)
@@ -6085,7 +6047,7 @@
 "eRI" = (
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6357,17 +6319,16 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
 "fbZ" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	dir = 1;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
@@ -6381,6 +6342,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6732,19 +6694,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
-"fqN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/slingcarrierdock)
 "frm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6816,9 +6765,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "ftz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7097,11 +7044,13 @@
 /turf/simulated/wall/r_lead,
 /area/expoutpost/reactoraccess)
 "fEs" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "fEH" = (
@@ -7432,9 +7381,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/washroom)
 "fWx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/carpet,
 /area/expoutpost/explodorm2)
@@ -7798,9 +7745,7 @@
 "giX" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
@@ -7999,6 +7944,8 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
@@ -8161,12 +8108,11 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/expoutpost/starboardbowairlock)
@@ -8244,13 +8190,15 @@
 /turf/simulated/floor,
 /area/expoutpost/lowersternhallway)
 "gDm" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/portqpadjunction)
@@ -8368,9 +8316,7 @@
 /turf/simulated/floor,
 /area/expoutpost/aicore)
 "gKW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8398,17 +8344,19 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/rndlobby)
 "gLm" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/kitchen)
@@ -8717,9 +8665,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
 "hae" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8737,7 +8683,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
@@ -9006,21 +8952,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/midsternhallway)
-"hkD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
-/area/expoutpost/portlowermaint)
 "hkS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9143,7 +9074,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/secureaccess)
@@ -9408,7 +9339,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9773,6 +9704,8 @@
 /area/expoutpost/reactorcr)
 "hLp" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/milspec/raised,
@@ -9844,7 +9777,7 @@
 /area/expoutpost/hangarfive)
 "hPF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -10229,9 +10162,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "igW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -10324,9 +10255,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
 "ikH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10352,9 +10281,7 @@
 /turf/simulated/floor,
 /area/expoutpost/staruppermaint)
 "ilP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10940,7 +10867,7 @@
 /area/space)
 "iKu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -11573,7 +11500,7 @@
 /area/shuttle/shuttle3/start)
 "jlK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11589,9 +11516,7 @@
 /turf/simulated/wall/rplastihull,
 /area/shuttle/needle)
 "jmh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12228,6 +12153,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -12251,9 +12177,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
 "jJo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12534,9 +12458,7 @@
 /turf/simulated/floor/reinforced,
 /area/expoutpost/washroom)
 "jVO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12735,7 +12657,7 @@
 /area/expoutpost/techstorage)
 "kfO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -12841,9 +12763,7 @@
 /area/expoutpost/explobriefroom)
 "kkw" = (
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13029,9 +12949,7 @@
 /turf/simulated/wall/r_wall,
 /area/expoutpost/starfuelstorage)
 "ktx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/disposal/wall{
 	dir = 4;
 	pixel_x = -35
@@ -13164,9 +13082,6 @@
 /area/expoutpost/hangarfive)
 "kyD" = (
 /obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -13176,6 +13091,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
@@ -13221,14 +13141,15 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
@@ -13236,17 +13157,16 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	dir = 1;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
@@ -13322,9 +13242,7 @@
 /turf/simulated/floor,
 /area/expoutpost/staginghangar)
 "kIa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13776,17 +13694,6 @@
 /area/expoutpost/rnd)
 "lbt" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -13797,20 +13704,30 @@
 	icon_state = "2-4"
 	},
 /obj/effect/catwalk_plated/techfloor,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/expoutpost/staginghangar)
 "lbA" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/lowersternhallway)
@@ -14081,12 +13998,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/starbowhallway)
 "lmY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
 "lnk" = (
@@ -14645,7 +14558,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14871,6 +14784,8 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -14921,9 +14836,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "lPp" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
@@ -15160,7 +15073,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/secureaccess)
@@ -15363,9 +15276,7 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/rnd)
 "mdJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15477,9 +15388,7 @@
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "miL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15588,6 +15497,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -15683,9 +15594,7 @@
 /turf/simulated/floor,
 /area/expoutpost/portexplomaint)
 "mpO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15902,9 +15811,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/expoutpost/staruppermaint)
 "myy" = (
@@ -16214,9 +16121,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/secarmory)
 "mMj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16241,6 +16146,8 @@
 /area/expoutpost/secarmory)
 "mMZ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -16265,7 +16172,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16292,9 +16199,7 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/suite2)
 "mOK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -16583,12 +16488,8 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/engoffice)
 "mZx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -16599,6 +16500,8 @@
 "mZV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/wall/rplastihull,
@@ -17036,19 +16939,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
-"nnA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor,
-/area/expoutpost/staruppermaint)
 "nnT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -17094,7 +16984,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/breakroom)
@@ -17279,9 +17169,7 @@
 /turf/simulated/floor,
 /area/shuttle/echidna)
 "nuL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17382,9 +17270,6 @@
 /area/expoutpost/reactorroom)
 "nyj" = (
 /obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -17394,6 +17279,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
@@ -17520,9 +17410,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/lowersternhallway)
 "nCc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17621,6 +17509,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -18170,9 +18060,7 @@
 /turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "obN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18220,15 +18108,20 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
@@ -18284,14 +18177,15 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
@@ -18308,9 +18202,10 @@
 /obj/machinery/shield_gen/external,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
-	icon_state = "0-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/staginghangar)
 "oeA" = (
@@ -18540,9 +18435,6 @@
 /turf/simulated/floor,
 /area/expoutpost/atmospherics)
 "ope" = (
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -18553,6 +18445,10 @@
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
@@ -18949,11 +18845,12 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarthree)
 "oFQ" = (
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/machinery/shield_capacitor,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/staginghangar)
 "oFW" = (
@@ -19119,9 +19016,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/lowersternhallway)
 "oOD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19133,6 +19028,8 @@
 /area/expoutpost/bar)
 "oON" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/milspec/raised,
@@ -19407,7 +19304,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19630,15 +19527,17 @@
 /turf/simulated/floor/grass2,
 /area/expoutpost/botany)
 "pnJ" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/pink/border,
 /obj/machinery/light,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/surgical1)
 "pnR" = (
@@ -19684,12 +19583,11 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/expoutpost/portbowairlock)
@@ -19749,9 +19647,7 @@
 "pvk" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 22
@@ -19788,15 +19684,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
 "pxb" = (
@@ -19928,7 +19826,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19993,6 +19891,7 @@
 	name = "Exploration Q-Pad"
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/milspec/raised,
@@ -20135,6 +20034,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/white,
@@ -20173,7 +20073,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/techstorage)
@@ -20201,14 +20101,13 @@
 /area/expoutpost/staginghangar)
 "pMu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	dir = 1;
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
 	},
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
@@ -20387,9 +20286,7 @@
 /turf/simulated/floor,
 /area/expoutpost/starlowermaint)
 "pVA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -20619,9 +20516,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
 "qci" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -20667,7 +20562,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/janitorial)
@@ -20872,6 +20767,8 @@
 /area/expoutpost/portuppermaint)
 "qnL" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -21002,7 +20899,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21397,11 +21294,13 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
@@ -21684,9 +21583,7 @@
 /turf/simulated/floor,
 /area/expoutpost/staruppermaint)
 "qQa" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
 "qQn" = (
@@ -21823,9 +21720,7 @@
 /turf/simulated/floor/carpet,
 /area/expoutpost/suite1)
 "qYF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21901,7 +21796,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/breakroom)
@@ -21912,9 +21807,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/gateway)
 "rcn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22064,9 +21957,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -22300,7 +22191,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -22314,6 +22205,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -22575,6 +22468,8 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
@@ -22988,15 +22883,6 @@
 "rKs" = (
 /turf/simulated/floor,
 /area/expoutpost/atmospherics)
-"rLj" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/shield_capacitor,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/milspec/raised,
-/area/expoutpost/staginghangar)
 "rLo" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -23292,15 +23178,20 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/green,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
@@ -23344,9 +23235,7 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
 "rVg" = (
@@ -23540,9 +23429,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
 "sdR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/closet/walllocker{
 	dir = 4;
 	pixel_x = 32
@@ -24158,9 +24045,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/slingcarrierdock)
 "sFB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24228,13 +24113,14 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/machinery/light_switch{
 	dir = 1;
 	pixel_x = 12;
 	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
@@ -24346,9 +24232,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
 "sPb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -24460,7 +24344,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -24659,7 +24543,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/expoutpost/atmospherics)
@@ -24714,16 +24598,15 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
 "tci" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	dir = 1;
-	icon_state = "4-8"
-	},
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/airlock/engineeringatmos{
 	name = "Atmospheric System";
 	req_one_access = list(10,24)
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/expoutpost/engoffice)
@@ -24900,11 +24783,13 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "tjX" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
@@ -25030,9 +24915,7 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/commanderroom)
 "tqk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -25713,9 +25596,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/lowersternhallway)
 "tQz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -26131,9 +26012,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/green,
 /obj/structure/cable/green{
-	icon_state = "0-2"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/staginghangar)
@@ -26282,21 +26164,20 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/techstorage)
 "ulN" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	dir = 1;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/engineering{
 	name = "R-UST Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/expoutpost/reactoraccess)
@@ -26417,26 +26298,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/cic)
-"uqu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/lowersternhallway)
 "uqw" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -26462,9 +26323,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/lowersternhallway)
 "uqU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -26506,10 +26365,12 @@
 	dir = 4;
 	pixel_x = 32
 	},
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/echidna)
 "usS" = (
@@ -27149,7 +27010,6 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	dir = 1;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/reinforced/airless,
@@ -27206,6 +27066,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d2 = 2;
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/steel_dirty,
@@ -27300,9 +27161,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/secureaccess)
 "uWq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
@@ -27422,9 +27281,6 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/machinery/disposal/wall{
 	dir = 8;
 	pixel_x = 35
@@ -27434,6 +27290,10 @@
 	dir = 1;
 	pixel_x = 12;
 	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/restrooms)
@@ -28121,9 +27981,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/expoutpost/gateway)
 "vCN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -28217,9 +28075,7 @@
 /turf/simulated/floor/grass2,
 /area/expoutpost/slingcarrierdock)
 "vGC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -28308,11 +28164,13 @@
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/expoutpost/starfuelstorage)
 "vKc" = (
@@ -28847,9 +28705,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/lowersternhallway)
 "wbs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -28927,7 +28783,7 @@
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -29239,14 +29095,16 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/cic)
 "woc" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
@@ -29285,14 +29143,15 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/stationqpad)
@@ -29595,7 +29454,6 @@
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
-	dir = 1;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -29817,9 +29675,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -29827,6 +29682,11 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/machinery/light,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
 "wQf" = (
@@ -29893,10 +29753,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/lowersternhallway)
 "wRB" = (
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/echidna)
 "wSp" = (
@@ -29965,9 +29827,6 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
@@ -29979,6 +29838,10 @@
 	dir = 1;
 	pixel_x = 12;
 	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/secbowcheckpoint)
@@ -30146,9 +30009,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/starbowhallway)
 "xeC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -30289,13 +30150,14 @@
 	name = "east bump";
 	pixel_x = 24
 	},
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = 24;
 	pixel_y = -12
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/suite1)
@@ -30413,9 +30275,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
 "xnj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -30991,12 +30851,14 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/techstorage)
 "xHV" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/panic_button{
 	pixel_x = 32
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/echidna)
@@ -31041,9 +30903,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -31174,9 +31034,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
 "xLO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -31323,10 +31181,12 @@
 /turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "xQK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
 "xQZ" = (
@@ -31403,13 +31263,15 @@
 	icon_state = "2-8"
 	},
 /obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor,
 /area/expoutpost/lowersternhallway)
@@ -31862,7 +31724,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/door/airlock/engineering{
@@ -57204,15 +57066,15 @@ wwm
 xvk
 kkw
 kkw
-dkW
-dkW
+jQX
+jQX
 qpa
-dkW
+jQX
 uqU
-dkW
-dkW
-dkW
-dkW
+jQX
+jQX
+jQX
+jQX
 cHH
 nYm
 pgP
@@ -57756,7 +57618,7 @@ wkI
 neW
 bGo
 bGo
-hkD
+pbu
 uLs
 nGu
 nGu
@@ -59306,7 +59168,7 @@ nvl
 vwg
 fse
 qKs
-uqu
+jtd
 nkx
 lpf
 nkx
@@ -59564,7 +59426,7 @@ nvl
 viN
 fse
 qKs
-uqu
+jtd
 xpM
 wlq
 wlq
@@ -59822,7 +59684,7 @@ nvl
 lJc
 fse
 qKs
-uqu
+jtd
 xJG
 wlq
 dww
@@ -60080,7 +59942,7 @@ buZ
 aAX
 fse
 hDj
-uqu
+jtd
 nkx
 xcO
 cGr
@@ -60596,7 +60458,7 @@ nvl
 viN
 fse
 lbA
-bIm
+rok
 nkx
 oYI
 sCt
@@ -60854,7 +60716,7 @@ nvl
 lJc
 fse
 epN
-uqu
+jtd
 xpM
 wlq
 qaW
@@ -61112,7 +60974,7 @@ fse
 oHt
 fse
 dzc
-uqu
+jtd
 xJG
 wlq
 wlq
@@ -61628,7 +61490,7 @@ inz
 viN
 fse
 oNO
-uqu
+jtd
 xpM
 aPh
 tay
@@ -61886,7 +61748,7 @@ fse
 fse
 fse
 qKs
-uqu
+jtd
 mmQ
 aPh
 ooQ
@@ -62144,7 +62006,7 @@ jAV
 jAV
 jAV
 hDj
-uqu
+jtd
 qkj
 aPh
 hga
@@ -63073,17 +62935,17 @@ mpO
 uAp
 mpO
 cbF
-fqN
+cof
 mOK
-fqN
-fqN
+cof
+cof
 pZR
-fqN
-fqN
+cof
+cof
 gvD
-fqN
-fqN
-fqN
+cof
+cof
+cof
 jMa
 mnz
 mMZ
@@ -64664,7 +64526,7 @@ bAe
 nOu
 mef
 fXV
-rLj
+oFQ
 hLp
 hsy
 nOu
@@ -65180,7 +65042,7 @@ bkS
 nOu
 hCD
 fXV
-rLj
+oFQ
 oON
 swn
 nOu
@@ -66685,17 +66547,17 @@ qYF
 qUx
 qYF
 ftz
-fqN
+cof
 pVA
-fqN
-fqN
+cof
+cof
 qCI
-fqN
-fqN
+cof
+cof
 qrC
-fqN
-fqN
-fqN
+cof
+cof
+cof
 iEb
 gyI
 crf
@@ -72684,10 +72546,10 @@ tYC
 vVN
 mxF
 mxF
-nnA
-nnA
-nnA
-nnA
+rOq
+rOq
+rOq
+rOq
 tJR
 vxd
 vxd

--- a/maps/southern_cross/southern_cross-casino.dmm
+++ b/maps/southern_cross/southern_cross-casino.dmm
@@ -6,6 +6,12 @@
 	},
 /turf/simulated/floor/outdoors/ice,
 /area/surface/outside/plains/outpost)
+"ab" = (
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship/wing_left)
+"ac" = (
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship)
 "ad" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -15,7 +21,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ae" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -29,7 +36,8 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "af" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/simulated/floor/wood/sif,
@@ -46,7 +54,8 @@
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ai" = (
 /mob/living/simple_mob/animal/sif/glitterfly,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -56,12 +65,14 @@
 "aj" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ak" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "al" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 4
@@ -69,14 +80,16 @@
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "am" = (
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "an" = (
 /mob/living/simple_mob/animal/passive/gaslamp/snow{
 	hovering = 1
@@ -89,7 +102,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "ap" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -99,12 +113,14 @@
 	health = 1e+006;
 	req_access = list(5)
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "aq" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "ar" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -112,7 +128,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "as" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -135,7 +152,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "au" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -146,7 +164,8 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "av" = (
 /turf/unsimulated/wall,
 /area/surface/outside/plains/outpost)
@@ -159,14 +178,16 @@
 	icon_state = "spline_fancy_corner"
 	},
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ay" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "az" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -179,7 +200,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "aA" = (
 /mob/living/simple_mob/animal/sif/diyaab{
 	hovering = 1
@@ -202,7 +224,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "aC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -224,11 +247,13 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "aE" = (
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "aF" = (
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -267,7 +292,8 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "aK" = (
 /mob/living/simple_mob/animal/passive/mouse/white,
 /turf/simulated/floor/outdoors/dirt{
@@ -280,13 +306,15 @@
 /obj/structure/bed/chair/sofa/right/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "aM" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "aN" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -296,15 +324,18 @@
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "aO" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "aP" = (
-/turf/simulated/wall/golddiamond)
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship/dorms)
 "aQ" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/dicecup{
@@ -328,7 +359,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "aR" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/pill_bottle/dice{
@@ -340,7 +372,8 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "aS" = (
 /obj/effect/blocker,
 /turf/simulated/mineral/ignore_mapgen/cave,
@@ -349,7 +382,8 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "aU" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -360,7 +394,8 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "aV" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -368,19 +403,22 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "aW" = (
 /obj/structure/noticeboard{
 	name = "Sentient prize board"
 	},
-/turf/simulated/wall/golddiamond)
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship)
 "aX" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	health = 1e+006;
 	req_access = list(5)
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "aY" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Casinoboth 1";
@@ -398,7 +436,8 @@
 	req_access = list(160)
 	},
 /obj/structure/closet/crate/bin,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "aZ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -408,7 +447,8 @@
 	health = 1e+006
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ba" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -419,7 +459,8 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "bb" = (
 /mob/living/simple_mob/animal/sif/glitterfly,
 /turf/simulated/floor/water,
@@ -433,7 +474,8 @@
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "bd" = (
 /mob/living/simple_mob/animal/sif/tymisian,
 /turf/simulated/floor/outdoors/dirt{
@@ -445,7 +487,8 @@
 "be" = (
 /obj/structure/sign/christmas/wreath,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "bf" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -455,7 +498,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "bg" = (
 /obj/structure/flora/tree/winter1,
 /mob/living/simple_mob/animal/sif/glitterfly,
@@ -463,17 +507,23 @@
 	temperature = 293.15
 	},
 /area/surface/outside/plains/outpost)
+"bh" = (
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "bi" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "bj" = (
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "bk" = (
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "bl" = (
 /obj/effect/blocker,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -506,10 +556,12 @@
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_right)
 "bo" = (
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "bp" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -521,23 +573,27 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "bq" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship/dorms)
 "br" = (
 /obj/effect/blocker,
 /turf/simulated/floor/water,
 /area/surface/outside/plains/outpost)
 "bs" = (
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "bt" = (
 /obj/machinery/door/airlock/silver{
 	name = "General storage";
 	req_access = list(160)
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "bu" = (
 /obj/effect/blocker,
 /turf/simulated/floor/water/deep,
@@ -549,12 +605,14 @@
 /obj/effect/simple_portal/linked{
 	portal_id = 7
 	},
-/turf/simulated/floor/redgrid/animated)
+/turf/simulated/floor/redgrid/animated,
+/area/casino/casino_ship)
 "bx" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "by" = (
 /turf/simulated/floor/outdoors/dirt{
 	can_atmos_pass = 0;
@@ -565,14 +623,16 @@
 "bz" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/flora/tree/pine/xmas/presents,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "bA" = (
 /obj/machinery/door/airlock/security{
 	name = "Cell 1";
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_right)
 "bB" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -580,15 +640,18 @@
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "bC" = (
 /obj/machinery/door/airlock/silver{
 	id_tag = "casinodorm5";
 	name = "Dorm room 5"
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "bD" = (
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "bE" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/spray/cleaner{
@@ -598,7 +661,8 @@
 /obj/item/weapon/reagent_containers/spray/cleaner{
 	pixel_x = 8
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "bF" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -607,7 +671,8 @@
 /obj/structure/sign/christmas/lights,
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "bG" = (
 /obj/effect/zone_divider,
 /turf/unsimulated/wall,
@@ -619,7 +684,8 @@
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "bI" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -664,14 +730,17 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "bN" = (
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "bO" = (
 /obj/machinery/casino_chip_exchanger{
 	pixel_x = -32
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "bP" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -683,7 +752,8 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "bQ" = (
 /obj/machinery/casino_chip_exchanger{
 	pixel_x = -32
@@ -691,7 +761,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "bR" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin{
@@ -706,7 +777,8 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "bS" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -727,10 +799,12 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "bU" = (
 /obj/structure/flora/tree/pine,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "bV" = (
 /obj/structure/table/rack/shelf,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -741,7 +815,8 @@
 	},
 /obj/item/weapon/reagent_containers/glass/bucket/wood,
 /obj/effect/mist,
-/turf/simulated/floor/tiled/techmaint)
+/turf/simulated/floor/tiled/techmaint,
+/area/casino/casino_ship)
 "bW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -757,7 +832,8 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "bX" = (
 /obj/structure/sink{
 	pixel_x = 16;
@@ -766,12 +842,14 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "bY" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "bZ" = (
 /obj/structure/closet/jcloset,
 /obj/item/weapon/soap/deluxe,
@@ -783,7 +861,8 @@
 	},
 /obj/item/device/lightreplacer,
 /obj/item/device/lightreplacer,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "ca" = (
 /obj/effect/blocker,
 /obj/structure/flora/tree/dead,
@@ -806,12 +885,14 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ce" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "cf" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -822,7 +903,8 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 17
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "cg" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/floor_decal/borderfloor{
@@ -834,13 +916,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "ch" = (
 /obj/structure/flora/bboulder1,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ci" = (
 /obj/structure/closet/athletic_mixed,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "cj" = (
 /mob/living/simple_mob/vore/rabbit/white,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -866,7 +951,8 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "cm" = (
 /obj/machinery/atmospherics/unary/heater/sauna{
 	dir = 4;
@@ -874,7 +960,8 @@
 	use_power = 1
 	},
 /obj/effect/mist,
-/turf/simulated/floor/tiled/techmaint)
+/turf/simulated/floor/tiled/techmaint,
+/area/casino/casino_ship)
 "cn" = (
 /mob/living/simple_mob/vore/rabbit/brown,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -894,7 +981,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "cp" = (
 /obj/machinery/atmospherics/unary/engine/biggest{
 	dir = 4
@@ -905,7 +993,8 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
-/turf/simulated/wall/golddiamond)
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship/wing_left)
 "cr" = (
 /obj/machinery/light{
 	dir = 4
@@ -913,7 +1002,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "cs" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -927,7 +1017,8 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ct" = (
 /obj/machinery/light{
 	dir = 1
@@ -936,7 +1027,8 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "cu" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/storage/wallet/casino,
@@ -955,7 +1047,8 @@
 /obj/item/weapon/storage/wallet/casino,
 /obj/item/weapon/storage/wallet/casino,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "cv" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -963,7 +1056,8 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "cw" = (
 /obj/structure/table/steel,
 /obj/item/weapon/grenade/chem_grenade/cleaner,
@@ -980,7 +1074,8 @@
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/item/weapon/reagent_containers/spray/cleaner,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "cx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -997,7 +1092,8 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "cy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -1010,15 +1106,18 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "cz" = (
 /obj/structure/flora/lily2,
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "cA" = (
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "cB" = (
 /obj/structure/flora/grass/green,
 /mob/living/simple_mob/vore/rabbit/brown,
@@ -1041,7 +1140,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "cE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -1059,7 +1159,8 @@
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "cG" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -1069,33 +1170,45 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "cH" = (
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "cI" = (
 /obj/structure/table/glass,
 /obj/item/toy/eight_ball,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "cJ" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
+"cK" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship/dorms)
 "cL" = (
 /obj/structure/flora/lily1,
-/turf/simulated/floor/water/indoors)
+/turf/simulated/floor/water/indoors,
+/area/casino/casino_ship)
 "cM" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "cN" = (
 /obj/structure/flora/tree/winter1,
 /obj/structure/flora/grass/brown,
@@ -1120,47 +1233,55 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "cQ" = (
 /obj/structure/flora/tree/pine{
 	desc = "A wondrous decorated Christmas tree. It has presents!";
 	icon_state = "pinepresents"
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "cR" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "cS" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "cT" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_2"
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "cU" = (
 /obj/machinery/door/airlock/silver{
 	name = "Sauna"
 	},
 /obj/structure/fans/tiny,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "cV" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "cW" = (
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 4
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "cX" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1168,7 +1289,8 @@
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "cY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -1188,7 +1310,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "da" = (
 /obj/machinery/light{
 	dir = 4
@@ -1196,7 +1319,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "db" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/stack/material/log/sif{
@@ -1212,24 +1336,31 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "dd" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
+"de" = (
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "df" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "dg" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/table/fancyblack,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "dh" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
@@ -1237,7 +1368,8 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "di" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -1254,10 +1386,12 @@
 /area/surface/outside/plains/mountains)
 "dj" = (
 /obj/effect/mist,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "dk" = (
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "dl" = (
 /obj/machinery/light{
 	dir = 4
@@ -1265,7 +1399,8 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "dm" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -1280,7 +1415,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "dn" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -1291,14 +1427,16 @@
 	health = 1e+006
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "do" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "dp" = (
 /obj/machinery/light{
 	dir = 8
@@ -1306,13 +1444,17 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "dq" = (
 /obj/structure/flora/tree/winter,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
 	temperature = 293.15
 	},
 /area/surface/outside/plains/outpost)
+"dr" = (
+/turf/simulated/floor/outdoors/dirt,
+/area/casino/casino_ship/wing_left)
 "ds" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
@@ -1320,7 +1462,8 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "dt" = (
 /obj/structure/ledge/ledge_stairs{
 	pixel_y = -3
@@ -1330,7 +1473,8 @@
 "du" = (
 /obj/structure/table/fancyblack,
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "dv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1355,19 +1499,23 @@
 	health = 1e+006;
 	req_access = list(5)
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "dx" = (
 /obj/structure/table/sifwoodentable,
 /obj/item/weapon/flame/candle/candelabra/everburn,
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
 "dy" = (
-/turf/simulated/floor/carpet/purcarpet)
+/turf/simulated/floor/carpet/purcarpet,
+/area/casino/casino_ship)
 "dz" = (
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "dA" = (
 /obj/structure/janitorialcart,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "dB" = (
 /obj/structure/table/bench/sifwooden,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -1387,14 +1535,16 @@
 	use_power = 1
 	},
 /obj/effect/mist,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "dC" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/reagent_containers/food/snacks/tamales,
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "dD" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/wood/sif,
@@ -1406,7 +1556,8 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "dF" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -1414,7 +1565,8 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "dG" = (
 /obj/structure/closet/gmcloset,
 /obj/item/glass_jar,
@@ -1455,7 +1607,11 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
+"dJ" = (
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "dK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -1472,14 +1628,16 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "dL" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "dM" = (
 /obj/structure/table/glass,
 /obj/item/device/communicator,
@@ -1490,7 +1648,8 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "dN" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy{
@@ -1502,13 +1661,15 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "dO" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 8
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "dP" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1520,7 +1681,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "dQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1532,7 +1694,8 @@
 /area/surface/outside/plains/mountains)
 "dR" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "dS" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1542,7 +1705,8 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "dT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -1550,12 +1714,14 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "dU" = (
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "dV" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -1567,7 +1733,8 @@
 	},
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "dW" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -1584,7 +1751,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "dX" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/borderfloor{
@@ -1593,7 +1761,8 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "dY" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/machinery/light{
@@ -1602,10 +1771,12 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "dZ" = (
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/carpet/purcarpet)
+/turf/simulated/floor/carpet/purcarpet,
+/area/casino/casino_ship)
 "ea" = (
 /obj/machinery/slot_machine,
 /obj/machinery/light{
@@ -1614,7 +1785,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "eb" = (
 /obj/machinery/slot_machine,
 /obj/machinery/light{
@@ -1623,7 +1795,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "ec" = (
 /obj/machinery/atm{
 	pixel_x = -32
@@ -1631,7 +1804,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "ed" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 8
@@ -1641,14 +1815,16 @@
 "ee" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloor,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "ef" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = 1e+006
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "eg" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1659,7 +1835,8 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "eh" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/book/codex/casino,
@@ -1682,7 +1859,8 @@
 /obj/item/weapon/book/codex/casino,
 /obj/item/weapon/book/codex/casino,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ei" = (
 /obj/structure/table/steel,
 /obj/item/weapon/flame/candle/everburn,
@@ -1698,10 +1876,12 @@
 	},
 /obj/structure/curtain/open/shower/engineering,
 /obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship/dorms)
 "ek" = (
 /obj/structure/bed/chair/oldsofa,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "el" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1711,13 +1891,15 @@
 	health = 1e+006
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "em" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "en" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -1730,42 +1912,50 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "eo" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ep" = (
-/turf/simulated/floor/outdoors/dirt)
+/turf/simulated/floor/outdoors/dirt,
+/area/casino/casino_ship/wing_right)
 "eq" = (
 /obj/machinery/slot_machine,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "er" = (
 /obj/structure/flora/lily2,
-/turf/simulated/floor/water/indoors)
+/turf/simulated/floor/water/indoors,
+/area/casino/casino_ship)
 "es" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/cedouble,
-/turf/simulated/floor/carpet/purcarpet)
+/turf/simulated/floor/carpet/purcarpet,
+/area/casino/casino_ship)
 "et" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "eu" = (
 /obj/structure/table/glass,
 /obj/item/weapon/book/codex/casino,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ev" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1774,7 +1964,8 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ew" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -1782,7 +1973,8 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "ex" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -1790,7 +1982,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "ey" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -1798,7 +1991,8 @@
 	pixel_y = 32
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ez" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -1813,7 +2007,8 @@
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "eA" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/water/hotspring{
@@ -1827,13 +2022,15 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "eC" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "eD" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -1850,9 +2047,11 @@
 	},
 /area/surface/outside/plains/mountains)
 "eE" = (
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "eF" = (
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "eG" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_3"
@@ -1869,7 +2068,8 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "eI" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
@@ -1877,12 +2077,14 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "eJ" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/device/starcaster_news,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "eK" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -1891,10 +2093,12 @@
 	},
 /obj/item/device/communicator,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "eL" = (
 /obj/structure/table/glass,
-/turf/simulated/floor/carpet/purcarpet)
+/turf/simulated/floor/carpet/purcarpet,
+/area/casino/casino_ship)
 "eM" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -1913,7 +2117,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "eO" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 4
@@ -1924,29 +2129,40 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "eP" = (
 /obj/structure/flora/lily1,
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "eQ" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "eR" = (
 /obj/machinery/door/airlock/security{
 	name = "Holding cells";
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_right)
+"eS" = (
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship/wing_right)
 "eT" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/laundry_basket,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "eU" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 9
@@ -1954,7 +2170,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "eV" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 8
@@ -1962,7 +2179,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "eW" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 10
@@ -1970,37 +2188,44 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "eX" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/event/present,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "eY" = (
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship/dorms)
 "eZ" = (
 /obj/item/weapon/stool/padded,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "fa" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "fb" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "fc" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fd" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/storage/wallet/casino,
@@ -2021,7 +2246,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fe" = (
 /obj/structure/table/marble,
 /obj/item/weapon/paper_bin{
@@ -2045,7 +2271,8 @@
 	name = "Front Desk Shutters"
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "ff" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
@@ -2055,7 +2282,8 @@
 	},
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fg" = (
 /obj/item/weapon/telecube/mated,
 /turf/simulated/floor/flock,
@@ -2084,7 +2312,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fi" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -2106,19 +2335,22 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fk" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/device/starcaster_news,
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fl" = (
 /obj/structure/table/fancyblack,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "fm" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -2129,7 +2361,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fn" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
@@ -2137,7 +2370,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fo" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
@@ -2147,10 +2381,12 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "fp" = (
 /obj/structure/table/fancyblack,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "fq" = (
 /obj/machinery/door/window/westright{
 	dir = 1;
@@ -2163,13 +2399,15 @@
 	layer = 3.2;
 	name = "Exchange booth shutters 1"
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "fr" = (
 /obj/machinery/light,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fs" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -2178,7 +2416,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ft" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2186,23 +2425,27 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "fu" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fv" = (
 /obj/structure/table/glass,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fw" = (
 /obj/structure/table/wooden_reinforced,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fx" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood/sif,
@@ -2213,7 +2456,8 @@
 	dir = 1
 	},
 /obj/item/weapon/gun/energy/sizegun,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "fz" = (
 /mob/living/simple_mob/animal/giant_spider/carrier,
 /turf/simulated/floor/outdoors/dirt{
@@ -2233,7 +2477,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fB" = (
 /obj/structure/flora/grass/both,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -2251,7 +2496,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fD" = (
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 4
@@ -2262,11 +2508,13 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "fE" = (
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "fF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -2274,7 +2522,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "fG" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/coffee{
@@ -2298,7 +2547,8 @@
 	pixel_x = -6;
 	pixel_y = -1
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "fH" = (
 /obj/machinery/vending/coffee,
 /obj/effect/floor_decal/spline/fancy{
@@ -2307,10 +2557,12 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fI" = (
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "fJ" = (
 /obj/item/weapon/book/codex/casino,
 /obj/structure/table/marble,
@@ -2323,7 +2575,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "fK" = (
 /obj/structure/flora/lily1,
 /obj/structure/sign/christmas/lights{
@@ -2331,7 +2584,8 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "fL" = (
 /obj/structure/flora/lily2,
 /obj/structure/sign/christmas/lights{
@@ -2339,7 +2593,8 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "fM" = (
 /obj/machinery/vending/snack,
 /obj/effect/floor_decal/spline/fancy{
@@ -2348,7 +2603,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fN" = (
 /obj/machinery/power/smes/buildable/hybrid,
 /obj/structure/cable/green{
@@ -2379,27 +2635,35 @@
 	pixel_x = -8;
 	pixel_y = -1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "fP" = (
 /obj/structure/sign/christmas/lights,
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "fQ" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
+"fR" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_right)
 "fS" = (
 /obj/machinery/door/airlock/multi_tile/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship)
 "fT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "fU" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 4
@@ -2410,11 +2674,13 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "fV" = (
 /obj/structure/table/glass,
 /obj/item/device/starcaster_news,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fW" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -2426,7 +2692,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "fX" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_3"
@@ -2442,7 +2709,8 @@
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "fZ" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -2454,7 +2722,8 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ga" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/ice,
@@ -2468,7 +2737,8 @@
 /obj/structure/mopbucket,
 /obj/item/weapon/mop,
 /obj/item/weapon/reagent_containers/glass/bucket,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "gc" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -2476,7 +2746,8 @@
 /obj/effect/floor_decal/corner/purple/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "gd" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -2491,7 +2762,8 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ge" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -2505,7 +2777,8 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "gf" = (
 /obj/machinery/appliance/cooker/grill,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -2526,7 +2799,8 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "gi" = (
 /obj/structure/flora/lily1,
 /obj/structure/sign/christmas/wreath{
@@ -2534,7 +2808,8 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "gj" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -2546,7 +2821,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "gk" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 4
@@ -2554,7 +2830,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "gl" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/spline/fancy{
@@ -2566,16 +2843,19 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "gm" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
 	req_access = list(160)
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "gn" = (
 /obj/structure/table/glass,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "go" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2591,7 +2871,8 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "gp" = (
 /obj/structure/table/rack,
 /obj/item/device/suit_cooling_unit,
@@ -2602,7 +2883,8 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "gq" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 4
@@ -2614,7 +2896,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "gr" = (
 /obj/effect/zone_divider,
 /turf/simulated/mineral/ignore_mapgen/cave,
@@ -2629,10 +2912,12 @@
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/wing_right)
 "gt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "gu" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4;
@@ -2642,7 +2927,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "gv" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/borderfloor{
@@ -2651,7 +2937,8 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "gw" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2659,7 +2946,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "gx" = (
 /obj/structure/casino_table/blackjack_m{
 	dir = 1
@@ -2668,7 +2956,8 @@
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "gy" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
@@ -2676,12 +2965,14 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "gz" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/outdoors/grass/heavy{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "gA" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/borderfloor{
@@ -2690,7 +2981,8 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "gB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -2707,7 +2999,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "gC" = (
 /obj/structure/flora/lily2,
 /obj/structure/sign/christmas/wreath{
@@ -2715,7 +3008,8 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "gD" = (
 /obj/machinery/door/airlock/glass_external{
 	autoclose = 0;
@@ -2733,7 +3027,8 @@
 	pixel_x = -24
 	},
 /obj/structure/fans/hardlight,
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship)
 "gE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -2746,7 +3041,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "gF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -2763,7 +3059,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "gG" = (
 /obj/machinery/door/airlock/glass_external{
 	autoclose = 0;
@@ -2774,14 +3071,16 @@
 	name = "Landing North External"
 	},
 /obj/structure/fans/hardlight,
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship)
 "gH" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "gI" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -2794,7 +3093,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "gJ" = (
 /obj/structure/table/marble,
 /obj/item/device/radio/headset/syndicate,
@@ -2812,7 +3112,8 @@
 	},
 /obj/item/clothing/head/crown/goose_king/christmas,
 /obj/item/clothing/head/crown/goose_queen/christmas,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "gK" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -2827,7 +3128,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "gL" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/spline/fancy{
@@ -2840,13 +3142,15 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "gM" = (
 /obj/structure/flora/tree/pine,
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "gN" = (
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/plains/outpost)
@@ -2859,7 +3163,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "gP" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
@@ -2867,7 +3172,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "gQ" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 1
@@ -2878,7 +3184,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "gR" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 1
@@ -2886,7 +3193,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "gS" = (
 /obj/structure/flora/tree/winter,
 /obj/structure/flora/grass/both,
@@ -2901,7 +3209,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "gU" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 8
@@ -2909,7 +3218,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "gV" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -2917,7 +3227,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "gW" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/grass/brown,
@@ -2938,13 +3249,15 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "gZ" = (
 /obj/item/weapon/stool/padded,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "ha" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -2953,11 +3266,13 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "hb" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/eight_ball/conch,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "hc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2970,7 +3285,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "he" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -2978,12 +3294,14 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "hf" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "hg" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/mud/sif/planetuse{
@@ -3018,13 +3336,18 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
+"hk" = (
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship/wing_right)
 "hl" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "hm" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
@@ -3032,7 +3355,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "hn" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
@@ -3046,7 +3370,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ho" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -3057,7 +3382,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "hp" = (
 /obj/structure/railing{
 	dir = 8
@@ -3074,7 +3400,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "hr" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -3095,7 +3422,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ht" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -3106,21 +3434,25 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "hu" = (
 /obj/structure/table/fancyblack,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "hv" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "hw" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "hx" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 4
@@ -3129,23 +3461,28 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "hy" = (
 /obj/structure/bed/chair/oldsofa,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "hz" = (
 /obj/structure/bed/chair/oldsofa/corner,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "hA" = (
 /obj/machinery/slot_machine,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "hB" = (
 /obj/structure/reagent_dispensers/water_cooler/full,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "hC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3166,22 +3503,26 @@
 "hD" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/storage/dicecup,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "hE" = (
 /obj/machinery/slot_machine,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "hF" = (
 /obj/structure/reagent_dispensers/water_cooler/full,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "hG" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "hH" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -3192,14 +3533,16 @@
 	req_access = list(5)
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "hI" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = 1e+006
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "hJ" = (
 /obj/item/weapon/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -3213,7 +3556,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "hL" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/spline/fancy{
@@ -3224,13 +3568,15 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "hM" = (
 /obj/structure/bed/chair/bar_stool,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "hN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
@@ -3242,7 +3588,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "hP" = (
 /turf/unsimulated/mineral,
 /area/surface/outside/plains/mountains)
@@ -3251,7 +3598,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "hR" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/spline/fancy{
@@ -3261,7 +3609,8 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "hS" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
@@ -3273,7 +3622,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "hT" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 1
@@ -3281,7 +3631,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "hU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -3301,7 +3652,8 @@
 /obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "hW" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -3311,7 +3663,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/casino/casino_ship)
 "hX" = (
 /obj/structure/flora/tree/dead,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -3329,7 +3682,8 @@
 	name = "casino curtain"
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "ia" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -3346,7 +3700,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ib" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -3357,7 +3712,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ic" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
@@ -3373,7 +3729,8 @@
 /obj/item/weapon/gun/energy/laser,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "id" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
@@ -3392,12 +3749,14 @@
 /obj/item/weapon/gun/energy/gun/burst,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "ie" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "if" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
@@ -3415,15 +3774,18 @@
 /obj/item/weapon/gun/projectile/automatic/p90,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "ig" = (
 /obj/structure/bed/chair/sofa/corner/yellow,
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "ih" = (
-/turf/simulated/floor/water/pool)
+/turf/simulated/floor/water/pool,
+/area/casino/casino_ship)
 "ii" = (
 /obj/structure/table/glass,
 /obj/item/weapon/book/codex/casino,
@@ -3433,17 +3795,26 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ij" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/eight_ball,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "ik" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
+"il" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "im" = (
 /obj/item/weapon/storage/belt/holding,
 /turf/simulated/floor/flock,
@@ -3455,7 +3826,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "io" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
@@ -3464,7 +3836,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ip" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -3490,7 +3863,8 @@
 /area/surface/outside/plains/mountains)
 "ir" = (
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "is" = (
 /obj/structure/bed/chair/sofa/left/yellow{
 	dir = 8
@@ -3498,13 +3872,15 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "it" = (
 /obj/structure/table/glass,
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "iu" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/book/codex/casino,
@@ -3514,13 +3890,15 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "iv" = (
 /obj/structure/closet/crate/bin,
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "iw" = (
 /obj/structure/bed/chair/sofa/right/yellow{
 	dir = 8
@@ -3528,7 +3906,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "ix" = (
 /obj/structure/bed/chair/sofa/corner/yellow{
 	dir = 8
@@ -3536,7 +3915,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "iy" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -3554,7 +3934,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "iz" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/flora/pottedplant/xmas{
@@ -3563,7 +3944,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "iA" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/coffee{
@@ -3590,7 +3972,8 @@
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "iB" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -3607,7 +3990,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "iC" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -3619,7 +4003,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "iD" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -3627,7 +4012,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "iE" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3636,13 +4022,15 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "iF" = (
 /obj/machinery/recharge_station,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "iG" = (
 /obj/machinery/light{
 	dir = 4
@@ -3650,7 +4038,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "iH" = (
 /obj/machinery/light{
 	dir = 4
@@ -3661,12 +4050,14 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "iI" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "iJ" = (
 /obj/machinery/casino_prize_dispenser{
 	category_clothing = 2;
@@ -3682,12 +4073,14 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "iK" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "iL" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -3696,7 +4089,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "iM" = (
 /obj/machinery/light{
 	dir = 8
@@ -3704,7 +4098,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "iN" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -3716,7 +4111,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "iO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/sif/broken,
@@ -3732,7 +4128,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "iQ" = (
 /obj/machinery/casino_prize_dispenser{
 	category_clothing = 2;
@@ -3746,7 +4143,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "iR" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/spline/fancy{
@@ -3757,10 +4155,12 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "iS" = (
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "iT" = (
 /obj/machinery/light{
 	dir = 1
@@ -3770,7 +4170,8 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "iU" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -3778,25 +4179,29 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "iV" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/lily3,
 /obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "iW" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "iX" = (
 /obj/structure/window/reinforced,
 /obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "iY" = (
 /obj/item/ammo_magazine/ammo_box/b12g/beanbag,
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel,
@@ -3807,12 +4212,14 @@
 "iZ" = (
 /obj/structure/window/reinforced,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ja" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "jb" = (
 /obj/machinery/power/apc/alarms_hidden{
 	dir = 4;
@@ -3827,7 +4234,8 @@
 "jc" = (
 /obj/machinery/recharge_station,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "jd" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/window/reinforced{
@@ -3837,13 +4245,15 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "je" = (
 /obj/machinery/light,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "jf" = (
 /mob/living/simple_mob/animal/giant_spider/webslinger,
 /turf/simulated/floor/outdoors/dirt{
@@ -3864,7 +4274,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "jh" = (
 /obj/structure/table/sifwoodentable,
 /turf/simulated/floor/wood/sif,
@@ -3880,14 +4291,16 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "jj" = (
 /obj/structure/sign/christmas/wreath,
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "jk" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/lily3,
@@ -3896,7 +4309,8 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "jl" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -3909,7 +4323,8 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "jn" = (
 /mob/living/simple_mob/animal/sif/sakimm{
 	hovering = 1
@@ -3933,7 +4348,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "jp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -3945,7 +4361,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "jq" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -3955,10 +4372,12 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "jr" = (
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "js" = (
 /obj/item/weapon/storage/secure/safe{
 	pixel_x = 35
@@ -3973,7 +4392,8 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "jt" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -3982,7 +4402,8 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "ju" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -4011,7 +4432,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "jw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4027,14 +4449,16 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "jx" = (
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/flock,
 /area/surface/outside/plains/mountains)
 "jy" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "jz" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -4043,7 +4467,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "jA" = (
 /obj/structure/table/marble,
 /obj/item/weapon/paper_bin{
@@ -4069,7 +4494,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jB" = (
 /obj/item/weapon/storage/secure/safe{
 	pixel_x = 35
@@ -4080,18 +4506,21 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "jC" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jD" = (
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jE" = (
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
@@ -4100,12 +4529,14 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jF" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jG" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4113,7 +4544,8 @@
 	layer = 3.1;
 	name = "Casino bar shutter"
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4125,7 +4557,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "jI" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4141,7 +4574,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "jJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4157,7 +4591,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "jK" = (
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
@@ -4166,17 +4601,20 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jM" = (
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/sifwood,
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/lonehome)
 "jO" = (
-/turf/simulated/floor/tiled/kafel_full/blue)
+/turf/simulated/floor/tiled/kafel_full/blue,
+/area/casino/casino_ship)
 "jP" = (
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
@@ -4187,10 +4625,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jQ" = (
 /obj/structure/table/gamblingtable,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "jR" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -4198,7 +4638,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "jS" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4209,7 +4650,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jT" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4220,7 +4662,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jU" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4230,7 +4673,8 @@
 	name = "Casino bar shutter"
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jV" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4240,7 +4684,8 @@
 	name = "Casino bar shutter"
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4252,10 +4697,12 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "jX" = (
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "jY" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4267,7 +4714,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "jZ" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4279,10 +4727,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "ka" = (
 /obj/structure/bed/chair/oldsofa/corner,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "kb" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4294,7 +4744,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "kc" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4306,7 +4757,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "kd" = (
 /obj/structure/closet/secure_closet/security{
 	req_access = list(201)
@@ -4317,7 +4769,8 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "ke" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -4340,7 +4793,8 @@
 	},
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4356,7 +4810,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "kh" = (
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
@@ -4364,7 +4819,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "ki" = (
 /obj/machinery/crystal/ice,
 /turf/simulated/floor/outdoors/dirt{
@@ -4383,13 +4839,15 @@
 	req_access = list(5)
 	},
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "kk" = (
 /obj/structure/table/wooden_reinforced,
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kl" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -4399,7 +4857,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "km" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -4409,13 +4868,15 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "kn" = (
 /obj/structure/closet/crate/bin,
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ko" = (
 /obj/machinery/light{
 	dir = 1
@@ -4423,12 +4884,14 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kp" = (
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kq" = (
 /obj/machinery/crystal/ice,
 /turf/simulated/floor/outdoors/dirt{
@@ -4443,12 +4906,14 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ks" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "kt" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -4476,7 +4941,8 @@
 	layer = 3.1;
 	name = "Casino bar shutter"
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "kw" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
@@ -4486,7 +4952,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kx" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -4499,12 +4966,14 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ky" = (
 /obj/machinery/atm{
 	pixel_x = -32
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "kz" = (
 /obj/machinery/vending/coffee,
 /obj/structure/sign/christmas/wreath{
@@ -4513,12 +4982,14 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kA" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kB" = (
 /obj/machinery/light,
 /obj/structure/flora/pottedplant/xmas{
@@ -4527,12 +4998,14 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kC" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "kD" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -4540,17 +5013,20 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "kE" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "kF" = (
 /obj/structure/casino_table/blackjack_l{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "kG" = (
 /obj/structure/casino_table/blackjack_m{
 	dir = 1
@@ -4559,7 +5035,8 @@
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "kH" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 4
@@ -4567,7 +5044,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -4586,7 +5064,8 @@
 "kJ" = (
 /obj/structure/table/wooden_reinforced,
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kK" = (
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 8
@@ -4594,7 +5073,8 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kL" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -4606,12 +5086,14 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "kM" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/reagent_containers/food/snacks/tamales,
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kN" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -4631,15 +5113,18 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "kP" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
 /obj/machinery/light,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "kQ" = (
 /obj/structure/event/santa_sack,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "kR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/disposal/deliveryChute{
@@ -4666,11 +5151,13 @@
 	dir = 1
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "kT" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper/card/heart,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "kU" = (
 /obj/item/weapon/pickaxe/drill,
 /turf/simulated/floor/outdoors/dirt{
@@ -4691,10 +5178,12 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "kW" = (
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kX" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy{
@@ -4704,7 +5193,8 @@
 	dir = 1
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "kY" = (
 /obj/machinery/computer/card{
 	dir = 4
@@ -4712,7 +5202,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "kZ" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -4720,17 +5211,20 @@
 /obj/structure/sign/christmas/lights,
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "la" = (
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "lb" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/event/present,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "lc" = (
 /obj/machinery/light{
 	dir = 8
@@ -4742,13 +5236,15 @@
 	dir = 8
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ld" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "le" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -4762,7 +5258,8 @@
 	dir = 4
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "lf" = (
 /obj/structure/bed/chair/wood{
 	dir = 4
@@ -4776,12 +5273,14 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "lh" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/purcarpet)
+/turf/simulated/floor/carpet/purcarpet,
+/area/casino/casino_ship)
 "li" = (
 /obj/machinery/light{
 	dir = 8
@@ -4795,13 +5294,15 @@
 	dir = 8
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "lj" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "lk" = (
 /obj/random/junk,
 /turf/simulated/floor/wood/sif,
@@ -4815,7 +5316,8 @@
 	dir = 8
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "lm" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
@@ -4824,7 +5326,8 @@
 	dir = 4
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ln" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -4833,7 +5336,8 @@
 	dir = 8;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "lo" = (
 /obj/machinery/light,
 /obj/structure/window/reinforced{
@@ -4841,21 +5345,24 @@
 	},
 /obj/structure/sign/christmas/lights,
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "lp" = (
 /obj/structure/table/glass,
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "lq" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "lr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4864,24 +5371,28 @@
 	health = 1e+006
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "ls" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/event/present,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "lt" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "lu" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/snow/snow2)
+/turf/simulated/floor/snow/snow2,
+/area/casino/casino_ship)
 "lv" = (
 /obj/machinery/light{
 	dir = 1
@@ -4890,14 +5401,16 @@
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "lw" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/dice,
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "lx" = (
 /obj/structure/flora/tree/winter1,
 /obj/structure/flora/grass/green,
@@ -4912,11 +5425,13 @@
 	},
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "lz" = (
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "lA" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/wallet/casino,
@@ -4931,11 +5446,13 @@
 /obj/item/weapon/storage/wallet/casino,
 /obj/item/weapon/storage/wallet/casino,
 /obj/item/weapon/storage/wallet/casino,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "lB" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/reagent_containers/food/snacks/tamales,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "lF" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -4946,47 +5463,60 @@
 /obj/structure/casino_table/blackjack_r{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "lM" = (
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "lN" = (
 /obj/structure/closet,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "lO" = (
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
+"lP" = (
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship/dorms)
 "lR" = (
 /obj/machinery/door/window/westleft{
 	req_access = list(160)
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "lS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/techfloor/grid)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/casino/casino_ship)
 "lT" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "lU" = (
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "lW" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
 	id_tag = "casino1_pump"
 	},
-/turf/simulated/floor/tiled/techfloor/grid)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/casino/casino_ship)
 "lX" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/purcarpet)
+/turf/simulated/floor/carpet/purcarpet,
+/area/casino/casino_ship)
 "mc" = (
 /turf/simulated/mineral/ignore_mapgen/cave,
 /area/surface/outside/plains/mountains)
@@ -4996,7 +5526,8 @@
 	req_access = list(201,160);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_right)
 "mh" = (
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/outdoors/dirt{
@@ -5010,7 +5541,8 @@
 /obj/structure/bed/chair/oldsofa{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "mp" = (
 /obj/random/maintenance/clean,
 /turf/simulated/floor/outdoors/dirt{
@@ -5023,11 +5555,13 @@
 "ms" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/toy/eight_ball,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "mv" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/book/codex/casino,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "mw" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/gun/launcher/confetti_cannon,
@@ -5036,23 +5570,27 @@
 /obj/item/weapon/grenade/confetti/party_ball,
 /obj/item/weapon/grenade/confetti/party_ball,
 /obj/item/weapon/grenade/confetti/party_ball,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "my" = (
 /obj/structure/table/gamblingtable,
 /obj/item/device/communicator,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "mB" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/outdoors/grass/sif/planetuse,
 /area/surface/outside/plains/mountains)
 "mC" = (
-/turf/simulated/floor/water/deep/pool)
+/turf/simulated/floor/water/deep/pool,
+/area/casino/casino_ship)
 "mF" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8;
 	icon_state = "spline_fancy_cee"
 	},
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "mG" = (
 /obj/random/trash,
 /turf/simulated/floor/wood/sif,
@@ -5078,7 +5616,8 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /obj/machinery/light,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "mL" = (
 /obj/random/material/precious,
 /turf/simulated/floor/outdoors/dirt{
@@ -5099,34 +5638,40 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "mP" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
 /obj/effect/mist,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "mQ" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/device/communicator,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "mR" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4;
 	icon_state = "spline_fancy_cee"
 	},
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "mU" = (
 /obj/structure/table/glass,
 /obj/item/weapon/soap,
 /obj/item/weapon/soap,
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "mW" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "na" = (
 /obj/structure/ledge/ledge_stairs{
 	dir = 1;
@@ -5178,7 +5723,8 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "nj" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/drinks/shaker{
@@ -5188,12 +5734,14 @@
 	pixel_x = -6
 	},
 /obj/item/weapon/reagent_containers/glass/rag,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "nn" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "np" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -5227,13 +5775,15 @@
 	pixel_x = -28
 	},
 /obj/structure/stripper_pole,
-/turf/simulated/floor/carpet/purcarpet)
+/turf/simulated/floor/carpet/purcarpet,
+/area/casino/casino_ship)
 "nB" = (
 /obj/machinery/door/airlock/silver{
 	name = "Casino crew bathrooms";
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "nC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5252,7 +5802,8 @@
 	name = "Landing South External"
 	},
 /obj/structure/fans/hardlight,
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship)
 "nM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/crystal/ice,
@@ -5290,7 +5841,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "nW" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood/sif,
@@ -5320,7 +5872,8 @@
 	dir = 1;
 	layer = 3
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "nZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -5332,10 +5885,12 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "ob" = (
 /obj/machinery/media/jukebox/casinojukebox,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "od" = (
 /turf/simulated/floor/water,
 /area/surface/outside/plains/mountains)
@@ -5354,7 +5909,8 @@
 "og" = (
 /obj/structure/table/glass,
 /obj/machinery/recharger,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "oh" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -5376,7 +5932,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship/dorms)
 "ol" = (
 /obj/structure/closet/grave/dirthole{
 	opened = 0
@@ -5397,7 +5954,8 @@
 /obj/structure/bed/chair/comfy/purp{
 	dir = 8
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "op" = (
 /obj/structure/grille/rustic,
 /obj/structure/window/phoronreinforced/full,
@@ -5405,7 +5963,8 @@
 /area/submap/lonehome)
 "os" = (
 /obj/structure/bed/chair/sofa/yellow,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "ot" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4;
@@ -5414,26 +5973,31 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ou" = (
 /obj/machinery/door/airlock/silver{
 	name = "Lap dance room 1-2"
 	},
-/turf/simulated/floor/carpet/purcarpet)
+/turf/simulated/floor/carpet/purcarpet,
+/area/casino/casino_ship)
 "oB" = (
 /obj/structure/table/glass,
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "oC" = (
 /obj/structure/casino_table/roulette_table,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "oD" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "oG" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/material/precious,
@@ -5446,7 +6010,8 @@
 /area/surface/outside/plains/mountains)
 "oJ" = (
 /obj/machinery/door/window/southright,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "oK" = (
 /turf/simulated/floor/water{
 	outdoors = 0
@@ -5477,14 +6042,16 @@
 	layer = 3.2;
 	name = "Front Desk Shutters"
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "oY" = (
 /obj/structure/table/marble,
 /obj/item/weapon/flame/candle/candelabra/everburn,
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
 "oZ" = (
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "pc" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/material/knife/machete/hatchet{
@@ -5502,14 +6069,16 @@
 "pd" = (
 /turf/simulated/floor/outdoors/grass/heavy{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "pe" = (
 /obj/machinery/door/window/southright{
 	dir = 4;
 	name = "Bar";
 	req_access = list(160)
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "ph" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/glass_external{
@@ -5527,11 +6096,13 @@
 	name = "Internal Access Button";
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship)
 "pk" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/deluxe/full,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "pm" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -5561,14 +6132,16 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "pp" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation room";
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_right)
 "ps" = (
 /obj/structure/boulder,
 /turf/simulated/floor/outdoors/dirt{
@@ -5587,7 +6160,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "pu" = (
 /obj/structure/table/sifwoodentable,
 /turf/simulated/floor/outdoors/dirt{
@@ -5607,7 +6181,8 @@
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor/plating)
+/turf/simulated/floor/plating,
+/area/casino/casino_ship/wing_right)
 "px" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Casinodormshutters5";
@@ -5617,12 +6192,14 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "py" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "pz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -5634,7 +6211,8 @@
 	layer = 3.3;
 	name = "Prize shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "pB" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -5650,10 +6228,12 @@
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "pH" = (
 /obj/structure/table/bench/marble,
-/turf/simulated/floor/grass2)
+/turf/simulated/floor/grass2,
+/area/casino/casino_ship)
 "pJ" = (
 /obj/structure/closet/secure_closet/engineering_welding{
 	req_access = list(203)
@@ -5661,10 +6241,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "pM" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "pO" = (
 /obj/structure/flora/tree/dead,
 /obj/effect/zone_divider,
@@ -5676,13 +6258,15 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "pT" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/item/weapon/melee/chainofcommand,
 /obj/item/weapon/scepter,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "pW" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -5704,7 +6288,8 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "qc" = (
 /turf/simulated/floor/water/deep,
 /area/surface/outside/plains/mountains)
@@ -5736,7 +6321,8 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "qf" = (
 /obj/machinery/suit_cycler/security{
 	req_access = list(201)
@@ -5750,7 +6336,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "qh" = (
 /obj/machinery/door/airlock/glass_external{
 	autoclose = 0;
@@ -5760,12 +6347,14 @@
 	locked = 1;
 	name = "Landing North Internal"
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship)
 "qi" = (
 /obj/structure/bed/chair/comfy/purp{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "qj" = (
 /obj/random/maintenance/medical,
 /turf/simulated/floor/outdoors/dirt{
@@ -5796,7 +6385,8 @@
 /area/surface/outside/plains/outpost)
 "qp" = (
 /obj/structure/table/gamblingtable,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "qq" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -27;
@@ -5808,16 +6398,19 @@
 /obj/structure/bed/chair/sofa/corner/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "qs" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/brown/bordercorner,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "qv" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "qw" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -5837,7 +6430,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "qB" = (
 /obj/structure/railing{
 	dir = 4
@@ -5850,7 +6444,8 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "qE" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/outdoors/dirt{
@@ -5863,7 +6458,8 @@
 "qF" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/dice,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "qH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/glass_external{
@@ -5881,13 +6477,15 @@
 	name = "Internal Access Button";
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship)
 "qK" = (
 /obj/machinery/door/airlock/silver{
 	name = "Casino manager sleeping quarters";
 	req_one_access = list(300)
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "qM" = (
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
 	temperature = 293.15
@@ -5925,7 +6523,8 @@
 /area/surface/outside/plains/outpost)
 "qW" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "qX" = (
 /obj/structure/table/bench/sifwooden,
 /obj/effect/mist,
@@ -5933,12 +6532,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "qY" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "rc" = (
 /obj/effect/blocker,
 /obj/structure/flora/grass/brown,
@@ -5950,7 +6551,8 @@
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "re" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -5979,13 +6581,15 @@
 	dir = 1
 	},
 /obj/structure/curtain/open/shower/engineering,
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship/dorms)
 "rj" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "rk" = (
 /turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
@@ -6012,10 +6616,12 @@
 "rK" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/deck/cah,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "rL" = (
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "rM" = (
 /obj/effect/floor_decal/stairs,
 /turf/simulated/floor/outdoors/dirt,
@@ -6024,7 +6630,8 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "rQ" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_3"
@@ -6040,7 +6647,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/techfloor/grid)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/casino/casino_ship)
 "rV" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/rddouble,
@@ -6061,7 +6669,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "sl" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet,
@@ -6102,7 +6711,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "sw" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -6133,7 +6743,8 @@
 /area/surface/outside/plains/mountains)
 "sI" = (
 /obj/machinery/clonepod/transhuman/full,
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "sJ" = (
 /obj/structure/table/glass,
 /obj/item/clothing/accessory/holster/armpit,
@@ -6143,7 +6754,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "sK" = (
 /obj/structure/flora/bboulder1,
 /obj/effect/zone_divider,
@@ -6175,10 +6787,17 @@
 /obj/machinery/door/window/brigdoor/northleft{
 	req_access = list(201)
 	},
+/obj/item/weapon/storage/box/empshells,
 /obj/item/ammo_magazine/ammo_box/b12g/pellet,
 /obj/item/ammo_magazine/ammo_box/b12g/pellet,
 /obj/item/ammo_magazine/ammo_box/b12g,
 /obj/item/ammo_magazine/ammo_box/b12g,
+/obj/item/ammo_magazine/m762garand,
+/obj/item/ammo_magazine/m762garand,
+/obj/item/ammo_magazine/m762garand,
+/obj/item/ammo_magazine/m762garand,
+/obj/item/ammo_magazine/m762garand,
+/obj/item/ammo_magazine/m762garand,
 /obj/item/ammo_magazine/m9mmt,
 /obj/item/ammo_magazine/m9mmt,
 /obj/item/ammo_magazine/m9mmt,
@@ -6189,7 +6808,8 @@
 /obj/item/ammo_magazine/m9mmt,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "sX" = (
 /obj/structure/barricade,
 /turf/simulated/floor/outdoors/dirt{
@@ -6204,7 +6824,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "tb" = (
 /turf/simulated/wall/log_sif,
 /area/surface/outside/plains/outpost)
@@ -6240,7 +6861,8 @@
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "to" = (
 /obj/structure/sink{
 	dir = 4;
@@ -6251,7 +6873,8 @@
 	pixel_x = 28;
 	pixel_y = 9
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "ts" = (
 /obj/effect/blocker,
 /turf/simulated/wall/solidrock{
@@ -6262,12 +6885,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "ty" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "tB" = (
 /obj/structure/window/phoronreinforced,
 /obj/structure/table/bench/wooden,
@@ -6288,7 +6913,8 @@
 /area/surface/outside/plains/outpost)
 "tF" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "tH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6330,17 +6956,20 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "tR" = (
 /obj/machinery/door/airlock/silver{
 	name = "Lap dance room 3-4"
 	},
-/turf/simulated/floor/carpet/purcarpet)
+/turf/simulated/floor/carpet/purcarpet,
+/area/casino/casino_ship)
 "tU" = (
 /obj/machinery/door/airlock/silver{
 	name = "Garden"
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "tZ" = (
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/lonehome)
@@ -6350,7 +6979,16 @@
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
+"uf" = (
+/mob/living/simple_mob/animal/wolf/direwolf,
+/turf/simulated/floor/outdoors/dirt{
+	can_atmos_pass = 0;
+	outdoors = 0;
+	temperature = 300
+	},
+/area/surface/outside/plains/mountains)
 "ui" = (
 /obj/machinery/vending/coffee,
 /obj/effect/floor_decal/borderfloor{
@@ -6362,7 +7000,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "uj" = (
 /obj/machinery/vending/engivend{
 	req_access = list(203);
@@ -6371,7 +7010,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "ul" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/drinks/cup{
@@ -6404,16 +7044,19 @@
 	pixel_x = -4;
 	pixel_y = 12
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "un" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "uo" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/item/toy/bosunwhistle,
+/obj/item/toy/crossbow,
 /obj/item/toy/cultsword,
 /obj/item/toy/eight_ball,
 /obj/item/toy/eight_ball/conch,
@@ -6424,7 +7067,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "ur" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -6435,7 +7079,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "uy" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -6443,10 +7088,12 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "uB" = (
 /obj/structure/table/wooden_reinforced,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "uC" = (
 /obj/structure/simple_door/iron,
 /turf/simulated/floor/wood/sif,
@@ -6465,7 +7112,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "uQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6481,7 +7129,8 @@
 /area/surface/outside/plains/mountains)
 "uU" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "uX" = (
 /obj/item/clothing/under/gentlesuit,
 /obj/item/clothing/under/gentlesuit,
@@ -6512,7 +7161,8 @@
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/glasses/sunglasses,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "vb" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -6541,7 +7191,8 @@
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "vk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -6586,7 +7237,8 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "vw" = (
 /obj/item/weapon/bone/skull{
 	anchored = 1;
@@ -6606,7 +7258,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "vA" = (
 /obj/effect/decal/remains/deer,
 /turf/simulated/floor/outdoors/dirt{
@@ -6649,12 +7302,14 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "vK" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "vL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -6671,14 +7326,16 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "vQ" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/effect/landmark/costume/cutewitch,
 /obj/effect/landmark/costume/imperium_monk,
 /obj/effect/landmark/costume/plaguedoctor,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "vS" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/water{
@@ -6689,7 +7346,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "vW" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/maintenance/medical,
@@ -6725,7 +7383,8 @@
 /obj/machinery/door/airlock/silver{
 	name = "Casino crew showers"
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "wf" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
@@ -6735,16 +7394,19 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "wh" = (
 /mob/living/simple_mob/animal/passive/fish/koi,
-/turf/simulated/floor/water/indoors)
+/turf/simulated/floor/water/indoors,
+/area/casino/casino_ship)
 "wi" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "wk" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Casinodormshutters1";
@@ -6754,7 +7416,8 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "wo" = (
 /obj/effect/map_helper/no_tele,
 /turf/simulated/wall/solidrock{
@@ -6790,19 +7453,22 @@
 	name = "Casino crew breakroom";
 	req_one_access = null
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "wy" = (
 /obj/structure/table/glass,
 /obj/machinery/recharger,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "wB" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "wD" = (
 /obj/structure/table/marble,
 /obj/item/weapon/card/id/casino,
@@ -6815,12 +7481,14 @@
 /obj/item/weapon/card/id/casino/medical,
 /obj/item/weapon/card/id/casino/security,
 /obj/item/weapon/card/id/casino/security,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "wH" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "wI" = (
 /obj/random/outcrop,
 /turf/simulated/floor/outdoors/dirt{
@@ -6837,10 +7505,12 @@
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "xe" = (
 /obj/structure/table/bench/marble,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "xf" = (
 /obj/machinery/appliance/cooker/oven,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -6857,7 +7527,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "xi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6886,7 +7557,8 @@
 	id_tag = "casinodorm1";
 	name = "Dorm room 1"
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "xp" = (
 /obj/structure/flora/tree/winter1,
 /obj/effect/zone_divider,
@@ -6905,11 +7577,13 @@
 /area/surface/outside/plains/outpost)
 "xz" = (
 /obj/structure/flora/tree/jungle_small,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "xH" = (
 /obj/structure/table/wooden_reinforced,
 /obj/random/plushie,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "xI" = (
 /obj/machinery/vending/boozeomat,
 /turf/simulated/wall/log_sif,
@@ -6927,7 +7601,8 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "xL" = (
 /obj/structure/railing{
 	dir = 4
@@ -6939,11 +7614,17 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/item/toy/ammo/crossbow,
+/obj/item/toy/ammo/crossbow,
+/obj/item/toy/ammo/crossbow,
+/obj/item/toy/ammo/crossbow,
+/obj/item/toy/ammo/crossbow,
 /obj/item/clothing/under/sexybunny_white/sexybunny_black,
 /obj/item/clothing/under/sexybunny_white,
 /obj/item/clothing/head/collectable/rabbitears,
 /obj/item/clothing/head/collectable/rabbitears,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "xR" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/o2{
@@ -6959,7 +7640,8 @@
 	pixel_x = -4;
 	pixel_y = -4
 	},
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "xV" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -6975,7 +7657,8 @@
 	},
 /area/surface/outside/plains/mountains)
 "xX" = (
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "ya" = (
 /obj/structure/flora/log1,
 /turf/simulated/floor/water,
@@ -6994,7 +7677,8 @@
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/wing_right)
 "yc" = (
 /obj/structure/barricade,
 /turf/simulated/floor/outdoors/dirt{
@@ -7025,13 +7709,15 @@
 /obj/item/weapon/deck/cah/black,
 /obj/item/weapon/deck/cah/black,
 /obj/item/weapon/deck/cah/black,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "ye" = (
 /obj/structure/table/fancyblack,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "yf" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/grass/green,
@@ -7051,7 +7737,8 @@
 /obj/item/weapon/deck/cards/casino,
 /obj/item/weapon/deck/cards/casino,
 /obj/item/weapon/deck/cards/casino,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "yn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/turcarpet,
@@ -7069,7 +7756,8 @@
 /obj/item/weapon/storage/box/donut{
 	pixel_y = 11
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "yp" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk,
@@ -7087,7 +7775,8 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "yu" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -7121,13 +7810,15 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "yD" = (
 /obj/machinery/door/airlock/silver{
 	id_tag = "casinodorm4";
 	name = "Dorm room 4"
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "yF" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -7135,7 +7826,8 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "yG" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -7193,15 +7885,18 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "yS" = (
 /obj/machinery/door/airlock/silver{
 	name = "Pool and Sauna"
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "yZ" = (
 /obj/machinery/slot_machine,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "za" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/dirt{
@@ -7225,7 +7920,8 @@
 	pixel_y = -6;
 	req_access = list(160)
 	},
-/turf/simulated/wall/golddiamond)
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship)
 "zg" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -7267,7 +7963,8 @@
 /obj/item/clothing/head/santa/green,
 /obj/item/clothing/head/santa/green,
 /obj/item/clothing/head/santa/green,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "zu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -7278,13 +7975,15 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "zx" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "zy" = (
 /obj/structure/barricade,
 /obj/structure/disposalpipe/segment,
@@ -7301,10 +8000,12 @@
 	dir = 4;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "zC" = (
 /obj/effect/floor_decal/techfloor/orange,
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "zE" = (
 /obj/structure/grille/broken/rustic,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -7339,17 +8040,20 @@
 	layer = 3.3;
 	name = "Prize shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "zP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "zQ" = (
 /obj/structure/casino_table/blackjack_r{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "zR" = (
 /obj/structure/flora/grass/green,
 /obj/structure/flora/grass/green,
@@ -7361,7 +8065,8 @@
 /obj/structure/bed/chair/sofa/corner/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "zW" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -7378,7 +8083,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "zY" = (
 /obj/structure/flora/bboulder1,
 /turf/simulated/floor/outdoors/dirt{
@@ -7391,14 +8097,17 @@
 /obj/structure/closet/secure_closet/medical3{
 	req_access = list(202)
 	},
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "Ad" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Af" = (
-/turf/simulated/floor/grass2)
+/turf/simulated/floor/grass2,
+/area/casino/casino_ship)
 "AA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7419,7 +8128,8 @@
 	dir = 8;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "AL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/sif,
@@ -7473,7 +8183,8 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "AU" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloor{
@@ -7485,25 +8196,30 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "AW" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "AY" = (
 /obj/item/weapon/stool/padded,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "AZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "Bb" = (
 /obj/machinery/shower{
 	pixel_y = 8
 	},
 /obj/structure/curtain/open/shower,
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "Bg" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/disposal/deliveryChute{
@@ -7532,13 +8248,15 @@
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_right)
 "Bl" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "Bm" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -7566,7 +8284,8 @@
 	},
 /obj/item/weapon/packageWrap,
 /obj/machinery/light,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Bt" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -7577,7 +8296,8 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "Bu" = (
 /obj/random/material/refined,
 /turf/simulated/floor/outdoors/dirt{
@@ -7592,12 +8312,14 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "Bx" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/water/deep/pool)
+/turf/simulated/floor/water/deep/pool,
+/area/casino/casino_ship)
 "BB" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
@@ -7619,16 +8341,19 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "BF" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "BG" = (
 /obj/effect/floor_decal/spline/fancy/wood/three_quarters,
 /obj/structure/stripper_pole,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "BH" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
@@ -7651,7 +8376,8 @@
 	dir = 2;
 	req_access = list(203)
 	},
-/turf/simulated/floor/tiled/steel_ridged)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/casino/casino_ship/wing_left)
 "BS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7661,10 +8387,12 @@
 "BT" = (
 /obj/structure/table/glass,
 /obj/item/weapon/beach_ball,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "BV" = (
 /mob/living/simple_mob/animal/space/goose/domesticated/casino,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "BW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -7678,11 +8406,13 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "BX" = (
 /obj/structure/table/reinforced,
 /obj/item/device/taperecorder,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "BZ" = (
 /obj/structure/flora/grass/brown,
 /mob/living/simple_mob/vore/rabbit/white,
@@ -7693,7 +8423,8 @@
 "Cb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/book/codex/casino,
-/turf/simulated/floor/grass2)
+/turf/simulated/floor/grass2,
+/area/casino/casino_ship)
 "Cg" = (
 /obj/structure/flora/grass/green,
 /obj/structure/flora/tree/dead,
@@ -7717,7 +8448,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Cm" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	locked = 0
@@ -7729,7 +8461,8 @@
 	dir = 1;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Ct" = (
 /obj/structure/flora/log1,
 /turf/simulated/floor/water/hotspring{
@@ -7740,7 +8473,8 @@
 /area/surface/outside/plains/mountains)
 "Cv" = (
 /obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "Cz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/disposal/deliveryChute{
@@ -7758,10 +8492,12 @@
 /area/surface/outside/plains/mountains)
 "CC" = (
 /obj/machinery/telecomms/relay/preset/casino,
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship/wing_left)
 "CD" = (
 /obj/structure/window/reinforced,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "CM" = (
 /mob/living/simple_mob/vore/rabbit/black,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -7770,21 +8506,25 @@
 /area/surface/outside/plains/outpost)
 "CN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "CS" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/book/codex/casino,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "CT" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "CX" = (
 /obj/structure/bed/chair/sofa/left/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "CY" = (
 /obj/structure/flora/rocks2,
 /mob/living/simple_mob/animal/sif/diyaab{
@@ -7811,7 +8551,8 @@
 	layer = 3.3;
 	name = "Prize shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship)
 "Db" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -7856,7 +8597,8 @@
 	name = "Casino manager bathroom";
 	req_one_access = newlist(/obj/machinery/power/debug_items/infinite_cable_powersink)
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship)
 "Do" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -7889,7 +8631,8 @@
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
-/turf/simulated/floor/tiled/steel_ridged)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/casino/casino_ship/wing_left)
 "Dw" = (
 /obj/effect/blocker,
 /obj/effect/zone_divider,
@@ -7905,6 +8648,10 @@
 	temperature = 293.15
 	},
 /area/surface/outside/plains/outpost)
+"Dy" = (
+/obj/structure/closet,
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "DB" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -7924,14 +8671,17 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "DF" = (
 /obj/structure/table/glass,
 /obj/item/device/starcaster_news,
-/turf/simulated/floor/grass2)
+/turf/simulated/floor/grass2,
+/area/casino/casino_ship)
 "DH" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "DL" = (
 /turf/simulated/floor/bronze,
 /area/surface/outside/plains/outpost)
@@ -8005,14 +8755,16 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "Ec" = (
 /obj/machinery/slot_machine,
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Ed" = (
 /obj/machinery/vending/tool{
 	req_log_access = 203
@@ -8023,7 +8775,8 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "Eg" = (
 /obj/structure/simple_door/flock,
 /obj/structure/cult/pylon/swarm/defender,
@@ -8045,7 +8798,8 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "En" = (
 /obj/structure/window/phoronreinforced,
 /obj/structure/table/bench/marble,
@@ -8056,7 +8810,8 @@
 /area/submap/lonehome)
 "Eo" = (
 /obj/structure/undies_wardrobe,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "Er" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -8065,7 +8820,8 @@
 /obj/structure/bed/chair/comfy/purp{
 	dir = 4
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "Es" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -8101,12 +8857,14 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "Ey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "EF" = (
 /obj/structure/window/reinforced,
 /obj/item/clothing/head/helmet/space/emergency,
@@ -8122,13 +8880,15 @@
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "EJ" = (
 /obj/structure/table/bench/marble,
 /obj/machinery/light{
 	layer = 3
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "EK" = (
 /obj/item/weapon/aliencoin/phoron,
 /turf/simulated/floor/flock,
@@ -8150,7 +8910,8 @@
 	req_access = list(160);
 	req_log_access = 160
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "EW" = (
 /obj/structure/simple_door/sifwood,
 /turf/simulated/floor/wood/sif,
@@ -8158,14 +8919,16 @@
 "Fa" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/dice,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Fe" = (
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
 "Fk" = (
 /obj/structure/bed/chair/comfy/purp,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Fm" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/clothing/head/santa,
@@ -8178,7 +8941,8 @@
 /obj/item/clothing/head/santa,
 /obj/item/clothing/head/santa,
 /obj/item/clothing/head/santa,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Fo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -8187,7 +8951,8 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "Fq" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -8228,7 +8993,8 @@
 	pixel_y = -4;
 	req_access = list(160)
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "FC" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/rddouble,
@@ -8238,14 +9004,16 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "FF" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1;
 	icon_state = "spline_fancy_corner"
 	},
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "FH" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -8257,7 +9025,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/dirt)
+/turf/simulated/floor/outdoors/dirt,
+/area/casino/casino_ship/wing_right)
 "FL" = (
 /obj/item/weapon/reagent_containers/food/snacks/snackplanet/phoron{
 	name = "Stabalized Phoron Singularity"
@@ -8268,7 +9037,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "FZ" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -8279,7 +9049,8 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 10
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "Ga" = (
 /obj/fiftyspawner/diamond,
 /turf/simulated/floor/flock,
@@ -8287,7 +9058,8 @@
 "Gb" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "Gc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -8298,14 +9070,16 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/wing_right)
 "Gh" = (
 /obj/structure/table/marble,
 /obj/item/glass_jar,
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
 "Gm" = (
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship)
 "Gn" = (
 /obj/structure/boulder,
 /obj/structure/disposalpipe/segment,
@@ -8346,7 +9120,8 @@
 	layer = 3.1;
 	name = "Casino bar shutter"
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Gv" = (
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/plains/mountains)
@@ -8355,7 +9130,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "GF" = (
 /obj/structure/simple_door/flock{
 	dir = 4
@@ -8384,7 +9160,8 @@
 /area/submap/lonehome)
 "GS" = (
 /obj/machinery/light,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "GU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8422,7 +9199,8 @@
 /area/submap/lonehome)
 "Hi" = (
 /obj/structure/table/bench/marble,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "Ho" = (
 /obj/structure/window/phoronreinforced{
 	dir = 1
@@ -8445,7 +9223,8 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "Hq" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -8456,7 +9235,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "Hr" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -8476,7 +9256,8 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "Hw" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -8513,25 +9294,29 @@
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/suit/space/emergency,
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "HQ" = (
 /obj/machinery/door/airlock/silver{
 	name = "Prize storage";
 	req_one_access = list(200)
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "HS" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	name = "Medical, Engineering, Janitor and EVA";
 	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "HW" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "HX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -8562,7 +9347,8 @@
 	pixel_x = -24
 	},
 /obj/structure/fans/hardlight,
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship)
 "Ib" = (
 /obj/machinery/slot_machine,
 /obj/machinery/light{
@@ -8571,7 +9357,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Ic" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -8593,7 +9380,8 @@
 	dir = 8;
 	icon_state = "spline_fancy_cee"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Il" = (
 /obj/structure/flora/rocks1,
 /obj/structure/barricade,
@@ -8608,22 +9396,26 @@
 	dir = 4;
 	pixel_x = -13
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "Iq" = (
 /obj/item/weapon/stool/padded,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "It" = (
 /obj/machinery/door/airlock/silver{
 	id_tag = "managerdoor";
 	name = "Casino manager office";
 	req_one_access = list(300)
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "Iz" = (
 /obj/structure/closet/secure_closet{
 	req_one_access = list(300)
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "ID" = (
 /obj/structure/railing{
 	dir = 8
@@ -8643,17 +9435,20 @@
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor/plating)
+/turf/simulated/floor/plating,
+/area/casino/casino_ship/wing_right)
 "IJ" = (
 /obj/machinery/door/airlock/security{
 	name = "Evidence room";
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_right)
 "IK" = (
 /obj/structure/table/reinforced,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "IL" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/orangedouble,
@@ -8670,7 +9465,8 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "IT" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/maintenance/clean,
@@ -8697,7 +9493,8 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "Ja" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8714,10 +9511,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "Jf" = (
 /obj/machinery/casinoslave_handler,
-/turf/simulated/wall/golddiamond)
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship)
 "Ji" = (
 /obj/structure/bonfire/permanent/sifwood,
 /turf/simulated/floor/outdoors/dirt{
@@ -8765,10 +9564,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "JD" = (
 /obj/machinery/light,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "JF" = (
 /obj/structure/table/standard,
 /obj/item/weapon/book/codex/casino,
@@ -8781,7 +9582,8 @@
 /obj/item/weapon/book/codex/casino,
 /obj/item/weapon/book/codex/casino,
 /obj/item/weapon/book/codex/casino,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "JG" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/material/refined,
@@ -8799,7 +9601,8 @@
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "JI" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -8835,7 +9638,8 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "Kc" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -8861,7 +9665,8 @@
 	dir = 1
 	},
 /obj/effect/mist,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "Kf" = (
 /obj/structure/disposalpipe/segment,
 /turf/unsimulated/mineral,
@@ -8875,22 +9680,26 @@
 /obj/effect/landmark/costume/sexyclown,
 /obj/item/clothing/head/hood/ian_hood,
 /obj/item/clothing/suit/storage/hooded/costume/ian,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Ki" = (
 /obj/machinery/vending/deluxe_boozeomat{
 	req_access = list(160);
 	req_log_access = 160
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "Kl" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Kr" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/book/codex/casino,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Kt" = (
 /obj/structure/kitchenspike,
 /turf/simulated/floor/tiled/freezer,
@@ -8918,10 +9727,12 @@
 	pixel_x = -6;
 	pixel_y = -1
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "Kz" = (
 /obj/structure/bed/chair/sofa/left/yellow,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "KG" = (
 /mob/living/simple_mob/animal/sif/glitterfly/rare{
 	canmove = 0;
@@ -8953,7 +9764,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "KN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8980,10 +9792,12 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "KU" = (
 /obj/structure/prop/dominator/orange,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "KV" = (
 /obj/structure/table/glass,
 /obj/machinery/button/remote/airlock{
@@ -8993,9 +9807,11 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "KW" = (
-/turf/simulated/floor/water/indoors)
+/turf/simulated/floor/water/indoors,
+/area/casino/casino_ship)
 "Lc" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -9048,7 +9864,8 @@
 /obj/effect/floor_decal/corner/yellow/border,
 /obj/fiftyspawner/steel,
 /obj/fiftyspawner/steel,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "Lm" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -9077,7 +9894,8 @@
 /obj/item/clothing/mask/breath/emergency,
 /obj/item/clothing/mask/breath/emergency,
 /obj/item/clothing/mask/breath/emergency,
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "Lw" = (
 /obj/item/weapon/storage/backpack/holding/duffle,
 /turf/simulated/floor/flock,
@@ -9108,7 +9926,8 @@
 	pixel_x = -28;
 	pixel_y = 8
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "LM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/borderfloor{
@@ -9117,22 +9936,26 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "LQ" = (
 /obj/machinery/door/airlock/silver{
 	name = "Casino crew toilet";
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "LS" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/toy/eight_ball/conch,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "LX" = (
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Mb" = (
 /mob/living/simple_mob/animal/sif/kururak/hibernate,
 /turf/simulated/floor/outdoors/dirt{
@@ -9150,13 +9973,15 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "Me" = (
 /obj/machinery/vending/fishing,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "Mf" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -9165,7 +9990,8 @@
 	dir = 8;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Mi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/outdoors/grass/sif/planetuse,
@@ -9190,7 +10016,8 @@
 /obj/fiftyspawner/silver,
 /obj/item/weapon/moneybag/vault,
 /obj/item/weapon/moneybag/vault,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "Mp" = (
 /obj/item/weapon/pickaxe/gold,
 /turf/simulated/floor/outdoors/dirt{
@@ -9219,7 +10046,8 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "Mv" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -9255,7 +10083,8 @@
 	layer = 3.2;
 	name = "Front Desk Shutters"
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "ME" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -9273,7 +10102,8 @@
 "MF" = (
 /obj/structure/table/bench/sifwooden,
 /obj/effect/mist,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "MG" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9292,16 +10122,19 @@
 /obj/item/weapon/tank/oxygen,
 /obj/item/weapon/tank/oxygen,
 /obj/item/weapon/tank/oxygen,
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "MI" = (
 /obj/structure/closet/crate/bin,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "MJ" = (
 /obj/machinery/door/airlock/silver{
 	id_tag = "casinodorm3";
 	name = "Dorm room 3"
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "MK" = (
 /obj/structure/table/sifwoodentable,
 /obj/machinery/light/floortube/flicker{
@@ -9352,12 +10185,14 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "MX" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "MY" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -9413,6 +10248,10 @@
 /obj/item/weapon/soap/nanotrasen,
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
+"Ns" = (
+/obj/structure/shuttle/engine/router,
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship/wing_left)
 "Nt" = (
 /obj/structure/flora/rocks1,
 /turf/simulated/floor/outdoors/dirt{
@@ -9443,7 +10282,8 @@
 /area/surface/outside/plains/outpost)
 "Nw" = (
 /obj/structure/table/wooden_reinforced,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Nx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9470,22 +10310,26 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "NA" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "NC" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "NG" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/outdoors/grass/heavy{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "NM" = (
 /obj/structure/table/glass,
 /obj/machinery/button/remote/airlock{
@@ -9495,11 +10339,13 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "NO" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/toy/eight_ball,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "NS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -9521,7 +10367,8 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "NY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/disposal/deliveryChute{
@@ -9546,7 +10393,8 @@
 	locked = 1;
 	name = "Landing South Internal"
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship)
 "Od" = (
 /turf/simulated/wall/log_sif,
 /area/submap/lonehome)
@@ -9571,7 +10419,8 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "Ok" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/wood/sif/broken,
@@ -9579,7 +10428,8 @@
 "Om" = (
 /obj/structure/table/standard,
 /obj/item/weapon/material/ashtray,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "On" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -9600,10 +10450,12 @@
 	id_tag = "casinodorm6";
 	name = "Dorm room 6"
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "Ou" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/outdoors/dirt)
+/turf/simulated/floor/outdoors/dirt,
+/area/casino/casino_ship/wing_left)
 "Ov" = (
 /obj/structure/flora/grass/brown,
 /obj/structure/flora/grass/brown,
@@ -9648,10 +10500,12 @@
 	dir = 1
 	},
 /obj/structure/curtain/open/shower,
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "OM" = (
 /obj/structure/prop/machine/conduit/starts_on,
-/turf/simulated/floor/redgrid/animated)
+/turf/simulated/floor/redgrid/animated,
+/area/casino/casino_ship)
 "ON" = (
 /obj/structure/flora/tree/winter1,
 /obj/structure/flora/grass/green,
@@ -9663,7 +10517,8 @@
 /obj/structure/bed/chair/sofa/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "OS" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -9700,7 +10555,8 @@
 	dir = 1;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Pc" = (
 /obj/structure/flora/grass/brown,
 /obj/structure/flora/grass/green,
@@ -9715,12 +10571,14 @@
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Ph" = (
 /obj/structure/casino_table/blackjack_l{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Pj" = (
 /obj/structure/closet/grave/dirthole{
 	opened = 0
@@ -9740,7 +10598,8 @@
 "Pp" = (
 /obj/structure/table/fancyblack,
 /obj/machinery/wheel_of_fortune,
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "Pq" = (
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/wood/sif,
@@ -9750,12 +10609,14 @@
 	dir = 4;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Pt" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "Pu" = (
 /obj/structure/table/sifwoodentable,
 /obj/item/weapon/storage/fancy/blackcandle_box,
@@ -9764,7 +10625,8 @@
 /area/submap/lonehome)
 "Pw" = (
 /obj/machinery/door/window/northleft,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Pz" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -9788,7 +10650,8 @@
 	},
 /obj/item/clothing/suit/armor/alien,
 /obj/item/weapon/storage/belt/utility/alien,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "PH" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/pill_bottle/dice_nerd{
@@ -9800,7 +10663,8 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "PK" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -9812,22 +10676,26 @@
 	tag_exterior_door = "Casino_North_Exterior";
 	tag_interior_door = "Casino_North_Interior"
 	},
-/turf/simulated/floor/tiled/techfloor/grid)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/casino/casino_ship)
 "PL" = (
 /obj/structure/closet/secure_closet/paramedic{
 	req_access = list(202)
 	},
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "PM" = (
 /obj/machinery/door/airlock/silver{
 	name = "Casino cockpit";
 	req_one_access = list(300)
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "PN" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/orange,
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_right)
 "PP" = (
 /turf/simulated/floor/outdoors/mud/sif/planetuse{
 	can_atmos_pass = 0;
@@ -9847,7 +10715,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/purcarpet)
+/turf/simulated/floor/carpet/purcarpet,
+/area/casino/casino_ship)
 "PW" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/full,
@@ -9858,11 +10727,13 @@
 /obj/structure/stripper_pole{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/turcarpet)
+/turf/simulated/floor/carpet/turcarpet,
+/area/casino/casino_ship)
 "Qe" = (
 /obj/structure/bed/chair/bar_stool,
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Qg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -9879,10 +10750,12 @@
 /obj/structure/bed/chair/sofa/left/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Qo" = (
 /obj/machinery/light,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "Qp" = (
 /obj/item/weapon/spacecasinocash/c200,
 /turf/simulated/floor/flock,
@@ -9891,7 +10764,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Qr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9923,7 +10797,8 @@
 	id_tag = "casinodorm2";
 	name = "Dorm room 2"
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "QD" = (
 /obj/structure/prop/statue/angel{
 	desc = "Further South, below once roaring thrusters, the treasure lays beyond an unsteady gaze, in front of a place of fire.";
@@ -9941,7 +10816,8 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "QH" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -9961,14 +10837,17 @@
 /obj/machinery/autolathe,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "QP" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "QS" = (
-/turf/simulated/floor/tiled/dark)
+/turf/simulated/floor/tiled/dark,
+/area/casino/casino_ship/wing_left)
 "Ra" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/solidrock{
@@ -9988,7 +10867,8 @@
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "Rk" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -10013,7 +10893,8 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "Rp" = (
 /turf/simulated/floor/water/deep{
 	outdoors = 0
@@ -10037,7 +10918,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "RC" = (
 /obj/structure/flora/rocks2,
 /turf/simulated/floor/outdoors/dirt{
@@ -10053,14 +10935,16 @@
 	},
 /obj/item/clothing/accessory/chameleon,
 /obj/item/clothing/glasses/monocoole,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "RG" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering center";
 	req_access = list(203);
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "RH" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 1
@@ -10071,7 +10955,8 @@
 /obj/machinery/light{
 	layer = 3
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "RL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -10088,7 +10973,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "RQ" = (
 /obj/structure/boulder,
 /turf/simulated/floor/outdoors/dirt{
@@ -10113,10 +10999,12 @@
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "RY" = (
 /obj/structure/flora/tree/jungle,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "Sb" = (
 /obj/structure/table/glass,
 /obj/machinery/button/remote/airlock{
@@ -10126,7 +11014,8 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "Se" = (
 /obj/item/clothing/ears/earring/dangle/diamond,
 /turf/simulated/floor/flock,
@@ -10135,7 +11024,8 @@
 /obj/machinery/light{
 	layer = 3
 	},
-/turf/simulated/floor/water/deep/pool)
+/turf/simulated/floor/water/deep/pool,
+/area/casino/casino_ship)
 "Sg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -10170,7 +11060,8 @@
 	},
 /obj/structure/table/marble,
 /obj/item/modular_computer/laptop/preset/custom_loadout/hybrid,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Sq" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Casinodormshutters2";
@@ -10180,7 +11071,8 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "Sr" = (
 /obj/item/weapon/spacecasinocash/c100,
 /turf/simulated/floor/flock,
@@ -10214,7 +11106,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/water/deep/pool)
+/turf/simulated/floor/water/deep/pool,
+/area/casino/casino_ship)
 "SC" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -10235,7 +11128,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "SF" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -10245,14 +11139,17 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/casino/casino_ship)
 "SL" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "SO" = (
 /obj/structure/closet/crate/bin,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "SQ" = (
 /obj/effect/map_effect/perma_light/gateway,
 /turf/simulated/floor/outdoors/dirt{
@@ -10268,7 +11165,8 @@
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "SZ" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -10279,12 +11177,14 @@
 "Tf" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/deck/cah/black,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Tg" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Tm" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -10307,7 +11207,8 @@
 	frequency = 1380;
 	id_tag = "casino2_pump"
 	},
-/turf/simulated/floor/tiled/techfloor/grid)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/casino/casino_ship)
 "Tt" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_3"
@@ -10326,10 +11227,12 @@
 /area/submap/lonehome)
 "Tw" = (
 /obj/structure/shuttle/engine/router,
-/turf/simulated/wall/golddiamond)
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship/wing_right)
 "Tx" = (
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "TG" = (
 /obj/structure/flora/tree/sif,
 /turf/simulated/floor/outdoors/mud/sif/planetuse{
@@ -10351,7 +11254,8 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "TM" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -10360,7 +11264,8 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "TP" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/medical,
@@ -10377,7 +11282,8 @@
 	dir = 8;
 	icon_state = "spline_fancy_cee"
 	},
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship)
 "TW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/crystal/ice,
@@ -10392,14 +11298,16 @@
 /obj/machinery/computer/transhuman/resleeving{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "TY" = (
 /obj/structure/bed/chair/comfy/purp,
 /obj/machinery/light{
 	dir = 8;
 	layer = 3
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "TZ" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -10409,11 +11317,13 @@
 /obj/item/weapon/gun/energy/temperature,
 /obj/item/weapon/gun/energy/particle/cannon,
 /obj/item/weapon/gun/energy/particle/advanced,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Ub" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "Uc" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8;
@@ -10422,7 +11332,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Ud" = (
 /mob/living/simple_mob/animal/passive/penguin{
 	hovering = 1
@@ -10431,7 +11342,8 @@
 /area/surface/outside/plains/outpost)
 "Ue" = (
 /obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "Ug" = (
 /obj/effect/floor_decal/stairs{
 	dir = 1
@@ -10456,7 +11368,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "Ul" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -10498,14 +11411,16 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Uw" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medbay";
 	req_access = list(202);
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_left)
 "Ux" = (
 /turf/simulated/floor/outdoors/ice/dark_smooth{
 	outdoors = 0
@@ -10543,19 +11458,22 @@
 /obj/item/clothing/under/sexybunny_white,
 /obj/item/clothing/under/sexybunny_white,
 /obj/item/clothing/under/sexybunny_white,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "UH" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/donut,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /obj/machinery/light,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "UK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "UN" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_2"
@@ -10569,7 +11487,8 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen"
 	},
-/turf/simulated/wall/golddiamond)
+/turf/simulated/wall/golddiamond,
+/area/casino/casino_ship)
 "UU" = (
 /turf/simulated/floor/wood/sif/broken{
 	outdoors = 1
@@ -10592,19 +11511,22 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "UX" = (
 /obj/structure/table/standard,
 /obj/item/weapon/material/ashtray,
 /obj/item/weapon/material/ashtray,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "Vd" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/outdoors/grass/heavy{
 	outdoors = 0
-	})
+	},
+/area/casino/casino_ship)
 "Vg" = (
 /obj/structure/closet/secure_closet/bar{
 	locked = 0
@@ -10613,7 +11535,8 @@
 /area/submap/lonehome)
 "Vj" = (
 /obj/effect/mist,
-/turf/simulated/floor/water/pool)
+/turf/simulated/floor/water/pool,
+/area/casino/casino_ship)
 "Vm" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -10627,7 +11550,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Vo" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -10652,18 +11576,21 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "VF" = (
 /obj/machinery/door/airlock/security{
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_right)
 "VG" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "VI" = (
 /obj/structure/flora/grass/brown,
 /obj/structure/flora/grass/green,
@@ -10675,7 +11602,8 @@
 "VK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "VL" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8;
@@ -10685,14 +11613,17 @@
 	dir = 4;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "VN" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Security wing"
 	},
-/turf/simulated/floor/tiled/steel_grid)
+/turf/simulated/floor/tiled/steel_grid,
+/area/casino/casino_ship/wing_right)
 "VR" = (
-/turf/simulated/floor/tiled/techfloor)
+/turf/simulated/floor/tiled/techfloor,
+/area/casino/casino_ship/wing_left)
 "VT" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -10713,13 +11644,15 @@
 /obj/machinery/door/window/westleft{
 	name = "shower door"
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "VX" = (
 /obj/structure/bed/chair/comfy/purp,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "VY" = (
 /obj/item/clothing/shoes/dress,
 /turf/simulated/floor/flock,
@@ -10756,12 +11689,14 @@
 	pixel_y = -28
 	},
 /obj/machinery/light,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "Wo" = (
 /obj/structure/bed/chair/sofa/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Ws" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/trash,
@@ -10773,17 +11708,26 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship)
 "Wu" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "Ww" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
+"WJ" = (
+/obj/structure/bed/chair/comfy/purp{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "WL" = (
 /turf/simulated/floor/wood/sif/broken,
 /area/surface/outside/plains/outpost)
@@ -10792,7 +11736,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "WQ" = (
 /turf/simulated/floor/outdoors/dirt{
 	can_atmos_pass = 0;
@@ -10805,7 +11750,8 @@
 	name = "Lounge";
 	req_one_access = list(300)
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "WT" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/bar_alc/full,
@@ -10845,12 +11791,14 @@
 "Xi" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/dice,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Xv" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Xx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10886,7 +11834,8 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship/dorms)
 "XG" = (
 /obj/structure/flora/log2,
 /turf/simulated/floor/water,
@@ -10894,7 +11843,8 @@
 "XH" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "XO" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/water,
@@ -10924,14 +11874,16 @@
 /area/surface/outside/plains/outpost)
 "XW" = (
 /obj/structure/table/wooden_reinforced,
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "XX" = (
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "O- Blood Locker";
 	pixel_x = -32;
 	req_access = list(202)
 	},
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "XY" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -10965,7 +11917,8 @@
 /obj/effect/floor_decal/corner/yellow/border,
 /obj/fiftyspawner/glass,
 /obj/fiftyspawner/glass,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "Ya" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -10977,7 +11930,8 @@
 	tag_exterior_door = "Casino_South_Exterior";
 	tag_interior_door = "Casino_South_Interior"
 	},
-/turf/simulated/floor/tiled/techfloor/grid)
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/casino/casino_ship)
 "Yf" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -10988,13 +11942,15 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "Yg" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "Yh" = (
 /obj/structure/flora/tree/winter1,
 /obj/structure/flora/grass/both,
@@ -11004,7 +11960,8 @@
 /area/surface/outside/plains/outpost)
 "Yj" = (
 /obj/machinery/slot_machine,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Yk" = (
 /obj/structure/window/phoronreinforced{
 	dir = 8
@@ -11026,7 +11983,8 @@
 /area/surface/outside/plains/mountains)
 "Yn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/kafel_full/blue)
+/turf/simulated/floor/tiled/kafel_full/blue,
+/area/casino/casino_ship)
 "Yq" = (
 /obj/machinery/light{
 	dir = 4
@@ -11034,12 +11992,14 @@
 /obj/structure/salvageable/console_os{
 	dir = 8
 	},
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "Ys" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Yz" = (
 /obj/structure/prop/statue/stump_plaque,
 /obj/item/weapon/bone/skull{
@@ -11060,11 +12020,13 @@
 /obj/item/weapon/material/ashtray/bronze,
 /obj/item/weapon/material/ashtray/bronze,
 /obj/machinery/recharger,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "YF" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/device/communicator,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "YI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11082,7 +12044,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "YM" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -11092,7 +12055,8 @@
 /obj/effect/landmark/costume/sexymime,
 /obj/item/clothing/suit/storage/hooded/costume/ian,
 /obj/item/clothing/head/hood/carp_hood,
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "YN" = (
 /obj/structure/table/bench/sifwooden,
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -11106,7 +12070,8 @@
 	use_power = 1
 	},
 /obj/effect/mist,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "YR" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/deliveryChute{
@@ -11123,7 +12088,8 @@
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "YW" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposalpipe/segment{
@@ -11141,7 +12107,8 @@
 /area/surface/outside/plains/mountains)
 "YX" = (
 /obj/structure/bed/chair/sofa/right/yellow,
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Za" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -11164,7 +12131,8 @@
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Zd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11196,7 +12164,8 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor)
+/turf/simulated/floor,
+/area/casino/casino_ship/dorms)
 "Zl" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 4
@@ -11204,7 +12173,8 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Zn" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -11215,7 +12185,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_left)
 "Zq" = (
 /obj/machinery/door/window/westright{
 	dir = 2;
@@ -11229,7 +12200,8 @@
 	layer = 3.2;
 	name = "Exchange booth shutters 2"
 	},
-/turf/simulated/floor/carpet/blucarpet)
+/turf/simulated/floor/carpet/blucarpet,
+/area/casino/casino_ship)
 "Zs" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -11238,12 +12210,14 @@
 	layer = 3.1;
 	name = "Casino bar shutter"
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "Zt" = (
 /obj/machinery/iv_drip,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white)
+/turf/simulated/floor/tiled/white,
+/area/casino/casino_ship/wing_left)
 "Zu" = (
 /obj/random/medical,
 /turf/simulated/floor/outdoors/dirt{
@@ -11267,29 +12241,35 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer)
+/turf/simulated/floor/tiled/freezer,
+/area/casino/casino_ship/dorms)
 "Zx" = (
 /obj/machinery/light{
 	dir = 4;
 	layer = 3
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/casino/casino_ship)
 "Zz" = (
 /obj/machinery/light/flamp,
-/turf/simulated/floor/grass)
+/turf/simulated/floor/grass,
+/area/casino/casino_ship)
 "ZB" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "ZF" = (
 /obj/structure/bed/chair/sofa/right/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet)
+/turf/simulated/floor/carpet/oracarpet,
+/area/casino/casino_ship)
 "ZG" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "ZL" = (
 /obj/effect/zone_divider,
 /turf/unsimulated/mineral,
@@ -11298,7 +12278,8 @@
 /obj/structure/table/sifwoodentable,
 /obj/item/weapon/bikehorn/rubberducky,
 /obj/effect/mist,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 "ZP" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -11309,18 +12290,21 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "ZR" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
-/turf/simulated/floor/tiled)
+/turf/simulated/floor/tiled,
+/area/casino/casino_ship/wing_right)
 "ZW" = (
 /obj/structure/table/glass,
 /obj/item/toy/eight_ball/conch,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet)
+/turf/simulated/floor/carpet/bcarpet,
+/area/casino/casino_ship)
 "ZZ" = (
 /obj/structure/table/bench/sifwooden,
 /obj/machinery/light,
@@ -11331,7 +12315,8 @@
 	dir = 5
 	},
 /obj/effect/mist,
-/turf/simulated/floor/wood)
+/turf/simulated/floor/wood,
+/area/casino/casino_ship)
 
 (1,1,1) = {"
 hP
@@ -15384,41 +16369,41 @@ mN
 mN
 mN
 mN
-aP
-aP
-ep
-ep
-ep
+ab
+ab
+dr
+dr
+dr
 cq
 cq
-ep
-ep
-ep
+dr
+dr
+dr
 cq
 cq
-aP
+ab
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+dr
+hk
+eS
+eS
 ep
 ep
 ep
+eS
+eS
 ep
 ep
 ep
-ep
-ep
-ep
-aP
-cq
-cq
-ep
-ep
-ep
-cq
-cq
-ep
-ep
-ep
-aP
-aP
+hk
+hk
 gN
 mN
 fB
@@ -15571,41 +16556,41 @@ mN
 mN
 cC
 mN
-aP
-aP
+ab
+ab
 cq
 cq
 cq
-Tw
-Tw
+Ns
+Ns
 cq
 cq
 cq
-Tw
-Tw
-Tw
-cq
-cq
+Ns
+Ns
+Ns
 cq
 cq
 cq
 cq
 cq
 cq
-cq
-Tw
-Tw
-Tw
 cq
 cq
 cq
 Tw
 Tw
-cq
-cq
-cq
-aP
-aP
+Tw
+eS
+eS
+eS
+Tw
+Tw
+eS
+eS
+eS
+hk
+hk
 mN
 mN
 mN
@@ -15758,41 +16743,41 @@ wt
 mN
 mN
 gN
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ac
 OM
-aP
+ac
 OM
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 gN
 mN
 fB
@@ -15945,19 +16930,19 @@ mN
 mN
 mN
 gN
-aP
+ab
 bZ
 dA
 fQ
-aP
+ab
 VR
 VR
 CC
-aP
+ab
 PL
 YL
 Ub
-aP
+ab
 jj
 eN
 lc
@@ -15967,19 +16952,19 @@ eW
 li
 eN
 lm
-aP
+hk
 bX
 PN
-aP
+hk
 eH
 eH
 cP
 cP
-aP
+hk
 pm
 lU
 ic
-aP
+hk
 mN
 mN
 mN
@@ -16132,19 +17117,19 @@ mN
 mN
 mN
 gN
-aP
+ab
 cf
-lU
+dJ
 fY
-aP
-aP
-aP
-aP
-aP
+ab
+ab
+ab
+ab
+ab
 zZ
 xX
 Mu
-aP
+ab
 be
 cQ
 ld
@@ -16154,19 +17139,19 @@ zC
 aX
 cQ
 lu
-aP
-QS
+hk
+de
 jy
-aP
+hk
 eT
 lU
-wH
+il
 lU
-aP
+hk
 AS
 lU
 id
-aP
+hk
 gN
 mN
 mN
@@ -16319,11 +17304,11 @@ cC
 mN
 mN
 gN
-aP
+ab
 cg
-lU
+dJ
 gb
-aP
+ab
 Ny
 XX
 YL
@@ -16331,7 +17316,7 @@ xX
 xX
 xX
 yt
-aP
+ab
 kS
 ak
 ar
@@ -16341,19 +17326,19 @@ NX
 bf
 lj
 lo
-aP
+hk
 bA
 yb
-aP
-aP
+hk
+hk
 IJ
-aP
-aP
-aP
+hk
+hk
+hk
 qf
 lU
 mJ
-aP
+hk
 gN
 mN
 mN
@@ -16506,11 +17491,11 @@ mN
 mN
 mN
 mN
-aP
+ab
 cl
-lU
+dJ
 gc
-aP
+ab
 JC
 xX
 xX
@@ -16518,7 +17503,7 @@ xX
 xX
 xX
 Ub
-aP
+ab
 cu
 eF
 dc
@@ -16528,7 +17513,7 @@ bN
 cv
 eF
 fd
-aP
+hk
 aq
 lU
 eR
@@ -16536,11 +17521,11 @@ lU
 lU
 ur
 FZ
-aP
+hk
 ng
 lU
 if
-aP
+hk
 gN
 mN
 mN
@@ -16693,11 +17678,11 @@ mN
 mN
 mN
 gN
-aP
+ab
 cw
 dR
-lU
-aP
+dJ
+ab
 tO
 xR
 xX
@@ -16705,7 +17690,7 @@ sI
 Bv
 TX
 Zt
-aP
+ab
 eh
 eF
 jX
@@ -16715,19 +17700,19 @@ bN
 CT
 eF
 fh
-aP
+hk
 bn
 yb
-aP
+hk
 SX
 lU
 BX
 ee
-aP
+hk
 qe
 lU
 sV
-aP
+hk
 gN
 mN
 hY
@@ -16880,19 +17865,19 @@ mN
 mN
 mN
 gN
-aP
-aP
-aP
+ab
+ab
+ab
 gm
-aP
-aP
-aP
+ab
+ab
+ab
 Uw
-aP
-aP
-aP
-aP
-aP
+ab
+ab
+ab
+ab
+ab
 em
 rd
 jX
@@ -16902,19 +17887,19 @@ bN
 CT
 rd
 fj
-aP
-QS
+hk
+de
 jy
-aP
+hk
 Vv
 lU
 UW
 ew
-aP
+hk
 yR
 lU
 Gb
-aP
+hk
 gN
 mN
 mN
@@ -17067,19 +18052,19 @@ mN
 mN
 mN
 gN
-aP
-aP
+ab
+ab
 dT
-lU
+dJ
 kD
 Zn
 BD
-lU
-aP
+dJ
+ab
 Ed
 uj
 Ll
-aP
+ab
 xH
 XW
 jX
@@ -17089,19 +18074,19 @@ bN
 CT
 XW
 fk
-aP
+hk
 vv
 PN
-aP
+hk
 yb
 pp
 IH
 pv
-aP
-aP
+hk
+hk
 Bk
-aP
-aP
+hk
+hk
 gN
 mN
 mN
@@ -17255,18 +18240,18 @@ mN
 mN
 mN
 mN
-aP
+ab
 dX
-lU
-lU
-lU
-lU
-lU
+dJ
+dJ
+dJ
+dJ
+dJ
 RG
-lU
-lU
+dJ
+dJ
 XZ
-aP
+ab
 ey
 Xi
 jX
@@ -17276,10 +18261,10 @@ bN
 CT
 mQ
 fm
-aP
-aP
-aP
-aP
+hk
+hk
+hk
+hk
 ui
 lU
 JH
@@ -17287,7 +18272,7 @@ yC
 Hq
 vj
 ZR
-aP
+hk
 mN
 mN
 mN
@@ -17442,18 +18427,18 @@ mN
 mN
 eG
 mN
-aP
-aP
+ab
+ab
 go
 lR
 MG
-lU
+dJ
 qs
-aP
+ab
 MW
-lU
+dJ
 QO
-aP
+ab
 eB
 Xv
 jX
@@ -17463,10 +18448,10 @@ bN
 CT
 Xv
 fn
-aP
+hk
 AU
 IK
-aP
+hk
 xb
 lU
 Ri
@@ -17474,7 +18459,7 @@ Ri
 lU
 py
 Hp
-aP
+hk
 gN
 mN
 mN
@@ -17629,18 +18614,18 @@ mN
 mN
 mN
 gN
-aP
-aP
+ab
+ab
 gp
-lU
+dJ
 HA
-lU
+dJ
 XH
-aP
+ab
 Yf
-lU
+dJ
 oD
-aP
+ab
 eC
 eF
 jX
@@ -17650,7 +18635,7 @@ bN
 CT
 eF
 fr
-aP
+hk
 Eb
 lU
 me
@@ -17660,8 +18645,8 @@ Om
 Om
 lU
 UX
-aP
-aP
+hk
+hk
 gN
 mN
 mN
@@ -17817,17 +18802,17 @@ mN
 mN
 mN
 mN
-aP
+ab
 gv
-lU
+dJ
 Lp
-lU
+dJ
 kP
-aP
+ab
 uy
-lU
+dJ
 qY
-aP
+ab
 eI
 rd
 jX
@@ -17837,17 +18822,17 @@ bN
 CT
 rd
 fu
-aP
+hk
 kd
 lU
-aP
+hk
 lU
 lU
 VG
 VG
 lU
 UH
-aP
+hk
 mN
 mN
 mN
@@ -18004,17 +18989,17 @@ mN
 eG
 mN
 gN
-aP
+ab
 gA
 wH
 EF
-lU
+dJ
 XH
-aP
+ab
 uy
-lU
+dJ
 pP
-aP
+ab
 eJ
 XW
 jX
@@ -18024,17 +19009,17 @@ bN
 CT
 ms
 fw
-aP
+hk
 kd
 lU
-aP
+hk
 lU
-wH
+il
 lU
 uc
 Ei
 Rn
-aP
+hk
 gN
 mN
 mN
@@ -18191,17 +19176,17 @@ mN
 mN
 mN
 mN
-aP
-aP
-aP
-aP
-lU
+ab
+ab
+ab
+ab
+dJ
 XH
-aP
+ab
 Ew
 pJ
 Kb
-aP
+ab
 eK
 Kr
 jX
@@ -18211,17 +19196,17 @@ bN
 CT
 XW
 fA
-aP
+hk
 co
 lU
-aP
+hk
 VF
-aP
+hk
 VF
-aP
-aP
-aP
-aP
+hk
+hk
+hk
+hk
 gN
 mN
 mN
@@ -18379,16 +19364,16 @@ mN
 mN
 mN
 gN
-aP
-aP
+ab
+ab
 QS
-lU
+dJ
 kD
-aP
-aP
-aP
-aP
-aP
+ab
+ab
+ab
+ab
+ab
 eB
 Xv
 jX
@@ -18398,16 +19383,16 @@ bN
 CT
 Xv
 fn
-aP
-aP
-aP
-aP
+hk
+hk
+hk
+hk
 lU
 gs
 Ri
 FA
-aP
-aP
+hk
+hk
 mN
 mN
 mN
@@ -18566,13 +19551,13 @@ mN
 mN
 mN
 gN
-aP
-aP
+ab
+ab
 QS
-lU
-lU
-lU
-aP
+dJ
+dJ
+dJ
+ab
 hR
 hS
 fH
@@ -18588,13 +19573,13 @@ wB
 fM
 gj
 gl
-aP
+hk
 lU
 Gc
 VK
 yb
-aP
-aP
+hk
+hk
 gN
 mN
 mN
@@ -18753,12 +19738,12 @@ mN
 mN
 mN
 gN
-aP
-aP
+ab
+ab
 Du
-lU
-lU
-lU
+dJ
+dJ
+dJ
 HS
 bN
 bN
@@ -18780,8 +19765,8 @@ lU
 ZG
 lU
 lU
-aP
-aP
+hk
+hk
 mN
 mN
 mN
@@ -18940,8 +19925,8 @@ mN
 mN
 mN
 mN
-aP
-aP
+ab
+ab
 BQ
 ji
 LM
@@ -18962,13 +19947,13 @@ gt
 gt
 gt
 AZ
-Gm
+fR
 yF
 nV
 ZP
 ZP
-aP
-aP
+hk
+hk
 gN
 mN
 mN
@@ -19127,13 +20112,13 @@ mN
 mN
 gN
 Ou
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+ab
+ab
+ab
+ab
+ab
+ab
+ab
 fF
 bN
 aU
@@ -19149,13 +20134,13 @@ bY
 bH
 bN
 fT
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 FJ
 gN
 gN
@@ -19688,15 +20673,15 @@ mN
 mN
 gN
 gN
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 fK
 bk
 bk
@@ -19708,15 +20693,15 @@ aX
 bo
 ch
 fP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 mN
 mN
 mN
@@ -19875,7 +20860,7 @@ mN
 mN
 mN
 gN
-aP
+ac
 nA
 dy
 dZ
@@ -19883,7 +20868,7 @@ lh
 dZ
 dy
 nA
-aP
+ac
 hV
 fE
 bk
@@ -19895,7 +20880,7 @@ dE
 bk
 cz
 et
-aP
+ac
 nA
 dy
 dZ
@@ -19903,7 +20888,7 @@ lh
 dZ
 dy
 nA
-aP
+ac
 gN
 mN
 mN
@@ -20062,15 +21047,15 @@ mN
 mN
 mN
 mN
-aP
+ac
 lX
 PU
-aP
+ac
 dy
-aP
+ac
 PU
 lX
-aP
+ac
 hV
 eP
 ch
@@ -20082,15 +21067,15 @@ aX
 bk
 fE
 gi
-aP
+ac
 lX
 PU
-aP
+ac
 dy
-aP
+ac
 PU
 lX
-aP
+ac
 mN
 mN
 mN
@@ -20249,15 +21234,15 @@ hY
 mN
 mN
 mN
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
 ou
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
 fL
 bk
 bk
@@ -20269,15 +21254,15 @@ dF
 la
 bk
 fP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
 tR
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
 mN
 mN
 gN
@@ -20434,9 +21419,9 @@ mN
 mN
 mN
 mN
-aP
-aP
-aP
+ac
+ac
+ac
 hL
 gK
 fC
@@ -20464,9 +21449,9 @@ vT
 fW
 gK
 gL
-aP
-aP
-aP
+ac
+ac
+ac
 gN
 mN
 mN
@@ -21007,15 +21992,15 @@ Kl
 cM
 NC
 Ie
-aP
-aP
+ac
+ac
 TV
 bN
 bN
 bN
 TV
-aP
-aP
+ac
+ac
 Ie
 ka
 cM
@@ -21556,7 +22541,7 @@ mN
 mN
 mN
 gN
-aP
+ac
 dW
 gT
 gT
@@ -21588,7 +22573,7 @@ gT
 gT
 gT
 gd
-aP
+ac
 gN
 mN
 mN
@@ -22677,8 +23662,8 @@ mN
 mN
 mN
 mN
-aP
-aP
+ac
+ac
 ea
 eZ
 bN
@@ -22710,8 +23695,8 @@ ha
 gT
 gT
 gd
-aP
-aP
+ac
+ac
 gN
 mN
 mN
@@ -23439,13 +24424,13 @@ cH
 bN
 bN
 en
-aP
+ac
 jU
 Zs
 Zs
 Zs
 jY
-aP
+ac
 kf
 bN
 bN
@@ -23799,7 +24784,7 @@ mN
 mN
 mN
 mN
-aP
+ac
 dg
 fp
 du
@@ -23833,7 +24818,7 @@ vT
 vT
 vT
 hq
-aP
+ac
 gN
 mN
 mN
@@ -23986,7 +24971,7 @@ mN
 mN
 mN
 mN
-aP
+ac
 Pp
 fp
 du
@@ -24020,7 +25005,7 @@ eF
 eF
 eF
 gh
-aP
+ac
 gN
 mN
 mN
@@ -24173,7 +25158,7 @@ wt
 mN
 mN
 mN
-aP
+ac
 dg
 fp
 du
@@ -24207,7 +25192,7 @@ wB
 wB
 wB
 hs
-aP
+ac
 mN
 mN
 mN
@@ -24561,13 +25546,13 @@ YX
 bN
 bN
 en
-aP
+ac
 jV
 Gu
 pe
 Gu
 jZ
-aP
+ac
 kf
 bN
 bN
@@ -25295,8 +26280,8 @@ mN
 mN
 mN
 mN
-aP
-aP
+ac
+ac
 eb
 Iq
 bD
@@ -25328,8 +26313,8 @@ Mf
 gT
 gT
 ge
-aP
-aP
+ac
+ac
 mN
 mN
 mN
@@ -26052,23 +27037,23 @@ Yj
 Iq
 CT
 aj
-aP
-aP
+ac
+ac
 ex
 hZ
-aP
+ac
 UT
-aP
+ac
 aW
 UT
 aW
-aP
+ac
 UT
-aP
+ac
 ex
 hZ
-aP
-aP
+ac
+ac
 iD
 eF
 jX
@@ -26792,8 +27777,8 @@ mN
 mN
 mN
 mN
-aP
-aP
+ac
+ac
 bT
 fv
 fV
@@ -26823,8 +27808,8 @@ wy
 fV
 fv
 fZ
-aP
-aP
+ac
+ac
 mN
 mN
 mN
@@ -27179,13 +28164,13 @@ gu
 bN
 bN
 dm
-aP
+ac
 fe
 MC
 oQ
 MC
 jA
-aP
+ac
 iR
 bN
 bN
@@ -27354,7 +28339,7 @@ hY
 mN
 mN
 gN
-aP
+ac
 aP
 aP
 aP
@@ -27366,7 +28351,7 @@ aP
 ao
 bN
 kX
-aP
+ac
 js
 qv
 bD
@@ -27384,7 +28369,7 @@ aP
 aP
 aP
 aP
-aP
+ac
 gN
 mN
 mN
@@ -27544,7 +28529,7 @@ mN
 mN
 jo
 mO
-lO
+bh
 Er
 aP
 Zw
@@ -27553,13 +28538,13 @@ aP
 bi
 bN
 kZ
-aP
-aP
+ac
+ac
 jt
 kC
 jz
-aP
-aP
+ac
+ac
 lq
 bN
 je
@@ -27568,7 +28553,7 @@ ej
 Zw
 aP
 mO
-lO
+bh
 Er
 gB
 mN
@@ -27731,7 +28716,7 @@ mN
 mN
 jp
 Ku
-eF
+lP
 oB
 aP
 eY
@@ -27751,11 +28736,11 @@ jX
 bN
 jr
 aP
-un
+cK
 eY
 aP
 iA
-eF
+lP
 gn
 gE
 gN
@@ -27918,7 +28903,7 @@ mN
 mN
 jp
 su
-eF
+lP
 on
 aP
 aP
@@ -27928,11 +28913,11 @@ cA
 bN
 CT
 iJ
-aP
+ac
 aY
 bD
 Sp
-aP
+ac
 iQ
 jX
 bN
@@ -27942,7 +28927,7 @@ lM
 aP
 aP
 yo
-eF
+lP
 XF
 gE
 gN
@@ -28105,31 +29090,31 @@ mN
 gN
 jp
 MI
-eF
-eF
+lP
+lP
 oi
-eF
-lO
+lP
+bh
 xo
 bN
 bN
 dN
-aP
-aP
-aP
+ac
+ac
+ac
 HQ
-aP
-aP
-aP
+ac
+ac
+ac
 iT
 bN
 bN
 yD
-lO
-eF
+bh
+lP
 oi
-eF
-eF
+lP
+lP
 MI
 gE
 gN
@@ -28293,7 +29278,7 @@ mN
 jv
 kT
 wk
-lO
+bh
 fo
 NM
 lN
@@ -28315,7 +29300,7 @@ aP
 lN
 KV
 fo
-lO
+bh
 QE
 kT
 gF
@@ -28666,7 +29651,7 @@ mN
 mN
 jw
 mO
-lO
+bh
 Er
 aP
 Zw
@@ -28690,7 +29675,7 @@ ej
 Zw
 aP
 mO
-lO
+bh
 Er
 vL
 mN
@@ -28853,7 +29838,7 @@ mN
 mN
 jH
 fG
-eF
+lP
 oB
 aP
 eY
@@ -28873,11 +29858,11 @@ iX
 bN
 jr
 aP
-un
+cK
 eY
 aP
 iA
-eF
+lP
 gn
 kV
 mN
@@ -29040,7 +30025,7 @@ mN
 mN
 jH
 su
-eF
+lP
 on
 aP
 aP
@@ -29064,7 +30049,7 @@ lM
 aP
 aP
 yo
-eF
+lP
 XF
 kV
 mN
@@ -29227,31 +30212,31 @@ mN
 gN
 jH
 MI
-eF
-eF
+lP
+lP
 oi
-eF
-lO
+lP
+bh
 QB
 bN
 Qo
 cS
-aP
-aP
-aP
+ac
+ac
+ac
 HQ
-aP
-aP
-aP
+ac
+ac
+ac
 jm
 BF
 bN
 bC
-lO
-eF
+bh
+lP
 oi
-eF
-eF
+lP
+lP
 MI
 kV
 gN
@@ -29415,7 +30400,7 @@ gN
 jI
 kT
 Sq
-lO
+bh
 fo
 pX
 lN
@@ -29423,13 +30408,13 @@ aP
 cA
 bN
 iE
-aP
+ac
 yj
 yd
 bD
 YE
 IN
-aP
+ac
 iZ
 bN
 hd
@@ -29437,7 +30422,7 @@ aP
 lN
 Sb
 fo
-lO
+bh
 px
 kT
 Zj
@@ -29610,13 +30595,13 @@ aP
 ao
 bN
 ft
-aP
+ac
 aQ
 bD
 bD
 bD
 Bq
-aP
+ac
 ja
 bN
 jr
@@ -29788,7 +30773,7 @@ mN
 gN
 jJ
 mO
-lO
+bh
 Er
 aP
 Zw
@@ -29797,13 +30782,13 @@ aP
 bi
 bN
 el
-aP
+ac
 aR
 PH
 bD
 bE
 bR
-aP
+ac
 jq
 bN
 je
@@ -29812,7 +30797,7 @@ ej
 Zw
 aP
 mO
-lO
+bh
 Er
 KK
 gN
@@ -29975,7 +30960,7 @@ mN
 gN
 jW
 fG
-eF
+lP
 oB
 aP
 eY
@@ -29984,22 +30969,22 @@ aP
 ao
 bN
 iF
-aP
-aP
-aP
+ac
+ac
+ac
 bt
-aP
-aP
-aP
+ac
+ac
+ac
 jc
 bN
 jr
 aP
-un
+cK
 eY
 aP
 iA
-eF
+lP
 gn
 gI
 gN
@@ -30162,7 +31147,7 @@ mN
 gN
 jW
 su
-eF
+lP
 on
 aP
 aP
@@ -30186,7 +31171,7 @@ lM
 aP
 aP
 yo
-eF
+lP
 XF
 gI
 gN
@@ -30349,11 +31334,11 @@ mN
 gN
 jW
 MI
-eF
-eF
+lP
+lP
 oi
-eF
-lO
+lP
+bh
 MJ
 bN
 bN
@@ -30369,11 +31354,11 @@ bN
 bN
 bN
 Op
-lO
-eF
+bh
+lP
 oi
-eF
-eF
+lP
+lP
 MI
 gI
 gN
@@ -30537,7 +31522,7 @@ gN
 kg
 kT
 Mc
-lO
+bh
 fo
 Oj
 lN
@@ -30559,7 +31544,7 @@ aP
 lN
 TK
 fo
-lO
+bh
 xK
 kT
 RL
@@ -30729,19 +31714,19 @@ aP
 aP
 aP
 aP
-aP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
+ac
 dk
 dz
 jF
-aP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
+ac
 aP
 aP
 aP
@@ -30920,11 +31905,11 @@ qW
 Pt
 xz
 rL
-aP
+ac
 jC
 dz
 jL
-aP
+ac
 ci
 Ue
 DE
@@ -31107,11 +32092,11 @@ Cb
 tF
 oZ
 qW
-aP
+ac
 dk
 dz
 jF
-aP
+ac
 lO
 lO
 lO
@@ -31481,11 +32466,11 @@ Af
 oZ
 oZ
 SL
-aP
+ac
 dk
 dz
 jF
-aP
+ac
 lO
 lO
 lO
@@ -31668,12 +32653,12 @@ Af
 oZ
 DH
 oZ
-aP
+ac
 jD
 dz
 jM
-aP
-lN
+ac
+Dy
 Eo
 lO
 lO
@@ -31855,16 +32840,16 @@ pd
 Zz
 oZ
 xz
-aP
+ac
 dk
 dz
 jF
-aP
-aP
-aP
+ac
+ac
+ac
 cU
-aP
-aP
+ac
+ac
 MX
 eE
 ih
@@ -32042,16 +33027,16 @@ Vd
 oZ
 oZ
 Tx
-aP
+ac
 dk
 dz
 jF
-aP
+ac
 cm
 mP
 dj
 ZM
-aP
+ac
 ih
 ih
 ih
@@ -32229,16 +33214,16 @@ pd
 oZ
 Cv
 JD
-aP
+ac
 jC
 dz
 jL
-aP
+ac
 bV
 mP
 dj
 MF
-aP
+ac
 mC
 mC
 mC
@@ -32416,16 +33401,16 @@ pd
 DH
 oZ
 tF
-aP
+ac
 dk
 dz
 jF
-aP
+ac
 Kd
 vx
 vx
 ZZ
-aP
+ac
 mC
 mC
 mC
@@ -32603,16 +33588,16 @@ pd
 oZ
 oZ
 RY
-aP
+ac
 jD
 dz
 jM
-aP
+ac
 qX
 Vj
 Vj
 xh
-aP
+ac
 mC
 SB
 mC
@@ -32790,16 +33775,16 @@ oZ
 mW
 oZ
 Cv
-aP
+ac
 jE
 dz
 jP
-aP
+ac
 YN
 Vj
 Vj
 dB
-aP
+ac
 aO
 aO
 aO
@@ -32965,35 +33950,35 @@ mN
 hX
 mN
 mN
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 WS
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
 mN
 mN
 mN
@@ -33152,9 +34137,9 @@ mN
 mN
 mN
 mN
-aP
-aP
-aP
+ac
+ac
+ac
 uX
 bD
 TY
@@ -33162,7 +34147,7 @@ zr
 Nw
 qi
 bD
-aP
+ac
 aD
 kl
 kn
@@ -33170,7 +34155,7 @@ eF
 kp
 kw
 kz
-aP
+ac
 dU
 lO
 tv
@@ -33179,8 +34164,8 @@ lO
 lO
 lO
 BV
-aP
-aP
+ac
+ac
 mN
 mN
 mN
@@ -33340,8 +34325,8 @@ mN
 mN
 mN
 gN
-aP
-aP
+ac
+ac
 UF
 bD
 Fk
@@ -33349,7 +34334,7 @@ Fm
 Nw
 qi
 bD
-aP
+ac
 bs
 eF
 eF
@@ -33357,7 +34342,7 @@ eF
 eF
 eF
 kA
-aP
+ac
 lO
 FD
 ks
@@ -33366,7 +34351,7 @@ gJ
 kY
 lO
 Mn
-aP
+ac
 gN
 mN
 mN
@@ -33527,8 +34512,8 @@ mN
 mN
 mN
 mN
-aP
-aP
+ac
+ac
 nX
 bD
 bD
@@ -33552,8 +34537,8 @@ dz
 wD
 HW
 Wn
-aP
-aP
+ac
+ac
 mN
 mN
 mN
@@ -33715,7 +34700,7 @@ mN
 mN
 mN
 mN
-aP
+ac
 JF
 bD
 bD
@@ -33723,7 +34708,7 @@ bD
 bD
 bD
 bD
-aP
+ac
 ct
 eF
 eF
@@ -33731,7 +34716,7 @@ eF
 eF
 eF
 kB
-aP
+ac
 lO
 FT
 Ys
@@ -33739,7 +34724,7 @@ Ys
 fJ
 Uv
 lO
-aP
+ac
 gN
 mN
 mN
@@ -33902,7 +34887,7 @@ mN
 mN
 mN
 mN
-aP
+ac
 lA
 bD
 VX
@@ -33910,7 +34895,7 @@ Nw
 qi
 bD
 bD
-aP
+ac
 cW
 Tg
 eF
@@ -33918,7 +34903,7 @@ eF
 eF
 LX
 kH
-aP
+ac
 dU
 lO
 Jb
@@ -33926,7 +34911,7 @@ lO
 lO
 lO
 kQ
-aP
+ac
 mN
 mN
 mN
@@ -34089,15 +35074,15 @@ mN
 wt
 mN
 gN
-aP
-aP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
+ac
+ac
 nB
-aP
-aP
+ac
+ac
 dC
 XW
 eF
@@ -34105,15 +35090,15 @@ eF
 eF
 lB
 kJ
-aP
-aP
+ac
+ac
 qK
-aP
-aP
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
+ac
+ac
 mN
 mN
 mN
@@ -34277,14 +35262,14 @@ mN
 mN
 mN
 mN
-aP
-aP
+ac
+ac
 rj
 LQ
 eE
 eE
 LI
-aP
+ac
 dO
 YV
 eF
@@ -34292,14 +35277,14 @@ eF
 eF
 RX
 kK
-aP
+ac
 og
 lO
 lO
 dy
 dy
-aP
-aP
+ac
+ac
 mN
 mN
 mN
@@ -34464,14 +35449,14 @@ mN
 mN
 mN
 gN
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
 un
 eE
 pM
-aP
+ac
 dV
 dn
 Qq
@@ -34479,14 +35464,14 @@ eF
 GS
 bp
 kL
-aP
+ac
 sJ
 lO
 lO
 dy
 es
-aP
-aP
+ac
+ac
 gN
 mN
 mN
@@ -34652,13 +35637,13 @@ mN
 mN
 mN
 gN
-aP
+ac
 dd
 LQ
 eE
 eE
 to
-aP
+ac
 cW
 Tg
 eF
@@ -34666,13 +35651,13 @@ eF
 eF
 LX
 kH
-aP
+ac
 Iz
 lO
 lO
 dy
 eL
-aP
+ac
 mN
 mN
 mN
@@ -34839,13 +35824,13 @@ mN
 mN
 mN
 mN
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
 wa
-aP
-aP
+ac
+ac
 kk
 lB
 eF
@@ -34853,13 +35838,13 @@ eF
 eF
 XW
 kM
-aP
+ac
 KU
 lO
 ZB
 Hs
-aP
-aP
+ac
+ac
 gN
 mN
 mN
@@ -35027,12 +36012,12 @@ mN
 mN
 mN
 gN
-aP
-aP
+ac
+ac
 Bb
 eE
 OH
-aP
+ac
 dO
 YV
 eF
@@ -35040,12 +36025,12 @@ eF
 eF
 RX
 kK
-aP
+ac
 df
 lO
-on
+WJ
 lO
-aP
+ac
 mN
 mN
 mN
@@ -35214,12 +36199,12 @@ mN
 mN
 mN
 wt
-aP
-aP
+ac
+ac
 MX
 eE
 pM
-aP
+ac
 cD
 km
 ko
@@ -35227,12 +36212,12 @@ eF
 kr
 kx
 kO
-aP
+ac
 lO
-lN
-aP
-aP
-aP
+Dy
+ac
+ac
+ac
 gN
 mN
 mN
@@ -35402,23 +36387,23 @@ mN
 mN
 mN
 mN
-aP
+ac
 Bb
 eE
 OH
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
 PM
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
 Dl
-aP
-aP
-aP
+ac
+ac
+ac
 mN
 mN
 mN
@@ -35589,11 +36574,11 @@ mN
 mN
 mN
 gN
-aP
-aP
+ac
+ac
 mU
-aP
-aP
+ac
+ac
 lO
 lO
 lO
@@ -35601,11 +36586,11 @@ lO
 lO
 lO
 lO
-aP
+ac
 eE
 Wt
-aP
-aP
+ac
+ac
 mN
 mN
 wt
@@ -35777,10 +36762,10 @@ mN
 mN
 mN
 mN
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
 lO
 FD
 ks
@@ -35788,10 +36773,10 @@ ks
 ks
 iW
 lO
-aP
+ac
 un
 rN
-aP
+ac
 gN
 mN
 mN
@@ -35964,10 +36949,10 @@ mN
 mN
 mN
 gN
-aP
-aP
-aP
-aP
+ac
+ac
+ac
+ac
 uO
 FT
 Ys
@@ -35975,10 +36960,10 @@ Zl
 Ys
 Uv
 EJ
-aP
+ac
 VV
-aP
-aP
+ac
+ac
 gN
 mN
 mN
@@ -36152,9 +37137,9 @@ mN
 mN
 mN
 gN
-aP
-aP
-aP
+ac
+ac
+ac
 Hi
 Hi
 Hi
@@ -36162,9 +37147,9 @@ Yq
 Hi
 Hi
 Hi
-aP
-aP
-aP
+ac
+ac
+ac
 gN
 mN
 mN
@@ -36341,15 +37326,15 @@ mN
 mN
 mN
 gN
-aP
-aP
+ac
+ac
 BW
 Bt
 Bt
 Bt
 nZ
-aP
-aP
+ac
+ac
 gN
 mN
 mN
@@ -39225,7 +40210,7 @@ mc
 mc
 mc
 kU
-by
+uf
 by
 by
 by
@@ -39788,7 +40773,7 @@ by
 RC
 Nt
 by
-by
+uf
 by
 by
 mc
@@ -39972,7 +40957,7 @@ mc
 mc
 by
 by
-by
+uf
 by
 by
 by
@@ -40532,7 +41517,7 @@ mc
 mc
 mc
 by
-by
+uf
 by
 Nt
 RC

--- a/maps/southern_cross/southern_cross-casino.dmm
+++ b/maps/southern_cross/southern_cross-casino.dmm
@@ -6,12 +6,6 @@
 	},
 /turf/simulated/floor/outdoors/ice,
 /area/surface/outside/plains/outpost)
-"ab" = (
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship/wing_left)
-"ac" = (
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship)
 "ad" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -21,8 +15,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ae" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -36,8 +29,7 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "af" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/simulated/floor/wood/sif,
@@ -54,8 +46,7 @@
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ai" = (
 /mob/living/simple_mob/animal/sif/glitterfly,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -65,14 +56,12 @@
 "aj" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ak" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "al" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 4
@@ -80,16 +69,14 @@
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "am" = (
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "an" = (
 /mob/living/simple_mob/animal/passive/gaslamp/snow{
 	hovering = 1
@@ -102,8 +89,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "ap" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -113,14 +99,12 @@
 	health = 1e+006;
 	req_access = list(5)
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "aq" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "ar" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -128,8 +112,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "as" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -152,8 +135,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "au" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -164,8 +146,7 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "av" = (
 /turf/unsimulated/wall,
 /area/surface/outside/plains/outpost)
@@ -178,16 +159,14 @@
 	icon_state = "spline_fancy_corner"
 	},
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ay" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "az" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -200,8 +179,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "aA" = (
 /mob/living/simple_mob/animal/sif/diyaab{
 	hovering = 1
@@ -224,8 +202,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "aC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -247,13 +224,11 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "aE" = (
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "aF" = (
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -292,8 +267,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "aK" = (
 /mob/living/simple_mob/animal/passive/mouse/white,
 /turf/simulated/floor/outdoors/dirt{
@@ -306,15 +280,13 @@
 /obj/structure/bed/chair/sofa/right/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "aM" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "aN" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -324,18 +296,15 @@
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "aO" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "aP" = (
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship/dorms)
+/turf/simulated/wall/golddiamond)
 "aQ" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/dicecup{
@@ -359,8 +328,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "aR" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/pill_bottle/dice{
@@ -372,8 +340,7 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "aS" = (
 /obj/effect/blocker,
 /turf/simulated/mineral/ignore_mapgen/cave,
@@ -382,8 +349,7 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "aU" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -394,8 +360,7 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "aV" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -403,22 +368,19 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "aW" = (
 /obj/structure/noticeboard{
 	name = "Sentient prize board"
 	},
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship)
+/turf/simulated/wall/golddiamond)
 "aX" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	health = 1e+006;
 	req_access = list(5)
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "aY" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Casinoboth 1";
@@ -436,8 +398,7 @@
 	req_access = list(160)
 	},
 /obj/structure/closet/crate/bin,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "aZ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -447,8 +408,7 @@
 	health = 1e+006
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ba" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -459,8 +419,7 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "bb" = (
 /mob/living/simple_mob/animal/sif/glitterfly,
 /turf/simulated/floor/water,
@@ -474,8 +433,7 @@
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "bd" = (
 /mob/living/simple_mob/animal/sif/tymisian,
 /turf/simulated/floor/outdoors/dirt{
@@ -487,8 +445,7 @@
 "be" = (
 /obj/structure/sign/christmas/wreath,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "bf" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -498,8 +455,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "bg" = (
 /obj/structure/flora/tree/winter1,
 /mob/living/simple_mob/animal/sif/glitterfly,
@@ -507,23 +463,17 @@
 	temperature = 293.15
 	},
 /area/surface/outside/plains/outpost)
-"bh" = (
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
 "bi" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "bj" = (
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "bk" = (
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "bl" = (
 /obj/effect/blocker,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -556,12 +506,10 @@
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/steel_grid)
 "bo" = (
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "bp" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -573,27 +521,23 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "bq" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/tiled/freezer)
 "br" = (
 /obj/effect/blocker,
 /turf/simulated/floor/water,
 /area/surface/outside/plains/outpost)
 "bs" = (
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "bt" = (
 /obj/machinery/door/airlock/silver{
 	name = "General storage";
 	req_access = list(160)
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "bu" = (
 /obj/effect/blocker,
 /turf/simulated/floor/water/deep,
@@ -605,14 +549,12 @@
 /obj/effect/simple_portal/linked{
 	portal_id = 7
 	},
-/turf/simulated/floor/redgrid/animated,
-/area/casino/casino_ship)
+/turf/simulated/floor/redgrid/animated)
 "bx" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "by" = (
 /turf/simulated/floor/outdoors/dirt{
 	can_atmos_pass = 0;
@@ -623,16 +565,14 @@
 "bz" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/flora/tree/pine/xmas/presents,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "bA" = (
 /obj/machinery/door/airlock/security{
 	name = "Cell 1";
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/steel_grid)
 "bB" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -640,18 +580,15 @@
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "bC" = (
 /obj/machinery/door/airlock/silver{
 	id_tag = "casinodorm5";
 	name = "Dorm room 5"
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "bD" = (
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "bE" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/spray/cleaner{
@@ -661,8 +598,7 @@
 /obj/item/weapon/reagent_containers/spray/cleaner{
 	pixel_x = 8
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "bF" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -671,8 +607,7 @@
 /obj/structure/sign/christmas/lights,
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "bG" = (
 /obj/effect/zone_divider,
 /turf/unsimulated/wall,
@@ -684,8 +619,7 @@
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "bI" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -730,17 +664,14 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "bN" = (
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "bO" = (
 /obj/machinery/casino_chip_exchanger{
 	pixel_x = -32
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "bP" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -752,8 +683,7 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "bQ" = (
 /obj/machinery/casino_chip_exchanger{
 	pixel_x = -32
@@ -761,8 +691,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "bR" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin{
@@ -777,8 +706,7 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "bS" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -799,12 +727,10 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "bU" = (
 /obj/structure/flora/tree/pine,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "bV" = (
 /obj/structure/table/rack/shelf,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -815,8 +741,7 @@
 	},
 /obj/item/weapon/reagent_containers/glass/bucket/wood,
 /obj/effect/mist,
-/turf/simulated/floor/tiled/techmaint,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techmaint)
 "bW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -832,8 +757,7 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "bX" = (
 /obj/structure/sink{
 	pixel_x = 16;
@@ -842,14 +766,12 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "bY" = (
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "bZ" = (
 /obj/structure/closet/jcloset,
 /obj/item/weapon/soap/deluxe,
@@ -861,8 +783,7 @@
 	},
 /obj/item/device/lightreplacer,
 /obj/item/device/lightreplacer,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "ca" = (
 /obj/effect/blocker,
 /obj/structure/flora/tree/dead,
@@ -885,14 +806,12 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ce" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "cf" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -903,8 +822,7 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 17
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "cg" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/floor_decal/borderfloor{
@@ -916,16 +834,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "ch" = (
 /obj/structure/flora/bboulder1,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ci" = (
 /obj/structure/closet/athletic_mixed,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "cj" = (
 /mob/living/simple_mob/vore/rabbit/white,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -951,8 +866,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "cm" = (
 /obj/machinery/atmospherics/unary/heater/sauna{
 	dir = 4;
@@ -960,8 +874,7 @@
 	use_power = 1
 	},
 /obj/effect/mist,
-/turf/simulated/floor/tiled/techmaint,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techmaint)
 "cn" = (
 /mob/living/simple_mob/vore/rabbit/brown,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -981,8 +894,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "cp" = (
 /obj/machinery/atmospherics/unary/engine/biggest{
 	dir = 4
@@ -993,8 +905,7 @@
 /obj/structure/shuttle/engine/heater{
 	dir = 8
 	},
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/wall/golddiamond)
 "cr" = (
 /obj/machinery/light{
 	dir = 4
@@ -1002,8 +913,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "cs" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -1017,8 +927,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ct" = (
 /obj/machinery/light{
 	dir = 1
@@ -1027,8 +936,7 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "cu" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/storage/wallet/casino,
@@ -1047,8 +955,7 @@
 /obj/item/weapon/storage/wallet/casino,
 /obj/item/weapon/storage/wallet/casino,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "cv" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -1056,8 +963,7 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "cw" = (
 /obj/structure/table/steel,
 /obj/item/weapon/grenade/chem_grenade/cleaner,
@@ -1074,8 +980,7 @@
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/item/weapon/reagent_containers/spray/cleaner,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "cx" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -1092,8 +997,7 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "cy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -1106,18 +1010,15 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "cz" = (
 /obj/structure/flora/lily2,
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "cA" = (
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "cB" = (
 /obj/structure/flora/grass/green,
 /mob/living/simple_mob/vore/rabbit/brown,
@@ -1140,8 +1041,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "cE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -1159,8 +1059,7 @@
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "cG" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -1170,45 +1069,33 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "cH" = (
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "cI" = (
 /obj/structure/table/glass,
 /obj/item/toy/eight_ball,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "cJ" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
-"cK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/snow/snow2)
 "cL" = (
 /obj/structure/flora/lily1,
-/turf/simulated/floor/water/indoors,
-/area/casino/casino_ship)
+/turf/simulated/floor/water/indoors)
 "cM" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "cN" = (
 /obj/structure/flora/tree/winter1,
 /obj/structure/flora/grass/brown,
@@ -1233,55 +1120,47 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "cQ" = (
 /obj/structure/flora/tree/pine{
 	desc = "A wondrous decorated Christmas tree. It has presents!";
 	icon_state = "pinepresents"
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "cR" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "cS" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "cT" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_2"
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "cU" = (
 /obj/machinery/door/airlock/silver{
 	name = "Sauna"
 	},
 /obj/structure/fans/tiny,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "cV" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "cW" = (
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 4
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "cX" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1289,8 +1168,7 @@
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "cY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -1310,8 +1188,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "da" = (
 /obj/machinery/light{
 	dir = 4
@@ -1319,8 +1196,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "db" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/stack/material/log/sif{
@@ -1336,31 +1212,24 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "dd" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
-"de" = (
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/freezer)
 "df" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "dg" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/table/fancyblack,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "dh" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
@@ -1368,8 +1237,7 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "di" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -1386,12 +1254,10 @@
 /area/surface/outside/plains/mountains)
 "dj" = (
 /obj/effect/mist,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "dk" = (
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "dl" = (
 /obj/machinery/light{
 	dir = 4
@@ -1399,8 +1265,7 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "dm" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -1415,8 +1280,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "dn" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -1427,16 +1291,14 @@
 	health = 1e+006
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "do" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "dp" = (
 /obj/machinery/light{
 	dir = 8
@@ -1444,17 +1306,13 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "dq" = (
 /obj/structure/flora/tree/winter,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
 	temperature = 293.15
 	},
 /area/surface/outside/plains/outpost)
-"dr" = (
-/turf/simulated/floor/outdoors/dirt,
-/area/casino/casino_ship/wing_left)
 "ds" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
@@ -1462,8 +1320,7 @@
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "dt" = (
 /obj/structure/ledge/ledge_stairs{
 	pixel_y = -3
@@ -1473,8 +1330,7 @@
 "du" = (
 /obj/structure/table/fancyblack,
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "dv" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1499,23 +1355,19 @@
 	health = 1e+006;
 	req_access = list(5)
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "dx" = (
 /obj/structure/table/sifwoodentable,
 /obj/item/weapon/flame/candle/candelabra/everburn,
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
 "dy" = (
-/turf/simulated/floor/carpet/purcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/purcarpet)
 "dz" = (
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "dA" = (
 /obj/structure/janitorialcart,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "dB" = (
 /obj/structure/table/bench/sifwooden,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -1535,16 +1387,14 @@
 	use_power = 1
 	},
 /obj/effect/mist,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "dC" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/reagent_containers/food/snacks/tamales,
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "dD" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/wood/sif,
@@ -1556,8 +1406,7 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "dF" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -1565,8 +1414,7 @@
 	req_access = list(5)
 	},
 /obj/structure/flora/bboulder2,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "dG" = (
 /obj/structure/closet/gmcloset,
 /obj/item/glass_jar,
@@ -1607,11 +1455,7 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
-"dJ" = (
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/snow/snow2)
 "dK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -1628,16 +1472,14 @@
 	layer = 3.5;
 	name = "Casino emergency shutter"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "dL" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "dM" = (
 /obj/structure/table/glass,
 /obj/item/device/communicator,
@@ -1648,8 +1490,7 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "dN" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy{
@@ -1661,15 +1502,13 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "dO" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 8
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "dP" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1681,8 +1520,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "dQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1694,8 +1532,7 @@
 /area/surface/outside/plains/mountains)
 "dR" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "dS" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1705,8 +1542,7 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "dT" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -1714,14 +1550,12 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "dU" = (
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "dV" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -1733,8 +1567,7 @@
 	},
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "dW" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -1751,8 +1584,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "dX" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/borderfloor{
@@ -1761,8 +1593,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "dY" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/machinery/light{
@@ -1771,12 +1602,10 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "dZ" = (
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/carpet/purcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/purcarpet)
 "ea" = (
 /obj/machinery/slot_machine,
 /obj/machinery/light{
@@ -1785,8 +1614,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "eb" = (
 /obj/machinery/slot_machine,
 /obj/machinery/light{
@@ -1795,8 +1623,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "ec" = (
 /obj/machinery/atm{
 	pixel_x = -32
@@ -1804,8 +1631,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "ed" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 8
@@ -1815,16 +1641,14 @@
 "ee" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloor,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "ef" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = 1e+006
 	},
 /obj/structure/window/reinforced,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "eg" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1835,8 +1659,7 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "eh" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/book/codex/casino,
@@ -1859,8 +1682,7 @@
 /obj/item/weapon/book/codex/casino,
 /obj/item/weapon/book/codex/casino,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ei" = (
 /obj/structure/table/steel,
 /obj/item/weapon/flame/candle/everburn,
@@ -1876,12 +1698,10 @@
 	},
 /obj/structure/curtain/open/shower/engineering,
 /obj/structure/window/reinforced,
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/tiled/freezer)
 "ek" = (
 /obj/structure/bed/chair/oldsofa,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "el" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1891,15 +1711,13 @@
 	health = 1e+006
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "em" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "en" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -1912,50 +1730,42 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "eo" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ep" = (
-/turf/simulated/floor/outdoors/dirt,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/outdoors/dirt)
 "eq" = (
 /obj/machinery/slot_machine,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "er" = (
 /obj/structure/flora/lily2,
-/turf/simulated/floor/water/indoors,
-/area/casino/casino_ship)
+/turf/simulated/floor/water/indoors)
 "es" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/cedouble,
-/turf/simulated/floor/carpet/purcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/purcarpet)
 "et" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "eu" = (
 /obj/structure/table/glass,
 /obj/item/weapon/book/codex/casino,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ev" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -1964,8 +1774,7 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ew" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -1973,8 +1782,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "ex" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -1982,8 +1790,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "ey" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -1991,8 +1798,7 @@
 	pixel_y = 32
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ez" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -2007,8 +1813,7 @@
 	health = 1e+006
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "eA" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/water/hotspring{
@@ -2022,15 +1827,13 @@
 	dir = 8
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "eC" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "eD" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -2047,11 +1850,9 @@
 	},
 /area/surface/outside/plains/mountains)
 "eE" = (
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "eF" = (
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "eG" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_3"
@@ -2068,8 +1869,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "eI" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
@@ -2077,14 +1877,12 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "eJ" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/device/starcaster_news,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "eK" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -2093,12 +1891,10 @@
 	},
 /obj/item/device/communicator,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "eL" = (
 /obj/structure/table/glass,
-/turf/simulated/floor/carpet/purcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/purcarpet)
 "eM" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -2117,8 +1913,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "eO" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 4
@@ -2129,40 +1924,29 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "eP" = (
 /obj/structure/flora/lily1,
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "eQ" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "eR" = (
 /obj/machinery/door/airlock/security{
 	name = "Holding cells";
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_right)
-"eS" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 8
-	},
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/steel_grid)
 "eT" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/laundry_basket,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "eU" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 9
@@ -2170,8 +1954,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "eV" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 8
@@ -2179,8 +1962,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "eW" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 10
@@ -2188,44 +1970,37 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "eX" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/event/present,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "eY" = (
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/tiled/freezer)
 "eZ" = (
 /obj/item/weapon/stool/padded,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "fa" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "fb" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "fc" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fd" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/storage/wallet/casino,
@@ -2246,8 +2021,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fe" = (
 /obj/structure/table/marble,
 /obj/item/weapon/paper_bin{
@@ -2271,8 +2045,7 @@
 	name = "Front Desk Shutters"
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "ff" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
@@ -2282,8 +2055,7 @@
 	},
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fg" = (
 /obj/item/weapon/telecube/mated,
 /turf/simulated/floor/flock,
@@ -2312,8 +2084,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fi" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -2335,22 +2106,19 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fk" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/device/starcaster_news,
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fl" = (
 /obj/structure/table/fancyblack,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "fm" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -2361,8 +2129,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fn" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
@@ -2370,8 +2137,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fo" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
@@ -2381,12 +2147,10 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "fp" = (
 /obj/structure/table/fancyblack,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "fq" = (
 /obj/machinery/door/window/westright{
 	dir = 1;
@@ -2399,15 +2163,13 @@
 	layer = 3.2;
 	name = "Exchange booth shutters 1"
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "fr" = (
 /obj/machinery/light,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fs" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -2416,8 +2178,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ft" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2425,27 +2186,23 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "fu" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fv" = (
 /obj/structure/table/glass,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fw" = (
 /obj/structure/table/wooden_reinforced,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fx" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood/sif,
@@ -2456,8 +2213,7 @@
 	dir = 1
 	},
 /obj/item/weapon/gun/energy/sizegun,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "fz" = (
 /mob/living/simple_mob/animal/giant_spider/carrier,
 /turf/simulated/floor/outdoors/dirt{
@@ -2477,8 +2233,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fB" = (
 /obj/structure/flora/grass/both,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -2496,8 +2251,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fD" = (
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 4
@@ -2508,13 +2262,11 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "fE" = (
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "fF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -2522,8 +2274,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "fG" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/coffee{
@@ -2547,8 +2298,7 @@
 	pixel_x = -6;
 	pixel_y = -1
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "fH" = (
 /obj/machinery/vending/coffee,
 /obj/effect/floor_decal/spline/fancy{
@@ -2557,12 +2307,10 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fI" = (
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "fJ" = (
 /obj/item/weapon/book/codex/casino,
 /obj/structure/table/marble,
@@ -2575,8 +2323,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "fK" = (
 /obj/structure/flora/lily1,
 /obj/structure/sign/christmas/lights{
@@ -2584,8 +2331,7 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "fL" = (
 /obj/structure/flora/lily2,
 /obj/structure/sign/christmas/lights{
@@ -2593,8 +2339,7 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "fM" = (
 /obj/machinery/vending/snack,
 /obj/effect/floor_decal/spline/fancy{
@@ -2603,8 +2348,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fN" = (
 /obj/machinery/power/smes/buildable/hybrid,
 /obj/structure/cable/green{
@@ -2635,35 +2379,27 @@
 	pixel_x = -8;
 	pixel_y = -1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "fP" = (
 /obj/structure/sign/christmas/lights,
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "fQ" = (
 /obj/machinery/washing_machine,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
-"fR" = (
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "fS" = (
 /obj/machinery/door/airlock/multi_tile/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/steel_grid)
 "fT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "fU" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 4
@@ -2674,13 +2410,11 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "fV" = (
 /obj/structure/table/glass,
 /obj/item/device/starcaster_news,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fW" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -2692,8 +2426,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "fX" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_3"
@@ -2709,8 +2442,7 @@
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "fZ" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -2722,8 +2454,7 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ga" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/ice,
@@ -2737,8 +2468,7 @@
 /obj/structure/mopbucket,
 /obj/item/weapon/mop,
 /obj/item/weapon/reagent_containers/glass/bucket,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "gc" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -2746,8 +2476,7 @@
 /obj/effect/floor_decal/corner/purple/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "gd" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -2762,8 +2491,7 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ge" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -2777,8 +2505,7 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "gf" = (
 /obj/machinery/appliance/cooker/grill,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -2799,8 +2526,7 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "gi" = (
 /obj/structure/flora/lily1,
 /obj/structure/sign/christmas/wreath{
@@ -2808,8 +2534,7 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "gj" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -2821,8 +2546,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "gk" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 4
@@ -2830,8 +2554,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "gl" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/spline/fancy{
@@ -2843,19 +2566,16 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "gm" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
 	req_access = list(160)
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "gn" = (
 /obj/structure/table/glass,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "go" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2871,8 +2591,7 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "gp" = (
 /obj/structure/table/rack,
 /obj/item/device/suit_cooling_unit,
@@ -2883,8 +2602,7 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "gq" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 4
@@ -2896,8 +2614,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "gr" = (
 /obj/effect/zone_divider,
 /turf/simulated/mineral/ignore_mapgen/cave,
@@ -2912,12 +2629,10 @@
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor)
 "gt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "gu" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4;
@@ -2927,8 +2642,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "gv" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/borderfloor{
@@ -2937,8 +2651,7 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "gw" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2946,8 +2659,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "gx" = (
 /obj/structure/casino_table/blackjack_m{
 	dir = 1
@@ -2956,8 +2668,7 @@
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "gy" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
@@ -2965,14 +2676,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "gz" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/outdoors/grass/heavy{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "gA" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/borderfloor{
@@ -2981,8 +2690,7 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "gB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -2999,8 +2707,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "gC" = (
 /obj/structure/flora/lily2,
 /obj/structure/sign/christmas/wreath{
@@ -3008,8 +2715,7 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "gD" = (
 /obj/machinery/door/airlock/glass_external{
 	autoclose = 0;
@@ -3027,8 +2733,7 @@
 	pixel_x = -24
 	},
 /obj/structure/fans/hardlight,
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/steel_grid)
 "gE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -3041,8 +2746,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "gF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -3059,8 +2763,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "gG" = (
 /obj/machinery/door/airlock/glass_external{
 	autoclose = 0;
@@ -3071,16 +2774,14 @@
 	name = "Landing North External"
 	},
 /obj/structure/fans/hardlight,
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/steel_grid)
 "gH" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "gI" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -3093,8 +2794,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "gJ" = (
 /obj/structure/table/marble,
 /obj/item/device/radio/headset/syndicate,
@@ -3112,8 +2812,7 @@
 	},
 /obj/item/clothing/head/crown/goose_king/christmas,
 /obj/item/clothing/head/crown/goose_queen/christmas,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "gK" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -3128,8 +2827,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "gL" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/spline/fancy{
@@ -3142,15 +2840,13 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "gM" = (
 /obj/structure/flora/tree/pine,
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "gN" = (
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/plains/outpost)
@@ -3163,8 +2859,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "gP" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
@@ -3172,8 +2867,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "gQ" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 1
@@ -3184,8 +2878,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "gR" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 1
@@ -3193,8 +2886,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "gS" = (
 /obj/structure/flora/tree/winter,
 /obj/structure/flora/grass/both,
@@ -3209,8 +2901,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "gU" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 8
@@ -3218,8 +2909,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "gV" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -3227,8 +2917,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "gW" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/grass/brown,
@@ -3249,15 +2938,13 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "gZ" = (
 /obj/item/weapon/stool/padded,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "ha" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -3266,13 +2953,11 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "hb" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/eight_ball/conch,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "hc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3285,8 +2970,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "he" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -3294,14 +2978,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "hf" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "hg" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/mud/sif/planetuse{
@@ -3336,18 +3018,13 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
-"hk" = (
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/carpet/blucarpet)
 "hl" = (
 /obj/structure/table/gamblingtable,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "hm" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
@@ -3355,8 +3032,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "hn" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
@@ -3370,8 +3046,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ho" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -3382,8 +3057,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "hp" = (
 /obj/structure/railing{
 	dir = 8
@@ -3400,8 +3074,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "hr" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -3422,8 +3095,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ht" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -3434,25 +3106,21 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "hu" = (
 /obj/structure/table/fancyblack,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "hv" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "hw" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "hx" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 4
@@ -3461,28 +3129,23 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "hy" = (
 /obj/structure/bed/chair/oldsofa,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "hz" = (
 /obj/structure/bed/chair/oldsofa/corner,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "hA" = (
 /obj/machinery/slot_machine,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "hB" = (
 /obj/structure/reagent_dispensers/water_cooler/full,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "hC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3503,26 +3166,22 @@
 "hD" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/storage/dicecup,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "hE" = (
 /obj/machinery/slot_machine,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "hF" = (
 /obj/structure/reagent_dispensers/water_cooler/full,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "hG" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "hH" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -3533,16 +3192,14 @@
 	req_access = list(5)
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "hI" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	health = 1e+006
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "hJ" = (
 /obj/item/weapon/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -3556,8 +3213,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "hL" = (
 /obj/machinery/recharge_station,
 /obj/effect/floor_decal/spline/fancy{
@@ -3568,15 +3224,13 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "hM" = (
 /obj/structure/bed/chair/bar_stool,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "hN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
@@ -3588,8 +3242,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "hP" = (
 /turf/unsimulated/mineral,
 /area/surface/outside/plains/mountains)
@@ -3598,8 +3251,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "hR" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/spline/fancy{
@@ -3609,8 +3261,7 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "hS" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
@@ -3622,8 +3273,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "hT" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 1
@@ -3631,8 +3281,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "hU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -3652,8 +3301,7 @@
 /obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "hW" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -3663,8 +3311,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor/grid)
 "hX" = (
 /obj/structure/flora/tree/dead,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -3682,8 +3329,7 @@
 	name = "casino curtain"
 	},
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "ia" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -3700,8 +3346,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ib" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -3712,8 +3357,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ic" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
@@ -3729,8 +3373,7 @@
 /obj/item/weapon/gun/energy/laser,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "id" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
@@ -3749,14 +3392,12 @@
 /obj/item/weapon/gun/energy/gun/burst,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "ie" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "if" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
@@ -3774,18 +3415,15 @@
 /obj/item/weapon/gun/projectile/automatic/p90,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "ig" = (
 /obj/structure/bed/chair/sofa/corner/yellow,
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "ih" = (
-/turf/simulated/floor/water/pool,
-/area/casino/casino_ship)
+/turf/simulated/floor/water/pool)
 "ii" = (
 /obj/structure/table/glass,
 /obj/item/weapon/book/codex/casino,
@@ -3795,26 +3433,17 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ij" = (
 /obj/structure/table/gamblingtable,
 /obj/item/toy/eight_ball,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "ik" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
-"il" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/grass)
 "im" = (
 /obj/item/weapon/storage/belt/holding,
 /turf/simulated/floor/flock,
@@ -3826,8 +3455,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "io" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
@@ -3836,8 +3464,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ip" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -3863,8 +3490,7 @@
 /area/surface/outside/plains/mountains)
 "ir" = (
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "is" = (
 /obj/structure/bed/chair/sofa/left/yellow{
 	dir = 8
@@ -3872,15 +3498,13 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "it" = (
 /obj/structure/table/glass,
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "iu" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/book/codex/casino,
@@ -3890,15 +3514,13 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "iv" = (
 /obj/structure/closet/crate/bin,
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "iw" = (
 /obj/structure/bed/chair/sofa/right/yellow{
 	dir = 8
@@ -3906,8 +3528,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "ix" = (
 /obj/structure/bed/chair/sofa/corner/yellow{
 	dir = 8
@@ -3915,8 +3536,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "iy" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -3934,8 +3554,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "iz" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/flora/pottedplant/xmas{
@@ -3944,8 +3563,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "iA" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/coffee{
@@ -3972,8 +3590,7 @@
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "iB" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -3990,8 +3607,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "iC" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -4003,8 +3619,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "iD" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -4012,8 +3627,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "iE" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4022,15 +3636,13 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "iF" = (
 /obj/machinery/recharge_station,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "iG" = (
 /obj/machinery/light{
 	dir = 4
@@ -4038,8 +3650,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "iH" = (
 /obj/machinery/light{
 	dir = 4
@@ -4050,14 +3661,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "iI" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "iJ" = (
 /obj/machinery/casino_prize_dispenser{
 	category_clothing = 2;
@@ -4073,14 +3682,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "iK" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "iL" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -4089,8 +3696,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "iM" = (
 /obj/machinery/light{
 	dir = 8
@@ -4098,8 +3704,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "iN" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -4111,8 +3716,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "iO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/sif/broken,
@@ -4128,8 +3732,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "iQ" = (
 /obj/machinery/casino_prize_dispenser{
 	category_clothing = 2;
@@ -4143,8 +3746,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "iR" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/spline/fancy{
@@ -4155,12 +3757,10 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "iS" = (
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "iT" = (
 /obj/machinery/light{
 	dir = 1
@@ -4170,8 +3770,7 @@
 	anchored = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "iU" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -4179,29 +3778,25 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "iV" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/lily3,
 /obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "iW" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "iX" = (
 /obj/structure/window/reinforced,
 /obj/structure/sign/christmas/wreath,
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "iY" = (
 /obj/item/ammo_magazine/ammo_box/b12g/beanbag,
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel,
@@ -4212,14 +3807,12 @@
 "iZ" = (
 /obj/structure/window/reinforced,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ja" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "jb" = (
 /obj/machinery/power/apc/alarms_hidden{
 	dir = 4;
@@ -4234,8 +3827,7 @@
 "jc" = (
 /obj/machinery/recharge_station,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "jd" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/window/reinforced{
@@ -4245,15 +3837,13 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "je" = (
 /obj/machinery/light,
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "jf" = (
 /mob/living/simple_mob/animal/giant_spider/webslinger,
 /turf/simulated/floor/outdoors/dirt{
@@ -4274,8 +3864,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "jh" = (
 /obj/structure/table/sifwoodentable,
 /turf/simulated/floor/wood/sif,
@@ -4291,16 +3880,14 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "jj" = (
 /obj/structure/sign/christmas/wreath,
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "jk" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/lily3,
@@ -4309,8 +3896,7 @@
 	},
 /turf/simulated/floor/water{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "jl" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -4323,8 +3909,7 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "jn" = (
 /mob/living/simple_mob/animal/sif/sakimm{
 	hovering = 1
@@ -4348,8 +3933,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "jp" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4361,8 +3945,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "jq" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -4372,12 +3955,10 @@
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "jr" = (
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "js" = (
 /obj/item/weapon/storage/secure/safe{
 	pixel_x = 35
@@ -4392,8 +3973,7 @@
 	dir = 4
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "jt" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -4402,8 +3982,7 @@
 	dir = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "ju" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -4432,8 +4011,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "jw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4449,16 +4027,14 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "jx" = (
 /obj/effect/decal/cleanable/ash,
 /turf/simulated/floor/flock,
 /area/surface/outside/plains/mountains)
 "jy" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "jz" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
@@ -4467,8 +4043,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "jA" = (
 /obj/structure/table/marble,
 /obj/item/weapon/paper_bin{
@@ -4494,8 +4069,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jB" = (
 /obj/item/weapon/storage/secure/safe{
 	pixel_x = 35
@@ -4506,21 +4080,18 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "jC" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jD" = (
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jE" = (
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
@@ -4529,14 +4100,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jF" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jG" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4544,8 +4113,7 @@
 	layer = 3.1;
 	name = "Casino bar shutter"
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jH" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4557,8 +4125,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "jI" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4574,8 +4141,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "jJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4591,8 +4157,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "jK" = (
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
@@ -4601,20 +4166,17 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jM" = (
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/sifwood,
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/lonehome)
 "jO" = (
-/turf/simulated/floor/tiled/kafel_full/blue,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/kafel_full/blue)
 "jP" = (
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
@@ -4625,12 +4187,10 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jQ" = (
 /obj/structure/table/gamblingtable,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "jR" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -4638,8 +4198,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "jS" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4650,8 +4209,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jT" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4662,8 +4220,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jU" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4673,8 +4230,7 @@
 	name = "Casino bar shutter"
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jV" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4684,8 +4240,7 @@
 	name = "Casino bar shutter"
 	},
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4697,12 +4252,10 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "jX" = (
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "jY" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4714,8 +4267,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "jZ" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4727,12 +4279,10 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "ka" = (
 /obj/structure/bed/chair/oldsofa/corner,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "kb" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4744,8 +4294,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "kc" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -4757,8 +4306,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "kd" = (
 /obj/structure/closet/secure_closet/security{
 	req_access = list(201)
@@ -4769,8 +4317,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "ke" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -4793,8 +4340,7 @@
 	},
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/sign/christmas/wreath,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -4810,8 +4356,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "kh" = (
 /obj/structure/flora/pottedplant/xmas{
 	anchored = 1
@@ -4819,8 +4364,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "ki" = (
 /obj/machinery/crystal/ice,
 /turf/simulated/floor/outdoors/dirt{
@@ -4839,15 +4383,13 @@
 	req_access = list(5)
 	},
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "kk" = (
 /obj/structure/table/wooden_reinforced,
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kl" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -4857,8 +4399,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "km" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -4868,15 +4409,13 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "kn" = (
 /obj/structure/closet/crate/bin,
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ko" = (
 /obj/machinery/light{
 	dir = 1
@@ -4884,14 +4423,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kp" = (
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kq" = (
 /obj/machinery/crystal/ice,
 /turf/simulated/floor/outdoors/dirt{
@@ -4906,14 +4443,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ks" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "kt" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -4941,8 +4476,7 @@
 	layer = 3.1;
 	name = "Casino bar shutter"
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "kw" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
@@ -4952,8 +4486,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kx" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -4966,14 +4499,12 @@
 /obj/structure/sign/christmas/lights{
 	dir = 4
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ky" = (
 /obj/machinery/atm{
 	pixel_x = -32
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "kz" = (
 /obj/machinery/vending/coffee,
 /obj/structure/sign/christmas/wreath{
@@ -4982,14 +4513,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kA" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kB" = (
 /obj/machinery/light,
 /obj/structure/flora/pottedplant/xmas{
@@ -4998,14 +4527,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kC" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "kD" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -5013,20 +4540,17 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "kE" = (
 /obj/structure/curtain/open/bed{
 	name = "casino curtain"
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "kF" = (
 /obj/structure/casino_table/blackjack_l{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "kG" = (
 /obj/structure/casino_table/blackjack_m{
 	dir = 1
@@ -5035,8 +4559,7 @@
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "kH" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 4
@@ -5044,8 +4567,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -5064,8 +4586,7 @@
 "kJ" = (
 /obj/structure/table/wooden_reinforced,
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kK" = (
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 8
@@ -5073,8 +4594,7 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kL" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -5086,14 +4606,12 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "kM" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/reagent_containers/food/snacks/tamales,
 /obj/structure/sign/christmas/lights,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kN" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -5113,18 +4631,15 @@
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "kP" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "kQ" = (
 /obj/structure/event/santa_sack,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "kR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/disposal/deliveryChute{
@@ -5151,13 +4666,11 @@
 	dir = 1
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "kT" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper/card/heart,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "kU" = (
 /obj/item/weapon/pickaxe/drill,
 /turf/simulated/floor/outdoors/dirt{
@@ -5178,12 +4691,10 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "kW" = (
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kX" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy{
@@ -5193,8 +4704,7 @@
 	dir = 1
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "kY" = (
 /obj/machinery/computer/card{
 	dir = 4
@@ -5202,8 +4712,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "kZ" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -5211,20 +4720,17 @@
 /obj/structure/sign/christmas/lights,
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "la" = (
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "lb" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/event/present,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "lc" = (
 /obj/machinery/light{
 	dir = 8
@@ -5236,15 +4742,13 @@
 	dir = 8
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ld" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "le" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -5258,8 +4762,7 @@
 	dir = 4
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "lf" = (
 /obj/structure/bed/chair/wood{
 	dir = 4
@@ -5273,14 +4776,12 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "lh" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/purcarpet)
 "li" = (
 /obj/machinery/light{
 	dir = 8
@@ -5294,15 +4795,13 @@
 	dir = 8
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "lj" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "lk" = (
 /obj/random/junk,
 /turf/simulated/floor/wood/sif,
@@ -5316,8 +4815,7 @@
 	dir = 8
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "lm" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
@@ -5326,8 +4824,7 @@
 	dir = 4
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ln" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -5336,8 +4833,7 @@
 	dir = 8;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "lo" = (
 /obj/machinery/light,
 /obj/structure/window/reinforced{
@@ -5345,24 +4841,21 @@
 	},
 /obj/structure/sign/christmas/lights,
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "lp" = (
 /obj/structure/table/glass,
 /obj/structure/sign/christmas/lights{
 	dir = 8
 	},
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "lq" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/sign/christmas/lights{
 	dir = 1
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "lr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -5371,28 +4864,24 @@
 	health = 1e+006
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "ls" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/structure/event/present,
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "lt" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
 /obj/structure/event/present,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "lu" = (
 /obj/structure/sign/christmas/wreath{
 	dir = 1
 	},
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/snow/snow2,
-/area/casino/casino_ship)
+/turf/simulated/floor/snow/snow2)
 "lv" = (
 /obj/machinery/light{
 	dir = 1
@@ -5401,16 +4890,14 @@
 /obj/structure/sign/christmas/wreath,
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "lw" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/dice,
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "lx" = (
 /obj/structure/flora/tree/winter1,
 /obj/structure/flora/grass/green,
@@ -5425,13 +4912,11 @@
 	},
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "lz" = (
 /obj/structure/event/present,
 /obj/item/weapon/a_gift,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "lA" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/wallet/casino,
@@ -5446,13 +4931,11 @@
 /obj/item/weapon/storage/wallet/casino,
 /obj/item/weapon/storage/wallet/casino,
 /obj/item/weapon/storage/wallet/casino,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "lB" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/reagent_containers/food/snacks/tamales,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "lF" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -5463,60 +4946,47 @@
 /obj/structure/casino_table/blackjack_r{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "lM" = (
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "lN" = (
 /obj/structure/closet,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "lO" = (
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
-"lP" = (
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "lR" = (
 /obj/machinery/door/window/westleft{
 	req_access = list(160)
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "lS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor/grid)
 "lT" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "lU" = (
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "lW" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
 	frequency = 1380;
 	id_tag = "casino1_pump"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor/grid)
 "lX" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/purcarpet)
 "mc" = (
 /turf/simulated/mineral/ignore_mapgen/cave,
 /area/surface/outside/plains/mountains)
@@ -5526,8 +4996,7 @@
 	req_access = list(201,160);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/steel_grid)
 "mh" = (
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/outdoors/dirt{
@@ -5541,8 +5010,7 @@
 /obj/structure/bed/chair/oldsofa{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "mp" = (
 /obj/random/maintenance/clean,
 /turf/simulated/floor/outdoors/dirt{
@@ -5555,13 +5023,11 @@
 "ms" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/toy/eight_ball,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "mv" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/book/codex/casino,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "mw" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/gun/launcher/confetti_cannon,
@@ -5570,27 +5036,23 @@
 /obj/item/weapon/grenade/confetti/party_ball,
 /obj/item/weapon/grenade/confetti/party_ball,
 /obj/item/weapon/grenade/confetti/party_ball,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "my" = (
 /obj/structure/table/gamblingtable,
 /obj/item/device/communicator,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "mB" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/outdoors/grass/sif/planetuse,
 /area/surface/outside/plains/mountains)
 "mC" = (
-/turf/simulated/floor/water/deep/pool,
-/area/casino/casino_ship)
+/turf/simulated/floor/water/deep/pool)
 "mF" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8;
 	icon_state = "spline_fancy_cee"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "mG" = (
 /obj/random/trash,
 /turf/simulated/floor/wood/sif,
@@ -5616,8 +5078,7 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "mL" = (
 /obj/random/material/precious,
 /turf/simulated/floor/outdoors/dirt{
@@ -5638,40 +5099,34 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "mP" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
 /obj/effect/mist,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "mQ" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/device/communicator,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "mR" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4;
 	icon_state = "spline_fancy_cee"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "mU" = (
 /obj/structure/table/glass,
 /obj/item/weapon/soap,
 /obj/item/weapon/soap,
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "mW" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "na" = (
 /obj/structure/ledge/ledge_stairs{
 	dir = 1;
@@ -5723,8 +5178,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "nj" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/drinks/shaker{
@@ -5734,14 +5188,12 @@
 	pixel_x = -6
 	},
 /obj/item/weapon/reagent_containers/glass/rag,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "nn" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "np" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -5775,15 +5227,13 @@
 	pixel_x = -28
 	},
 /obj/structure/stripper_pole,
-/turf/simulated/floor/carpet/purcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/purcarpet)
 "nB" = (
 /obj/machinery/door/airlock/silver{
 	name = "Casino crew bathrooms";
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "nC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5802,8 +5252,7 @@
 	name = "Landing South External"
 	},
 /obj/structure/fans/hardlight,
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/steel_grid)
 "nM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/crystal/ice,
@@ -5841,8 +5290,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "nW" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood/sif,
@@ -5872,8 +5320,7 @@
 	dir = 1;
 	layer = 3
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "nZ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -5885,12 +5332,10 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "ob" = (
 /obj/machinery/media/jukebox/casinojukebox,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "od" = (
 /turf/simulated/floor/water,
 /area/surface/outside/plains/mountains)
@@ -5909,8 +5354,7 @@
 "og" = (
 /obj/structure/table/glass,
 /obj/machinery/recharger,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "oh" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -5932,8 +5376,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/carpet/bcarpet)
 "ol" = (
 /obj/structure/closet/grave/dirthole{
 	opened = 0
@@ -5954,8 +5397,7 @@
 /obj/structure/bed/chair/comfy/purp{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "op" = (
 /obj/structure/grille/rustic,
 /obj/structure/window/phoronreinforced/full,
@@ -5963,8 +5405,7 @@
 /area/submap/lonehome)
 "os" = (
 /obj/structure/bed/chair/sofa/yellow,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "ot" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4;
@@ -5973,31 +5414,26 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ou" = (
 /obj/machinery/door/airlock/silver{
 	name = "Lap dance room 1-2"
 	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/purcarpet)
 "oB" = (
 /obj/structure/table/glass,
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "oC" = (
 /obj/structure/casino_table/roulette_table,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "oD" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "oG" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/material/precious,
@@ -6010,8 +5446,7 @@
 /area/surface/outside/plains/mountains)
 "oJ" = (
 /obj/machinery/door/window/southright,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "oK" = (
 /turf/simulated/floor/water{
 	outdoors = 0
@@ -6042,16 +5477,14 @@
 	layer = 3.2;
 	name = "Front Desk Shutters"
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "oY" = (
 /obj/structure/table/marble,
 /obj/item/weapon/flame/candle/candelabra/everburn,
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
 "oZ" = (
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "pc" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/material/knife/machete/hatchet{
@@ -6069,16 +5502,14 @@
 "pd" = (
 /turf/simulated/floor/outdoors/grass/heavy{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "pe" = (
 /obj/machinery/door/window/southright{
 	dir = 4;
 	name = "Bar";
 	req_access = list(160)
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "ph" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/glass_external{
@@ -6096,13 +5527,11 @@
 	name = "Internal Access Button";
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/steel_grid)
 "pk" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/deluxe/full,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "pm" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced{
@@ -6132,16 +5561,14 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "pp" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation room";
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/steel_grid)
 "ps" = (
 /obj/structure/boulder,
 /turf/simulated/floor/outdoors/dirt{
@@ -6160,8 +5587,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "pu" = (
 /obj/structure/table/sifwoodentable,
 /turf/simulated/floor/outdoors/dirt{
@@ -6181,8 +5607,7 @@
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor/plating,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/plating)
 "px" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Casinodormshutters5";
@@ -6192,14 +5617,12 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "py" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "pz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -6211,8 +5634,7 @@
 	layer = 3.3;
 	name = "Prize shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "pB" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -6228,12 +5650,10 @@
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "pH" = (
 /obj/structure/table/bench/marble,
-/turf/simulated/floor/grass2,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass2)
 "pJ" = (
 /obj/structure/closet/secure_closet/engineering_welding{
 	req_access = list(203)
@@ -6241,12 +5661,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "pM" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "pO" = (
 /obj/structure/flora/tree/dead,
 /obj/effect/zone_divider,
@@ -6258,15 +5676,13 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "pT" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/item/weapon/melee/chainofcommand,
 /obj/item/weapon/scepter,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "pW" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -6288,8 +5704,7 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "qc" = (
 /turf/simulated/floor/water/deep,
 /area/surface/outside/plains/mountains)
@@ -6321,8 +5736,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "qf" = (
 /obj/machinery/suit_cycler/security{
 	req_access = list(201)
@@ -6336,8 +5750,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "qh" = (
 /obj/machinery/door/airlock/glass_external{
 	autoclose = 0;
@@ -6347,14 +5760,12 @@
 	locked = 1;
 	name = "Landing North Internal"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/steel_grid)
 "qi" = (
 /obj/structure/bed/chair/comfy/purp{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "qj" = (
 /obj/random/maintenance/medical,
 /turf/simulated/floor/outdoors/dirt{
@@ -6385,8 +5796,7 @@
 /area/surface/outside/plains/outpost)
 "qp" = (
 /obj/structure/table/gamblingtable,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "qq" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = -27;
@@ -6398,19 +5808,16 @@
 /obj/structure/bed/chair/sofa/corner/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "qs" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/brown/bordercorner,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "qv" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "qw" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -6430,8 +5837,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "qB" = (
 /obj/structure/railing{
 	dir = 4
@@ -6444,8 +5850,7 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "qE" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/outdoors/dirt{
@@ -6458,8 +5863,7 @@
 "qF" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/dice,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "qH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/door/airlock/glass_external{
@@ -6477,15 +5881,13 @@
 	name = "Internal Access Button";
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/steel_grid)
 "qK" = (
 /obj/machinery/door/airlock/silver{
 	name = "Casino manager sleeping quarters";
 	req_one_access = list(300)
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "qM" = (
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
 	temperature = 293.15
@@ -6523,8 +5925,7 @@
 /area/surface/outside/plains/outpost)
 "qW" = (
 /obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "qX" = (
 /obj/structure/table/bench/sifwooden,
 /obj/effect/mist,
@@ -6532,14 +5933,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "qY" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "rc" = (
 /obj/effect/blocker,
 /obj/structure/flora/grass/brown,
@@ -6551,8 +5950,7 @@
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "re" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -6581,15 +5979,13 @@
 	dir = 1
 	},
 /obj/structure/curtain/open/shower/engineering,
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/tiled/freezer)
 "rj" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "rk" = (
 /turf/simulated/floor/plating,
 /area/surface/outside/plains/outpost)
@@ -6616,12 +6012,10 @@
 "rK" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/deck/cah,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "rL" = (
 /obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "rM" = (
 /obj/effect/floor_decal/stairs,
 /turf/simulated/floor/outdoors/dirt,
@@ -6630,8 +6024,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "rQ" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_3"
@@ -6647,8 +6040,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor/grid)
 "rV" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/rddouble,
@@ -6669,8 +6061,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "sl" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet,
@@ -6711,8 +6102,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "sw" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -6743,8 +6133,7 @@
 /area/surface/outside/plains/mountains)
 "sI" = (
 /obj/machinery/clonepod/transhuman/full,
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "sJ" = (
 /obj/structure/table/glass,
 /obj/item/clothing/accessory/holster/armpit,
@@ -6754,8 +6143,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "sK" = (
 /obj/structure/flora/bboulder1,
 /obj/effect/zone_divider,
@@ -6787,17 +6175,10 @@
 /obj/machinery/door/window/brigdoor/northleft{
 	req_access = list(201)
 	},
-/obj/item/weapon/storage/box/empshells,
 /obj/item/ammo_magazine/ammo_box/b12g/pellet,
 /obj/item/ammo_magazine/ammo_box/b12g/pellet,
 /obj/item/ammo_magazine/ammo_box/b12g,
 /obj/item/ammo_magazine/ammo_box/b12g,
-/obj/item/ammo_magazine/m762garand,
-/obj/item/ammo_magazine/m762garand,
-/obj/item/ammo_magazine/m762garand,
-/obj/item/ammo_magazine/m762garand,
-/obj/item/ammo_magazine/m762garand,
-/obj/item/ammo_magazine/m762garand,
 /obj/item/ammo_magazine/m9mmt,
 /obj/item/ammo_magazine/m9mmt,
 /obj/item/ammo_magazine/m9mmt,
@@ -6808,8 +6189,7 @@
 /obj/item/ammo_magazine/m9mmt,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "sX" = (
 /obj/structure/barricade,
 /turf/simulated/floor/outdoors/dirt{
@@ -6824,8 +6204,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "tb" = (
 /turf/simulated/wall/log_sif,
 /area/surface/outside/plains/outpost)
@@ -6861,8 +6240,7 @@
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "to" = (
 /obj/structure/sink{
 	dir = 4;
@@ -6873,8 +6251,7 @@
 	pixel_x = 28;
 	pixel_y = 9
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "ts" = (
 /obj/effect/blocker,
 /turf/simulated/wall/solidrock{
@@ -6885,14 +6262,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "ty" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "tB" = (
 /obj/structure/window/phoronreinforced,
 /obj/structure/table/bench/wooden,
@@ -6913,8 +6288,7 @@
 /area/surface/outside/plains/outpost)
 "tF" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "tH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6956,20 +6330,17 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "tR" = (
 /obj/machinery/door/airlock/silver{
 	name = "Lap dance room 3-4"
 	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/purcarpet)
 "tU" = (
 /obj/machinery/door/airlock/silver{
 	name = "Garden"
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "tZ" = (
 /turf/simulated/floor/wood/sif/broken,
 /area/submap/lonehome)
@@ -6979,16 +6350,7 @@
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
-"uf" = (
-/mob/living/simple_mob/animal/wolf/direwolf,
-/turf/simulated/floor/outdoors/dirt{
-	can_atmos_pass = 0;
-	outdoors = 0;
-	temperature = 300
-	},
-/area/surface/outside/plains/mountains)
+/turf/simulated/floor/tiled)
 "ui" = (
 /obj/machinery/vending/coffee,
 /obj/effect/floor_decal/borderfloor{
@@ -7000,8 +6362,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "uj" = (
 /obj/machinery/vending/engivend{
 	req_access = list(203);
@@ -7010,8 +6371,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "ul" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/drinks/cup{
@@ -7044,19 +6404,16 @@
 	pixel_x = -4;
 	pixel_y = 12
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "un" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "uo" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/item/toy/bosunwhistle,
-/obj/item/toy/crossbow,
 /obj/item/toy/cultsword,
 /obj/item/toy/eight_ball,
 /obj/item/toy/eight_ball/conch,
@@ -7067,8 +6424,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "ur" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -7079,8 +6435,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "uy" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -7088,12 +6443,10 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "uB" = (
 /obj/structure/table/wooden_reinforced,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "uC" = (
 /obj/structure/simple_door/iron,
 /turf/simulated/floor/wood/sif,
@@ -7112,8 +6465,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "uQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7129,8 +6481,7 @@
 /area/surface/outside/plains/mountains)
 "uU" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "uX" = (
 /obj/item/clothing/under/gentlesuit,
 /obj/item/clothing/under/gentlesuit,
@@ -7161,8 +6512,7 @@
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/glasses/sunglasses,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "vb" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -7191,8 +6541,7 @@
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "vk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -7237,8 +6586,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "vw" = (
 /obj/item/weapon/bone/skull{
 	anchored = 1;
@@ -7258,8 +6606,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "vA" = (
 /obj/effect/decal/remains/deer,
 /turf/simulated/floor/outdoors/dirt{
@@ -7302,14 +6649,12 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "vK" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "vL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -7326,16 +6671,14 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "vQ" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/effect/landmark/costume/cutewitch,
 /obj/effect/landmark/costume/imperium_monk,
 /obj/effect/landmark/costume/plaguedoctor,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "vS" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/water{
@@ -7346,8 +6689,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "vW" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/maintenance/medical,
@@ -7383,8 +6725,7 @@
 /obj/machinery/door/airlock/silver{
 	name = "Casino crew showers"
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "wf" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
@@ -7394,19 +6735,16 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "wh" = (
 /mob/living/simple_mob/animal/passive/fish/koi,
-/turf/simulated/floor/water/indoors,
-/area/casino/casino_ship)
+/turf/simulated/floor/water/indoors)
 "wi" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "wk" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Casinodormshutters1";
@@ -7416,8 +6754,7 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "wo" = (
 /obj/effect/map_helper/no_tele,
 /turf/simulated/wall/solidrock{
@@ -7453,22 +6790,19 @@
 	name = "Casino crew breakroom";
 	req_one_access = null
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "wy" = (
 /obj/structure/table/glass,
 /obj/machinery/recharger,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "wB" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "wD" = (
 /obj/structure/table/marble,
 /obj/item/weapon/card/id/casino,
@@ -7481,14 +6815,12 @@
 /obj/item/weapon/card/id/casino/medical,
 /obj/item/weapon/card/id/casino/security,
 /obj/item/weapon/card/id/casino/security,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "wH" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "wI" = (
 /obj/random/outcrop,
 /turf/simulated/floor/outdoors/dirt{
@@ -7505,12 +6837,10 @@
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "xe" = (
 /obj/structure/table/bench/marble,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "xf" = (
 /obj/machinery/appliance/cooker/oven,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -7527,8 +6857,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "xi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7557,8 +6886,7 @@
 	id_tag = "casinodorm1";
 	name = "Dorm room 1"
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "xp" = (
 /obj/structure/flora/tree/winter1,
 /obj/effect/zone_divider,
@@ -7577,13 +6905,11 @@
 /area/surface/outside/plains/outpost)
 "xz" = (
 /obj/structure/flora/tree/jungle_small,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "xH" = (
 /obj/structure/table/wooden_reinforced,
 /obj/random/plushie,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "xI" = (
 /obj/machinery/vending/boozeomat,
 /turf/simulated/wall/log_sif,
@@ -7601,8 +6927,7 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "xL" = (
 /obj/structure/railing{
 	dir = 4
@@ -7614,17 +6939,11 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/item/toy/ammo/crossbow,
-/obj/item/toy/ammo/crossbow,
-/obj/item/toy/ammo/crossbow,
-/obj/item/toy/ammo/crossbow,
-/obj/item/toy/ammo/crossbow,
 /obj/item/clothing/under/sexybunny_white/sexybunny_black,
 /obj/item/clothing/under/sexybunny_white,
 /obj/item/clothing/head/collectable/rabbitears,
 /obj/item/clothing/head/collectable/rabbitears,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "xR" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/o2{
@@ -7640,8 +6959,7 @@
 	pixel_x = -4;
 	pixel_y = -4
 	},
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "xV" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -7657,8 +6975,7 @@
 	},
 /area/surface/outside/plains/mountains)
 "xX" = (
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "ya" = (
 /obj/structure/flora/log1,
 /turf/simulated/floor/water,
@@ -7677,8 +6994,7 @@
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor)
 "yc" = (
 /obj/structure/barricade,
 /turf/simulated/floor/outdoors/dirt{
@@ -7709,15 +7025,13 @@
 /obj/item/weapon/deck/cah/black,
 /obj/item/weapon/deck/cah/black,
 /obj/item/weapon/deck/cah/black,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "ye" = (
 /obj/structure/table/fancyblack,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "yf" = (
 /obj/structure/flora/grass/both,
 /obj/structure/flora/grass/green,
@@ -7737,8 +7051,7 @@
 /obj/item/weapon/deck/cards/casino,
 /obj/item/weapon/deck/cards/casino,
 /obj/item/weapon/deck/cards/casino,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "yn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet/turcarpet,
@@ -7756,8 +7069,7 @@
 /obj/item/weapon/storage/box/donut{
 	pixel_y = 11
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "yp" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk,
@@ -7775,8 +7087,7 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "yu" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -7810,15 +7121,13 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "yD" = (
 /obj/machinery/door/airlock/silver{
 	id_tag = "casinodorm4";
 	name = "Dorm room 4"
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "yF" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -7826,8 +7135,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "yG" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -7885,18 +7193,15 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "yS" = (
 /obj/machinery/door/airlock/silver{
 	name = "Pool and Sauna"
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "yZ" = (
 /obj/machinery/slot_machine,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "za" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/outdoors/dirt{
@@ -7920,8 +7225,7 @@
 	pixel_y = -6;
 	req_access = list(160)
 	},
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship)
+/turf/simulated/wall/golddiamond)
 "zg" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -7963,8 +7267,7 @@
 /obj/item/clothing/head/santa/green,
 /obj/item/clothing/head/santa/green,
 /obj/item/clothing/head/santa/green,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "zu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
@@ -7975,15 +7278,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "zx" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "zy" = (
 /obj/structure/barricade,
 /obj/structure/disposalpipe/segment,
@@ -8000,12 +7301,10 @@
 	dir = 4;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "zC" = (
 /obj/effect/floor_decal/techfloor/orange,
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "zE" = (
 /obj/structure/grille/broken/rustic,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -8040,20 +7339,17 @@
 	layer = 3.3;
 	name = "Prize shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "zP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "zQ" = (
 /obj/structure/casino_table/blackjack_r{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "zR" = (
 /obj/structure/flora/grass/green,
 /obj/structure/flora/grass/green,
@@ -8065,8 +7361,7 @@
 /obj/structure/bed/chair/sofa/corner/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "zW" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -8083,8 +7378,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "zY" = (
 /obj/structure/flora/bboulder1,
 /turf/simulated/floor/outdoors/dirt{
@@ -8097,17 +7391,14 @@
 /obj/structure/closet/secure_closet/medical3{
 	req_access = list(202)
 	},
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "Ad" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Af" = (
-/turf/simulated/floor/grass2,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass2)
 "AA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8128,8 +7419,7 @@
 	dir = 8;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "AL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/sif,
@@ -8183,8 +7473,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "AU" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloor{
@@ -8196,30 +7485,25 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "AW" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "AY" = (
 /obj/item/weapon/stool/padded,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "AZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "Bb" = (
 /obj/machinery/shower{
 	pixel_y = 8
 	},
 /obj/structure/curtain/open/shower,
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "Bg" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/disposal/deliveryChute{
@@ -8248,15 +7532,13 @@
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/steel_grid)
 "Bl" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "Bm" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -8284,8 +7566,7 @@
 	},
 /obj/item/weapon/packageWrap,
 /obj/machinery/light,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Bt" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -8296,8 +7577,7 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "Bu" = (
 /obj/random/material/refined,
 /turf/simulated/floor/outdoors/dirt{
@@ -8312,14 +7592,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "Bx" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/water/deep/pool,
-/area/casino/casino_ship)
+/turf/simulated/floor/water/deep/pool)
 "BB" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
@@ -8341,19 +7619,16 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "BF" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "BG" = (
 /obj/effect/floor_decal/spline/fancy/wood/three_quarters,
 /obj/structure/stripper_pole,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "BH" = (
 /obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
@@ -8376,8 +7651,7 @@
 	dir = 2;
 	req_access = list(203)
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_ridged)
 "BS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8387,12 +7661,10 @@
 "BT" = (
 /obj/structure/table/glass,
 /obj/item/weapon/beach_ball,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "BV" = (
 /mob/living/simple_mob/animal/space/goose/domesticated/casino,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "BW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -8406,13 +7678,11 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "BX" = (
 /obj/structure/table/reinforced,
 /obj/item/device/taperecorder,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "BZ" = (
 /obj/structure/flora/grass/brown,
 /mob/living/simple_mob/vore/rabbit/white,
@@ -8423,8 +7693,7 @@
 "Cb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/book/codex/casino,
-/turf/simulated/floor/grass2,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass2)
 "Cg" = (
 /obj/structure/flora/grass/green,
 /obj/structure/flora/tree/dead,
@@ -8448,8 +7717,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Cm" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	locked = 0
@@ -8461,8 +7729,7 @@
 	dir = 1;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Ct" = (
 /obj/structure/flora/log1,
 /turf/simulated/floor/water/hotspring{
@@ -8473,8 +7740,7 @@
 /area/surface/outside/plains/mountains)
 "Cv" = (
 /obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "Cz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/disposal/deliveryChute{
@@ -8492,12 +7758,10 @@
 /area/surface/outside/plains/mountains)
 "CC" = (
 /obj/machinery/telecomms/relay/preset/casino,
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/techfloor)
 "CD" = (
 /obj/structure/window/reinforced,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "CM" = (
 /mob/living/simple_mob/vore/rabbit/black,
 /turf/simulated/floor/outdoors/snow/sif/planetuse{
@@ -8506,25 +7770,21 @@
 /area/surface/outside/plains/outpost)
 "CN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "CS" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/book/codex/casino,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "CT" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "CX" = (
 /obj/structure/bed/chair/sofa/left/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "CY" = (
 /obj/structure/flora/rocks2,
 /mob/living/simple_mob/animal/sif/diyaab{
@@ -8551,8 +7811,7 @@
 	layer = 3.3;
 	name = "Prize shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship)
+/turf/simulated/floor)
 "Db" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -8597,8 +7856,7 @@
 	name = "Casino manager bathroom";
 	req_one_access = newlist(/obj/machinery/power/debug_items/infinite_cable_powersink)
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled)
 "Do" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -8631,8 +7889,7 @@
 /obj/structure/window/reinforced{
 	health = 1e+006
 	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_ridged)
 "Dw" = (
 /obj/effect/blocker,
 /obj/effect/zone_divider,
@@ -8648,10 +7905,6 @@
 	temperature = 293.15
 	},
 /area/surface/outside/plains/outpost)
-"Dy" = (
-/obj/structure/closet,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
 "DB" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -8671,17 +7924,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "DF" = (
 /obj/structure/table/glass,
 /obj/item/device/starcaster_news,
-/turf/simulated/floor/grass2,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass2)
 "DH" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "DL" = (
 /turf/simulated/floor/bronze,
 /area/surface/outside/plains/outpost)
@@ -8755,16 +8005,14 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "Ec" = (
 /obj/machinery/slot_machine,
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Ed" = (
 /obj/machinery/vending/tool{
 	req_log_access = 203
@@ -8775,8 +8023,7 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "Eg" = (
 /obj/structure/simple_door/flock,
 /obj/structure/cult/pylon/swarm/defender,
@@ -8798,8 +8045,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "En" = (
 /obj/structure/window/phoronreinforced,
 /obj/structure/table/bench/marble,
@@ -8810,8 +8056,7 @@
 /area/submap/lonehome)
 "Eo" = (
 /obj/structure/undies_wardrobe,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "Er" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen";
@@ -8820,8 +8065,7 @@
 /obj/structure/bed/chair/comfy/purp{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "Es" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -8857,14 +8101,12 @@
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "Ey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "EF" = (
 /obj/structure/window/reinforced,
 /obj/item/clothing/head/helmet/space/emergency,
@@ -8880,15 +8122,13 @@
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
 /obj/item/clothing/head/helmet/space/emergency,
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "EJ" = (
 /obj/structure/table/bench/marble,
 /obj/machinery/light{
 	layer = 3
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "EK" = (
 /obj/item/weapon/aliencoin/phoron,
 /turf/simulated/floor/flock,
@@ -8910,8 +8150,7 @@
 	req_access = list(160);
 	req_log_access = 160
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "EW" = (
 /obj/structure/simple_door/sifwood,
 /turf/simulated/floor/wood/sif,
@@ -8919,16 +8158,14 @@
 "Fa" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/dice,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Fe" = (
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
 "Fk" = (
 /obj/structure/bed/chair/comfy/purp,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Fm" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/clothing/head/santa,
@@ -8941,8 +8178,7 @@
 /obj/item/clothing/head/santa,
 /obj/item/clothing/head/santa,
 /obj/item/clothing/head/santa,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Fo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -8951,8 +8187,7 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "Fq" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -8993,8 +8228,7 @@
 	pixel_y = -4;
 	req_access = list(160)
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "FC" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/rddouble,
@@ -9004,16 +8238,14 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "FF" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1;
 	icon_state = "spline_fancy_corner"
 	},
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "FH" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -9025,8 +8257,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/dirt,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/outdoors/dirt)
 "FL" = (
 /obj/item/weapon/reagent_containers/food/snacks/snackplanet/phoron{
 	name = "Stabalized Phoron Singularity"
@@ -9037,8 +8268,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "FZ" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -9049,8 +8279,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "Ga" = (
 /obj/fiftyspawner/diamond,
 /turf/simulated/floor/flock,
@@ -9058,8 +8287,7 @@
 "Gb" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "Gc" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -9070,16 +8298,14 @@
 	dir = 4;
 	health = 1e+006
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor)
 "Gh" = (
 /obj/structure/table/marble,
 /obj/item/glass_jar,
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
 "Gm" = (
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/steel_grid)
 "Gn" = (
 /obj/structure/boulder,
 /obj/structure/disposalpipe/segment,
@@ -9120,8 +8346,7 @@
 	layer = 3.1;
 	name = "Casino bar shutter"
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Gv" = (
 /turf/simulated/floor/outdoors/dirt,
 /area/surface/outside/plains/mountains)
@@ -9130,8 +8355,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "GF" = (
 /obj/structure/simple_door/flock{
 	dir = 4
@@ -9160,8 +8384,7 @@
 /area/submap/lonehome)
 "GS" = (
 /obj/machinery/light,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "GU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9199,8 +8422,7 @@
 /area/submap/lonehome)
 "Hi" = (
 /obj/structure/table/bench/marble,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "Ho" = (
 /obj/structure/window/phoronreinforced{
 	dir = 1
@@ -9223,8 +8445,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "Hq" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -9235,8 +8456,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "Hr" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -9256,8 +8476,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "Hw" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -9294,29 +8513,25 @@
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/suit/space/emergency,
 /obj/item/clothing/suit/space/emergency,
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "HQ" = (
 /obj/machinery/door/airlock/silver{
 	name = "Prize storage";
 	req_one_access = list(200)
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "HS" = (
 /obj/machinery/door/airlock/multi_tile/metal{
 	name = "Medical, Engineering, Janitor and EVA";
 	req_one_access = list(160)
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "HW" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "HX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -9347,8 +8562,7 @@
 	pixel_x = -24
 	},
 /obj/structure/fans/hardlight,
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/steel_grid)
 "Ib" = (
 /obj/machinery/slot_machine,
 /obj/machinery/light{
@@ -9357,8 +8571,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Ic" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -9380,8 +8593,7 @@
 	dir = 8;
 	icon_state = "spline_fancy_cee"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Il" = (
 /obj/structure/flora/rocks1,
 /obj/structure/barricade,
@@ -9396,26 +8608,22 @@
 	dir = 4;
 	pixel_x = -13
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "Iq" = (
 /obj/item/weapon/stool/padded,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "It" = (
 /obj/machinery/door/airlock/silver{
 	id_tag = "managerdoor";
 	name = "Casino manager office";
 	req_one_access = list(300)
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "Iz" = (
 /obj/structure/closet/secure_closet{
 	req_one_access = list(300)
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "ID" = (
 /obj/structure/railing{
 	dir = 8
@@ -9435,20 +8643,17 @@
 	dir = 8;
 	health = 1e+006
 	},
-/turf/simulated/floor/plating,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/plating)
 "IJ" = (
 /obj/machinery/door/airlock/security{
 	name = "Evidence room";
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/steel_grid)
 "IK" = (
 /obj/structure/table/reinforced,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "IL" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/orangedouble,
@@ -9465,8 +8670,7 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "IT" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/maintenance/clean,
@@ -9493,8 +8697,7 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "Ja" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9511,12 +8714,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "Jf" = (
 /obj/machinery/casinoslave_handler,
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship)
+/turf/simulated/wall/golddiamond)
 "Ji" = (
 /obj/structure/bonfire/permanent/sifwood,
 /turf/simulated/floor/outdoors/dirt{
@@ -9564,12 +8765,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "JD" = (
 /obj/machinery/light,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "JF" = (
 /obj/structure/table/standard,
 /obj/item/weapon/book/codex/casino,
@@ -9582,8 +8781,7 @@
 /obj/item/weapon/book/codex/casino,
 /obj/item/weapon/book/codex/casino,
 /obj/item/weapon/book/codex/casino,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "JG" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/material/refined,
@@ -9601,8 +8799,7 @@
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "JI" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -9638,8 +8835,7 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "Kc" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -9665,8 +8861,7 @@
 	dir = 1
 	},
 /obj/effect/mist,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "Kf" = (
 /obj/structure/disposalpipe/segment,
 /turf/unsimulated/mineral,
@@ -9680,26 +8875,22 @@
 /obj/effect/landmark/costume/sexyclown,
 /obj/item/clothing/head/hood/ian_hood,
 /obj/item/clothing/suit/storage/hooded/costume/ian,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Ki" = (
 /obj/machinery/vending/deluxe_boozeomat{
 	req_access = list(160);
 	req_log_access = 160
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "Kl" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Kr" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/book/codex/casino,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Kt" = (
 /obj/structure/kitchenspike,
 /turf/simulated/floor/tiled/freezer,
@@ -9727,12 +8918,10 @@
 	pixel_x = -6;
 	pixel_y = -1
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "Kz" = (
 /obj/structure/bed/chair/sofa/left/yellow,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "KG" = (
 /mob/living/simple_mob/animal/sif/glitterfly/rare{
 	canmove = 0;
@@ -9764,8 +8953,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "KN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9792,12 +8980,10 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "KU" = (
 /obj/structure/prop/dominator/orange,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "KV" = (
 /obj/structure/table/glass,
 /obj/machinery/button/remote/airlock{
@@ -9807,11 +8993,9 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "KW" = (
-/turf/simulated/floor/water/indoors,
-/area/casino/casino_ship)
+/turf/simulated/floor/water/indoors)
 "Lc" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -9864,8 +9048,7 @@
 /obj/effect/floor_decal/corner/yellow/border,
 /obj/fiftyspawner/steel,
 /obj/fiftyspawner/steel,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "Lm" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -9894,8 +9077,7 @@
 /obj/item/clothing/mask/breath/emergency,
 /obj/item/clothing/mask/breath/emergency,
 /obj/item/clothing/mask/breath/emergency,
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "Lw" = (
 /obj/item/weapon/storage/backpack/holding/duffle,
 /turf/simulated/floor/flock,
@@ -9926,8 +9108,7 @@
 	pixel_x = -28;
 	pixel_y = 8
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "LM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/borderfloor{
@@ -9936,26 +9117,22 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "LQ" = (
 /obj/machinery/door/airlock/silver{
 	name = "Casino crew toilet";
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "LS" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/toy/eight_ball/conch,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "LX" = (
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Mb" = (
 /mob/living/simple_mob/animal/sif/kururak/hibernate,
 /turf/simulated/floor/outdoors/dirt{
@@ -9973,15 +9150,13 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "Me" = (
 /obj/machinery/vending/fishing,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "Mf" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -9990,8 +9165,7 @@
 	dir = 8;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Mi" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/outdoors/grass/sif/planetuse,
@@ -10016,8 +9190,7 @@
 /obj/fiftyspawner/silver,
 /obj/item/weapon/moneybag/vault,
 /obj/item/weapon/moneybag/vault,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "Mp" = (
 /obj/item/weapon/pickaxe/gold,
 /turf/simulated/floor/outdoors/dirt{
@@ -10046,8 +9219,7 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "Mv" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -10083,8 +9255,7 @@
 	layer = 3.2;
 	name = "Front Desk Shutters"
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "ME" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -10102,8 +9273,7 @@
 "MF" = (
 /obj/structure/table/bench/sifwooden,
 /obj/effect/mist,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "MG" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10122,19 +9292,16 @@
 /obj/item/weapon/tank/oxygen,
 /obj/item/weapon/tank/oxygen,
 /obj/item/weapon/tank/oxygen,
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "MI" = (
 /obj/structure/closet/crate/bin,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "MJ" = (
 /obj/machinery/door/airlock/silver{
 	id_tag = "casinodorm3";
 	name = "Dorm room 3"
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "MK" = (
 /obj/structure/table/sifwoodentable,
 /obj/machinery/light/floortube/flicker{
@@ -10185,14 +9352,12 @@
 /obj/effect/floor_decal/corner/yellow/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "MX" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "MY" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -10248,10 +9413,6 @@
 /obj/item/weapon/soap/nanotrasen,
 /turf/simulated/floor/wood/sif,
 /area/submap/lonehome)
-"Ns" = (
-/obj/structure/shuttle/engine/router,
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship/wing_left)
 "Nt" = (
 /obj/structure/flora/rocks1,
 /turf/simulated/floor/outdoors/dirt{
@@ -10282,8 +9443,7 @@
 /area/surface/outside/plains/outpost)
 "Nw" = (
 /obj/structure/table/wooden_reinforced,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Nx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10310,26 +9470,22 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "NA" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "NC" = (
 /obj/structure/bed/chair/oldsofa/corner{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "NG" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/outdoors/grass/heavy{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "NM" = (
 /obj/structure/table/glass,
 /obj/machinery/button/remote/airlock{
@@ -10339,13 +9495,11 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "NO" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/toy/eight_ball,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "NS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
@@ -10367,8 +9521,7 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "NY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/disposal/deliveryChute{
@@ -10393,8 +9546,7 @@
 	locked = 1;
 	name = "Landing South Internal"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/steel_grid)
 "Od" = (
 /turf/simulated/wall/log_sif,
 /area/submap/lonehome)
@@ -10419,8 +9571,7 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "Ok" = (
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/wood/sif/broken,
@@ -10428,8 +9579,7 @@
 "Om" = (
 /obj/structure/table/standard,
 /obj/item/weapon/material/ashtray,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "On" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -10450,12 +9600,10 @@
 	id_tag = "casinodorm6";
 	name = "Dorm room 6"
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "Ou" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/outdoors/dirt,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/outdoors/dirt)
 "Ov" = (
 /obj/structure/flora/grass/brown,
 /obj/structure/flora/grass/brown,
@@ -10500,12 +9648,10 @@
 	dir = 1
 	},
 /obj/structure/curtain/open/shower,
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "OM" = (
 /obj/structure/prop/machine/conduit/starts_on,
-/turf/simulated/floor/redgrid/animated,
-/area/casino/casino_ship)
+/turf/simulated/floor/redgrid/animated)
 "ON" = (
 /obj/structure/flora/tree/winter1,
 /obj/structure/flora/grass/green,
@@ -10517,8 +9663,7 @@
 /obj/structure/bed/chair/sofa/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "OS" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -10555,8 +9700,7 @@
 	dir = 1;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Pc" = (
 /obj/structure/flora/grass/brown,
 /obj/structure/flora/grass/green,
@@ -10571,14 +9715,12 @@
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Ph" = (
 /obj/structure/casino_table/blackjack_l{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Pj" = (
 /obj/structure/closet/grave/dirthole{
 	opened = 0
@@ -10598,8 +9740,7 @@
 "Pp" = (
 /obj/structure/table/fancyblack,
 /obj/machinery/wheel_of_fortune,
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "Pq" = (
 /obj/structure/closet/cabinet,
 /turf/simulated/floor/wood/sif,
@@ -10609,14 +9750,12 @@
 	dir = 4;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Pt" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "Pu" = (
 /obj/structure/table/sifwoodentable,
 /obj/item/weapon/storage/fancy/blackcandle_box,
@@ -10625,8 +9764,7 @@
 /area/submap/lonehome)
 "Pw" = (
 /obj/machinery/door/window/northleft,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Pz" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -10650,8 +9788,7 @@
 	},
 /obj/item/clothing/suit/armor/alien,
 /obj/item/weapon/storage/belt/utility/alien,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "PH" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/pill_bottle/dice_nerd{
@@ -10663,8 +9800,7 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "PK" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -10676,26 +9812,22 @@
 	tag_exterior_door = "Casino_North_Exterior";
 	tag_interior_door = "Casino_North_Interior"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor/grid)
 "PL" = (
 /obj/structure/closet/secure_closet/paramedic{
 	req_access = list(202)
 	},
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "PM" = (
 /obj/machinery/door/airlock/silver{
 	name = "Casino cockpit";
 	req_one_access = list(300)
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "PN" = (
 /obj/structure/bed,
 /obj/item/weapon/bedsheet/orange,
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/dark)
 "PP" = (
 /turf/simulated/floor/outdoors/mud/sif/planetuse{
 	can_atmos_pass = 0;
@@ -10715,8 +9847,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/purcarpet)
 "PW" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/full,
@@ -10727,13 +9858,11 @@
 /obj/structure/stripper_pole{
 	anchored = 1
 	},
-/turf/simulated/floor/carpet/turcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/turcarpet)
 "Qe" = (
 /obj/structure/bed/chair/bar_stool,
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Qg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -10750,12 +9879,10 @@
 /obj/structure/bed/chair/sofa/left/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Qo" = (
 /obj/machinery/light,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "Qp" = (
 /obj/item/weapon/spacecasinocash/c200,
 /turf/simulated/floor/flock,
@@ -10764,8 +9891,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Qr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10797,8 +9923,7 @@
 	id_tag = "casinodorm2";
 	name = "Dorm room 2"
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "QD" = (
 /obj/structure/prop/statue/angel{
 	desc = "Further South, below once roaring thrusters, the treasure lays beyond an unsteady gaze, in front of a place of fire.";
@@ -10816,8 +9941,7 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "QH" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -10837,17 +9961,14 @@
 /obj/machinery/autolathe,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/yellow/border,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "QP" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "QS" = (
-/turf/simulated/floor/tiled/dark,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/dark)
 "Ra" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/solidrock{
@@ -10867,8 +9988,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "Rk" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -10893,8 +10013,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "Rp" = (
 /turf/simulated/floor/water/deep{
 	outdoors = 0
@@ -10918,8 +10037,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "RC" = (
 /obj/structure/flora/rocks2,
 /turf/simulated/floor/outdoors/dirt{
@@ -10935,16 +10053,14 @@
 	},
 /obj/item/clothing/accessory/chameleon,
 /obj/item/clothing/glasses/monocoole,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "RG" = (
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering center";
 	req_access = list(203);
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "RH" = (
 /obj/structure/bed/chair/oldsofa{
 	dir = 1
@@ -10955,8 +10071,7 @@
 /obj/machinery/light{
 	layer = 3
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "RL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -10973,8 +10088,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "RQ" = (
 /obj/structure/boulder,
 /turf/simulated/floor/outdoors/dirt{
@@ -10999,12 +10113,10 @@
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "RY" = (
 /obj/structure/flora/tree/jungle,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "Sb" = (
 /obj/structure/table/glass,
 /obj/machinery/button/remote/airlock{
@@ -11014,8 +10126,7 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "Se" = (
 /obj/item/clothing/ears/earring/dangle/diamond,
 /turf/simulated/floor/flock,
@@ -11024,8 +10135,7 @@
 /obj/machinery/light{
 	layer = 3
 	},
-/turf/simulated/floor/water/deep/pool,
-/area/casino/casino_ship)
+/turf/simulated/floor/water/deep/pool)
 "Sg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/trunk{
@@ -11060,8 +10170,7 @@
 	},
 /obj/structure/table/marble,
 /obj/item/modular_computer/laptop/preset/custom_loadout/hybrid,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Sq" = (
 /obj/machinery/button/remote/blast_door{
 	id = "Casinodormshutters2";
@@ -11071,8 +10180,7 @@
 	},
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "Sr" = (
 /obj/item/weapon/spacecasinocash/c100,
 /turf/simulated/floor/flock,
@@ -11106,8 +10214,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/water/deep/pool,
-/area/casino/casino_ship)
+/turf/simulated/floor/water/deep/pool)
 "SC" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -11128,8 +10235,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "SF" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -11139,17 +10245,14 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor/grid)
 "SL" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "SO" = (
 /obj/structure/closet/crate/bin,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "SQ" = (
 /obj/effect/map_effect/perma_light/gateway,
 /turf/simulated/floor/outdoors/dirt{
@@ -11165,8 +10268,7 @@
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "SZ" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -11177,14 +10279,12 @@
 "Tf" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/deck/cah/black,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Tg" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Tm" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -11207,8 +10307,7 @@
 	frequency = 1380;
 	id_tag = "casino2_pump"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor/grid)
 "Tt" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_3"
@@ -11227,12 +10326,10 @@
 /area/submap/lonehome)
 "Tw" = (
 /obj/structure/shuttle/engine/router,
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/wall/golddiamond)
 "Tx" = (
 /obj/structure/flora/ausbushes/sunnybush,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "TG" = (
 /obj/structure/flora/tree/sif,
 /turf/simulated/floor/outdoors/mud/sif/planetuse{
@@ -11254,8 +10351,7 @@
 	specialfunctions = 4
 	},
 /obj/random/plushie,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "TM" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -11264,8 +10360,7 @@
 	dir = 2;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "TP" = (
 /obj/structure/disposalpipe/segment,
 /obj/random/medical,
@@ -11282,8 +10377,7 @@
 	dir = 8;
 	icon_state = "spline_fancy_cee"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor)
 "TW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/crystal/ice,
@@ -11298,16 +10392,14 @@
 /obj/machinery/computer/transhuman/resleeving{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "TY" = (
 /obj/structure/bed/chair/comfy/purp,
 /obj/machinery/light{
 	dir = 8;
 	layer = 3
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "TZ" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -11317,13 +10409,11 @@
 /obj/item/weapon/gun/energy/temperature,
 /obj/item/weapon/gun/energy/particle/cannon,
 /obj/item/weapon/gun/energy/particle/advanced,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Ub" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "Uc" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8;
@@ -11332,8 +10422,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Ud" = (
 /mob/living/simple_mob/animal/passive/penguin{
 	hovering = 1
@@ -11342,8 +10431,7 @@
 /area/surface/outside/plains/outpost)
 "Ue" = (
 /obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "Ug" = (
 /obj/effect/floor_decal/stairs{
 	dir = 1
@@ -11368,8 +10456,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "Ul" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -11411,16 +10498,14 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 6
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Uw" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medbay";
 	req_access = list(202);
 	req_one_access = null
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/steel_grid)
 "Ux" = (
 /turf/simulated/floor/outdoors/ice/dark_smooth{
 	outdoors = 0
@@ -11458,22 +10543,19 @@
 /obj/item/clothing/under/sexybunny_white,
 /obj/item/clothing/under/sexybunny_white,
 /obj/item/clothing/under/sexybunny_white,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "UH" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/donut,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "UK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "UN" = (
 /obj/structure/flora/tree/pine{
 	icon_state = "pine_2"
@@ -11487,8 +10569,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	icon_state = "screen"
 	},
-/turf/simulated/wall/golddiamond,
-/area/casino/casino_ship)
+/turf/simulated/wall/golddiamond)
 "UU" = (
 /turf/simulated/floor/wood/sif/broken{
 	outdoors = 1
@@ -11511,22 +10592,19 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "UX" = (
 /obj/structure/table/standard,
 /obj/item/weapon/material/ashtray,
 /obj/item/weapon/material/ashtray,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "Vd" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/outdoors/grass/heavy{
 	outdoors = 0
-	},
-/area/casino/casino_ship)
+	})
 "Vg" = (
 /obj/structure/closet/secure_closet/bar{
 	locked = 0
@@ -11535,8 +10613,7 @@
 /area/submap/lonehome)
 "Vj" = (
 /obj/effect/mist,
-/turf/simulated/floor/water/pool,
-/area/casino/casino_ship)
+/turf/simulated/floor/water/pool)
 "Vm" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -11550,8 +10627,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Vo" = (
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/disposalpipe/trunk{
@@ -11576,21 +10652,18 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "VF" = (
 /obj/machinery/door/airlock/security{
 	req_access = list(201);
 	req_one_access = list()
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/steel_grid)
 "VG" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "VI" = (
 /obj/structure/flora/grass/brown,
 /obj/structure/flora/grass/green,
@@ -11602,8 +10675,7 @@
 "VK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "VL" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8;
@@ -11613,17 +10685,14 @@
 	dir = 4;
 	icon_state = "spline_fancy_corner"
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "VN" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Security wing"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled/steel_grid)
 "VR" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/techfloor)
 "VT" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
@@ -11644,15 +10713,13 @@
 /obj/machinery/door/window/westleft{
 	name = "shower door"
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "VX" = (
 /obj/structure/bed/chair/comfy/purp,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "VY" = (
 /obj/item/clothing/shoes/dress,
 /turf/simulated/floor/flock,
@@ -11689,14 +10756,12 @@
 	pixel_y = -28
 	},
 /obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "Wo" = (
 /obj/structure/bed/chair/sofa/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Ws" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/trash,
@@ -11708,26 +10773,17 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/freezer)
 "Wu" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "Ww" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
-"WJ" = (
-/obj/structure/bed/chair/comfy/purp{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "WL" = (
 /turf/simulated/floor/wood/sif/broken,
 /area/surface/outside/plains/outpost)
@@ -11736,8 +10792,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "WQ" = (
 /turf/simulated/floor/outdoors/dirt{
 	can_atmos_pass = 0;
@@ -11750,8 +10805,7 @@
 	name = "Lounge";
 	req_one_access = list(300)
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "WT" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/bar_alc/full,
@@ -11791,14 +10845,12 @@
 "Xi" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/dice,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Xv" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Xx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11834,8 +10886,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/wood)
 "XG" = (
 /obj/structure/flora/log2,
 /turf/simulated/floor/water,
@@ -11843,8 +10894,7 @@
 "XH" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "XO" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/water,
@@ -11874,16 +10924,14 @@
 /area/surface/outside/plains/outpost)
 "XW" = (
 /obj/structure/table/wooden_reinforced,
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "XX" = (
 /obj/structure/closet/secure_closet/medical_wall{
 	name = "O- Blood Locker";
 	pixel_x = -32;
 	req_access = list(202)
 	},
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "XY" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -11917,8 +10965,7 @@
 /obj/effect/floor_decal/corner/yellow/border,
 /obj/fiftyspawner/glass,
 /obj/fiftyspawner/glass,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "Ya" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -11930,8 +10977,7 @@
 	tag_exterior_door = "Casino_South_Exterior";
 	tag_interior_door = "Casino_South_Interior"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/techfloor/grid)
 "Yf" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -11942,15 +10988,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "Yg" = (
 /obj/effect/floor_decal/spline/fancy,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "Yh" = (
 /obj/structure/flora/tree/winter1,
 /obj/structure/flora/grass/both,
@@ -11960,8 +11004,7 @@
 /area/surface/outside/plains/outpost)
 "Yj" = (
 /obj/machinery/slot_machine,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Yk" = (
 /obj/structure/window/phoronreinforced{
 	dir = 8
@@ -11983,8 +11026,7 @@
 /area/surface/outside/plains/mountains)
 "Yn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/kafel_full/blue,
-/area/casino/casino_ship)
+/turf/simulated/floor/tiled/kafel_full/blue)
 "Yq" = (
 /obj/machinery/light{
 	dir = 4
@@ -11992,14 +11034,12 @@
 /obj/structure/salvageable/console_os{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "Ys" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Yz" = (
 /obj/structure/prop/statue/stump_plaque,
 /obj/item/weapon/bone/skull{
@@ -12020,13 +11060,11 @@
 /obj/item/weapon/material/ashtray/bronze,
 /obj/item/weapon/material/ashtray/bronze,
 /obj/machinery/recharger,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "YF" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/device/communicator,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "YI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12044,8 +11082,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "YM" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -12055,8 +11092,7 @@
 /obj/effect/landmark/costume/sexymime,
 /obj/item/clothing/suit/storage/hooded/costume/ian,
 /obj/item/clothing/head/hood/carp_hood,
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "YN" = (
 /obj/structure/table/bench/sifwooden,
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -12070,8 +11106,7 @@
 	use_power = 1
 	},
 /obj/effect/mist,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "YR" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/deliveryChute{
@@ -12088,8 +11123,7 @@
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "YW" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposalpipe/segment{
@@ -12107,8 +11141,7 @@
 /area/surface/outside/plains/mountains)
 "YX" = (
 /obj/structure/bed/chair/sofa/right/yellow,
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Za" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -12131,8 +11164,7 @@
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Zd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12164,8 +11196,7 @@
 	layer = 3.5;
 	name = "Casino Privacy shutters"
 	},
-/turf/simulated/floor,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor)
 "Zl" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 4
@@ -12173,8 +11204,7 @@
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Zn" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -12185,8 +11215,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled)
 "Zq" = (
 /obj/machinery/door/window/westright{
 	dir = 2;
@@ -12200,8 +11229,7 @@
 	layer = 3.2;
 	name = "Exchange booth shutters 2"
 	},
-/turf/simulated/floor/carpet/blucarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/blucarpet)
 "Zs" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters{
@@ -12210,14 +11238,12 @@
 	layer = 3.1;
 	name = "Casino bar shutter"
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "Zt" = (
 /obj/machinery/iv_drip,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/turf/simulated/floor/tiled/white,
-/area/casino/casino_ship/wing_left)
+/turf/simulated/floor/tiled/white)
 "Zu" = (
 /obj/random/medical,
 /turf/simulated/floor/outdoors/dirt{
@@ -12241,35 +11267,29 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/freezer,
-/area/casino/casino_ship/dorms)
+/turf/simulated/floor/tiled/freezer)
 "Zx" = (
 /obj/machinery/light{
 	dir = 4;
 	layer = 3
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/gaycarpet)
 "Zz" = (
 /obj/machinery/light/flamp,
-/turf/simulated/floor/grass,
-/area/casino/casino_ship)
+/turf/simulated/floor/grass)
 "ZB" = (
 /obj/structure/table/woodentable,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "ZF" = (
 /obj/structure/bed/chair/sofa/right/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/oracarpet)
 "ZG" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "ZL" = (
 /obj/effect/zone_divider,
 /turf/unsimulated/mineral,
@@ -12278,8 +11298,7 @@
 /obj/structure/table/sifwoodentable,
 /obj/item/weapon/bikehorn/rubberducky,
 /obj/effect/mist,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 "ZP" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -12290,21 +11309,18 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "ZR" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
-/turf/simulated/floor/tiled,
-/area/casino/casino_ship/wing_right)
+/turf/simulated/floor/tiled)
 "ZW" = (
 /obj/structure/table/glass,
 /obj/item/toy/eight_ball/conch,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/casino/casino_ship)
+/turf/simulated/floor/carpet/bcarpet)
 "ZZ" = (
 /obj/structure/table/bench/sifwooden,
 /obj/machinery/light,
@@ -12315,8 +11331,7 @@
 	dir = 5
 	},
 /obj/effect/mist,
-/turf/simulated/floor/wood,
-/area/casino/casino_ship)
+/turf/simulated/floor/wood)
 
 (1,1,1) = {"
 hP
@@ -16369,41 +15384,41 @@ mN
 mN
 mN
 mN
-ab
-ab
-dr
-dr
-dr
+aP
+aP
+ep
+ep
+ep
 cq
 cq
-dr
-dr
-dr
+ep
+ep
+ep
 cq
 cq
-ab
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-dr
-hk
-eS
-eS
+aP
 ep
 ep
 ep
-eS
-eS
 ep
 ep
 ep
-hk
-hk
+ep
+ep
+ep
+aP
+cq
+cq
+ep
+ep
+ep
+cq
+cq
+ep
+ep
+ep
+aP
+aP
 gN
 mN
 fB
@@ -16556,19 +15571,19 @@ mN
 mN
 cC
 mN
-ab
-ab
+aP
+aP
 cq
 cq
 cq
-Ns
-Ns
+Tw
+Tw
 cq
 cq
 cq
-Ns
-Ns
-Ns
+Tw
+Tw
+Tw
 cq
 cq
 cq
@@ -16581,16 +15596,16 @@ cq
 Tw
 Tw
 Tw
-eS
-eS
-eS
+cq
+cq
+cq
 Tw
 Tw
-eS
-eS
-eS
-hk
-hk
+cq
+cq
+cq
+aP
+aP
 mN
 mN
 mN
@@ -16743,41 +15758,41 @@ wt
 mN
 mN
 gN
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ac
-ac
-ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
 OM
-ac
+aP
 OM
-ac
-ac
-ac
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
 gN
 mN
 fB
@@ -16930,19 +15945,19 @@ mN
 mN
 mN
 gN
-ab
+aP
 bZ
 dA
 fQ
-ab
+aP
 VR
 VR
 CC
-ab
+aP
 PL
 YL
 Ub
-ab
+aP
 jj
 eN
 lc
@@ -16952,19 +15967,19 @@ eW
 li
 eN
 lm
-hk
+aP
 bX
 PN
-hk
+aP
 eH
 eH
 cP
 cP
-hk
+aP
 pm
 lU
 ic
-hk
+aP
 mN
 mN
 mN
@@ -17117,19 +16132,19 @@ mN
 mN
 mN
 gN
-ab
+aP
 cf
-dJ
+lU
 fY
-ab
-ab
-ab
-ab
-ab
+aP
+aP
+aP
+aP
+aP
 zZ
 xX
 Mu
-ab
+aP
 be
 cQ
 ld
@@ -17139,19 +16154,19 @@ zC
 aX
 cQ
 lu
-hk
-de
+aP
+QS
 jy
-hk
+aP
 eT
 lU
-il
+wH
 lU
-hk
+aP
 AS
 lU
 id
-hk
+aP
 gN
 mN
 mN
@@ -17304,11 +16319,11 @@ cC
 mN
 mN
 gN
-ab
+aP
 cg
-dJ
+lU
 gb
-ab
+aP
 Ny
 XX
 YL
@@ -17316,7 +16331,7 @@ xX
 xX
 xX
 yt
-ab
+aP
 kS
 ak
 ar
@@ -17326,19 +16341,19 @@ NX
 bf
 lj
 lo
-hk
+aP
 bA
 yb
-hk
-hk
+aP
+aP
 IJ
-hk
-hk
-hk
+aP
+aP
+aP
 qf
 lU
 mJ
-hk
+aP
 gN
 mN
 mN
@@ -17491,11 +16506,11 @@ mN
 mN
 mN
 mN
-ab
+aP
 cl
-dJ
+lU
 gc
-ab
+aP
 JC
 xX
 xX
@@ -17503,7 +16518,7 @@ xX
 xX
 xX
 Ub
-ab
+aP
 cu
 eF
 dc
@@ -17513,7 +16528,7 @@ bN
 cv
 eF
 fd
-hk
+aP
 aq
 lU
 eR
@@ -17521,11 +16536,11 @@ lU
 lU
 ur
 FZ
-hk
+aP
 ng
 lU
 if
-hk
+aP
 gN
 mN
 mN
@@ -17678,11 +16693,11 @@ mN
 mN
 mN
 gN
-ab
+aP
 cw
 dR
-dJ
-ab
+lU
+aP
 tO
 xR
 xX
@@ -17690,7 +16705,7 @@ sI
 Bv
 TX
 Zt
-ab
+aP
 eh
 eF
 jX
@@ -17700,19 +16715,19 @@ bN
 CT
 eF
 fh
-hk
+aP
 bn
 yb
-hk
+aP
 SX
 lU
 BX
 ee
-hk
+aP
 qe
 lU
 sV
-hk
+aP
 gN
 mN
 hY
@@ -17865,19 +16880,19 @@ mN
 mN
 mN
 gN
-ab
-ab
-ab
+aP
+aP
+aP
 gm
-ab
-ab
-ab
+aP
+aP
+aP
 Uw
-ab
-ab
-ab
-ab
-ab
+aP
+aP
+aP
+aP
+aP
 em
 rd
 jX
@@ -17887,19 +16902,19 @@ bN
 CT
 rd
 fj
-hk
-de
+aP
+QS
 jy
-hk
+aP
 Vv
 lU
 UW
 ew
-hk
+aP
 yR
 lU
 Gb
-hk
+aP
 gN
 mN
 mN
@@ -18052,19 +17067,19 @@ mN
 mN
 mN
 gN
-ab
-ab
+aP
+aP
 dT
-dJ
+lU
 kD
 Zn
 BD
-dJ
-ab
+lU
+aP
 Ed
 uj
 Ll
-ab
+aP
 xH
 XW
 jX
@@ -18074,19 +17089,19 @@ bN
 CT
 XW
 fk
-hk
+aP
 vv
 PN
-hk
+aP
 yb
 pp
 IH
 pv
-hk
-hk
+aP
+aP
 Bk
-hk
-hk
+aP
+aP
 gN
 mN
 mN
@@ -18240,18 +17255,18 @@ mN
 mN
 mN
 mN
-ab
+aP
 dX
-dJ
-dJ
-dJ
-dJ
-dJ
+lU
+lU
+lU
+lU
+lU
 RG
-dJ
-dJ
+lU
+lU
 XZ
-ab
+aP
 ey
 Xi
 jX
@@ -18261,10 +17276,10 @@ bN
 CT
 mQ
 fm
-hk
-hk
-hk
-hk
+aP
+aP
+aP
+aP
 ui
 lU
 JH
@@ -18272,7 +17287,7 @@ yC
 Hq
 vj
 ZR
-hk
+aP
 mN
 mN
 mN
@@ -18427,18 +17442,18 @@ mN
 mN
 eG
 mN
-ab
-ab
+aP
+aP
 go
 lR
 MG
-dJ
+lU
 qs
-ab
+aP
 MW
-dJ
+lU
 QO
-ab
+aP
 eB
 Xv
 jX
@@ -18448,10 +17463,10 @@ bN
 CT
 Xv
 fn
-hk
+aP
 AU
 IK
-hk
+aP
 xb
 lU
 Ri
@@ -18459,7 +17474,7 @@ Ri
 lU
 py
 Hp
-hk
+aP
 gN
 mN
 mN
@@ -18614,18 +17629,18 @@ mN
 mN
 mN
 gN
-ab
-ab
+aP
+aP
 gp
-dJ
+lU
 HA
-dJ
+lU
 XH
-ab
+aP
 Yf
-dJ
+lU
 oD
-ab
+aP
 eC
 eF
 jX
@@ -18635,7 +17650,7 @@ bN
 CT
 eF
 fr
-hk
+aP
 Eb
 lU
 me
@@ -18645,8 +17660,8 @@ Om
 Om
 lU
 UX
-hk
-hk
+aP
+aP
 gN
 mN
 mN
@@ -18802,17 +17817,17 @@ mN
 mN
 mN
 mN
-ab
+aP
 gv
-dJ
+lU
 Lp
-dJ
+lU
 kP
-ab
+aP
 uy
-dJ
+lU
 qY
-ab
+aP
 eI
 rd
 jX
@@ -18822,17 +17837,17 @@ bN
 CT
 rd
 fu
-hk
+aP
 kd
 lU
-hk
+aP
 lU
 lU
 VG
 VG
 lU
 UH
-hk
+aP
 mN
 mN
 mN
@@ -18989,17 +18004,17 @@ mN
 eG
 mN
 gN
-ab
+aP
 gA
 wH
 EF
-dJ
+lU
 XH
-ab
+aP
 uy
-dJ
+lU
 pP
-ab
+aP
 eJ
 XW
 jX
@@ -19009,17 +18024,17 @@ bN
 CT
 ms
 fw
-hk
+aP
 kd
 lU
-hk
+aP
 lU
-il
+wH
 lU
 uc
 Ei
 Rn
-hk
+aP
 gN
 mN
 mN
@@ -19176,17 +18191,17 @@ mN
 mN
 mN
 mN
-ab
-ab
-ab
-ab
-dJ
+aP
+aP
+aP
+aP
+lU
 XH
-ab
+aP
 Ew
 pJ
 Kb
-ab
+aP
 eK
 Kr
 jX
@@ -19196,17 +18211,17 @@ bN
 CT
 XW
 fA
-hk
+aP
 co
 lU
-hk
+aP
 VF
-hk
+aP
 VF
-hk
-hk
-hk
-hk
+aP
+aP
+aP
+aP
 gN
 mN
 mN
@@ -19364,16 +18379,16 @@ mN
 mN
 mN
 gN
-ab
-ab
+aP
+aP
 QS
-dJ
+lU
 kD
-ab
-ab
-ab
-ab
-ab
+aP
+aP
+aP
+aP
+aP
 eB
 Xv
 jX
@@ -19383,16 +18398,16 @@ bN
 CT
 Xv
 fn
-hk
-hk
-hk
-hk
+aP
+aP
+aP
+aP
 lU
 gs
 Ri
 FA
-hk
-hk
+aP
+aP
 mN
 mN
 mN
@@ -19551,13 +18566,13 @@ mN
 mN
 mN
 gN
-ab
-ab
+aP
+aP
 QS
-dJ
-dJ
-dJ
-ab
+lU
+lU
+lU
+aP
 hR
 hS
 fH
@@ -19573,13 +18588,13 @@ wB
 fM
 gj
 gl
-hk
+aP
 lU
 Gc
 VK
 yb
-hk
-hk
+aP
+aP
 gN
 mN
 mN
@@ -19738,12 +18753,12 @@ mN
 mN
 mN
 gN
-ab
-ab
+aP
+aP
 Du
-dJ
-dJ
-dJ
+lU
+lU
+lU
 HS
 bN
 bN
@@ -19765,8 +18780,8 @@ lU
 ZG
 lU
 lU
-hk
-hk
+aP
+aP
 mN
 mN
 mN
@@ -19925,8 +18940,8 @@ mN
 mN
 mN
 mN
-ab
-ab
+aP
+aP
 BQ
 ji
 LM
@@ -19947,13 +18962,13 @@ gt
 gt
 gt
 AZ
-fR
+Gm
 yF
 nV
 ZP
 ZP
-hk
-hk
+aP
+aP
 gN
 mN
 mN
@@ -20112,13 +19127,13 @@ mN
 mN
 gN
 Ou
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+aP
+aP
+aP
+aP
+aP
+aP
+aP
 fF
 bN
 aU
@@ -20134,13 +19149,13 @@ bY
 bH
 bN
 fT
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+aP
+aP
+aP
+aP
+aP
+aP
+aP
 FJ
 gN
 gN
@@ -20673,15 +19688,15 @@ mN
 mN
 gN
 gN
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
 fK
 bk
 bk
@@ -20693,15 +19708,15 @@ aX
 bo
 ch
 fP
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
 mN
 mN
 mN
@@ -20860,7 +19875,7 @@ mN
 mN
 mN
 gN
-ac
+aP
 nA
 dy
 dZ
@@ -20868,7 +19883,7 @@ lh
 dZ
 dy
 nA
-ac
+aP
 hV
 fE
 bk
@@ -20880,7 +19895,7 @@ dE
 bk
 cz
 et
-ac
+aP
 nA
 dy
 dZ
@@ -20888,7 +19903,7 @@ lh
 dZ
 dy
 nA
-ac
+aP
 gN
 mN
 mN
@@ -21047,15 +20062,15 @@ mN
 mN
 mN
 mN
-ac
+aP
 lX
 PU
-ac
+aP
 dy
-ac
+aP
 PU
 lX
-ac
+aP
 hV
 eP
 ch
@@ -21067,15 +20082,15 @@ aX
 bk
 fE
 gi
-ac
+aP
 lX
 PU
-ac
+aP
 dy
-ac
+aP
 PU
 lX
-ac
+aP
 mN
 mN
 mN
@@ -21234,15 +20249,15 @@ hY
 mN
 mN
 mN
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
 ou
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
 fL
 bk
 bk
@@ -21254,15 +20269,15 @@ dF
 la
 bk
 fP
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
 tR
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
 mN
 mN
 gN
@@ -21419,9 +20434,9 @@ mN
 mN
 mN
 mN
-ac
-ac
-ac
+aP
+aP
+aP
 hL
 gK
 fC
@@ -21449,9 +20464,9 @@ vT
 fW
 gK
 gL
-ac
-ac
-ac
+aP
+aP
+aP
 gN
 mN
 mN
@@ -21992,15 +21007,15 @@ Kl
 cM
 NC
 Ie
-ac
-ac
+aP
+aP
 TV
 bN
 bN
 bN
 TV
-ac
-ac
+aP
+aP
 Ie
 ka
 cM
@@ -22541,7 +21556,7 @@ mN
 mN
 mN
 gN
-ac
+aP
 dW
 gT
 gT
@@ -22573,7 +21588,7 @@ gT
 gT
 gT
 gd
-ac
+aP
 gN
 mN
 mN
@@ -23662,8 +22677,8 @@ mN
 mN
 mN
 mN
-ac
-ac
+aP
+aP
 ea
 eZ
 bN
@@ -23695,8 +22710,8 @@ ha
 gT
 gT
 gd
-ac
-ac
+aP
+aP
 gN
 mN
 mN
@@ -24424,13 +23439,13 @@ cH
 bN
 bN
 en
-ac
+aP
 jU
 Zs
 Zs
 Zs
 jY
-ac
+aP
 kf
 bN
 bN
@@ -24784,7 +23799,7 @@ mN
 mN
 mN
 mN
-ac
+aP
 dg
 fp
 du
@@ -24818,7 +23833,7 @@ vT
 vT
 vT
 hq
-ac
+aP
 gN
 mN
 mN
@@ -24971,7 +23986,7 @@ mN
 mN
 mN
 mN
-ac
+aP
 Pp
 fp
 du
@@ -25005,7 +24020,7 @@ eF
 eF
 eF
 gh
-ac
+aP
 gN
 mN
 mN
@@ -25158,7 +24173,7 @@ wt
 mN
 mN
 mN
-ac
+aP
 dg
 fp
 du
@@ -25192,7 +24207,7 @@ wB
 wB
 wB
 hs
-ac
+aP
 mN
 mN
 mN
@@ -25546,13 +24561,13 @@ YX
 bN
 bN
 en
-ac
+aP
 jV
 Gu
 pe
 Gu
 jZ
-ac
+aP
 kf
 bN
 bN
@@ -26280,8 +25295,8 @@ mN
 mN
 mN
 mN
-ac
-ac
+aP
+aP
 eb
 Iq
 bD
@@ -26313,8 +25328,8 @@ Mf
 gT
 gT
 ge
-ac
-ac
+aP
+aP
 mN
 mN
 mN
@@ -27037,23 +26052,23 @@ Yj
 Iq
 CT
 aj
-ac
-ac
+aP
+aP
 ex
 hZ
-ac
+aP
 UT
-ac
+aP
 aW
 UT
 aW
-ac
+aP
 UT
-ac
+aP
 ex
 hZ
-ac
-ac
+aP
+aP
 iD
 eF
 jX
@@ -27777,8 +26792,8 @@ mN
 mN
 mN
 mN
-ac
-ac
+aP
+aP
 bT
 fv
 fV
@@ -27808,8 +26823,8 @@ wy
 fV
 fv
 fZ
-ac
-ac
+aP
+aP
 mN
 mN
 mN
@@ -28164,13 +27179,13 @@ gu
 bN
 bN
 dm
-ac
+aP
 fe
 MC
 oQ
 MC
 jA
-ac
+aP
 iR
 bN
 bN
@@ -28339,7 +27354,7 @@ hY
 mN
 mN
 gN
-ac
+aP
 aP
 aP
 aP
@@ -28351,7 +27366,7 @@ aP
 ao
 bN
 kX
-ac
+aP
 js
 qv
 bD
@@ -28369,7 +27384,7 @@ aP
 aP
 aP
 aP
-ac
+aP
 gN
 mN
 mN
@@ -28529,7 +27544,7 @@ mN
 mN
 jo
 mO
-bh
+lO
 Er
 aP
 Zw
@@ -28538,13 +27553,13 @@ aP
 bi
 bN
 kZ
-ac
-ac
+aP
+aP
 jt
 kC
 jz
-ac
-ac
+aP
+aP
 lq
 bN
 je
@@ -28553,7 +27568,7 @@ ej
 Zw
 aP
 mO
-bh
+lO
 Er
 gB
 mN
@@ -28716,7 +27731,7 @@ mN
 mN
 jp
 Ku
-lP
+eF
 oB
 aP
 eY
@@ -28736,11 +27751,11 @@ jX
 bN
 jr
 aP
-cK
+un
 eY
 aP
 iA
-lP
+eF
 gn
 gE
 gN
@@ -28903,7 +27918,7 @@ mN
 mN
 jp
 su
-lP
+eF
 on
 aP
 aP
@@ -28913,11 +27928,11 @@ cA
 bN
 CT
 iJ
-ac
+aP
 aY
 bD
 Sp
-ac
+aP
 iQ
 jX
 bN
@@ -28927,7 +27942,7 @@ lM
 aP
 aP
 yo
-lP
+eF
 XF
 gE
 gN
@@ -29090,31 +28105,31 @@ mN
 gN
 jp
 MI
-lP
-lP
+eF
+eF
 oi
-lP
-bh
+eF
+lO
 xo
 bN
 bN
 dN
-ac
-ac
-ac
+aP
+aP
+aP
 HQ
-ac
-ac
-ac
+aP
+aP
+aP
 iT
 bN
 bN
 yD
-bh
-lP
+lO
+eF
 oi
-lP
-lP
+eF
+eF
 MI
 gE
 gN
@@ -29278,7 +28293,7 @@ mN
 jv
 kT
 wk
-bh
+lO
 fo
 NM
 lN
@@ -29300,7 +28315,7 @@ aP
 lN
 KV
 fo
-bh
+lO
 QE
 kT
 gF
@@ -29651,7 +28666,7 @@ mN
 mN
 jw
 mO
-bh
+lO
 Er
 aP
 Zw
@@ -29675,7 +28690,7 @@ ej
 Zw
 aP
 mO
-bh
+lO
 Er
 vL
 mN
@@ -29838,7 +28853,7 @@ mN
 mN
 jH
 fG
-lP
+eF
 oB
 aP
 eY
@@ -29858,11 +28873,11 @@ iX
 bN
 jr
 aP
-cK
+un
 eY
 aP
 iA
-lP
+eF
 gn
 kV
 mN
@@ -30025,7 +29040,7 @@ mN
 mN
 jH
 su
-lP
+eF
 on
 aP
 aP
@@ -30049,7 +29064,7 @@ lM
 aP
 aP
 yo
-lP
+eF
 XF
 kV
 mN
@@ -30212,31 +29227,31 @@ mN
 gN
 jH
 MI
-lP
-lP
+eF
+eF
 oi
-lP
-bh
+eF
+lO
 QB
 bN
 Qo
 cS
-ac
-ac
-ac
+aP
+aP
+aP
 HQ
-ac
-ac
-ac
+aP
+aP
+aP
 jm
 BF
 bN
 bC
-bh
-lP
+lO
+eF
 oi
-lP
-lP
+eF
+eF
 MI
 kV
 gN
@@ -30400,7 +29415,7 @@ gN
 jI
 kT
 Sq
-bh
+lO
 fo
 pX
 lN
@@ -30408,13 +29423,13 @@ aP
 cA
 bN
 iE
-ac
+aP
 yj
 yd
 bD
 YE
 IN
-ac
+aP
 iZ
 bN
 hd
@@ -30422,7 +29437,7 @@ aP
 lN
 Sb
 fo
-bh
+lO
 px
 kT
 Zj
@@ -30595,13 +29610,13 @@ aP
 ao
 bN
 ft
-ac
+aP
 aQ
 bD
 bD
 bD
 Bq
-ac
+aP
 ja
 bN
 jr
@@ -30773,7 +29788,7 @@ mN
 gN
 jJ
 mO
-bh
+lO
 Er
 aP
 Zw
@@ -30782,13 +29797,13 @@ aP
 bi
 bN
 el
-ac
+aP
 aR
 PH
 bD
 bE
 bR
-ac
+aP
 jq
 bN
 je
@@ -30797,7 +29812,7 @@ ej
 Zw
 aP
 mO
-bh
+lO
 Er
 KK
 gN
@@ -30960,7 +29975,7 @@ mN
 gN
 jW
 fG
-lP
+eF
 oB
 aP
 eY
@@ -30969,22 +29984,22 @@ aP
 ao
 bN
 iF
-ac
-ac
-ac
+aP
+aP
+aP
 bt
-ac
-ac
-ac
+aP
+aP
+aP
 jc
 bN
 jr
 aP
-cK
+un
 eY
 aP
 iA
-lP
+eF
 gn
 gI
 gN
@@ -31147,7 +30162,7 @@ mN
 gN
 jW
 su
-lP
+eF
 on
 aP
 aP
@@ -31171,7 +30186,7 @@ lM
 aP
 aP
 yo
-lP
+eF
 XF
 gI
 gN
@@ -31334,11 +30349,11 @@ mN
 gN
 jW
 MI
-lP
-lP
+eF
+eF
 oi
-lP
-bh
+eF
+lO
 MJ
 bN
 bN
@@ -31354,11 +30369,11 @@ bN
 bN
 bN
 Op
-bh
-lP
+lO
+eF
 oi
-lP
-lP
+eF
+eF
 MI
 gI
 gN
@@ -31522,7 +30537,7 @@ gN
 kg
 kT
 Mc
-bh
+lO
 fo
 Oj
 lN
@@ -31544,7 +30559,7 @@ aP
 lN
 TK
 fo
-bh
+lO
 xK
 kT
 RL
@@ -31714,19 +30729,19 @@ aP
 aP
 aP
 aP
-ac
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
+aP
 dk
 dz
 jF
-ac
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
+aP
 aP
 aP
 aP
@@ -31905,11 +30920,11 @@ qW
 Pt
 xz
 rL
-ac
+aP
 jC
 dz
 jL
-ac
+aP
 ci
 Ue
 DE
@@ -32092,11 +31107,11 @@ Cb
 tF
 oZ
 qW
-ac
+aP
 dk
 dz
 jF
-ac
+aP
 lO
 lO
 lO
@@ -32466,11 +31481,11 @@ Af
 oZ
 oZ
 SL
-ac
+aP
 dk
 dz
 jF
-ac
+aP
 lO
 lO
 lO
@@ -32653,12 +31668,12 @@ Af
 oZ
 DH
 oZ
-ac
+aP
 jD
 dz
 jM
-ac
-Dy
+aP
+lN
 Eo
 lO
 lO
@@ -32840,16 +31855,16 @@ pd
 Zz
 oZ
 xz
-ac
+aP
 dk
 dz
 jF
-ac
-ac
-ac
+aP
+aP
+aP
 cU
-ac
-ac
+aP
+aP
 MX
 eE
 ih
@@ -33027,16 +32042,16 @@ Vd
 oZ
 oZ
 Tx
-ac
+aP
 dk
 dz
 jF
-ac
+aP
 cm
 mP
 dj
 ZM
-ac
+aP
 ih
 ih
 ih
@@ -33214,16 +32229,16 @@ pd
 oZ
 Cv
 JD
-ac
+aP
 jC
 dz
 jL
-ac
+aP
 bV
 mP
 dj
 MF
-ac
+aP
 mC
 mC
 mC
@@ -33401,16 +32416,16 @@ pd
 DH
 oZ
 tF
-ac
+aP
 dk
 dz
 jF
-ac
+aP
 Kd
 vx
 vx
 ZZ
-ac
+aP
 mC
 mC
 mC
@@ -33588,16 +32603,16 @@ pd
 oZ
 oZ
 RY
-ac
+aP
 jD
 dz
 jM
-ac
+aP
 qX
 Vj
 Vj
 xh
-ac
+aP
 mC
 SB
 mC
@@ -33775,16 +32790,16 @@ oZ
 mW
 oZ
 Cv
-ac
+aP
 jE
 dz
 jP
-ac
+aP
 YN
 Vj
 Vj
 dB
-ac
+aP
 aO
 aO
 aO
@@ -33950,35 +32965,35 @@ mN
 hX
 mN
 mN
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
 WS
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
+aP
 mN
 mN
 mN
@@ -34137,9 +33152,9 @@ mN
 mN
 mN
 mN
-ac
-ac
-ac
+aP
+aP
+aP
 uX
 bD
 TY
@@ -34147,7 +33162,7 @@ zr
 Nw
 qi
 bD
-ac
+aP
 aD
 kl
 kn
@@ -34155,7 +33170,7 @@ eF
 kp
 kw
 kz
-ac
+aP
 dU
 lO
 tv
@@ -34164,8 +33179,8 @@ lO
 lO
 lO
 BV
-ac
-ac
+aP
+aP
 mN
 mN
 mN
@@ -34325,8 +33340,8 @@ mN
 mN
 mN
 gN
-ac
-ac
+aP
+aP
 UF
 bD
 Fk
@@ -34334,7 +33349,7 @@ Fm
 Nw
 qi
 bD
-ac
+aP
 bs
 eF
 eF
@@ -34342,7 +33357,7 @@ eF
 eF
 eF
 kA
-ac
+aP
 lO
 FD
 ks
@@ -34351,7 +33366,7 @@ gJ
 kY
 lO
 Mn
-ac
+aP
 gN
 mN
 mN
@@ -34512,8 +33527,8 @@ mN
 mN
 mN
 mN
-ac
-ac
+aP
+aP
 nX
 bD
 bD
@@ -34537,8 +33552,8 @@ dz
 wD
 HW
 Wn
-ac
-ac
+aP
+aP
 mN
 mN
 mN
@@ -34700,7 +33715,7 @@ mN
 mN
 mN
 mN
-ac
+aP
 JF
 bD
 bD
@@ -34708,7 +33723,7 @@ bD
 bD
 bD
 bD
-ac
+aP
 ct
 eF
 eF
@@ -34716,7 +33731,7 @@ eF
 eF
 eF
 kB
-ac
+aP
 lO
 FT
 Ys
@@ -34724,7 +33739,7 @@ Ys
 fJ
 Uv
 lO
-ac
+aP
 gN
 mN
 mN
@@ -34887,7 +33902,7 @@ mN
 mN
 mN
 mN
-ac
+aP
 lA
 bD
 VX
@@ -34895,7 +33910,7 @@ Nw
 qi
 bD
 bD
-ac
+aP
 cW
 Tg
 eF
@@ -34903,7 +33918,7 @@ eF
 eF
 LX
 kH
-ac
+aP
 dU
 lO
 Jb
@@ -34911,7 +33926,7 @@ lO
 lO
 lO
 kQ
-ac
+aP
 mN
 mN
 mN
@@ -35074,15 +34089,15 @@ mN
 wt
 mN
 gN
-ac
-ac
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
+aP
+aP
 nB
-ac
-ac
+aP
+aP
 dC
 XW
 eF
@@ -35090,15 +34105,15 @@ eF
 eF
 lB
 kJ
-ac
-ac
+aP
+aP
 qK
-ac
-ac
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
+aP
+aP
 mN
 mN
 mN
@@ -35262,14 +34277,14 @@ mN
 mN
 mN
 mN
-ac
-ac
+aP
+aP
 rj
 LQ
 eE
 eE
 LI
-ac
+aP
 dO
 YV
 eF
@@ -35277,14 +34292,14 @@ eF
 eF
 RX
 kK
-ac
+aP
 og
 lO
 lO
 dy
 dy
-ac
-ac
+aP
+aP
 mN
 mN
 mN
@@ -35449,14 +34464,14 @@ mN
 mN
 mN
 gN
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
 un
 eE
 pM
-ac
+aP
 dV
 dn
 Qq
@@ -35464,14 +34479,14 @@ eF
 GS
 bp
 kL
-ac
+aP
 sJ
 lO
 lO
 dy
 es
-ac
-ac
+aP
+aP
 gN
 mN
 mN
@@ -35637,13 +34652,13 @@ mN
 mN
 mN
 gN
-ac
+aP
 dd
 LQ
 eE
 eE
 to
-ac
+aP
 cW
 Tg
 eF
@@ -35651,13 +34666,13 @@ eF
 eF
 LX
 kH
-ac
+aP
 Iz
 lO
 lO
 dy
 eL
-ac
+aP
 mN
 mN
 mN
@@ -35824,13 +34839,13 @@ mN
 mN
 mN
 mN
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
 wa
-ac
-ac
+aP
+aP
 kk
 lB
 eF
@@ -35838,13 +34853,13 @@ eF
 eF
 XW
 kM
-ac
+aP
 KU
 lO
 ZB
 Hs
-ac
-ac
+aP
+aP
 gN
 mN
 mN
@@ -36012,12 +35027,12 @@ mN
 mN
 mN
 gN
-ac
-ac
+aP
+aP
 Bb
 eE
 OH
-ac
+aP
 dO
 YV
 eF
@@ -36025,12 +35040,12 @@ eF
 eF
 RX
 kK
-ac
+aP
 df
 lO
-WJ
+on
 lO
-ac
+aP
 mN
 mN
 mN
@@ -36199,12 +35214,12 @@ mN
 mN
 mN
 wt
-ac
-ac
+aP
+aP
 MX
 eE
 pM
-ac
+aP
 cD
 km
 ko
@@ -36212,12 +35227,12 @@ eF
 kr
 kx
 kO
-ac
+aP
 lO
-Dy
-ac
-ac
-ac
+lN
+aP
+aP
+aP
 gN
 mN
 mN
@@ -36387,23 +35402,23 @@ mN
 mN
 mN
 mN
-ac
+aP
 Bb
 eE
 OH
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
 PM
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
 Dl
-ac
-ac
-ac
+aP
+aP
+aP
 mN
 mN
 mN
@@ -36574,11 +35589,11 @@ mN
 mN
 mN
 gN
-ac
-ac
+aP
+aP
 mU
-ac
-ac
+aP
+aP
 lO
 lO
 lO
@@ -36586,11 +35601,11 @@ lO
 lO
 lO
 lO
-ac
+aP
 eE
 Wt
-ac
-ac
+aP
+aP
 mN
 mN
 wt
@@ -36762,10 +35777,10 @@ mN
 mN
 mN
 mN
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
 lO
 FD
 ks
@@ -36773,10 +35788,10 @@ ks
 ks
 iW
 lO
-ac
+aP
 un
 rN
-ac
+aP
 gN
 mN
 mN
@@ -36949,10 +35964,10 @@ mN
 mN
 mN
 gN
-ac
-ac
-ac
-ac
+aP
+aP
+aP
+aP
 uO
 FT
 Ys
@@ -36960,10 +35975,10 @@ Zl
 Ys
 Uv
 EJ
-ac
+aP
 VV
-ac
-ac
+aP
+aP
 gN
 mN
 mN
@@ -37137,9 +36152,9 @@ mN
 mN
 mN
 gN
-ac
-ac
-ac
+aP
+aP
+aP
 Hi
 Hi
 Hi
@@ -37147,9 +36162,9 @@ Yq
 Hi
 Hi
 Hi
-ac
-ac
-ac
+aP
+aP
+aP
 gN
 mN
 mN
@@ -37326,15 +36341,15 @@ mN
 mN
 mN
 gN
-ac
-ac
+aP
+aP
 BW
 Bt
 Bt
 Bt
 nZ
-ac
-ac
+aP
+aP
 gN
 mN
 mN
@@ -40210,7 +39225,7 @@ mc
 mc
 mc
 kU
-uf
+by
 by
 by
 by
@@ -40773,7 +39788,7 @@ by
 RC
 Nt
 by
-uf
+by
 by
 by
 mc
@@ -40957,7 +39972,7 @@ mc
 mc
 by
 by
-uf
+by
 by
 by
 by
@@ -41517,7 +40532,7 @@ mc
 mc
 mc
 by
-uf
+by
 by
 Nt
 RC


### PR DESCRIPTION

## About The Pull Request
This was painful.

Woe, pipes and wires upon ye. This is my attempts at removing duplicate and/or broken prefabs for wires and pipes. This SHOULD hopefully make mapping wiring and atmos/disposals a lot easier as all the prefabs should work now. Should being the key word, as I had to replace a lot of shit. I'm 99% sure everything should still be functional but mapping likes to be an ass so, ping me if something breaks :^)

I didn't notice any issues in my testing but I also couldn't sit around and test things for a full 6 hours so, it should work based off the fact that any duplicate prefabs were replaced with a prefab that I know works (based off testing or in0round functionality on live).
## Changelog
:cl:
del: Removed some messy and unnecessary wiring in the R-UST SMES room and on the carrier. Tidied up some carrier wiring.
maptweak: Scanned through EVERY prefab I could find for wiring, disposal pipes and atmos pipes. Any duplicates and/or prefabs that were found to not work have been deleted and replaced with consistent (and hopefully working) prefabs. No more duplicate prefabs in SDMM. Should be consistent and working variables across the board. This affects nearly all SC_Maps and I also combed through the template map file that some use for mapping, as some broken/duplicate prefabs were found in the templates.
/:cl:
