### PR TITLE
Icon access violation crash prevention attempt

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -529,17 +529,17 @@
 
 	if(light_on)
 		// Generate object icon.
-		if(!light_overlay_cache["[light_overlay]_icon"])
-			light_overlay_cache["[light_overlay]_icon"] = image(icon = 'icons/obj/light_overlays.dmi', icon_state = "[light_overlay]")
-		helmet_light = light_overlay_cache["[light_overlay]_icon"]
+		if(!GLOB.light_overlay_cache["[light_overlay]_icon"]) //ChompEDIT Managed GLOB
+			GLOB.light_overlay_cache["[light_overlay]_icon"] = image(icon = 'icons/obj/light_overlays.dmi', icon_state = "[light_overlay]") //ChompEDIT Managed GLOB
+		helmet_light = GLOB.light_overlay_cache["[light_overlay]_icon"] //ChompEDIT Managed GLOB
 		add_overlay(helmet_light)
 
 		// Generate and cache the on-mob icon, which is used in update_inv_head().
 		var/body_type = (H && H.species.get_bodytype(H))
 		var/cache_key = "[light_overlay][body_type && LAZYACCESS(sprite_sheets, body_type) ? body_type : ""]"
-		if(!light_overlay_cache[cache_key])
+		if(!GLOB.light_overlay_cache[cache_key]) //ChompEDIT Managed GLOB
 			var/use_icon = LAZYACCESS(sprite_sheets, body_type) || 'icons/mob/light_overlays.dmi'
-			light_overlay_cache[cache_key] = image(icon = use_icon, icon_state = "[light_overlay]")
+			GLOB.light_overlay_cache[cache_key] = image(icon = use_icon, icon_state = "[light_overlay]") //ChompEDIT Managed GLOB
 
 	else if(helmet_light)
 		cut_overlay(helmet_light)

--- a/code/modules/clothing/clothing_icons.dm
+++ b/code/modules/clothing/clothing_icons.dm
@@ -15,8 +15,8 @@
 	var/image/standing = ..()
 	if(light_on && slot_name == slot_head_str)
 		var/cache_key = "[light_overlay][LAZYACCESS(sprite_sheets, body_type) ? "_[body_type]" : ""]"
-		if(standing && light_overlay_cache[cache_key])
-			standing.add_overlay(light_overlay_cache[cache_key])
+		if(standing && GLOB.light_overlay_cache[cache_key]) //ChompEDIT Managed GLOB
+			standing.add_overlay(GLOB.light_overlay_cache[cache_key]) //ChompEDIT Managed GLOB
 	return standing
 
 //SUIT: Blood state is slightly different

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -2,11 +2,13 @@
 	Global associative list for caching humanoid icons.
 	Index format m or f, followed by a string of 0 and 1 to represent bodyparts followed by husk fat hulk skeleton 1 or 0.
 */
-var/global/list/human_icon_cache = list() //key is incredibly complex, see update_icons_body()
-var/global/list/tail_icon_cache = list() //key is [species.race_key][r_skin][g_skin][b_skin]
-var/global/list/wing_icon_cache = list() // See tail.
-var/global/list/light_overlay_cache = list() //see make_worn_icon() on helmets
-var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
+//ChompEDIT START - change to managed GLOB
+GLOBAL_LIST_EMPTY(human_icon_cache) //key is incredibly complex, see update_icons_body()
+GLOBAL_LIST_EMPTY(tail_icon_cache) //key is [species.race_key][r_skin][g_skin][b_skin]
+GLOBAL_LIST_EMPTY(wing_icon_cache) // See tail.
+GLOBAL_LIST_EMPTY(light_overlay_cache) //see make_worn_icon() on helmets
+GLOBAL_LIST_EMPTY(damage_icon_parts) //see UpdateDamageIcon()
+//ChompEDIT END
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // # Human Icon Updating System
@@ -226,13 +228,13 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 		if(O.damage_state == "00") continue
 		var/icon/DI
 		var/cache_index = "[O.damage_state]/[O.icon_name]/[species.get_blood_colour(src)]/[species.get_bodytype(src)]"
-		if(damage_icon_parts[cache_index] == null)
+		if(GLOB.damage_icon_parts[cache_index] == null) //ChompEDIT Managed GLOB
 			DI = icon(species.get_damage_overlays(src), O.damage_state)			// the damage icon for whole human
 			DI.Blend(icon(species.get_damage_mask(src), O.icon_name), ICON_MULTIPLY)	// mask with this organ's pixels
 			DI.Blend(species.get_blood_colour(src), ICON_MULTIPLY)
-			damage_icon_parts[cache_index] = DI
+			GLOB.damage_icon_parts[cache_index] = DI //ChompEDIT Managed GLOB
 		else
-			DI = damage_icon_parts[cache_index]
+			DI = GLOB.damage_icon_parts[cache_index] //ChompEDIT Managed GLOB
 
 		standing_image.add_overlay(DI)
 
@@ -348,91 +350,94 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 
 	icon_key = "[icon_key][husk ? 1 : 0][fat ? 1 : 0][hulk ? 1 : 0][skeleton ? 1 : 0]"
 	var/icon/base_icon
-	if(human_icon_cache[icon_key])
-		base_icon = human_icon_cache[icon_key]
+	/* //ChompEDIT START- remove icon cache usage
+	if(GLOB.human_icon_cache[icon_key])
+		base_icon = GLOB.human_icon_cache[icon_key]
 	else
-		//BEGIN CACHED ICON GENERATION.
-		var/obj/item/organ/external/chest = get_organ(BP_TORSO)
-		base_icon = chest?.get_icon(skeleton, !wholeicontransparent)
+	*/ //ChompEDIT END
 
-		var/apply_extra_transparency_leg = organs_by_name[BP_L_LEG] && organs_by_name[BP_R_LEG]
-		var/apply_extra_transparency_foot = organs_by_name[BP_L_FOOT] && organs_by_name[BP_R_FOOT]
+	//BEGIN CACHED ICON GENERATION. //ChompEDIT START - Do not edit cached icons
+	var/obj/item/organ/external/chest = get_organ(BP_TORSO)
+	base_icon = chest?.get_icon(skeleton, !wholeicontransparent)
 
-		var/icon/Cutter = null
-		var/icon_x_offset = 0
-		var/icon_y_offset = 0
+	var/apply_extra_transparency_leg = organs_by_name[BP_L_LEG] && organs_by_name[BP_R_LEG]
+	var/apply_extra_transparency_foot = organs_by_name[BP_L_FOOT] && organs_by_name[BP_R_FOOT]
 
-		if(istype(tail_style, /datum/sprite_accessory/tail/taur))	// Tail icon 'cookie cutters' are filled in where icons are preserved. We need to invert that.
-			if(tail_style.clip_mask) //VOREStation Edit.
-				Cutter = new(icon = (tail_style.clip_mask_icon ? tail_style.clip_mask_icon : tail_style.icon), icon_state = tail_style.clip_mask_state)
+	var/icon/Cutter = null
+	var/icon_x_offset = 0
+	var/icon_y_offset = 0
 
-				Cutter.Blend("#000000", ICON_MULTIPLY)	// Make it all black.
+	if(istype(tail_style, /datum/sprite_accessory/tail/taur))	// Tail icon 'cookie cutters' are filled in where icons are preserved. We need to invert that.
+		if(tail_style.clip_mask) //VOREStation Edit.
+			Cutter = new(icon = (tail_style.clip_mask_icon ? tail_style.clip_mask_icon : tail_style.icon), icon_state = tail_style.clip_mask_state)
 
-				Cutter.SwapColor("#00000000", "#FFFFFFFF")	// Everywhere empty, make white.
-				Cutter.SwapColor("#000000FF", "#00000000")	// Everywhere black, make empty.
+			Cutter.Blend("#000000", ICON_MULTIPLY)	// Make it all black.
 
-				Cutter.Blend("#000000", ICON_MULTIPLY)	// Black again.
+			Cutter.SwapColor("#00000000", "#FFFFFFFF")	// Everywhere empty, make white.
+			Cutter.SwapColor("#000000FF", "#00000000")	// Everywhere black, make empty.
 
-				icon_x_offset = tail_style.offset_x
-				icon_y_offset = tail_style.offset_y
+			Cutter.Blend("#000000", ICON_MULTIPLY)	// Black again.
 
-		for(var/obj/item/organ/external/part in organs)
-			if(isnull(part) || part.is_stump() || part == chest || part.is_hidden_by_sprite_accessory()) //VOREStation Edit allowing tails to prevent bodyparts rendering, granting more spriter freedom for taur/digitigrade stuff.
-				continue
-			var/icon/temp = part.get_icon(skeleton, !wholeicontransparent)
+			icon_x_offset = tail_style.offset_x
+			icon_y_offset = tail_style.offset_y
 
-			if((part.organ_tag in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)) && Cutter)
-				temp.Blend(Cutter, ICON_AND, x = icon_x_offset, y = icon_y_offset)
+	for(var/obj/item/organ/external/part in organs)
+		if(isnull(part) || part.is_stump() || part == chest || part.is_hidden_by_sprite_accessory()) //VOREStation Edit allowing tails to prevent bodyparts rendering, granting more spriter freedom for taur/digitigrade stuff.
+			continue
+		var/icon/temp = part.get_icon(skeleton, !wholeicontransparent)
 
-			//That part makes left and right legs drawn topmost and lowermost when human looks WEST or EAST
-			//And no change in rendering for other parts (they icon_position is 0, so goes to 'else' part)
-			if(part.icon_position & (LEFT | RIGHT))
-				var/icon/temp2 = new(species.icon_template ? species.icon_template : 'icons/mob/human.dmi', icon_state = "blank")
-				temp2.Insert(new/icon(temp,dir=NORTH),dir=NORTH)
-				temp2.Insert(new/icon(temp,dir=SOUTH),dir=SOUTH)
-				if(!(part.icon_position & LEFT))
-					temp2.Insert(new/icon(temp,dir=EAST),dir=EAST)
-				if(!(part.icon_position & RIGHT))
-					temp2.Insert(new/icon(temp,dir=WEST),dir=WEST)
-				base_icon.Blend(temp2, ICON_OVERLAY)
-				temp2.Insert(temp2,"blank",dir=NORTH) //faaaaairly certain this is more efficient than reloading temp2, doing this so we don't blend the icons twice (it matters more in transparent limbs)
-				temp2.Insert(temp2,"blank",dir=SOUTH)
-				temp2.Insert(temp2,"blank",dir=EAST)
-				temp2.Insert(temp2,"blank",dir=WEST)
-				if(part.icon_position & LEFT)
-					temp2.Insert(new/icon(temp,dir=EAST),dir=EAST)
-				if(part.icon_position & RIGHT)
-					temp2.Insert(new/icon(temp,dir=WEST),dir=WEST)
-				if (part.transparent && !wholeicontransparent) //apply a little (a lot) extra transparency to make it look better //VORESTATION EDIT: transparent instead of nonsolid
-					if ((istype(part, /obj/item/organ/external/leg) && apply_extra_transparency_leg) || (istype(part, /obj/item/organ/external/foot) && apply_extra_transparency_foot)) //maybe
-						temp2 += rgb(,,,30)
-				base_icon.Blend(temp2, ICON_UNDERLAY)
-			else if(part.icon_position & UNDER)
-				base_icon.Blend(temp, ICON_UNDERLAY)
-			else
-				base_icon.Blend(temp, ICON_OVERLAY)
+		if((part.organ_tag in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT)) && Cutter)
+			temp.Blend(Cutter, ICON_AND, x = icon_x_offset, y = icon_y_offset)
 
-		if (wholeicontransparent) //because, I mean. It's basically never gonna happen that you'll have just one non-transparent limb but if you do your icon will look meh. Still good but meh, will have some areas with higher transparencies unless you're literally just a torso and a head
-			base_icon += rgb(,,,180)
+		//That part makes left and right legs drawn topmost and lowermost when human looks WEST or EAST
+		//And no change in rendering for other parts (they icon_position is 0, so goes to 'else' part)
+		if(part.icon_position & (LEFT | RIGHT))
+			var/icon/temp2 = new(species.icon_template ? species.icon_template : 'icons/mob/human.dmi', icon_state = "blank")
+			temp2.Insert(new/icon(temp,dir=NORTH),dir=NORTH)
+			temp2.Insert(new/icon(temp,dir=SOUTH),dir=SOUTH)
+			if(!(part.icon_position & LEFT))
+				temp2.Insert(new/icon(temp,dir=EAST),dir=EAST)
+			if(!(part.icon_position & RIGHT))
+				temp2.Insert(new/icon(temp,dir=WEST),dir=WEST)
+			base_icon.Blend(temp2, ICON_OVERLAY)
+			temp2.Insert(temp2,"blank",dir=NORTH) //faaaaairly certain this is more efficient than reloading temp2, doing this so we don't blend the icons twice (it matters more in transparent limbs)
+			temp2.Insert(temp2,"blank",dir=SOUTH)
+			temp2.Insert(temp2,"blank",dir=EAST)
+			temp2.Insert(temp2,"blank",dir=WEST)
+			if(part.icon_position & LEFT)
+				temp2.Insert(new/icon(temp,dir=EAST),dir=EAST)
+			if(part.icon_position & RIGHT)
+				temp2.Insert(new/icon(temp,dir=WEST),dir=WEST)
+			if (part.transparent && !wholeicontransparent) //apply a little (a lot) extra transparency to make it look better //VORESTATION EDIT: transparent instead of nonsolid
+				if ((istype(part, /obj/item/organ/external/leg) && apply_extra_transparency_leg) || (istype(part, /obj/item/organ/external/foot) && apply_extra_transparency_foot)) //maybe
+					temp2 += rgb(,,,30)
+			base_icon.Blend(temp2, ICON_UNDERLAY)
+		else if(part.icon_position & UNDER)
+			base_icon.Blend(temp, ICON_UNDERLAY)
+		else
+			base_icon.Blend(temp, ICON_OVERLAY)
 
-		if(!skeleton)
-			if(husk)
-				base_icon.ColorTone(husk_color_mod)
-			else if(hulk)
-				var/list/tone = rgb2num(hulk_color_mod)
-				base_icon.MapColors(rgb(tone[1],0,0),rgb(0,tone[2],0),rgb(0,0,tone[3]))
+	if (wholeicontransparent) //because, I mean. It's basically never gonna happen that you'll have just one non-transparent limb but if you do your icon will look meh. Still good but meh, will have some areas with higher transparencies unless you're literally just a torso and a head
+		base_icon += rgb(,,,180)
 
-		//Handle husk overlay.
-		if(husk && ("overlay_husk" in cached_icon_states(species.icobase)))
-			var/icon/mask = new(base_icon)
-			var/icon/husk_over = new(species.icobase,"overlay_husk")
-			mask.MapColors(0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,0)
-			husk_over.Blend(mask, ICON_ADD)
-			base_icon.Blend(husk_over, ICON_OVERLAY)
+	if(!skeleton)
+		if(husk)
+			base_icon.ColorTone(husk_color_mod)
+		else if(hulk)
+			var/list/tone = rgb2num(hulk_color_mod)
+			base_icon.MapColors(rgb(tone[1],0,0),rgb(0,tone[2],0),rgb(0,0,tone[3]))
 
-		human_icon_cache[icon_key] = base_icon
+	//Handle husk overlay.
+	if(husk && ("overlay_husk" in cached_icon_states(species.icobase)))
+		var/icon/mask = new(base_icon)
+		var/icon/husk_over = new(species.icobase,"overlay_husk")
+		mask.MapColors(0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,0)
+		husk_over.Blend(mask, ICON_ADD)
+		base_icon.Blend(husk_over, ICON_OVERLAY)
 
-	//END CACHED ICON GENERATION.
+	GLOB.human_icon_cache[icon_key] = base_icon
+
+	//END CACHED ICON GENERATION. //ChompEDIT END
 	stand_icon.Blend(base_icon,ICON_OVERLAY)
 
 	var/image/body = image(stand_icon)
@@ -1118,7 +1123,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 //TODO: Is this the appropriate place for this, and not on species...?
 /mob/living/carbon/human/proc/get_tail_icon()
 	var/icon_key = "[species.get_race_key(src)][r_skin][g_skin][b_skin][r_hair][g_hair][b_hair]"
-	var/icon/tail_icon = tail_icon_cache[icon_key]
+	var/icon/tail_icon = GLOB.tail_icon_cache[icon_key] //ChompEDIT Managed GLOB
 	if(!tail_icon)
 		//generate a new one
 		var/species_tail_anim = species.get_tail_animation(src)
@@ -1132,7 +1137,7 @@ var/global/list/damage_icon_parts = list() //see UpdateDamageIcon()
 			var/icon/hair_icon = icon('icons/effects/species.dmi', "[species.get_tail(src)]_[use_species_tail]")
 			hair_icon.Blend(rgb(r_hair, g_hair, b_hair), species.color_mult ? ICON_MULTIPLY : ICON_ADD)				//Check for species color_mult
 			tail_icon.Blend(hair_icon, ICON_OVERLAY)
-		tail_icon_cache[icon_key] = tail_icon
+		GLOB.tail_icon_cache[icon_key] = tail_icon //ChompEDIT Managed GLOB
 
 	return tail_icon
 


### PR DESCRIPTION
Another attempt at nailing the occasional server hard crashes we get, which seem to always be a result of editing cached icons

:cl:
fix: Icon edit access violation crash fit attempt
/:cl:
