### PR TITLE
map view fixes and tcomms

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -313,7 +313,7 @@
 
 
 		if("freq")
-			var/newfreq = tgui_input_number(usr, "Specify a new frequency to filter (GHz). Decimals assigned automatically.", src, null, 9999)
+			var/newfreq = tgui_input_number(usr, "Specify a new frequency to filter (GHz). Decimals assigned automatically.", src, max_value=9999)
 			if(newfreq && canAccess(usr))
 				if(findtext(num2text(newfreq), "."))
 					newfreq *= 10 // shift the decimal one place

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -313,13 +313,13 @@
 
 
 		if("freq")
-			var/newfreq = input(usr, "Specify a new frequency to filter (GHz). Decimals assigned automatically.", src, network) as null|num
+			var/newfreq = tgui_input_number(usr, "Specify a new frequency to filter (GHz). Decimals assigned automatically.", src, null, 9999)
 			if(newfreq && canAccess(usr))
 				if(findtext(num2text(newfreq), "."))
 					newfreq *= 10 // shift the decimal one place
 				if(!(newfreq in freq_listening) && newfreq < 10000)
 					freq_listening.Add(newfreq)
-					set_temp("-% New frequency filter assigned: \"[newfreq] GHz\" %-", "average")
+					set_temp("-% New frequency filter assigned: \"[newfreq/10] GHz\" %-", "average")
 				. = TRUE
 
 		if("delete")

--- a/code/modules/asset_cache/asset_list_items.dm
+++ b/code/modules/asset_cache/asset_list_items.dm
@@ -470,9 +470,9 @@
 	assets = list(
 		// CHOMP Edit: Restored for chomp station. Removed Tether.
 		"southern_cross_nanomap_z1.png"		= 'icons/_nanomaps/southern_cross_nanomap_z1.png',
-		"southern_cross_nanomap_z10.png"	= 'icons/_nanomaps/southern_cross_nanomap_z10.png',
 		"southern_cross_nanomap_z2.png"		= 'icons/_nanomaps/southern_cross_nanomap_z2.png',
 		"southern_cross_nanomap_z3.png"		= 'icons/_nanomaps/southern_cross_nanomap_z3.png',
+		"southern_cross_nanomap_z4.png"		= 'icons/_nanomaps/southern_cross_nanomap_z4.png',
 		"southern_cross_nanomap_z5.png"		= 'icons/_nanomaps/southern_cross_nanomap_z5.png',
 		"southern_cross_nanomap_z6.png"		= 'icons/_nanomaps/southern_cross_nanomap_z6.png',
 		"southern_cross_nanomap_z7.png"		= 'icons/_nanomaps/southern_cross_nanomap_z7.png',

--- a/code/modules/tgui/modules/atmos_control.dm
+++ b/code/modules/tgui/modules/atmos_control.dm
@@ -50,7 +50,7 @@
 	. = ..()
 
 	var/z = get_z(user)
-	var/list/map_levels = using_map.get_map_levels(z)
+	var/list/map_levels = using_map.get_visible_map_levels(z) //CHOMPEdit
 
 	// TODO: Move these to a cache, similar to cameras
 	var/alarms[0]
@@ -67,12 +67,13 @@
 			"y" = alarm.y,
 			"z" = alarm.z)
 	.["alarms"] = alarms
+	.["zoomScale"] = world.maxx + world.maxy
 
 /datum/tgui_module/atmos_control/tgui_data(mob/user)
 	var/list/data = list()
 
 	var/z = get_z(user)
-	var/list/map_levels = using_map.get_map_levels(z)
+	var/list/map_levels = using_map.get_visible_map_levels(z) //CHOMPEdit
 	data["map_levels"] = map_levels
 
 	return data

--- a/code/modules/tgui/modules/crew_monitor.dm
+++ b/code/modules/tgui/modules/crew_monitor.dm
@@ -32,7 +32,7 @@
 
 /datum/tgui_module/crew_monitor/tgui_interact(mob/user, datum/tgui/ui = null)
 	var/z = get_z(user)
-	var/list/map_levels = using_map.get_map_levels(z, TRUE, om_range = DEFAULT_OVERMAP_RANGE)
+	var/list/map_levels = using_map.get_visible_map_levels(z, TRUE)  //CHOMPEdit
 
 	if(!map_levels.len)
 		to_chat(user, "<span class='warning'>The crew monitor doesn't seem like it'll work here.</span>")
@@ -46,6 +46,9 @@
 		ui.autoupdate = TRUE
 		ui.open()
 
+/datum/tgui_module/crew_monitor/tgui_static_data(mob/user)
+	. = ..()
+	.["zoomScale"] = world.maxx + world.maxy
 
 /datum/tgui_module/crew_monitor/tgui_data(mob/user)
 	var/data[0]
@@ -53,7 +56,7 @@
 	data["isAI"] = isAI(user)
 
 	var/z = get_z(user)
-	var/list/map_levels = uniqueList(using_map.get_map_levels(z, TRUE, om_range = DEFAULT_OVERMAP_RANGE))
+	var/list/map_levels = uniqueList(using_map.get_visible_map_levels(z, TRUE))  //CHOMPEdit
 	data["map_levels"] = map_levels
 
 	var/list/crewmembers = list()

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -234,7 +234,6 @@ var/list/all_maps = list()
 		return contact_levels.Copy() - admin_levels
 	//If in station levels, return station levels
 	else if (srcz in station_levels)
-		to_world("Just station, ye?")
 		return station_levels.Copy()
 	//Just give them back their zlevel
 	else

--- a/maps/~map_system/maps.dm
+++ b/maps/~map_system/maps.dm
@@ -228,6 +228,19 @@ var/list/all_maps = list()
 	if(z) // Else, it's not a valid z and we want to expunge it
 		empty_levels |= z
 
+//CHOMPAdd Start restricted map view
+/datum/map/proc/get_visible_map_levels(var/srcz, var/long_range = FALSE)
+	if (long_range && (srcz in contact_levels))
+		return contact_levels.Copy() - admin_levels
+	//If in station levels, return station levels
+	else if (srcz in station_levels)
+		to_world("Just station, ye?")
+		return station_levels.Copy()
+	//Just give them back their zlevel
+	else
+		return list(srcz)
+//CHOMPAdd End
+
 // Get a list of 'nearby' or 'connected' zlevels.
 // You should at least return a list with the given z if nothing else.
 /datum/map/proc/get_map_levels(var/srcz, var/long_range = FALSE, var/om_range = -1)

--- a/tgui/packages/tgui/components/NanoMap.jsx
+++ b/tgui/packages/tgui/components/NanoMap.jsx
@@ -16,8 +16,6 @@ const pauseEvent = (e) => {
   return false;
 };
 
-const zoomScale = 280;
-
 export class NanoMap extends Component {
   constructor(props) {
     super(props);
@@ -79,8 +77,8 @@ export class NanoMap extends Component {
     };
 
     this.handleOnClick = (e) => {
-      let byondX = e.offsetX / this.state.zoom / zoomScale;
-      let byondY = 1 - e.offsetY / this.state.zoom / zoomScale; // Byond origin is bottom left, this is top left
+      let byondX = e.offsetX / this.state.zoom / this.props.zoomScale;
+      let byondY = 1 - e.offsetY / this.state.zoom / this.props.zoomScale; // Byond origin is bottom left, this is top left
 
       e.byondX = byondX;
       e.byondY = byondY;
@@ -130,7 +128,7 @@ export class NanoMap extends Component {
       config.map + '_nanomap_z' + config.mapZLevel + '.png',
     );
     // (x * zoom), x Needs to be double the turf- map size. (for virgo, 140x140)
-    const mapSize = zoomScale * zoom + 'px';
+    const mapSize = this.props.zoomScale * zoom + 'px';
     const newStyle = {
       width: mapSize,
       height: mapSize,

--- a/tgui/packages/tgui/interfaces/AtmosControl.jsx
+++ b/tgui/packages/tgui/interfaces/AtmosControl.jsx
@@ -50,7 +50,7 @@ export const AtmosControlContent = (props) => {
     // and change the @for scss to match.
     body = (
       <Box height="526px" mb="0.5rem" overflow="hidden">
-        <NanoMap onZoom={(v) => setZoom(v)}>
+        <NanoMap zoomScale={data.zoomScale} onZoom={(v) => setZoom(v)}>
           {sortedAlarms
             .filter((x) => ~~x.z === ~~config.mapZLevel)
             .map((cm) => (

--- a/tgui/packages/tgui/interfaces/CrewMonitor.jsx
+++ b/tgui/packages/tgui/interfaces/CrewMonitor.jsx
@@ -165,7 +165,7 @@ const CrewMonitorMapView = (props) => {
   const { act, config, data } = useBackend();
   return (
     <Box height="526px" mb="0.5rem" overflow="hidden">
-      <NanoMap onZoom={(v) => props.onZoom(v)}>
+      <NanoMap zoomScale={data.zoomScale} onZoom={(v) => props.onZoom(v)}>
         {data.crewmembers
           .filter(
             (x) => x.sensor_type === 3 && ~~x.realZ === ~~config.mapZLevel,

--- a/tgui/packages/tgui/interfaces/TelecommsMultitoolMenu.jsx
+++ b/tgui/packages/tgui/interfaces/TelecommsMultitoolMenu.jsx
@@ -122,7 +122,17 @@ const TelecommsMultitoolMenuStatus = (props) => {
           ))}
         </LabeledList>
       </Section>
-      <Section title="Filtering Frequencies" mt={1}>
+      <Section
+        title="Filtering Frequencies"
+        mt={1}
+        buttons={
+          <Button
+            icon="pen"
+            content="Add Frequency"
+            onClick={() => act('freq')}
+          />
+        }
+      >
         {filter.map((f) => (
           <Button.Confirm
             key={f.index}


### PR DESCRIPTION
## About The Pull Request
Contain changes from this https://github.com/VOREStation/VOREStation/pull/15899

fixes #8129
fixes #8066
## Changelog
:cl:
fix NanoMaps Marker offset on non 140x140 mapsize (NanoMaps now needs the zoomSize as props, handled as maxx+maxy in the tgui data)
fix: Telecomms filters can be added through the multitool menu
fix: admin maps showing on mapview (overmap is no longer considered for mapview)
/:cl:
