### PR TITLE
Add catslug to basic metamorphosis ray

### DIFF
--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -424,7 +424,8 @@
 		"opossum" = /mob/living/simple_mob/animal/passive/opossum,
 		"horse" = /mob/living/simple_mob/vore/horse,
 		"goose" = /mob/living/simple_mob/animal/space/goose,
-		"sheep" = /mob/living/simple_mob/vore/sheep
+		"sheep" = /mob/living/simple_mob/vore/sheep,
+		"catslug" = /mob/living/simple_mob/vore/alienanimals/catslug
 		)
 
 /obj/item/weapon/gun/energy/mouseray/metamorphosis/advanced


### PR DESCRIPTION

## About The Pull Request
Catslugs seem to be about the same level as the rest of the critters on the non-admin metamorph ray, so. Adding it in.
## Changelog
:cl:
add: Catslug is now an option on the basic metamorph raygun
/:cl:
