### PR TITLE
Shadekin Phase Animation Size

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -418,6 +418,7 @@
 			if(A == src) continue
 			if(istype(A,/mob/living))
 				if(A:lying) continue
+				if(A.is_incorporeal()) continue // CHOMPEdit - For phased entities
 				src.throw_impact(A,speed)
 			if(isobj(A))
 				if(!A.density || A.throwpass)

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/shadekin/shadekin_abilities.dm
@@ -140,6 +140,8 @@
 
 		//Cosmetics mostly
 		var/obj/effect/temp_visual/shadekin/phase_in/phaseanim = new /obj/effect/temp_visual/shadekin/phase_in(src.loc)
+		phaseanim.pixel_y = (src.size_multiplier - 1) * 16 // Pixel shift for the animation placement
+		phaseanim.adjust_scale(src.size_multiplier, src.size_multiplier)
 		phaseanim.dir = dir
 		alpha = 0
 		custom_emote(1,"phases in!")
@@ -232,6 +234,8 @@
 			B.escapable = FALSE
 
 		var/obj/effect/temp_visual/shadekin/phase_out/phaseanim = new /obj/effect/temp_visual/shadekin/phase_out(src.loc)
+		phaseanim.pixel_y = (src.size_multiplier - 1) * 16 // Pixel shift for the animation placement
+		phaseanim.adjust_scale(src.size_multiplier, src.size_multiplier)
 		phaseanim.dir = dir
 		alpha = 0
 		add_modifier(/datum/modifier/shadekin_phase_vision)


### PR DESCRIPTION

## About The Pull Request

So I've seen **a lot** of different sized shadekins, but their animation was always the same size. Be it 200% or 25%, the animation was for 100%. Well, no more. Now the size of the shadekin will be taken in consideration for the animation as well.

Also, objects thrown should pass through phased kins as well.

## Changelog
:cl:
qol: Shadekin Phase In/Out animation now adjusts to the shadekin's size
fix: Thrown objects not passing though phased kins
/:cl:
