### PR TITLE
Shield diffusers gets disabled with meteors

### DIFF
--- a/code/modules/shieldgen/shield_diffuser.dm
+++ b/code/modules/shieldgen/shield_diffuser.dm
@@ -85,6 +85,8 @@
 	if(!duration)
 		return
 	alarm = round(max(alarm, duration))
+	for(var/obj/machinery/shield_gen/gen in global.machines) // CHOMPEdit - Fills the gaps made by diffusers
+		gen.fill_diffused()
 	update_icon()
 
 /obj/machinery/shield_diffuser/examine(var/mob/user)

--- a/code/modules/shieldgen/shield_gen.dm
+++ b/code/modules/shieldgen/shield_gen.dm
@@ -258,6 +258,21 @@
 		for(var/mob/M in view(5,src))
 			to_chat(M, "[icon2html(src, M.client)] You hear heavy droning fade out.")
 		shield_hum.stop()
+// CHOMPAdd Start - Fills gaps when meteors happen
+/obj/machinery/shield_gen/proc/fill_diffused()
+	if(active)
+		var/list/covered_turfs = get_shielded_turfs()
+		var/turf/T = get_turf(src)
+		var/obj/effect/energy_field/E
+		if(T in covered_turfs)
+			covered_turfs.Remove(T)
+		for(var/turf/O in covered_turfs)
+			if(locate(/obj/effect/energy_field, O))
+				continue
+			E = new(O, src)
+			field.Add(E)
+		covered_turfs = null
+// CHOMPAdd End
 
 /obj/machinery/shield_gen/update_icon()
 	if(stat & BROKEN)


### PR DESCRIPTION

## About The Pull Request

Don't worry airlocks, you will be safe from all those pesky meteors now. Shields diffusers will now turn the shield off when meteors happens, so they will also be protected.

closes #8119 

## Changelog
:cl:
fix: Shields diffusers will actually work when meteors happen
/:cl:
