### PR TITLE
Make the default for blood stains being oil if no DNA is found.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -466,7 +466,7 @@
 
 	was_bloodied = TRUE
 	if(!blood_color)
-		blood_color = "#A10808"
+		blood_color = SYNTH_BLOOD_COLOUR
 	if(istype(M))
 		if (!istype(M.dna, /datum/dna))
 			M.dna = new /datum/dna(null)


### PR DESCRIPTION

## About The Pull Request
So if you picked up on object with hands stained with blood from a non existent mob, the game hard coded it to red no matter what. This will make it so oil-stained hands (from synthetics/puddles) will stain the object 'oil-stained'

There *is* a bug where if you do attack someone at one point, the blood DNA will stay on your hands and will use their blood color even if you cleaned it, but this is a behavior that already existed in game and is outside of scope of this PR. More testing may be needed.
## Changelog
:cl:
fix: Adjustments to item staining with 'bloody' hands.
/:cl:
