### PR TITLE
robot language selection fix

### DIFF
--- a/code/modules/mob/living/default_language.dm
+++ b/code/modules/mob/living/default_language.dm
@@ -17,7 +17,10 @@
 	// Silicons have no species language usually. So let's default them to GALCOM
 	if(!language)
 		to_chat(src, "<span class='notice'>You will now speak your standard default language, common, if you do not specify a language when speaking.</span>")
-		default_language = LANGUAGE_GALCOM
+		for(var/datum/language/lang in speech_synthesizer_langs)
+			if(lang.name == LANGUAGE_GALCOM)
+				default_language = lang
+				break
 		return
 	apply_language(language)
 


### PR DESCRIPTION

## About The Pull Request
Guh seems I oversighted something with setting the default to galcom in case of cancelling...
## Changelog
:cl:
fix: resetting robot language to galcom should now work properly with the set default language verb on cancel
/:cl:
