### PR TITLE
Mind Binder food and cryo fixes

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -426,7 +426,7 @@
 			for(var/mob/living/V in W.possessed_voice) //CHOMPEdit - Revert temporary patch
 				//CHOMPEdit Start - Don't try and despawn, instead just ghost and delete, same as item destruction
 				V.ghostize(0)
-				V.Destroy()
+				qdel(V)
 				//CHOMPEdit End
 		//VOREStation Addition Start
 		if(istype(W, /obj/item/device/pda))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -423,9 +423,11 @@
 
 	for(var/obj/item/W in items)
 		if(islist(W.possessed_voice)) //CHOMPAdd
-			W.forceMove(get_turf(src)) //CHOMPAdd - this crashes the MC, so now they get spat back out.
-			items -= W
-			continue //CHOMPAdd
+			for(var/mob/living/V in W.possessed_voice) //CHOMPEdit - Revert temporary patch
+				//CHOMPEdit Start - Don't try and despawn, instead just ghost and delete, same as item destruction
+				V.ghostize(0)
+				V.Destroy()
+				//CHOMPEdit End
 		//VOREStation Addition Start
 		if(istype(W, /obj/item/device/pda))
 			var/obj/item/device/pda/found_pda = W

--- a/code/modules/food/food.dm
+++ b/code/modules/food/food.dm
@@ -56,6 +56,7 @@
 		pixel_y = (CELLSIZE * (0.5 + cell_y)) - center_of_mass["y"]
 
 /obj/item/weapon/reagent_containers/food/container_resist(mob/living/M)
+	if(istype(M, /mob/living/voice)) return	// CHOMPAdd - Stops sentient food from astral projecting
 	if(food_inserted_micros)
 		food_inserted_micros -= M
 	M.forceMove(get_turf(src))


### PR DESCRIPTION

## About The Pull Request
Fixes two things. Struggling while turned into a food item no longer pops the possession voice mob into the world, as reported in bug #7947. Sentient items are now properly removed when using cryo without crashing the machines MC subsystem.
## Changelog
:cl:
fix: Sentient food items can no longer astral project if they struggle
fix: Sentient items now despawn correctly when leaving through cryo/gateway
/:cl:
