### PR TITLE
give pint when it says pint

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -119,7 +119,7 @@ RSF
 			product = new glasstype()
 			used_energy = 50
 		if(3)
-			product = new /obj/item/weapon/reagent_containers/food/drinks/metaglass()	//YW Changes begin
+			product = new /obj/item/weapon/reagent_containers/food/drinks/metaglass/metapint()	//YW Changes begin
 			used_energy = 50
 		if(4)
 			product = new /obj/item/weapon/paper()


### PR DESCRIPTION

## About The Pull Request
Even though it's usually done through the container output. When having a quick selection for PINT glasses, it should give PINT glasses.
## Changelog
:cl:
fix: fixes a wrong glass type given out on a quick selection on the RSF
/:cl:
