### PR TITLE
Fixes the verb manager based stat entries to show

### DIFF
--- a/code/controllers/subsystems/verb_manager_ch.dm
+++ b/code/controllers/subsystems/verb_manager_ch.dm
@@ -161,5 +161,7 @@ SUBSYSTEM_DEF(verb_manager)
 	verbs_executed_per_second = MC_AVG_SECONDS(verbs_executed_per_second, executed_verbs, wait SECONDS)
 	//note that wait SECONDS is incorrect if this is called outside of fire() but because byond is garbage i need to add a timer to rustg to find a valid solution
 
-/datum/controller/subsystem/verb_manager/stat_entry()
-	..("V/S: [round(verbs_executed_per_second, 0.01)]")
+/datum/controller/subsystem/verb_manager/stat_entry(msg)
+	. = ..()
+	if (use_default_stats)
+		. += "V/S: [round(verbs_executed_per_second, 0.01)]"


### PR DESCRIPTION


## Changelog
:cl:
admin: The stats of Verb Manager and Speech Controller now show inside of the MC tab.
/:cl:
