### PR TITLE
[Deck 0] Maintenance Deck fixes and changes

### DIFF
--- a/code/game/area/Space Station 13 areas_ch.dm
+++ b/code/game/area/Space Station 13 areas_ch.dm
@@ -160,3 +160,6 @@
 	name = "\improper Cargo - Disposals Sorting"
 	icon_state = "quart"
 	flags = AREA_FLAG_IS_NOT_PERSISTENT
+
+/area/maintenance/field
+	name = "Maintenance Deck Field"

--- a/code/modules/events/mutants.dm
+++ b/code/modules/events/mutants.dm
@@ -7,6 +7,7 @@
 #define LOC_HANGAR1 6
 #define LOC_HANGAR2 7
 #define LOC_HANGAR3 8
+#define LOC_FIELD 9 // CHOMPEdit - More mutant places! This one might allow them to grow
 
 
 #define VERM_RATS 0
@@ -22,7 +23,7 @@
 
 /datum/event/mutants/start()
 
-	location = rand(0,8)
+	location = rand(0,9) // CHOMPEdit - Bumping up to 9
 	var/list/turf/simulated/floor/turfs = list()
 	var/spawn_area_type
 	switch(location)
@@ -53,6 +54,9 @@
 		if(LOC_HANGAR3)
 			spawn_area_type = /area/hangar/three
 			locstring = "the hangar deck"
+		if(LOC_FIELD) // CHOMPEdit - Another one for the list...
+			spawn_area_type = /area/maintenance/maintdeck/field
+			locstring = "the maintenance deck"
 
 	for(var/areapath in typesof(spawn_area_type))
 		var/area/A = locate(areapath)

--- a/code/modules/events/mutants.dm
+++ b/code/modules/events/mutants.dm
@@ -55,7 +55,7 @@
 			spawn_area_type = /area/hangar/three
 			locstring = "the hangar deck"
 		if(LOC_FIELD) // CHOMPEdit - Another one for the list...
-			spawn_area_type = /area/maintenance/maintdeck/field
+			spawn_area_type = /area/maintenance/field
 			locstring = "the maintenance deck"
 
 	for(var/areapath in typesof(spawn_area_type))

--- a/code/modules/mob/living/simple_mob/subtypes/vore/rat_ch.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/rat_ch.dm
@@ -14,3 +14,21 @@
 	icon_rest = "labrat_rest"
 	faction = "neutral"
 	icon = 'modular_chomp/icons/mob/vore64x32_ch.dmi'
+
+/mob/living/simple_mob/vore/aggressive/rat/labrat/genetics
+	name = "Nibbles"
+	desc = "A giant rat that made it's nest in an abandoned genetics lab. This one seems fairly docile."
+	ai_holder_type = /datum/ai_holder/simple_mob/retaliate
+
+	vore_active = 1
+	vore_capacity = 1
+	vore_escape_chance = 20
+	swallowTime = 25
+	vore_bump_chance = 100
+	faction_bump_vore = 1
+	vore_standing_too = TRUE
+	vore_pounce_chance = 75
+	vore_pounce_maxhealth = 80
+	vore_bump_emote = "knocks over and attempts to engulf"
+
+	can_be_drop_prey = FALSE

--- a/maps/southern_cross/southern_cross-0.dmm
+++ b/maps/southern_cross/southern_cross-0.dmm
@@ -2833,6 +2833,7 @@
 	id_tag = "MaintRoom1";
 	req_one_access = null
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/wood/turfpack/station,
 /area/maintenance/bar/dorm_1)
 "kV" = (
@@ -8479,6 +8480,7 @@
 	id_tag = "MaintRoom2";
 	req_one_access = null
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/wood/turfpack/station,
 /area/maintenance/bar/dorm_2)
 "HI" = (

--- a/maps/southern_cross/southern_cross-0.dmm
+++ b/maps/southern_cross/southern_cross-0.dmm
@@ -5202,12 +5202,6 @@
 /obj/structure/smolebuilding/warehouses,
 /turf/simulated/floor/smole,
 /area/maintenance/smoleroom)
-"ut" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/space,
-/area/space)
 "uy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -49472,7 +49466,7 @@ wZ
 wZ
 wZ
 wZ
-ut
+jx
 wZ
 wZ
 HE

--- a/maps/southern_cross/southern_cross-0.dmm
+++ b/maps/southern_cross/southern_cross-0.dmm
@@ -129,7 +129,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "aw" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -212,7 +212,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "aN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -397,7 +397,7 @@
 "bj" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "bl" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -424,7 +424,7 @@
 "bo" = (
 /obj/item/device/radio/subspace,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "bp" = (
 /obj/structure/prop/dark_node,
 /turf/simulated/floor/plating/turfpack/station,
@@ -556,7 +556,7 @@
 	},
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "bT" = (
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor/glass,
@@ -574,7 +574,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "bV" = (
 /obj/structure/bed/chair/wood,
 /obj/structure/cable{
@@ -634,7 +634,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "cn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -656,7 +656,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "cq" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -677,7 +677,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "ct" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -710,12 +710,12 @@
 "cz" = (
 /obj/item/weapon/laserdome_flag/red,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "cD" = (
 /obj/random/trash,
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "cE" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -779,7 +779,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "cP" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -800,7 +800,7 @@
 	},
 /obj/random/tool/powermaint,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "cV" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -815,7 +815,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "cX" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -978,7 +978,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "dG" = (
 /obj/structure/railing,
 /turf/simulated/floor/wood/alt/panel/broken/turfpack/station,
@@ -1012,7 +1012,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "dO" = (
 /obj/random/trash,
 /turf/simulated/floor/lino,
@@ -1264,7 +1264,7 @@
 "eM" = (
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "eN" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -1282,7 +1282,7 @@
 /obj/structure/catwalk,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "eQ" = (
 /obj/structure/table/rack/shelf,
 /obj/random/tool,
@@ -1391,7 +1391,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "fl" = (
 /obj/structure/table/rack/shelf,
 /obj/random/mainttoyloot,
@@ -1407,7 +1407,7 @@
 "fm" = (
 /obj/machinery/light/floortube,
 /turf/simulated/floor/grass2/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "fo" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/cobweb,
@@ -1458,7 +1458,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "fx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1589,7 +1589,7 @@
 "gc" = (
 /obj/structure/hyperball_goal/blue,
 /turf/simulated/floor/tiled/monotile,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "gd" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -1679,7 +1679,7 @@
 	},
 /obj/random/tool,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "gp" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1929,7 +1929,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "ht" = (
 /obj/structure/bed/pillowpilefront/orange,
 /turf/simulated/floor/wood/broken/turfpack/station,
@@ -1970,7 +1970,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "hC" = (
 /turf/simulated/wall,
 /area/maintenance/janitoral)
@@ -2026,7 +2026,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "hR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -2159,14 +2159,14 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "ir" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "iu" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2267,7 +2267,7 @@
 /area/space)
 "iS" = (
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "iU" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -2280,7 +2280,7 @@
 "iX" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "iY" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -2292,7 +2292,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "jb" = (
 /obj/random/trash,
 /obj/random/junk,
@@ -2350,7 +2350,7 @@
 "jm" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "jn" = (
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
@@ -2405,7 +2405,7 @@
 	},
 /obj/random/flashlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "ju" = (
 /obj/effect/decal/cleanable/flour,
 /obj/structure/cable{
@@ -2592,7 +2592,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "kb" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
@@ -2635,7 +2635,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "kg" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -2714,7 +2714,7 @@
 /area/maintenance/aft)
 "kt" = (
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "kw" = (
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
@@ -2756,11 +2756,11 @@
 "kI" = (
 /obj/structure/hyperball_goal/red,
 /turf/simulated/floor/tiled/monotile,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "kJ" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "kK" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -2933,7 +2933,7 @@
 /area/maintenance/abcargo)
 "lt" = (
 /turf/simulated/floor/tiled/monotile,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "lv" = (
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/plating/turfpack/station,
@@ -2999,7 +2999,7 @@
 /area/engineering/backuppowerlobby)
 "lK" = (
 /turf/simulated/floor/grass2/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "lL" = (
 /turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/bar/dorm_2)
@@ -3057,7 +3057,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "ma" = (
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -3068,7 +3068,7 @@
 /area/engineering/gravgen)
 "mb" = (
 /turf/simulated/wall,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "me" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
@@ -3076,7 +3076,7 @@
 "mh" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "mj" = (
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
@@ -3087,7 +3087,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "mo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3153,7 +3153,7 @@
 "my" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "mz" = (
 /obj/structure/door_assembly/door_assembly_highsecurity,
 /turf/simulated/floor/plating,
@@ -3192,7 +3192,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "mF" = (
 /obj/structure/sign/levels/engineering{
 	dir = 5
@@ -3208,10 +3208,10 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "mJ" = (
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "mK" = (
 /obj/structure/table/rack/shelf,
 /obj/random/powercell,
@@ -3237,7 +3237,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "mN" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -3246,7 +3246,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "mO" = (
 /obj/structure/sign/directions/stairs_up{
 	dir = 10
@@ -3298,7 +3298,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "mW" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
@@ -3360,7 +3360,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "nc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3372,7 +3372,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "nf" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/turfpack/station,
@@ -3591,7 +3591,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "nU" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -3903,7 +3903,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "pg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating/turfpack/station,
@@ -3941,7 +3941,7 @@
 	pixel_x = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "pq" = (
 /obj/structure/table/rack/shelf,
 /obj/random/medical/pillbottle,
@@ -4107,7 +4107,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "pW" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -4177,7 +4177,7 @@
 "qo" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "qq" = (
 /turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/lookout)
@@ -4382,12 +4382,12 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "qW" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "rc" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -4638,7 +4638,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "sa" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
@@ -4646,7 +4646,7 @@
 "sc" = (
 /obj/random/trash,
 /turf/simulated/floor/grass2/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "se" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/turfpack/station,
@@ -4677,7 +4677,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "sk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -4825,7 +4825,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "sL" = (
 /obj/item/weapon/storage/firstaid/regular{
 	pixel_x = 2;
@@ -4850,7 +4850,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "sT" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
@@ -4861,7 +4861,7 @@
 /area/engineering/lowlobby)
 "sW" = (
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "sY" = (
 /obj/structure/table/woodentable,
 /obj/random/maintenance/foodstuff,
@@ -4873,7 +4873,7 @@
 /area/maintenance/engineering/gravgen)
 "tb" = (
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "tf" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4977,7 +4977,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "tx" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5041,7 +5041,7 @@
 	},
 /obj/random/flashlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "tN" = (
 /obj/item/weapon/storage/briefcase/inflatable,
 /turf/simulated/floor/plating/turfpack/station,
@@ -5101,7 +5101,7 @@
 /obj/structure/hyperball_pedestal,
 /obj/item/weapon/laserdome_hyperball,
 /turf/simulated/floor/grass2/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "ue" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow{
@@ -5241,11 +5241,11 @@
 	pixel_x = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "uG" = (
 /obj/item/weapon/laserdome_flag/blue,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "uH" = (
 /obj/machinery/door/airlock/hatch{
 	icon_state = "door_locked";
@@ -5427,7 +5427,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "vx" = (
 /obj/structure/closet/lasertag/blue,
 /obj/item/device/tvcamera{
@@ -5439,7 +5439,7 @@
 	name = "hyperball camera drone"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "vy" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -5490,7 +5490,7 @@
 "vJ" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "vK" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
@@ -5512,14 +5512,14 @@
 	name = "hyperball camera drone"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "vM" = (
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor/multi_tile/glass{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "vN" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/wood/alt/parquet/turfpack/station,
@@ -5848,13 +5848,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "xb" = (
 /obj/structure/sign/directions/ladder_up{
 	dir = 1
 	},
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "xd" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5987,7 +5987,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "xG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6124,7 +6124,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "yj" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -6220,14 +6220,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "yM" = (
 /obj/structure/railing/grey{
 	dir = 4
 	},
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "yN" = (
 /turf/simulated/wall/r_wall/turfpack/station,
 /area/engineering/backuppowerlobby)
@@ -6376,7 +6376,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "zu" = (
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abcargo)
@@ -6507,7 +6507,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/barricade,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Af" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -7011,7 +7011,7 @@
 /area/maintenance/bar)
 "BZ" = (
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Ca" = (
 /obj/structure/sign/directions/recreation{
 	dir = 4
@@ -7038,7 +7038,7 @@
 	on = 0
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Cg" = (
 /obj/structure/sign/warning/radioactive{
 	pixel_y = -32
@@ -7068,7 +7068,7 @@
 "Cl" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "Cm" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -7251,7 +7251,7 @@
 /obj/structure/table/rack/shelf,
 /obj/item/device/radio/subspace,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "CR" = (
 /obj/structure/flora/pottedplant/decorative,
 /turf/simulated/floor/plating/turfpack/station,
@@ -7342,7 +7342,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Dk" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -7571,7 +7571,7 @@
 "Eq" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "Er" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -7679,7 +7679,7 @@
 "EM" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "EN" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/plating/turfpack/station,
@@ -7689,7 +7689,7 @@
 /obj/machinery/light/small,
 /obj/item/device/radio/subspace,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "EP" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/lino,
@@ -7760,7 +7760,7 @@
 	on = 0
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "Fb" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7858,7 +7858,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Fs" = (
 /obj/random/trash,
 /obj/machinery/alarm{
@@ -7915,7 +7915,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "FH" = (
 /obj/structure/smoletrack/roadF,
 /turf/simulated/floor/smole,
@@ -8157,7 +8157,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "GD" = (
 /obj/machinery/door/firedoor/multi_tile/glass{
 	dir = 1
@@ -8348,7 +8348,7 @@
 "Hk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Hl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -8709,7 +8709,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "ID" = (
 /obj/structure/sign/warning/radioactive{
 	pixel_y = -32
@@ -8847,7 +8847,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "Jm" = (
 /obj/structure/dark_portal/minion,
 /turf/simulated/floor/weird_things/dark,
@@ -8914,7 +8914,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "JH" = (
 /obj/structure/prop/dark_node/dust,
 /turf/simulated/floor/plating/turfpack/station,
@@ -8972,7 +8972,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "JP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9010,7 +9010,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "JY" = (
 /obj/random/trash,
 /obj/effect/floor_decal/rust,
@@ -9107,7 +9107,7 @@
 	on = 0
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Kl" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/cobweb2,
@@ -9248,7 +9248,7 @@
 "KM" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "KQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating/turfpack/station,
@@ -9775,7 +9775,7 @@
 "Ny" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Nz" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
@@ -9840,17 +9840,17 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "NM" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/item/tape/engineering,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "NN" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "NQ" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/plating/turfpack/station,
@@ -9901,7 +9901,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "NY" = (
 /obj/random/trash,
 /obj/structure/mob_spawner/mouse_nest/mousehole,
@@ -9988,7 +9988,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "Ok" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10020,7 +10020,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Oo" = (
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 3
@@ -10038,7 +10038,7 @@
 "Op" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "Oq" = (
 /obj/item/stack/material/smolebricks,
 /turf/simulated/floor/plating/turfpack/station,
@@ -10086,7 +10086,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "OE" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating/turfpack/station,
@@ -10207,7 +10207,7 @@
 "Pc" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Pd" = (
 /obj/structure/table/rack/shelf,
 /obj/random/maintenance/engineering,
@@ -10511,7 +10511,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Qq" = (
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abmedical)
@@ -10674,7 +10674,7 @@
 "Rd" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Re" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/plating/turfpack/station,
@@ -10712,7 +10712,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "Rl" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -10727,7 +10727,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Ro" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10745,7 +10745,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "Rt" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
@@ -10801,7 +10801,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "RL" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
@@ -10824,7 +10824,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "RQ" = (
 /turf/simulated/wall,
 /area/maintenance/abhydroponicssupp)
@@ -10955,7 +10955,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "SB" = (
 /obj/random/instrument,
 /turf/simulated/floor/wood/alt/panel,
@@ -10990,7 +10990,7 @@
 /obj/structure/railing/grey,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "SI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11013,7 +11013,7 @@
 /area/engineering/backuppower)
 "SN" = (
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "SP" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11030,7 +11030,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "ST" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -11073,7 +11073,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "SY" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
@@ -11112,7 +11112,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Ti" = (
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood/turfpack/station,
@@ -11176,7 +11176,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Tx" = (
 /obj/random/crate,
 /turf/simulated/floor/tiled,
@@ -11325,7 +11325,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "TW" = (
 /obj/random/mouseremains,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11388,7 +11388,7 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Up" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/gravgen)
@@ -11428,7 +11428,7 @@
 "Ux" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Uz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11460,7 +11460,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "UJ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow{
@@ -11663,7 +11663,7 @@
 "Vt" = (
 /obj/random/junk,
 /turf/simulated/floor/grass2/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Vu" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11850,7 +11850,7 @@
 "Wb" = (
 /obj/item/device/radio/subspace,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Wc" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
@@ -11875,7 +11875,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Wm" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/floor_decal/borderfloor,
@@ -11961,7 +11961,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Wx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12021,7 +12021,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "WN" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -12111,7 +12111,7 @@
 	},
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Xm" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable{
@@ -12459,7 +12459,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/maintenance/maintdeck/field)
+/area/maintenance/field)
 "Yt" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -12559,14 +12559,14 @@
 /area/maintenance/engineering/gravgen)
 "YG" = (
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "YH" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "YI" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12656,7 +12656,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldthrift)
+/area/maintenance/fieldthrift)
 "Zd" = (
 /turf/simulated/wall/turfpack/station,
 /area/maintenance/starboard)
@@ -12711,7 +12711,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 "Zm" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -13005,7 +13005,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/maintdeck/fieldhallway)
+/area/maintenance/fieldhallway)
 
 (1,1,1) = {"
 wZ

--- a/maps/southern_cross/southern_cross-0.dmm
+++ b/maps/southern_cross/southern_cross-0.dmm
@@ -3595,7 +3595,7 @@
 "nU" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
-/turf/simulated/wall/r_wall/turfpack/station,
+/turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abscience)
 "nX" = (
 /obj/item/weapon/material/shard{
@@ -4721,6 +4721,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
@@ -8428,7 +8431,7 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/barricade,
 /obj/machinery/door/firedoor/border_only,
-/turf/simulated/wall/r_wall/turfpack/station,
+/turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abscience)
 "Hz" = (
 /obj/structure/cable{

--- a/maps/southern_cross/southern_cross-0.dmm
+++ b/maps/southern_cross/southern_cross-0.dmm
@@ -143,9 +143,16 @@
 /turf/simulated/floor/tiled/white,
 /area/maintenance/abfirstaid)
 "ay" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows/yellow{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/arrows/yellow{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance/common,
-/obj/item/tape/engineering,
-/turf/simulated/floor/plating/turfpack/station,
+/obj/item/tape/atmos,
+/turf/simulated/floor/tiled/techmaint,
 /area/maintenance/starboard)
 "aC" = (
 /obj/effect/floor_decal/rust,
@@ -1056,6 +1063,18 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/hydro,
 /area/maintenance/abhydroponicssupp)
+"dX" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "d0_outer";
+	locked = 1;
+	name = "External Airlock Access";
+	req_access = list(13)
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "dY" = (
 /obj/structure/curtain/bed,
 /turf/simulated/floor/plating/turfpack/station,
@@ -1179,6 +1198,8 @@
 	name = "External Airlock Access";
 	req_access = list(13)
 	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/effect/map_helper/airlock/button/ext_button,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "ez" = (
@@ -1486,6 +1507,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/aft)
+"fL" = (
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating/turfpack/station,
+/area/maintenance/engineering)
 "fM" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -2076,6 +2101,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/starboard)
 "ic" = (
@@ -2094,6 +2120,7 @@
 	name = "Internal Airlock Access";
 	req_access = list(13)
 	},
+/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "if" = (
@@ -2414,6 +2441,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
@@ -3775,20 +3805,9 @@
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/starboard)
 "oH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar)
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating/turfpack/station,
+/area/maintenance/starboard)
 "oJ" = (
 /obj/structure/sign/directions/recreation{
 	dir = 5
@@ -4015,9 +4034,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/engineering/gravgen)
 "pE" = (
-/mob/living/simple_mob/vore/aggressive/rat/labrat{
-	faction = "mouse"
-	},
+/mob/living/simple_mob/vore/aggressive/rat/labrat/genetics,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/absgenetics)
 "pH" = (
@@ -4284,6 +4301,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/port)
 "qJ" = (
@@ -5287,6 +5306,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/port)
 "uS" = (
@@ -5791,20 +5811,18 @@
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/aft)
 "wV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1379;
+	icon_state = "door_locked";
+	id_tag = "d0_inner";
+	locked = 1;
+	name = "Internal Airlock Access";
+	req_access = list(13)
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/effect/map_helper/airlock/button/int_button,
+/turf/simulated/floor/plating,
+/area/maintenance/port)
 "wW" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating,
@@ -6622,6 +6640,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/port)
 "AE" = (
@@ -7219,10 +7238,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/port)
 "CK" = (
-/obj/effect/floor_decal/rust,
-/obj/item/tape/medical,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/abchemistry)
+/area/maintenance/aft)
 "CN" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/item/tape/engineering,
@@ -7415,16 +7433,6 @@
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/engineering)
 "DN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -8407,7 +8415,6 @@
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/port)
 "Hw" = (
-/obj/structure/closet/crate/mimic/cointoss,
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
@@ -8893,9 +8900,6 @@
 /area/maintenance/engineering/gravgen)
 "JC" = (
 /obj/effect/floor_decal/rust,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -10053,6 +10057,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/backuppower)
+"Ox" = (
+/obj/structure/catwalk,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating/turfpack/station,
+/area/maintenance/port)
 "Oy" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -10855,6 +10864,7 @@
 	name = "Medical Storage";
 	req_one_access = null
 	},
+/obj/item/tape/medical,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/abchemistry)
 "Se" = (
@@ -11812,6 +11822,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/port)
 "VY" = (
@@ -12480,14 +12491,11 @@
 	frequency = 1379;
 	master_tag = "d3_port_dorms_airlock";
 	name = "exterior access button";
-	pixel_x = 25;
-	pixel_y = -26;
-	req_access = null
+	pixel_y = 0;
+	req_access = null;
+	dir = 8;
+	pixel_x = 25
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating/turfpack/airless,
 /area/space)
 "YB" = (
@@ -33504,7 +33512,7 @@ sV
 sV
 sV
 ua
-sA
+Ox
 Do
 ua
 iP
@@ -36101,8 +36109,8 @@ iP
 iP
 iP
 nS
+nS
 YA
-iP
 TJ
 wZ
 wZ
@@ -36358,7 +36366,7 @@ Cm
 PN
 We
 We
-ex
+dX
 ex
 ua
 ua
@@ -37132,7 +37140,7 @@ Ac
 qh
 ca
 dm
-ie
+wV
 ie
 jU
 ua
@@ -39161,7 +39169,7 @@ Td
 Td
 Td
 EK
-wV
+uy
 AV
 zK
 WF
@@ -39939,7 +39947,7 @@ uy
 WG
 Hc
 WG
-oH
+WG
 fe
 uy
 WG
@@ -39959,7 +39967,7 @@ xf
 xz
 xf
 Sd
-CK
+sr
 Xm
 SF
 Ir
@@ -42255,7 +42263,7 @@ pj
 jC
 qf
 Et
-OE
+CK
 Mq
 Mq
 wZ
@@ -46124,7 +46132,7 @@ jC
 Ng
 cX
 jC
-OE
+CK
 fb
 xS
 xS
@@ -46395,7 +46403,7 @@ CE
 CE
 gG
 Sb
-Ky
+fL
 dd
 jd
 lc
@@ -50044,7 +50052,7 @@ pj
 qf
 jC
 xL
-OE
+CK
 OE
 pj
 pj
@@ -52821,8 +52829,8 @@ wZ
 wZ
 wZ
 wZ
-wZ
-wZ
+XU
+xC
 wZ
 wZ
 wZ
@@ -53080,7 +53088,7 @@ wZ
 wZ
 wZ
 wZ
-wZ
+eY
 wZ
 wZ
 wZ
@@ -53336,9 +53344,9 @@ wZ
 wZ
 wZ
 wZ
-wZ
-wZ
-wZ
+il
+il
+eY
 wZ
 wZ
 wZ
@@ -53594,9 +53602,9 @@ wZ
 wZ
 wZ
 wZ
-wZ
-XU
-xC
+il
+lR
+Yk
 wZ
 wZ
 wZ
@@ -53852,9 +53860,9 @@ wZ
 wZ
 wZ
 wZ
-wZ
-wZ
-eY
+il
+il
+Yk
 wZ
 wZ
 wZ
@@ -54110,9 +54118,9 @@ wZ
 wZ
 wZ
 wZ
-il
-il
-eY
+wZ
+wZ
+Yk
 wZ
 wZ
 wZ
@@ -54368,8 +54376,8 @@ wZ
 wZ
 wZ
 wZ
-il
-lR
+wZ
+wZ
 Yk
 Yk
 Yk
@@ -54626,8 +54634,8 @@ wZ
 wZ
 wZ
 wZ
-Yk
-Yk
+wZ
+wZ
 Yk
 wZ
 wZ
@@ -54886,7 +54894,7 @@ wZ
 wZ
 wZ
 wZ
-Yk
+wZ
 wZ
 wZ
 wZ
@@ -57504,7 +57512,7 @@ Fv
 Fv
 Fv
 Fv
-ZK
+oH
 xh
 gL
 Yk
@@ -59011,7 +59019,7 @@ wZ
 wZ
 wZ
 wZ
-wZ
+Yk
 eY
 eY
 wZ
@@ -59269,8 +59277,8 @@ wZ
 wZ
 wZ
 wZ
-wZ
-wZ
+Yk
+lR
 eY
 eY
 eY
@@ -59527,9 +59535,9 @@ wZ
 wZ
 wZ
 wZ
-wZ
-wZ
-wZ
+Yk
+Yk
+Yk
 wZ
 wZ
 wZ

--- a/maps/southern_cross/southern_cross-0.dmm
+++ b/maps/southern_cross/southern_cross-0.dmm
@@ -220,7 +220,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "aO" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/foam,
@@ -291,7 +291,7 @@
 	on = 0
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "aV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -464,7 +464,7 @@
 /area/maintenance/abscience)
 "bs" = (
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "bt" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/alarm{
@@ -953,7 +953,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "dx" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -967,7 +967,7 @@
 /area/maintenance/central)
 "dB" = (
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "dD" = (
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abchemistry)
@@ -993,7 +993,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "dJ" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -1020,7 +1020,7 @@
 "dP" = (
 /obj/structure/bed/chair/bay/chair/padded/red/bignest,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "dR" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -1188,7 +1188,7 @@
 /obj/structure/table/standard,
 /obj/random/maintenance/foodstuff,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "ex" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -1719,7 +1719,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "gB" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
@@ -1875,7 +1875,7 @@
 /area/maintenance/thrift)
 "he" = (
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "hg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating/turfpack/station,
@@ -1933,7 +1933,7 @@
 "ht" = (
 /obj/structure/bed/pillowpilefront/orange,
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "hx" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating/turfpack/station,
@@ -2701,7 +2701,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "kq" = (
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/smoleroom)
@@ -2835,7 +2835,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "kV" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/head/fishing,
@@ -3003,7 +3003,7 @@
 /area/maintenance/field)
 "lL" = (
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "lM" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/grass,
@@ -3453,7 +3453,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "nq" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 5
@@ -3735,7 +3735,7 @@
 	on = 0
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "oq" = (
 /obj/structure/table/rack/shelf,
 /obj/random/material,
@@ -3795,7 +3795,7 @@
 	specialfunctions = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "oE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -4313,7 +4313,7 @@
 "qK" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "qL" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -4433,7 +4433,7 @@
 "rh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "ri" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -4466,7 +4466,7 @@
 "rn" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "ro" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/landmark/event_spawn/morphspawn,
@@ -6024,7 +6024,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "xL" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
@@ -6572,7 +6572,7 @@
 	},
 /obj/structure/bed/pillowpilefront/teal,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "An" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating/turfpack/station,
@@ -7080,7 +7080,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "Co" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -7092,7 +7092,7 @@
 "Cq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "Cr" = (
 /obj/random/junk,
 /obj/structure/cable{
@@ -8093,7 +8093,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "Gn" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -8451,7 +8451,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "HE" = (
 /turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/ragecage)
@@ -8482,7 +8482,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "HI" = (
 /obj/structure/sign/directions/engineering{
 	dir = 9;
@@ -9259,7 +9259,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "KS" = (
 /obj/structure/closet/crate/secure/large,
 /obj/effect/floor_decal/rust,
@@ -9448,7 +9448,7 @@
 /area/maintenance/central)
 "LY" = (
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "Mf" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -9576,7 +9576,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "MH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9805,7 +9805,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "NG" = (
 /obj/structure/sign/levels/engineering/gravgen{
 	pixel_y = 5
@@ -10430,7 +10430,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "PV" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -10550,7 +10550,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "QE" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/light/small{
@@ -10577,7 +10577,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "QM" = (
 /turf/simulated/floor/tiled/hydro,
 /area/maintenance/abhydroponics)
@@ -11292,7 +11292,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_1)
+/area/maintenance/bar/dorms/dorm_1)
 "TR" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
@@ -12866,7 +12866,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar/dorm_2)
+/area/maintenance/bar/dorms/dorm_2)
 "ZF" = (
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag{
@@ -40207,7 +40207,7 @@ he
 he
 kU
 he
-lL
+he
 lL
 lL
 HH
@@ -40465,7 +40465,7 @@ Am
 LY
 TQ
 QC
-lL
+he
 dI
 dB
 gy
@@ -40723,7 +40723,7 @@ aU
 aN
 PU
 ev
-lL
+he
 op
 ZE
 Gm
@@ -40981,7 +40981,7 @@ np
 Cq
 Cn
 dw
-lL
+he
 MF
 rh
 HC
@@ -41239,7 +41239,7 @@ NF
 xK
 dP
 rn
-lL
+he
 QJ
 dB
 bs
@@ -41497,7 +41497,7 @@ he
 he
 he
 he
-lL
+he
 lL
 qK
 KR

--- a/maps/southern_cross/southern_cross_areas.dm
+++ b/maps/southern_cross/southern_cross_areas.dm
@@ -2331,12 +2331,9 @@ End Chompstation Edit*/
 /area/maintenance/engineering/gravgen
 	name = "Gravity Generator Maintenance"
 
-/area/maintenance/maintdeck/field
-	name = "Maintenance Deck Field"
-
-/area/maintenance/maintdeck/fieldhallway
+/area/maintenance/fieldhallway
 	name = "Maintenance Deck Field Hallway"
-/area/maintenance/maintdeck/fieldthrift
+/area/maintenance/fieldthrift
 	name = "Maintenance Deck Thrift Store Hallway"
 
 /area/maintenance/abhydroponicssupp

--- a/maps/southern_cross/southern_cross_areas.dm
+++ b/maps/southern_cross/southern_cross_areas.dm
@@ -2351,8 +2351,17 @@ End Chompstation Edit*/
 /area/maintenance/lookout
 	name = "Maintenance Deck Lookout"
 
-/area/maintenance/bar/dorm_1
+/area/maintenance/bar/dorms
+	name = "Maintenance Bar Dorms"
+	icon_state = "Sleep"
+	soundproofed = TRUE
+	limit_mob_size = FALSE
+	block_suit_sensors = TRUE
+	flags = RAD_SHIELDED
+	block_tracking = TRUE
+
+/area/maintenance/bar/dorms/dorm_1
 	name = "Maintenance Deck Bar Dorms 1"
 
-/area/maintenance/bar/dorm_2
+/area/maintenance/bar/dorms/dorm_2
 	name = "Maintenance Deck Bar Dorms 2"

--- a/modular_chomp/code/game/objects/mob_spawner.dm
+++ b/modular_chomp/code/game/objects/mob_spawner.dm
@@ -31,8 +31,9 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "tunnel_hole"
 	spawn_types = list(
-	/mob/living/simple_mob/animal/passive/mouse= 100,
+	/mob/living/simple_mob/animal/passive/mouse = 100,
     /mob/living/simple_mob/animal/passive/cockroach = 25,
+	/mob/living/simple_mob/animal/passive/mouse/rat = 10, // Because I'm a horrible person. <3
 	/obj/effect/spider/spiderling/non_growing = 5)
 
 /obj/structure/mob_spawner/mouse_nest/mousehole/New()

--- a/modular_chomp/code/modules/event/event_container_ch.dm
+++ b/modular_chomp/code/modules/event/event_container_ch.dm
@@ -85,7 +85,7 @@
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Grub Infestation",			/datum/event/grub_infestation,			-20,	list(ASSIGNMENT_SECURITY = 40, ASSIGNMENT_ENGINEER = 40), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Infected Room",			/datum/event/infectedroom,				-30,	list(ASSIGNMENT_MEDICAL = 30, ASSIGNMENT_JANITOR = 10, ASSIGNMENT_ANY = 1), 	1, min_jobs = list(ASSIGNMENT_MEDICAL = 2)),
 		// Pure RP fun, no mechanical effects.
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					-125,	list(ASSIGNMENT_AI = 80, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_SCIENTIST = 5), min_jobs = list(ASSIGNMENT_SCIENTIST = 1, ASSIGNMENT_CYBORG = 3)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Ion Storm",				/datum/event/ionstorm, 					-125,	list(ASSIGNMENT_AI = 80, ASSIGNMENT_CYBORG = 50, ASSIGNMENT_ENGINEER = 15, ASSIGNMENT_SCIENTIST = 5), min_jobs = list(ASSIGNMENT_CYBORG = 3)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Jellyfish School",			/datum/event/jellyfish_migration,		5,		list(ASSIGNMENT_ANY = 1, ASSIGNMENT_SECURITY = 5, ASSIGNMENT_MEDICAL = 3), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Maintenance Predator",		/datum/event/maintenance_predator,		75,		list(ASSIGNMENT_SECURITY = 25, ASSIGNMENT_SCIENTIST = 10), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Meaty Ore Shower",			/datum/event/meteor_wave/meatyores,		-50,	list(ASSIGNMENT_ENGINEER = 45), 1, min_jobs = list(ASSIGNMENT_ENGINEER = 2)),


### PR DESCRIPTION
## About The Pull Request

A few things people have been pointing out
Also throwing it here, taking off the sci requirement for Ion Storms

## Changelog
:cl:
add: Small chance of rats to pop out of mice spawners in Maintenance Deck
add: Mutants event may trigger in the Maintenance Deck
qol: Abandoned Genetics rat is a bit more friendly now. Sometimes a bit too friendly.
qol: Scientist requirement for Ion Storms removed
maptweak: Added a missing supply pipe in Maintenance Deck
maptweak: Fixed airlock leading to space not working
maptweak: Removed duplicated wires
del: Removed mimic crate from Abandoned Cargo
/:cl:
