### PR TITLE
Chattags not visible tweak

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -354,12 +354,15 @@ GLOBAL_LIST_EMPTY(text_tag_cache)
 /proc/create_text_tag(var/tagname, var/tagdesc = tagname, var/client/C = null)
 	if(!(C && C.is_preference_enabled(/datum/client_preference/chat_tags)))
 		return tagdesc
+	//ChompEDIT START
+	var/datum/asset/spritesheet/chatassets = get_asset_datum(/datum/asset/spritesheet/chat)
+	chatassets.send(C)
 	if(!GLOB.text_tag_cache[tagname])
-		var/datum/asset/spritesheet/chatassets = get_asset_datum(/datum/asset/spritesheet/chat)
 		GLOB.text_tag_cache[tagname] = {"<span class='[chatassets.icon_class_name(tagname)] text_tag'></span>"}
 	if(!C.tgui_panel.is_ready() || C.tgui_panel.oldchat)
 		return "<IMG src='\ref[text_tag_icons]' class='text_tag' iconstate='[tagname]'" + (tagdesc ? " alt='[tagdesc]'" : "") + ">"
 	return GLOB.text_tag_cache[tagname]
+	//ChompEDIT END
 
 /proc/create_text_tag_old(var/tagname, var/tagdesc = tagname, var/client/C = null)
 	if(!(C && C.is_preference_enabled(/datum/client_preference/chat_tags)))

--- a/code/modules/asset_cache/assets/chat.dm
+++ b/code/modules/asset_cache/assets/chat.dm
@@ -1,5 +1,7 @@
 /datum/asset/spritesheet/chat
 	name = "chat"
 
+//ChompEDIT START
 /datum/asset/spritesheet/chat/create_spritesheets()
 	InsertAll("", text_tag_icons) //Chomp - OOC, LOOC ect icons
+//ChompEDIT END


### PR DESCRIPTION

## About The Pull Request

Under certain conditions, the chat tags seem to dissapear. the tgui_panel initialise doesn't seem to reliably send them, so i'm trying this instead. I think the assets system will handle re-calling this a few times itself. 

## Changelog
:cl:
fix: Fix Chat tags not showing
/:cl:
