### PR TITLE
Allows item use when in weakened state

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -68,7 +68,7 @@
 		CtrlClickOn(A)
 		return 1
 
-	if(stat || paralysis || stunned || weakened)
+	if(stat || paralysis || stunned) //CHOMPedit, removed weakened to allow item use while crawling
 		return
 
 	face_atom(A) // change direction to face what you clicked on

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -972,7 +972,7 @@
 
 	if(incapacitated(INCAPACITATION_KNOCKOUT) || incapacitated(INCAPACITATION_STUNNED)) // CHOMPAdd - Making sure we're in good condition to crawl
 		canmove = 0
-		drop_both_hands()
+		//drop_both_hands() CHOMPremove, purple stuns dont drop items, this makes space EVA less frustrating and slips/shoves are already coded to drop your stuff.
 	else
 		canmove = 1
 

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -541,6 +541,7 @@
 		var/mob/living/carbon/human/H = T
 		if(H.species.lightweight == 1)
 			H.Stun(3) // CHOMPEdit - Crawling made this useless. Changing to stun instead.
+			H.drop_both_hands() //Stuns no longer drop items, so were forcing it >:3
 			return
 	var/armor_block = run_armor_check(T, "melee")
 	var/armor_soak = get_armor_soak(T, "melee")


### PR DESCRIPTION

## About The Pull Request
This PR will allow you to be able to pick stuff up and use items now when you're in a weakened state (Yellow stun) Which means even if you get pushed down, slipped, or forced down via delta-P, you are still able to pick up objects and use things.

Unfortunately, there is no way to differentiate between certain sources of weaken if one is from knockdown or if one is from pain but most sources of hard stuns (Bone breaks, blood loss, security tasers, t3 grabs) will still be unaffected, the main ones this affects is slips, shoves, and delta-P.

This also gets rid of object dropping when full stunned (purple symbol) so things like EVA travel wont drop your objects, (May need adjustment), Purple stuns are unchanged.

This will affect PvP as getting a push in wont be a instant win anymore, but things like tasers and non-lethal methods are unaffected as you black out from halloss.
## Changelog
:cl:
del: Removed items being dropped when in a purple stun, Less butter fingers when doing EVA!
balance: 'Weaken' status now allows you to use items. You still got a second chance!
/:cl:
