### PR TITLE
Weaken to Stun

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -540,10 +540,10 @@
 	if(ishuman(T))
 		var/mob/living/carbon/human/H = T
 		if(H.species.lightweight == 1)
-			H.Weaken(3)
+			H.Stun(3) // CHOMPEdit - Crawling made this useless. Changing to stun instead.
 			return
 	var/armor_block = run_armor_check(T, "melee")
 	var/armor_soak = get_armor_soak(T, "melee")
 	T.apply_damage(20, HALLOSS,, armor_block, armor_soak)
 	if(prob(75)) //75% chance to stun for 5 seconds, really only going to be 4 bcus click cooldown+animation.
-		T.apply_effect(5, WEAKEN, armor_block)
+		T.apply_effect(5, STUN, armor_block)


### PR DESCRIPTION

## About The Pull Request
Small oversight with crawling; It made borg pouncing useless. Changing from weakened to stun so those affected will drop things on their hands and not able to crawl away.
:cl:
fix: Borg pounce changed to stun
/:cl:
