### PR TITLE
Makes phased kins not behave like walls

### DIFF
--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -48,7 +48,7 @@ default behaviour is:
 		return 0
 
 /mob/living/Bump(atom/movable/AM)
-	if(now_pushing || !loc || buckled == AM || AM.is_incorporeal()) // CHOMPEdit - This should take care of phase interactions...
+	if(now_pushing || !loc || buckled == AM)
 		return
 	now_pushing = 1
 	if (istype(AM, /mob/living))

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -214,7 +214,7 @@
  */
 /mob/living/proc/handle_micro_bump_helping(mob/living/tmob)
 	// CHOMPAdd - Phased
-	if(is_incorporeal || tmob.is_incorporeal())
+	if(is_incorporeal() || tmob.is_incorporeal())
 		return FALSE
 	//Riding and being moved to us or something similar
 	if(tmob in buckled_mobs)
@@ -276,7 +276,7 @@
 	if(!canmove || buckled)
 		return
 	// CHOMPAdd - Phased
-	if(is_incorporeal || tmob.is_incorporeal())
+	if(is_incorporeal() || tmob.is_incorporeal())
 		return
 
 	//Riding and being moved to us or something similar

--- a/code/modules/vore/resizing/resize_vr.dm
+++ b/code/modules/vore/resizing/resize_vr.dm
@@ -213,6 +213,9 @@
  * @return false if normal code should continue, true to prevent normal code.
  */
 /mob/living/proc/handle_micro_bump_helping(mob/living/tmob)
+	// CHOMPAdd - Phased
+	if(is_incorporeal || tmob.is_incorporeal())
+		return FALSE
 	//Riding and being moved to us or something similar
 	if(tmob in buckled_mobs)
 		return TRUE
@@ -271,6 +274,9 @@
 		return
 	//We can't be stepping on anyone
 	if(!canmove || buckled)
+		return
+	// CHOMPAdd - Phased
+	if(is_incorporeal || tmob.is_incorporeal())
 		return
 
 	//Riding and being moved to us or something similar


### PR DESCRIPTION

## About The Pull Request

So I accidentally made shadekins NOT get bumped at all. This will bring them back be able to be swapped places or pushed, but not knocked down or pinned underpaw.

## Changelog
:cl:
fix: Phased kins won't stop people from moving
/:cl:
