### PR TITLE
Crystals Moved

### DIFF
--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -1543,17 +1543,6 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/item/weapon/bluespace_crystal/artificial{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/obj/item/weapon/bluespace_crystal/artificial{
-	pixel_y = 7
-	},
-/obj/item/weapon/bluespace_crystal/artificial{
-	pixel_x = -7;
-	pixel_y = 7
-	},
 /turf/simulated/floor,
 /area/tcomm/tcomstorage)
 "agc" = (
@@ -26120,6 +26109,18 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/bluespace_crystal/artificial{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/weapon/bluespace_crystal/artificial{
+	pixel_y = 7
+	},
+/obj/item/weapon/bluespace_crystal/artificial{
+	pixel_x = -7;
+	pixel_y = 7
 	},
 /turf/simulated/floor/tiled,
 /area/tcomm/computer)


### PR DESCRIPTION

Hoo boy, will keep it short here but this may need discussion before merging despite being a small change. Suggestion made by Kascc during discussion of feedback.
## Changelog
:cl:
maptweak: Bluespace crystals in telecomms moved into a neighbouring room
/:cl:
