### PR TITLE
Drop items in hands on mouse ray transformation

### DIFF
--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -92,6 +92,7 @@
 	if(target != firer)	//If you shot yourself, you probably want to be TFed so don't bother with prefs.
 		if(!M.allow_spontaneous_tf && !tf_admin_pref_override)
 			return
+	M.drop_both_hands()	//CHOMPAdd - Drop items in hand before transformation
 	if(M.tf_mob_holder)
 		new /obj/effect/effect/teleport_greyscale(M.loc) //CHOMPEdit Start
 		var/mob/living/ourmob = M.tf_mob_holder


### PR DESCRIPTION

## About The Pull Request
Fixing a side effect of #8154 where upon shooting yourself with a mouse ray variant the gun would no longer drop on the floor. It would instead stay held by the player's mob inside the TF mob holder. This would mean it's inaccessible for others to revert the transformation using the gun again.
## Changelog
:cl:
fix: Mice rays drop on the floor properly when shooting yourself
/:cl:
