### PR TITLE
Deal with clients or keys on qdel of /mob/observer/dead

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -554,6 +554,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		M.following_mobs -= src
 	stop_following()
 	observer_mob_list -= src
+	//ChompEDIT START - deal with weird behavior on qdelled ghosts
+	if(client) //qdelling a ghost with a client = make a new ghost i guess
+		ghostize()
+	if(key) //qdelling a ghost with a key = remove the key first to prevent logging into the GC queue
+		key = null
+	//ChompEDIT END
+
 	return ..()
 
 /mob/Moved(atom/old_loc, direction, forced = FALSE)


### PR DESCRIPTION
This might prevent some weird glitchy behavior on ghosts

:cl:
add: Check for client/key and remove on qdel of a ghost
/:cl:
