### PR TITLE
Confirmed outbreak of a less stupid biohazard system

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -128,7 +128,7 @@
 	// Format currently matches that of newscaster feeds: Registered Name (Assigned Rank)
 	return I.assignment ? "[I.registered_name] ([I.assignment])" : I.registered_name
 
-/proc/level_seven_announcement()
+/proc/level_seven_announcement() // Chomp note - Do not use this.
 	command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard \the [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
 
 /proc/ion_storm_announcement()

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -8,4 +8,5 @@
 	spacevines_spawned = 1
 
 /datum/event/spacevine/announce()
-	level_seven_announcement()
+	//level_seven_announcement() // Chomp Edit, this was stupid and vague and wrong.
+	command_announcement.Announce("Hazardous plant infestation detected on \the [station_name()]. Station facilities may be overgrown.", "Hazardous Biomass")

--- a/code/modules/events/viral_infection.dm
+++ b/code/modules/events/viral_infection.dm
@@ -22,16 +22,18 @@ var/global/list/event_viruses = list() // so that event viruses are kept around 
 		viruses += D
 
 /datum/event/viral_infection/announce()
-	var/level
+	/*var/level
 	if (severity == EVENT_LEVEL_MUNDANE)
 		return
 	else if (severity == EVENT_LEVEL_MODERATE)
 		level = pick("one", "two", "three", "four")
 	else
-		level = "five"
+		level = "five"*/
+	// Chomp removal
 
 	if (severity == EVENT_LEVEL_MAJOR || prob(60))
-		command_announcement.Announce("Confirmed outbreak of level [level] biohazard aboard \the [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak5.ogg')
+		command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard \the [station_name()]. All personnel must contain the outbreak.", "Viral Outbreak", new_sound = 'sound/AI/outbreak7.ogg')
+		// Chomp edit: Changed "Biohazard Alert" to "Viral Outbreak" and also changed level level 5 to level 7. Lower = More urgent.
 
 /datum/event/viral_infection/start()
 	if(!viruses.len) return

--- a/code/modules/events/viral_outbreak.dm
+++ b/code/modules/events/viral_outbreak.dm
@@ -8,8 +8,9 @@
 	severity = rand(2, 4)
 
 /datum/event/viral_outbreak/announce()
-	command_alert("Confirmed outbreak of level 7 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert")
+	command_alert("Confirmed outbreak of level 7 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Viral Outbreak")
 	world << sound('sound/AI/outbreak7.ogg')
+	// Chomp edit: Changed "Biohazard Alert" to "Viral Outbreak" and yes I know this file isn't used anymore but I'm going to be consistent in case it does get used.
 
 /datum/event/viral_outbreak/start()
 	var/list/candidates = list()	//list of candidate keys

--- a/code/modules/events/wallrot.dm
+++ b/code/modules/events/wallrot.dm
@@ -18,7 +18,8 @@
 
 /datum/event/wallrot/announce()
 	if(center)
-		command_announcement.Announce("Harmful fungi detected on \the [station_name()] nearby [center.loc.name]. Station structures may be contaminated.", "Biohazard Alert")
+		command_announcement.Announce("Harmful fungi detected on \the [station_name()]. Hull integrity near [center.loc.name] may be compromised.", "Hazardous Biomass")
+		// Chomp edit - Better wording as to what the hell it actually does.
 
 /datum/event/wallrot/start()
 	spawn()

--- a/code/modules/gamemaster/event2/events/engineering/blob.dm
+++ b/code/modules/gamemaster/event2/events/engineering/blob.dm
@@ -143,8 +143,8 @@
 			multiblob = TRUE
 
 		var/list/lines = list()
-		lines += "Confirmed outbreak of level [7 + danger_level] biohazard[multiblob ? "s": ""] \
-		aboard [location_name()]. All personnel must contain the outbreak."
+		//lines += "Confirmed outbreak of level [7 + danger_level] biohazard[multiblob ? "s": ""]
+		lines += "Confirmed outbreak of level 5 biohazard[multiblob ? "s": ""] aboard [location_name()]. All personnel must contain the outbreak."
 
 		if(danger_level >= BLOB_DIFFICULTY_MEDIUM) // Tell them what kind of blob it is if it's tough.
 			lines += "The biohazard[multiblob ? "s have": " has"] been identified as [english_list(blob_type_names)]."
@@ -157,4 +157,6 @@
 		if(danger_level >= BLOB_DIFFICULTY_SUPERHARD)
 			lines += "Extreme caution is advised."
 
-		command_announcement.Announce(lines.Join("\n"), "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
+		//command_announcement.Announce(lines.Join("\n"), "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
+		command_announcement.Announce(lines.Join("\n"), "Hazardous Biomass - URGENT!", new_sound = 'sound/AI/outbreak5.ogg')
+		// Chomp edit - Better wording and also made the alert level 5. Lower number = More urgent.

--- a/code/modules/gamemaster/event2/events/engineering/spacevine.dm
+++ b/code/modules/gamemaster/event2/events/engineering/spacevine.dm
@@ -11,7 +11,8 @@
 
 
 /datum/event2/event/spacevine/announce()
-	level_seven_announcement()
+	//level_seven_announcement() // Chomp Edit
+	command_announcement.Announce("Hazardous plant infestation detected on \the [station_name()]. Station facilities may be overgrown.", "Hazardous Biomass")
 
 /datum/event2/event/spacevine/start()
 	spacevine_infestation()

--- a/code/modules/gamemaster/event2/events/medical/virus.dm
+++ b/code/modules/gamemaster/event2/events/medical/virus.dm
@@ -49,8 +49,8 @@
 	candidates = shuffle(candidates)
 
 /datum/event2/event/virus/announce()
-	command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard \the [location_name()]. \
-	All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
+	command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard \the [location_name()]. All personnel must contain the outbreak.", "Viral Outbreak", new_sound = 'sound/AI/outbreak7.ogg')
+	// Chomp edit: Changed "Biohazard Alert" to "Viral Outbreak"
 
 /datum/event2/event/virus/start()
 	if(!candidates.len)

--- a/modular_chomp/code/modules/event/infectedroom.dm
+++ b/modular_chomp/code/modules/event/infectedroom.dm
@@ -90,7 +90,7 @@
 		message_admins("Infected room event started; Virus: <a href='?src=\ref[virus];[HrefToken()];info=1'>[virus.name()]</a>")
 
 /datum/event/infectedroom/announce()
-	command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard \the [location_name()]. All personnel must contain the outbreak.", "Infectious Contaminant", new_sound = 'sound/AI/outbreak7.ogg')
+	command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard \the [location_name()]. All personnel must contain the outbreak.", "Infectious Contaminant in [target_area.name]", new_sound = 'sound/AI/outbreak7.ogg')
 	// Chomp edit: Changed "Biohazard Alert" to "Infectious Contaminant" and also changed level 5 to level 7.
 
 /datum/event/infectedroom/start()

--- a/modular_chomp/code/modules/event/infectedroom.dm
+++ b/modular_chomp/code/modules/event/infectedroom.dm
@@ -91,7 +91,6 @@
 
 /datum/event/infectedroom/announce()
 	command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard \the [location_name()]. All personnel must contain the outbreak.", "Infectious Contaminant in [target_area.name]", new_sound = 'sound/AI/outbreak7.ogg')
-	// Chomp edit: Changed "Biohazard Alert" to "Infectious Contaminant" and also changed level 5 to level 7.
 
 /datum/event/infectedroom/start()
 	var/obj/effect/decal/cleanable/mucus/mapped/M

--- a/modular_chomp/code/modules/event/infectedroom.dm
+++ b/modular_chomp/code/modules/event/infectedroom.dm
@@ -90,8 +90,8 @@
 		message_admins("Infected room event started; Virus: <a href='?src=\ref[virus];[HrefToken()];info=1'>[virus.name()]</a>")
 
 /datum/event/infectedroom/announce()
-	command_announcement.Announce("Confirmed outbreak of level 5 biohazard aboard \the [location_name()]. \
-	All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak5.ogg')
+	command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard \the [location_name()]. All personnel must contain the outbreak.", "Infectious Contaminant", new_sound = 'sound/AI/outbreak7.ogg')
+	// Chomp edit: Changed "Biohazard Alert" to "Infectious Contaminant" and also changed level 5 to level 7.
 
 /datum/event/infectedroom/start()
 	var/obj/effect/decal/cleanable/mucus/mapped/M


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
I call it stupid but really this is just a result of really old Baycode that no one ever bothered to clean up or make consistent in any way so people have just been sort of blindly doing their own thing because nobody told them otherwise.

From now on.
Level 7 biohazard = stuff that's a danger but isn't immediately deadly. Level 5 biohazard = more severe stuff that you ought to react to like right now. The lower the number goes, the more urgent it is to handle. Level 7 is just the start of things that all crew have to react to.  Basically, the lower the number, the more urgent the issue is. A hypothetical level 1 biohazard would be just "the station is no man's land, arm the nuke, it must never be allowed to spread, nothing may survive, and quarantine the area afterwards just to be safe". Like that's a universe level threat kind of biohazard and will never be encountered in gameplay.

Furthermore, I made "Biohazard Alert" actually tell you what the fucking alert is now. So no more stupid "Wtf is a level 5 again?" "It's virus" "No it's vines" "No it's wallrot." Turns out, the alerts were made up and the numbers didn't matter. I fixed that.

Vines no longer trigger a level 5 alert also.

In conclusion, this is not a good solution but it's better than what we had.

Really we should just redo literally all the AI voice lines, but that's out of the scope of this PR.

## Changelog

:cl:Ace
qol: Made Biohazard levels actually tell you what they are.
/:cl: