### PR TITLE
Fixes runtime with taur-less humanmob buckling

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories_taur.dm
+++ b/code/modules/mob/new_player/sprite_accessories_taur.dm
@@ -99,7 +99,7 @@
 		visible_message("<span class='notice'>[M] starts riding [name]!</span>")
 
 /mob/living/carbon/human/attack_hand(mob/user as mob)
-	if(LAZYLEN(buckled_mobs))
+	if(LAZYLEN(buckled_mobs) && riding_datum)
 		//We're getting off!
 		if(user in buckled_mobs)
 			riding_datum.force_dismount(user)

--- a/code/modules/mob/new_player/sprite_accessories_taur.dm
+++ b/code/modules/mob/new_player/sprite_accessories_taur.dm
@@ -99,7 +99,7 @@
 		visible_message("<span class='notice'>[M] starts riding [name]!</span>")
 
 /mob/living/carbon/human/attack_hand(mob/user as mob)
-	if(LAZYLEN(buckled_mobs) && riding_datum)
+	if(LAZYLEN(buckled_mobs) && riding_datum) //CHOMPEdit
 		//We're getting off!
 		if(user in buckled_mobs)
 			riding_datum.force_dismount(user)


### PR DESCRIPTION

## About The Pull Request
Found this bug while messing around with forced buckling. Fixes empty hand interactions not working at all on non-taur-ridable humanmobs with buckled mobs.
## Changelog
:cl:
fix: Fixed empty hand interactions not working on non-rideable humanmobs with forced buckling.
/:cl:
