### PR TITLE
fix some weakened and speech issues

### DIFF
--- a/code/game/objects/items_vr.dm
+++ b/code/game/objects/items_vr.dm
@@ -3,7 +3,7 @@
 	var/list/warned_of_possession //Checks to see who has been informed this item is possessed.
 
 
-/obj/item/proc/inhabit_item(var/mob/candidate, var/candidate_name, var/mob/living/candidate_original_form)
+/obj/item/proc/inhabit_item(var/mob/candidate, var/candidate_name, var/mob/living/candidate_original_form, var/is_item_tf = FALSE) //CHOMPEdit
 	//This makes it so that any object in the game can have something put in it like the cursed sword!
 	//This means the proc can also be manually called by admin commands.
 	//Handle moving the person into the object.
@@ -27,6 +27,9 @@
 	remove_verb(new_voice,/mob/living/voice/verb/hang_up ) //Also you can't hang up. You are the item! //CHOMPEdit
 	src.item_tf_spawnpoint_used() //CHOMPEdit - Item TF spawnpoints
 	//CHOMPEdit Start - Let the inhabitor know what happened to them
+	if(!istype(src, /obj/item/device/communicator))
+		new_voice.item_tf = is_item_tf 					// allows items to use /me
+		new_voice.emote_type = 1
 	if(istype(src, /obj/item/device/mindbinder))
 		to_chat(new_voice,"<span class='notice'>Your mind has been stored in [src]!</span>")
 	else

--- a/code/game/objects/items_vr.dm
+++ b/code/game/objects/items_vr.dm
@@ -27,7 +27,7 @@
 	remove_verb(new_voice,/mob/living/voice/verb/hang_up ) //Also you can't hang up. You are the item! //CHOMPEdit
 	src.item_tf_spawnpoint_used() //CHOMPEdit - Item TF spawnpoints
 	//CHOMPEdit Start - Let the inhabitor know what happened to them
-	if(!istype(src, /obj/item/device/communicator))
+	if(!istype(src, /obj/item/device/communicator) && is_item_tf)
 		new_voice.item_tf = is_item_tf 					// allows items to use /me
 		new_voice.emote_type = 1
 	if(istype(src, /obj/item/device/mindbinder))

--- a/code/modules/mob/language/language.dm
+++ b/code/modules/mob/language/language.dm
@@ -298,13 +298,13 @@
 	if(href_list["default_lang"])
 		if(href_list["default_lang"] == "reset")
 			if (species_language)
-				set_default_language(GLOB.all_languages[species_language])
+				apply_default_language(GLOB.all_languages[species_language]) //CHOMPEdit
 			else
-				set_default_language(GLOB.all_languages[LANGUAGE_GIBBERISH])
+				apply_default_language(GLOB.all_languages[LANGUAGE_GIBBERISH]) //CHOMPEdit
 		else
 			var/datum/language/L = locate(href_list["default_lang"])
 			if(L && (L in languages))
-				set_default_language(L)
+				apply_default_language(L) //CHOMPEdit
 		check_languages()
 		return 1
 	else if(href_list["set_lang_key"])

--- a/code/modules/mob/living/default_language.dm
+++ b/code/modules/mob/living/default_language.dm
@@ -8,7 +8,7 @@
 
 	var/language = tgui_input_list(usr, "Select your default language", "Available languages", languages)
 
-	apply_language(language)
+	apply_default_language(language)
 
 
 // Silicons can't neccessarily speak everything in their languages list
@@ -22,9 +22,9 @@
 				default_language = lang
 				break
 		return
-	apply_language(language)
+	apply_default_language(language)
 
-/mob/living/proc/apply_language(var/language)
+/mob/living/proc/apply_default_language(var/language)
 	if (only_species_language && language != GLOB.all_languages[src.species_language])
 		to_chat(src, "<span class='notice'>You can only speak your species language, [src.species_language].</span>")
 		return 0

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -548,4 +548,4 @@
 	T.apply_damage(20, HALLOSS,, armor_block, armor_soak)
 	if(prob(75)) //75% chance to stun for 5 seconds, really only going to be 4 bcus click cooldown+animation.
 		T.apply_effect(5, STUN, armor_block)
-		T.drop_both_hands() //Stuns no longer drop items
+		T.drop_both_hands() //CHOMPEdit Stuns no longer drop items

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_modules_vr.dm
@@ -548,3 +548,4 @@
 	T.apply_damage(20, HALLOSS,, armor_block, armor_soak)
 	if(prob(75)) //75% chance to stun for 5 seconds, really only going to be 4 bcus click cooldown+animation.
 		T.apply_effect(5, STUN, armor_block)
+		T.drop_both_hands() //Stuns no longer drop items

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -33,7 +33,7 @@
 	silicon_mob_list |= src
 	..()
 	add_language(LANGUAGE_GALCOM)
-	set_default_language(GLOB.all_languages[LANGUAGE_GALCOM])
+	apply_default_language(GLOB.all_languages[LANGUAGE_GALCOM]) //CHOMPEdit
 	init_id()
 	init_subsystems()
 

--- a/code/modules/mob/living/voice/voice.dm
+++ b/code/modules/mob/living/voice/voice.dm
@@ -9,7 +9,7 @@
 
 /mob/living/voice/Initialize(loc)
 	add_language(LANGUAGE_GALCOM)
-	set_default_language(GLOB.all_languages[LANGUAGE_GALCOM])
+	apply_default_language(GLOB.all_languages[LANGUAGE_GALCOM]) //CHOMPEdit
 
 	if(istype(loc, /obj/item/device/communicator))
 		comm = loc

--- a/code/modules/mob/living/voice/voice.dm
+++ b/code/modules/mob/living/voice/voice.dm
@@ -4,6 +4,7 @@
 	desc = "How are you examining me?"
 	see_invisible = SEE_INVISIBLE_LIVING
 	var/obj/item/device/communicator/comm = null
+	var/item_tf = FALSE //CHOMPEdit
 
 	emote_type = 2 //This lets them emote through containers.  The communicator has a image feed of the person calling them so...
 
@@ -140,5 +141,10 @@
 	return ..()
 
 /mob/living/voice/custom_emote(var/m_type = VISIBLE_MESSAGE, var/message = null, var/range = world.view)
-	if(!comm) return
-	..(m_type,message,comm.video_range)
+	//CHOMPEdit Start
+	if(comm)
+		..(m_type,message,comm.video_range)
+	else if(item_tf)
+		..(m_type,message,range)
+	//CHOMPEdit End
+

--- a/code/modules/virus2/effect_vr.dm
+++ b/code/modules/virus2/effect_vr.dm
@@ -34,7 +34,7 @@
 	chance_maxm = 2
 
 /datum/disease2/effect/lang/activate(var/mob/living/carbon/mob,var/multiplier)
-	mob.set_default_language(pick(mob.languages))
+	mob.apply_default_language(pick(mob.languages)) //CHOMPEdit
 
 ///////////////////////////////////////////////
 /////////////////// Stage 3 ///////////////////

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -683,6 +683,8 @@
 	prey.ai_holder?.react_to_attack(user)
 
 	//Timer and progress bar
+	if(!user.client && prey.weakened > 0) // CHOMPEdit stop crwaling instantly break swallow attempt for mobvore
+		prey.Stun(min(prey.weakened, 2)) // CHOMPEdit stop crwaling instantly break swallow attempt for mobvore
 	if(!do_after(user, swallow_time, prey, exclusive = TASK_USER_EXCLUSIVE))
 		return FALSE // Prey escpaed (or user disabled) before timer expired.
 

--- a/modular_chomp/code/game/objects/items/devices/mind_binder.dm
+++ b/modular_chomp/code/game/objects/items/devices/mind_binder.dm
@@ -125,7 +125,7 @@
 			log_and_message_admins("attempted to bind themselves to \an [item] with a Mind Binder.")
 			usr.visible_message("<span class='warning'>[usr] presses [src] against [item]. The device beginning to let out a series of beeps!</span>","<span class='notice'>You begin to bind yourself into [item]!</span>")
 			if(do_after(usr,30 SECONDS,item))
-				item.inhabit_item(usr, null, null)
+				item.inhabit_item(usr, null, null, TRUE)
 				self_bind = !self_bind
 				update_icon()
 				to_chat(usr,"<span class='notice'>Your mind as been bound to [item].</span>")
@@ -136,7 +136,7 @@
 	if(do_after(usr,5 SECONDS,item))
 		if(possessed_voice.len == 1)
 			var/mob/living/voice/V = possessed_voice[1]
-			item.inhabit_item(V, null, V.tf_mob_holder)
+			item.inhabit_item(V, null, V.tf_mob_holder, TRUE)
 			V.Destroy()
 			possessed_voice = list()
 			to_chat(usr,"<span class='notice'>Mind bound to [item].</span>")


### PR DESCRIPTION
## About The Pull Request

closes #8236
fixes #8234

## Changelog
:cl:
fix: borg pounces properly disarm on successful hits again
fix: vore mobs stun at min(weakened, 2) seconds to prevent instant interruptions of vore attempts
fix: multiple verb usages for speech setting instead of proc calls
fix: mind_bound items can use /me now
/:cl:
