### PR TITLE
Gives VR avatars a custom job, Fixes duplicate PDAs, new VR roleplay room

### DIFF
--- a/code/__defines/misc_ch.dm
+++ b/code/__defines/misc_ch.dm
@@ -4,6 +4,7 @@
 //Job defines
 #define JOB_OUTSIDER            "Outsider"
 #define JOB_ANOMALY			"Anomaly"
+#define JOB_VR	"VR Avatar"
 
 //Material defines
 #define MAT_CARPET				"red carpet"

--- a/maps/southern_cross/submaps/virtual_reality/constructVR.dm
+++ b/maps/southern_cross/submaps/virtual_reality/constructVR.dm
@@ -155,6 +155,11 @@
 	icon_state = "pink"
 	ambience = list('sound/ambience/vaporwave.ogg')
 
+/area/vr/powered/mall/secondlife
+	name = "VR Thirdlife Bar"
+	icon_state = "pink"
+	ambience = list(AMBIENCE_GENERIC,'sound/ambience/ghostly/ghostly1.ogg')
+
 /area/vr/powered/mall/dorms
 	name = "VR Mall Dorms"
 	icon_state = "Sleep"
@@ -163,6 +168,30 @@
 	block_suit_sensors = TRUE
 	flags = RAD_SHIELDED
 	block_tracking = TRUE
+
+/area/vr/powered/mall/dorms/dorms1
+
+/area/vr/powered/mall/dorms/dorms2
+
+/area/vr/powered/mall/dorms/dorms3
+
+/area/vr/powered/mall/dorms/dorms4
+
+/area/vr/powered/mall/dorms/dorms5
+
+/area/vr/powered/mall/dorms/dorms6
+
+/area/vr/powered/mall/dorms/secondlife
+	name = "VR Third-Life Dorms"
+
+/area/vr/powered/mall/dorms/secondlife2
+
+/area/vr/powered/mall/dorms/secondlife3
+
+/area/vr/powered/mall/dorms/secondlife4
+
+/area/vr/powered/mall/dorms/secondlife5
+
 
 /area/vr/outdoors/powered/mall
 	name = "VR Mall Outdoors"
@@ -216,3 +245,7 @@
 			"color" = "#F07AD8"
 		)
 	)
+
+// VR EXCLUSIVE ITEMS
+/obj/item/weapon/reagent_containers/glass/beaker/mayo
+	prefill = list("mayo" = 30) //;)

--- a/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
+++ b/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
@@ -2457,6 +2457,7 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/handcuffs/legcuffs/fuzzy,
 /obj/item/device/camera,
+/obj/item/toy/balloon,
 /turf/simulated/floor/carpet/purple,
 /area/vr/powered/mall/dorms/secondlife2)
 "caK" = (
@@ -9683,6 +9684,14 @@
 /obj/item/weapon/bedsheet/iandouble,
 /turf/simulated/floor/carpet/blucarpet,
 /area/vr/powered)
+"hXP" = (
+/obj/structure/table/darkglass,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/item/weapon/gun/energy/sizegun,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "hXV" = (
 /obj/machinery/light{
 	dir = 8
@@ -16884,6 +16893,11 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/vr/powered/mall)
+"nGa" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/gun/energy/sizegun,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "nGe" = (
 /obj/machinery/light/floortube{
 	dir = 8
@@ -25652,6 +25666,7 @@
 	},
 /obj/structure/table/woodentable,
 /obj/item/weapon/handcuffs/fuzzy,
+/obj/item/weapon/gun/energy/sizegun,
 /turf/simulated/floor/carpet/purcarpet,
 /area/vr/powered/mall/dorms/secondlife3)
 "uqB" = (
@@ -86319,7 +86334,7 @@ vrG
 fuy
 iyQ
 uzw
-uzw
+hXP
 pTD
 lut
 lut
@@ -87354,7 +87369,7 @@ hIK
 eCg
 eCg
 eoO
-lut
+nGa
 qvq
 qbH
 jWY
@@ -89160,7 +89175,7 @@ rgm
 sOV
 xma
 lut
-lut
+nGa
 soT
 qbH
 qbH

--- a/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
+++ b/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
@@ -31,6 +31,11 @@
 /obj/item/weapon/storage/firstaid/adv,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/building2)
+"acm" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "acC" = (
 /obj/effect/landmark/virtual_reality{
 	name = "Cultist Base"
@@ -82,9 +87,6 @@
 	movement_cost = 0
 	},
 /area/vr/outdoors/powered)
-"aeS" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms3)
 "afn" = (
 /obj/structure/window/phoronreinforced{
 	dir = 1
@@ -126,6 +128,15 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/flock,
 /area/vr/powered/rocks)
+"aiP" = (
+/obj/structure/bed/chair/sofa/right/beige{
+	dir = 4
+	},
+/obj/machinery/light/floortube{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "ajk" = (
 /obj/structure/barricade,
 /obj/effect/floor_decal/rust,
@@ -474,9 +485,11 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
 "azq" = (
-/obj/item/weapon/material/twohanded/riding_crop,
-/obj/effect/decal/cleanable/blood/oil/streak,
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/unsimulated/shuttle/floor/purple,
 /area/vr/powered/mall/secondlife)
 "azz" = (
 /obj/machinery/vending/dinnerware{
@@ -585,6 +598,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/dungeon)
+"aCd" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 10
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "aCM" = (
 /obj/structure/table/marble{
 	pixel_y = 0
@@ -748,7 +768,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms2)
+/area/vr/powered/mall/dorms/dorms6)
 "aJB" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/item/clothing/under/teshari/undercoat/standard/black_grey,
@@ -803,13 +823,8 @@
 	},
 /area/vr/powered)
 "aLr" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms4)
 "aLx" = (
 /obj/item/weapon/pickaxe,
 /obj/structure/table/rack/shelf/steel,
@@ -845,6 +860,17 @@
 /obj/structure/table/alien/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
+"aMT" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "aNd" = (
 /obj/structure/table/fancyblack,
 /turf/simulated/floor/wood,
@@ -885,14 +911,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cult)
-"aOK" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/obj/item/clothing/under/swimsuit/purple,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "aPz" = (
 /obj/machinery/disperser/back{
 	dir = 1
@@ -1206,11 +1224,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
-"bbT" = (
-/obj/structure/table/darkglass,
-/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
-/turf/simulated/floor/tiled/milspec/raised,
-/area/vr/powered/mall/secondlife)
 "bcC" = (
 /obj/structure/table/hardwoodtable,
 /obj/random/drinkbottle,
@@ -1312,6 +1325,14 @@
 	outdoors = 0
 	},
 /area/vr/powered/dungeon)
+"bgW" = (
+/obj/item/weapon/digestion_remains/skull/teshari,
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/item/clothing/mask/muzzle/ballgag{
+	pixel_y = -7
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "bhs" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
@@ -1411,10 +1432,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
-"blH" = (
-/obj/item/clothing/under/shiny/catsuit/poly,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "bmi" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/under/pants/camo,
@@ -1472,12 +1489,6 @@
 /obj/random/plushie,
 /turf/simulated/floor/carpet/turcarpet,
 /area/vr/powered/mall/dorms/dorms3)
-"boF" = (
-/obj/structure/bed/chair/sofa/left/beige{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "boL" = (
 /obj/effect/floor_decal/corner/white/border{
 	dir = 5
@@ -1488,10 +1499,6 @@
 	outdoors = 0
 	},
 /area/vr/powered/dungeon)
-"bpF" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "bpP" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod{
@@ -1596,6 +1603,11 @@
 	},
 /turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
+"buS" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "bvk" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/foodcart,
@@ -2023,14 +2035,6 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
-"bNT" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/secondlife)
 "bOh" = (
 /turf/simulated/wall/durasteel,
 /area/vr/powered/mall/backrooms)
@@ -2358,15 +2362,6 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
-"bZJ" = (
-/obj/structure/bed/chair/sofa/right/beige{
-	dir = 4
-	},
-/obj/machinery/light/floortube{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "cag" = (
 /obj/effect/decal/cleanable/fruit_smudge,
 /obj/machinery/light/small{
@@ -3215,6 +3210,11 @@
 "cKr" = (
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/building1)
+"cKW" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "cLi" = (
 /obj/structure/table/fancyblack,
 /obj/item/weapon/reagent_containers/food/snacks/ribplate,
@@ -3295,6 +3295,10 @@
 /obj/item/weapon/bedsheet/hosdouble,
 /turf/simulated/floor/carpet/purple,
 /area/vr/powered/mall/dorms/dorms6)
+"cQA" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "cQR" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/light/poi,
@@ -3500,6 +3504,10 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"cZL" = (
+/obj/item/toy/balloon,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "cZN" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -3522,13 +3530,6 @@
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/carpet/green,
 /area/vr/powered/mall/dorms/dorms5)
-"dbk" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 6
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "dcB" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/door/airlock/medical{
@@ -3613,6 +3614,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/space/whiteship)
+"ddW" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "des" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/beach/sand/desert{
@@ -3669,14 +3681,14 @@
 /area/vr/powered/mall)
 "dgT" = (
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms5)
+/area/vr/powered/mall/dorms/dorms6)
 "dha" = (
 /obj/item/toy/plushie/susred,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
 "dhl" = (
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms4)
 "dhv" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/reagent_containers/food/drinks/soymilk,
@@ -4082,8 +4094,10 @@
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/whiteship)
 "dzQ" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms4)
+/obj/structure/table/hardwoodtable,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "dzT" = (
 /obj/machinery/door/airlock/gold{
 	id_tag = "VRmallSL1"
@@ -4257,6 +4271,13 @@
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/vr/powered/mall/dorms/dorms2)
+"dGb" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 6
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "dGC" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -4297,12 +4318,6 @@
 "dHI" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/vr/powered/cult)
-"dHL" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms5)
 "dKF" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -4378,6 +4393,14 @@
 	},
 /turf/simulated/floor/lava,
 /area/vr/outdoors/powered/lava)
+"dMH" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "dNs" = (
 /obj/structure/window/reinforced/survival_pod{
 	opacity = 1
@@ -4681,14 +4704,6 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/sciship)
-"dRn" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "dRJ" = (
 /obj/structure/curtain/black,
 /obj/random/junk,
@@ -4940,6 +4955,7 @@
 /obj/item/weapon/handcuffs/fuzzy,
 /obj/item/weapon/handcuffs/legcuffs/fuzzy,
 /obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/obj/item/toy/balloon,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/vr/powered/mall/secondlife)
 "eas" = (
@@ -5240,8 +5256,9 @@
 	},
 /area/vr/powered/rocks)
 "enN" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms1)
+/obj/item/clothing/under/shiny/catsuit/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "eoA" = (
 /obj/machinery/light{
 	dir = 8
@@ -5261,11 +5278,12 @@
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/sciship)
 "eoO" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms6)
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "epd" = (
 /turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms5)
 "epk" = (
 /obj/structure/table/marble{
 	pixel_y = 0
@@ -5491,10 +5509,6 @@
 /turf/simulated/floor/wood,
 /area/vr/powered)
 "eCg" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
 /turf/unsimulated/shuttle/floor/purple,
 /area/vr/powered/mall/secondlife)
 "eCs" = (
@@ -5827,16 +5841,17 @@
 /turf/simulated/floor/carpet/geo,
 /area/vr/powered/mall)
 "eKD" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
 	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
 	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "eKF" = (
 /obj/structure/bed/chair/sofa/brown{
 	dir = 8
@@ -6347,13 +6362,6 @@
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
-"fgs" = (
-/obj/item/toy/plushie/black_fox{
-	pixel_y = 0;
-	name = "latex black fox"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "fgP" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/wormcan,
@@ -6449,20 +6457,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered)
-"flB" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "flS" = (
 /turf/space,
 /turf/simulated/floor/beach/sand/desert{
@@ -6923,17 +6917,6 @@
 /obj/item/weapon/bedsheet/hosdouble,
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall/dorms/dorms4)
-"fDN" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "fDV" = (
 /obj/structure/cliff/automatic{
 	dir = 8
@@ -7075,6 +7058,19 @@
 /obj/item/toy/plushie/otter,
 /turf/simulated/floor/carpet/bcarpet,
 /area/vr/powered/mall/dorms/secondlife5)
+"fKO" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 31
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
+"fLo" = (
+/obj/item/toy/plushie/black_fox{
+	pixel_y = 0;
+	name = "latex black fox"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "fLs" = (
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 5
@@ -7172,14 +7168,6 @@
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/crayon/grey,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
-"fMZ" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "fNa" = (
 /obj/structure/lattice,
 /turf/space,
@@ -7278,6 +7266,7 @@
 	color = "#f700ff";
 	dir = 2
 	},
+/obj/item/toy/balloon,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "fSz" = (
@@ -7524,6 +7513,14 @@
 /obj/structure/bed/chair/sofa/black,
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/mall)
+"geC" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "geP" = (
 /obj/structure/cliff/automatic{
 	dir = 5
@@ -7633,14 +7630,6 @@
 "gjB" = (
 /turf/simulated/wall/r_wall,
 /area/vr/powered/bluebase)
-"gla" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/flock,
-/area/vr/powered/mall/secondlife)
 "glK" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -7934,10 +7923,6 @@
 	outdoors = 1
 	},
 /area/vr/outdoors/powered)
-"gDd" = (
-/obj/item/weapon/digestion_remains/variant3,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "gDe" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
@@ -8280,6 +8265,17 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
+"gUF" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL2";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "gVk" = (
 /obj/structure/table/alien/blue,
 /obj/structure/window/reinforced/survival_pod{
@@ -8479,12 +8475,6 @@
 	outdoors = 1
 	},
 /area/vr/outdoors/powered)
-"hfV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms3)
 "hgg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -8939,6 +8929,14 @@
 /obj/item/weapon/reagent_containers/food/snacks/donerkebab,
 /turf/simulated/floor/wood/alt,
 /area/vr/powered/mall)
+"hzt" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "hzJ" = (
 /obj/machinery/fitness/heavy/lifter,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -9177,16 +9175,8 @@
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/dungeon)
 "hOI" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL2";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms/secondlife2)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms2)
 "hPd" = (
 /obj/structure/railing/grey{
 	pixel_y = 0;
@@ -9513,8 +9503,16 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/constore)
 "iag" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms6)
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL1";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "iam" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -9550,6 +9548,10 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/dungeon)
+"ibm" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "icz" = (
 /obj/structure/sign/warning/vacuum,
 /turf/unsimulated/wall,
@@ -9759,14 +9761,6 @@
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/concrete,
 /area/vr/powered/mall)
-"ijc" = (
-/obj/structure/table/darkglass,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 5
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "ijw" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/snacks/slice/sushi/filled/filled{
@@ -9837,6 +9831,14 @@
 "ikE" = (
 /turf/unsimulated/floor/tiled/techfloor,
 /area/vr/powered/mall)
+"ikQ" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "ilo" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/mech_toy,
@@ -10349,6 +10351,11 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
+"iFw" = (
+/obj/item/weapon/material/twohanded/riding_crop,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "iGx" = (
 /obj/structure/table/marble,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -10392,7 +10399,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms5)
 "iIl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -10433,12 +10440,6 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/whiteship)
-"iKR" = (
-/obj/structure/bookcase,
-/obj/item/weapon/book/manual,
-/obj/item/weapon/book/manual,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "iLp" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -10598,7 +10599,7 @@
 "iWc" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
+/area/vr/powered/mall/dorms/dorms3)
 "iWh" = (
 /obj/item/toy/plushie/possum,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10626,8 +10627,13 @@
 	},
 /area/vr/outdoors/powered)
 "iXf" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms5)
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 2;
+	pixel_y = 0
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "iXg" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/device/communicator,
@@ -10658,22 +10664,6 @@
 	},
 /turf/space,
 /area/vr/space)
-"iXX" = (
-/obj/structure/table/darkglass,
-/obj/item/device/bodysnatcher{
-	pixel_y = 4;
-	pixel_x = 3
-	},
-/obj/item/device/bodysnatcher{
-	pixel_y = -2;
-	pixel_x = -2
-	},
-/obj/item/device/bodysnatcher{
-	pixel_y = -4;
-	pixel_x = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "iYh" = (
 /obj/machinery/vending/giftvendor,
 /turf/simulated/floor/tiled,
@@ -10782,15 +10772,6 @@
 /obj/item/weapon/gun/energy/locked/frontier/unlocked,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
-"jbT" = (
-/obj/structure/table/darkglass,
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "jbY" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -10846,6 +10827,11 @@
 	color = "#f700ff";
 	dir = 4
 	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
+"jdZ" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/stripper_green,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "jem" = (
@@ -11141,6 +11127,12 @@
 /obj/machinery/vending/loadout/uniform,
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
+"jrm" = (
+/obj/structure/bed/chair/sofa/left/beige{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "jrC" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/lime/border,
@@ -11255,6 +11247,10 @@
 /obj/structure/reagent_dispensers/beerkeg/fakenuke,
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
+"juK" = (
+/obj/item/clothing/mask/muzzle/ballgag,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "juM" = (
 /obj/structure/table/marble,
 /obj/item/weapon/storage/box/glasses/meta/metapint{
@@ -11294,11 +11290,6 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/unsimulated/wall,
 /area/vr/outdoors/powered)
-"jxd" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "jxe" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/carpet/blue,
@@ -11320,6 +11311,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/vet)
+"jxw" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 6
+	},
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "jxO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -11393,10 +11396,6 @@
 	},
 /turf/simulated/floor/carpet/geo,
 /area/vr/powered/mall)
-"jCa" = (
-/obj/structure/table/hardwoodtable,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "jCk" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/mimedouble,
@@ -11628,15 +11627,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
-"jKc" = (
-/obj/structure/table/hardwoodtable,
-/obj/machinery/light/small{
-	dir = 4;
-	nightshift_enabled = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "jKl" = (
 /obj/effect/landmark/button_mob_spawner_landmark/second,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -11915,7 +11905,7 @@
 /obj/effect/floor_decal/milspec/color/silver,
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms6)
 "jWs" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -12078,8 +12068,14 @@
 /turf/simulated/wall/solidrock,
 /area/vr/powered/rocks)
 "kdB" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms2)
+/obj/structure/table/darkglass,
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "kdJ" = (
 /mob/living/simple_mob/animal/passive/pillbug,
 /turf/simulated/floor/wood{
@@ -12164,6 +12160,14 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
+"kgD" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 9
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "khm" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -12296,6 +12300,13 @@
 /obj/mecha/combat/gygax/old,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/mechfactory)
+"kkW" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "kls" = (
 /obj/effect/overlay/palmtree_l,
 /obj/effect/overlay/coconut,
@@ -12615,12 +12626,6 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
-"kCv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms4)
 "kCO" = (
 /mob/living/simple_mob/animal/giant_spider/hunter,
 /turf/simulated/floor/outdoors/mud{
@@ -12817,14 +12822,6 @@
 /obj/effect/landmark/button_mob_spawner_landmark,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/building2)
-"kLe" = (
-/obj/item/weapon/digestion_remains/skull/teshari,
-/obj/effect/decal/cleanable/fruit_smudge,
-/obj/item/clothing/mask/muzzle/ballgag{
-	pixel_y = -7
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "kLz" = (
 /obj/machinery/power/emitter/antique,
 /obj/structure/cable/green,
@@ -12915,6 +12912,10 @@
 /obj/item/weapon/material/knife/machete,
 /turf/simulated/floor/reinforced,
 /area/vr/powered/redbase)
+"kNz" = (
+/obj/item/weapon/digestion_remains/variant2,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "kNU" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small,
@@ -13095,20 +13096,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
+"kUr" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "kUt" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
-"kVm" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/obj/item/clothing/accessory/shiny/gloves/poly,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "kVX" = (
 /obj/machinery/door/window/northright{
 	name = "Server Room";
@@ -13272,10 +13273,6 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
-"lcd" = (
-/obj/item/weapon/tape_roll,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "lcF" = (
 /turf/simulated/wall/skipjack,
 /area/vr/powered/space/sciship)
@@ -13393,6 +13390,22 @@
 /obj/structure/table/darkglass,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
+"liN" = (
+/obj/structure/table/darkglass,
+/obj/item/device/mindbinder{
+	pixel_y = 4;
+	pixel_x = -2
+	},
+/obj/item/device/mindbinder{
+	pixel_y = -4;
+	pixel_x = -3
+	},
+/obj/item/device/mindbinder{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "liP" = (
 /obj/structure/window/phoronreinforced{
 	dir = 4
@@ -13417,14 +13430,6 @@
 /obj/item/weapon/grenade/confetti/party_ball,
 /turf/simulated/floor/tiled,
 /area/vr/powered/dungeon)
-"ljQ" = (
-/obj/structure/table/darkglass,
-/obj/structure/stripper_pole{
-	icon_scale_x = 0.5;
-	icon_scale_y = 0.5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "lkk" = (
 /obj/effect/map_effect/perma_light/brighter{
 	light_color = "#d817ff"
@@ -13519,10 +13524,6 @@
 	},
 /turf/simulated/floor/bmarble,
 /area/vr/powered/mall)
-"loW" = (
-/obj/item/weapon/handcuffs/legcuffs/fuzzy,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "lpe" = (
 /obj/machinery/light{
 	dir = 8
@@ -13733,6 +13734,22 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/whiteship)
+"ltS" = (
+/obj/structure/table/darkglass,
+/obj/item/device/bodysnatcher{
+	pixel_y = 4;
+	pixel_x = 3
+	},
+/obj/item/device/bodysnatcher{
+	pixel_y = -2;
+	pixel_x = -2
+	},
+/obj/item/device/bodysnatcher{
+	pixel_y = -4;
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "lub" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -13758,17 +13775,6 @@
 /obj/structure/table/darkglass,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/vr/powered/mall/secondlife)
-"luH" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "lvj" = (
 /obj/structure/table/rack/wood,
 /obj/item/clothing/under/color/grey{
@@ -13973,9 +13979,6 @@
 /obj/machinery/cell_charger,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/space/mechfactory)
-"lAT" = (
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "lBi" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/wmarble,
@@ -13990,10 +13993,6 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
-"lBI" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "lBL" = (
 /obj/structure/table/fancyblack,
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/excitingsuppermatter,
@@ -14748,9 +14747,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/sciship)
 "mfJ" = (
-/obj/item/clothing/mask/muzzle/ballgag,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual,
+/obj/item/weapon/book/manual,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "mgc" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/wood,
@@ -14787,6 +14788,10 @@
 /obj/item/ammo_magazine/s357,
 /turf/simulated/floor/tiled,
 /area/vr/powered/gunshop)
+"mhv" = (
+/obj/item/weapon/digestion_remains/variant3,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "mhy" = (
 /obj/structure/table/marble,
 /obj/structure/sink/countertop{
@@ -15034,16 +15039,6 @@
 	outdoors = -1
 	},
 /area/vr/powered/mall)
-"mqT" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
-"mqX" = (
-/obj/structure/table/bench/wooden,
-/obj/item/weapon/pen/blade/blue,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "msk" = (
 /obj/structure/closet/walllocker_double/medical/west,
 /obj/item/weapon/storage/firstaid,
@@ -15088,6 +15083,10 @@
 	},
 /turf/simulated/floor/weird_things/dark,
 /area/vr/powered/mall/backrooms)
+"mtk" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "mtx" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/tiled,
@@ -15427,6 +15426,26 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/clusterbang,
 /turf/simulated/floor/airless,
 /area/vr/space)
+"mIC" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms5)
+"mII" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "mIK" = (
 /obj/machinery/light{
 	dir = 8
@@ -15582,7 +15601,7 @@
 	pixel_x = -5
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms2)
 "mOS" = (
 /obj/structure/bed/chair/backed_red{
 	dir = 4
@@ -15609,10 +15628,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
-"mPJ" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "mQL" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/outdoors/rocks{
@@ -15693,7 +15708,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
+/area/vr/powered/mall/dorms/dorms1)
 "mUR" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -15994,6 +16009,12 @@
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/pineapple,
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
+"nhK" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms1)
 "nie" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/dip/salsa,
@@ -16196,14 +16217,6 @@
 	},
 /turf/simulated/shuttle/floor/purple,
 /area/vr/powered/dungeon)
-"nog" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "noI" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
@@ -16363,6 +16376,17 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/vr/powered/mall/secondlife)
+"nwd" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "nwE" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/contraband/nofail,
@@ -16404,10 +16428,6 @@
 /obj/structure/curtain,
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/vr/powered/mall/dorms/dorms2)
-"nyl" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "nyq" = (
 /obj/structure/bed/chair/backed_red{
 	dir = 4
@@ -16461,10 +16481,6 @@
 /obj/structure/stripper_pole,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
-"nzP" = (
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "nAa" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/carpet/oracarpet,
@@ -16541,20 +16557,6 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
-"nDt" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "nDZ" = (
 /obj/structure/table/hardwoodtable,
 /obj/machinery/chemical_dispenser/bar_soft/full{
@@ -16754,6 +16756,14 @@
 /obj/item/weapon/reagent_containers/glass/rag,
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
+"nIy" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "nIW" = (
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
@@ -16792,19 +16802,8 @@
 	},
 /area/vr/outdoors/powered)
 "nJM" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms1)
 "nJZ" = (
 /obj/item/weapon/material/twohanded/baseballbat/gold,
 /obj/item/stack/material/gold,
@@ -16855,9 +16854,8 @@
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/dungeon)
 "nKT" = (
-/obj/item/clothing/accessory/shiny/gloves/poly,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms6)
 "nLa" = (
 /obj/structure/bed/pillowpile/orange,
 /obj/effect/floor_decal/corner/purple/border{
@@ -17276,18 +17274,6 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
-"oae" = (
-/obj/effect/decal/cleanable/fruit_smudge,
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL5";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/vr/powered/mall/dorms/secondlife5)
 "oaU" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/simple_portal/linked{
@@ -17365,6 +17351,14 @@
 /obj/item/weapon/material/knife/machete/deluxe,
 /turf/simulated/floor/tiled,
 /area/vr/powered/gunshop)
+"oeg" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "oeP" = (
 /obj/structure/prop/statue,
 /turf/simulated/floor/water/pool{
@@ -17888,6 +17882,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vr/outdoors/powered)
+"ovv" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/stripper_pink,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
+"ovJ" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/mask/muzzle/ballgag,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "ovM" = (
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
@@ -18051,6 +18055,11 @@
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/dungeon)
+"oBk" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "oBA" = (
 /obj/random/maintenance,
 /obj/machinery/light/small{
@@ -18220,6 +18229,10 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/vr/powered/mall/dorms/dorms5)
+"oHr" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "oHz" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/storage/toolbox/electrical,
@@ -18267,13 +18280,8 @@
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
 "oIG" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 2;
-	pixel_y = 0
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms1)
 "oJb" = (
 /obj/machinery/light{
 	dir = 1
@@ -18326,6 +18334,14 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
+"oKR" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 5
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "oLe" = (
 /obj/structure/window/basic,
 /obj/structure/table/rack/wood,
@@ -18399,17 +18415,6 @@
 	},
 /turf/space,
 /area/vr/space)
-"oOj" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "oOr" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -18436,6 +18441,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/whiteship)
+"oPm" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/light/small{
+	dir = 4;
+	nightshift_enabled = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "oPY" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/fishing,
@@ -18517,14 +18531,6 @@
 /obj/item/weapon/towel/random,
 /turf/simulated/floor/carpet/bcarpet,
 /area/vr/powered)
-"oVy" = (
-/obj/structure/table/darkglass,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 9
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "oVM" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/water/pool{
@@ -18532,6 +18538,12 @@
 	outdoors = 1
 	},
 /area/vr/outdoors/powered)
+"oVQ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms4)
 "oVV" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -18577,6 +18589,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/blue,
 /area/vr/powered/motel)
+"pat" = (
+/obj/item/weapon/tape_roll,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "paD" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wmarble,
@@ -19036,11 +19052,6 @@
 /obj/machinery/portable_atmospherics/powered/pump/huge,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/cult)
-"pqd" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/mask/muzzle/ballgag,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "pqD" = (
 /turf/simulated/wall/r_wall,
 /area/vr/powered/art)
@@ -19102,17 +19113,6 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/vr/powered)
-"pul" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL3";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/vr/powered/mall/dorms/secondlife3)
 "pvd" = (
 /obj/structure/table/fancyblack,
 /obj/effect/floor_decal/spline/fancy{
@@ -19221,17 +19221,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
-"pzL" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL4";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "pzO" = (
 /obj/structure/railing,
 /turf/simulated/floor/wood{
@@ -19334,20 +19323,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/slice/sushi/filled/filled,
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
-"pDR" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "pEd" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	locked = 0
@@ -19423,8 +19398,8 @@
 	},
 /area/vr/powered/rocks)
 "pGH" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms2)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms3)
 "pGO" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -19630,12 +19605,6 @@
 /obj/structure/table/alien/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
-"pNM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms1)
 "pNU" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -19704,7 +19673,7 @@
 "pRJ" = (
 /obj/effect/floor_decal/milspec/color/silver,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
+/area/vr/powered/mall/dorms/dorms2)
 "pRN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -19811,11 +19780,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/vet)
-"pXn" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/mankini,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "pXD" = (
 /obj/machinery/vending/wardrobe/virodrobe{
 	req_access = null
@@ -19931,7 +19895,7 @@
 "qba" = (
 /obj/effect/floor_decal/milspec/color/silver,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
+/area/vr/powered/mall/dorms/dorms6)
 "qbf" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/cult{
@@ -20968,7 +20932,7 @@
 /obj/structure/table/bench/wooden,
 /obj/item/weapon/pen/blade/blue,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
+/area/vr/powered/mall/dorms/dorms3)
 "qMa" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -20982,6 +20946,20 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
+"qMW" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "qMX" = (
 /obj/machinery/sleeper{
 	dir = 4;
@@ -21226,6 +21204,14 @@
 "qZX" = (
 /turf/simulated/floor/carpet/blue,
 /area/vr/powered/motel)
+"raz" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/item/clothing/under/swimsuit/purple,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "raK" = (
 /obj/item/weapon/pack/cardemon,
 /turf/simulated/floor/wood,
@@ -21236,6 +21222,10 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/space/sciship)
+"rbj" = (
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "rbq" = (
 /obj/machinery/disperser/front{
 	dir = 1
@@ -21310,6 +21300,17 @@
 /obj/item/weapon/storage/backpack/dufflebag/syndie,
 /turf/simulated/floor/wmarble,
 /area/vr/powered/motel)
+"rdT" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "reW" = (
 /obj/structure/flora/rocks2,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -21703,6 +21704,14 @@
 	},
 /turf/unsimulated/elevator_shaft,
 /area/vr/outdoors/powered)
+"rwl" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
 "rwn" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -21872,6 +21881,14 @@
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
+"rET" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "rFf" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/gear_dispenser/suit/ert{
@@ -21910,7 +21927,7 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
 "rHw" = (
-/turf/simulated/floor/wood/alt/parquet,
+/turf/simulated/floor/carpet/oracarpet,
 /area/vr/powered/mall/dorms/dorms1)
 "rHO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -21937,6 +21954,10 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered)
+"rJH" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "rKk" = (
 /obj/structure/table/rack/shelf,
 /obj/item/ammo_magazine/m45,
@@ -22025,15 +22046,15 @@
 /obj/structure/salvageable/computer_os,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/sciship)
+"rMG" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "rMK" = (
 /obj/effect/zone_divider,
 /obj/effect/zone_divider,
 /turf/unsimulated/wall,
 /area/vr/powered/cult)
-"rNo" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "rOk" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod{
@@ -22280,6 +22301,9 @@
 	},
 /turf/space,
 /area/vr/space)
+"rYA" = (
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms5)
 "rYV" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -22426,20 +22450,6 @@
 	},
 /turf/unsimulated/floor/tiled/techfloor,
 /area/vr/powered/mall)
-"sed" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "seo" = (
 /obj/effect/rune,
 /obj/effect/step_trigger/message{
@@ -22561,11 +22571,6 @@
 "siU" = (
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/sciship)
-"sjg" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/stripper_green,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "sjQ" = (
 /obj/machinery/vending/wardrobe/detdrobe{
 	req_access = null
@@ -22661,22 +22666,6 @@
 /obj/structure/sign/warning/vacuum,
 /turf/simulated/wall/skipjack,
 /area/vr/powered/space/sciship)
-"spe" = (
-/obj/structure/table/darkglass,
-/obj/item/device/mindbinder{
-	pixel_y = 4;
-	pixel_x = -2
-	},
-/obj/item/device/mindbinder{
-	pixel_y = -4;
-	pixel_x = -3
-	},
-/obj/item/device/mindbinder{
-	pixel_y = 2;
-	pixel_x = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "spC" = (
 /obj/item/weapon/storage/box/wormcan,
 /turf/simulated/floor/beach/sand/desert{
@@ -22834,6 +22823,14 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/space/mechfactory)
+"svw" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "svz" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -23003,13 +23000,6 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
-"sAO" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 8
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "sAQ" = (
 /obj/structure/window/basic,
 /obj/structure/table/rack/wood,
@@ -23266,14 +23256,6 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
-"sJv" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "sJy" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/dip/guac,
@@ -23525,8 +23507,9 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/vr/powered/mall)
 "sWf" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms4)
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "sWx" = (
 /turf/simulated/shuttle/floor/darkred,
 /area/vr/powered/space/sciship)
@@ -23582,11 +23565,6 @@
 	icon_state = "cult-narsie"
 	},
 /area/vr/powered/cult)
-"tbN" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "tcB" = (
 /obj/structure/table/woodentable,
 /obj/item/stack/cable_coil{
@@ -23777,6 +23755,12 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered)
+"tlv" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms2)
 "tlY" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
@@ -23788,11 +23772,6 @@
 /obj/machinery/vending/magivend,
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
-"tme" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "tmj" = (
 /obj/effect/floor_decal/industrial/loading,
 /turf/simulated/shuttle/floor/voidcraft/light,
@@ -24060,13 +24039,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/space/sciship)
-"tyk" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 10
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "tyJ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
@@ -24079,6 +24051,20 @@
 "tyN" = (
 /turf/simulated/wall,
 /area/vr/powered/material)
+"tyP" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "tyX" = (
 /obj/structure/salvageable/console_os{
 	name = "Turret control console"
@@ -24272,10 +24258,8 @@
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
 "tGg" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms3)
 "tGi" = (
 /obj/machinery/light{
 	layer = 3
@@ -24356,6 +24340,17 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
+"tJt" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL4";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "tJU" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/snacks/enchiladas{
@@ -24820,6 +24815,7 @@
 /obj/item/clothing/head/shiny_hood/closed/poly,
 /obj/item/clothing/under/shiny/catsuit/poly,
 /obj/structure/table/darkglass,
+/obj/item/toy/balloon,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/vr/powered/mall/secondlife)
 "tZR" = (
@@ -25001,14 +24997,6 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
-"ugg" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "ugj" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod{
@@ -25246,18 +25234,6 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
-"uqt" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 6
-	},
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "uqx" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
@@ -26056,12 +26032,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "uVX" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/wood/alt/parquet,
 /area/vr/powered/mall/dorms/dorms2)
 "uWc" = (
 /obj/effect/catwalk_plated/dark,
@@ -26106,12 +26077,6 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
-"uYk" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms6)
 "uYl" = (
 /obj/machinery/appliance/cooker/grill,
 /turf/simulated/floor/wood,
@@ -26176,9 +26141,8 @@
 /area/vr/outdoors/powered)
 "vdb" = (
 /obj/structure/table/hardwoodtable,
-/obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms1)
 "vdd" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/outdoors/grass{
@@ -26314,10 +26278,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/whiteship)
-"vin" = (
-/obj/item/weapon/digestion_remains/variant2,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "vip" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor,
@@ -26690,18 +26650,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
-"vwn" = (
+/area/vr/powered/mall/dorms/dorms1)
+"vwK" = (
 /obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
+/obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
+/area/vr/powered/mall/dorms/dorms1)
 "vwT" = (
 /obj/structure/bed/chair/sofa/left/black,
 /turf/simulated/floor/wood,
@@ -26956,10 +26910,6 @@
 /obj/machinery/light/poi,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/sciship)
-"vJD" = (
-/obj/structure/curtain/black,
-/turf/simulated/floor/flock,
-/area/vr/powered/mall/secondlife)
 "vJF" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/action_figure{
@@ -27190,6 +27140,9 @@
 	nightshift_enabled = 1
 	},
 /obj/structure/table/woodentable,
+/obj/item/toy/balloon,
+/obj/item/toy/balloon,
+/obj/item/toy/balloon,
 /turf/simulated/floor/carpet/gaycarpet,
 /area/vr/powered/mall/dorms/secondlife4)
 "vTq" = (
@@ -27206,6 +27159,20 @@
 "vTF" = (
 /turf/simulated/floor/lava,
 /area/vr/powered/cult)
+"vTM" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "vTN" = (
 /obj/machinery/light{
 	dir = 8
@@ -27299,6 +27266,17 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"vYc" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL3";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "vYq" = (
 /obj/structure/grille/cult,
 /obj/structure/window/phoronreinforced/full,
@@ -27845,6 +27823,11 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"wvA" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "wwm" = (
 /obj/structure/reagent_dispensers/foam,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -28323,17 +28306,6 @@
 "wPa" = (
 /turf/simulated/wall/wood,
 /area/vr/powered/rocks)
-"wPk" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL1";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms/secondlife)
 "wPm" = (
 /obj/structure/toilet{
 	dir = 4
@@ -28480,10 +28452,19 @@
 /turf/unsimulated/floor/tiled/techfloor,
 /area/vr/powered/mall)
 "wUw" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/stripper_pink,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "wUx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -28603,10 +28584,9 @@
 /turf/simulated/floor/tiled/red,
 /area/vr/powered/mall/dorms/dorms5)
 "wWt" = (
-/obj/structure/table/darkglass,
-/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "wWC" = (
 /obj/machinery/light{
 	dir = 8
@@ -28895,12 +28875,6 @@
 /obj/machinery/chem_master,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/vr/powered/cult)
-"xkx" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 31
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "xkB" = (
 /obj/machinery/vending/wardrobe/genedrobe{
 	req_access = null
@@ -29026,6 +29000,14 @@
 	},
 /turf/simulated/floor/weird_things/dark,
 /area/vr/powered/mall/backrooms)
+"xrL" = (
+/obj/structure/table/darkglass,
+/obj/structure/stripper_pole{
+	icon_scale_x = 0.5;
+	icon_scale_y = 0.5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "xsb" = (
 /obj/structure/table/marble,
 /obj/structure/window/reinforced{
@@ -29445,10 +29427,17 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
-"xJs" = (
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+"xJr" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "xJF" = (
 /obj/machinery/light,
 /turf/simulated/floor/concrete,
@@ -29493,18 +29482,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
-"xKL" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "xLm" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/item/weapon/stool{
@@ -29582,6 +29559,11 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
+"xPs" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/mankini,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "xPH" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -29595,6 +29577,18 @@
 /obj/machinery/floorlayer,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
+"xPV" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL5";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "xQB" = (
 /obj/machinery/light{
 	dir = 1
@@ -29634,6 +29628,11 @@
 /obj/structure/window/plastitanium,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
+"xSP" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "xTe" = (
 /obj/machinery/vending/wardrobe/clowndrobe{
 	req_access = null
@@ -29725,6 +29724,12 @@
 /obj/item/weapon/cell/slime,
 /turf/simulated/floor/reinforced,
 /area/vr/powered/redbase)
+"xWW" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms3)
 "xXa" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -29770,6 +29775,11 @@
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube,
 /turf/simulated/floor/wood,
 /area/vr/powered/dungeon)
+"xYt" = (
+/obj/structure/table/bench/wooden,
+/obj/item/weapon/pen/blade/blue,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "xYu" = (
 /obj/machinery/light/floortube{
 	dir = 2
@@ -69164,17 +69174,17 @@ jNo
 mbF
 mbF
 mbF
-enN
-enN
-enN
-enN
-enN
-enN
-enN
-enN
-enN
-enN
-enN
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
 oVM
 kIl
 jPG
@@ -69422,17 +69432,17 @@ jNo
 mbF
 mbF
 mbF
-enN
+oIG
 gFH
 avf
 wkd
 rGJ
 rbF
 pYB
-enN
-pRJ
-sed
-enN
+oIG
+ibm
+qMW
+oIG
 oVM
 hSI
 jPG
@@ -69680,17 +69690,17 @@ jNo
 mbF
 sHe
 mbF
-enN
+oIG
 ixQ
 cTE
 cTE
 cTE
 cTE
 cTE
-enN
-nog
-luH
-enN
+oIG
+hzt
+mUk
+oIG
 oVM
 kIl
 jPG
@@ -69938,17 +69948,17 @@ jNo
 mbF
 mbF
 sHe
-enN
+oIG
 wSm
 cTE
 cTE
 cTE
 cTE
 qAG
-enN
-enN
-tme
-enN
+oIG
+oIG
+vwK
+oIG
 tGE
 kIl
 jPG
@@ -70197,16 +70207,16 @@ mbF
 sHe
 mbF
 gBz
-rHw
-rHw
-rHw
-rHw
-rHw
-rHw
-rHw
-pNM
-rHw
-enN
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nhK
+nJM
+oIG
 oVM
 kIl
 jPG
@@ -70454,17 +70464,17 @@ jNo
 mbF
 mbF
 mbF
-enN
+oIG
 rQv
-boF
-bZJ
-lAT
-lAT
-enN
-enN
-enN
+jrm
+vwl
+rHw
+rHw
+oIG
+oIG
+oIG
 mYs
-enN
+oIG
 oVM
 dsG
 jPG
@@ -70712,13 +70722,13 @@ jNo
 mKY
 mbF
 mKY
-enN
-lAT
+oIG
+rHw
 pBo
-qLF
-iWc
+xYt
+wWt
 ifd
-enN
+oIG
 qxv
 iVO
 aHs
@@ -70970,13 +70980,13 @@ jNo
 mbF
 mbF
 mbF
-enN
-iKR
-lAT
-lAT
-iWc
-jCa
-enN
+oIG
+mfJ
+rHw
+rHw
+wWt
+vdb
+oIG
 aJP
 aHs
 aHs
@@ -71228,17 +71238,17 @@ jNo
 mbF
 mKY
 nrp
-enN
-iKR
-xkx
-xkx
-iWc
-jKc
-enN
+oIG
+mfJ
+fKO
+fKO
+wWt
+oPm
+oIG
 khJ
 uqE
 cWw
-enN
+oIG
 oVM
 kIl
 jPG
@@ -71486,17 +71496,17 @@ jNo
 mbF
 mbF
 nrp
-enN
-enN
-enN
-enN
-enN
-enN
-enN
-enN
-enN
-enN
-enN
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
 oVM
 kIl
 jPG
@@ -71744,17 +71754,17 @@ jNo
 mbF
 mbF
 nrp
-kdB
+hOI
 iDr
 ane
 joA
 qRP
 dFF
 jSK
-kdB
-qba
-flB
-kdB
+hOI
+pRJ
+vTM
+hOI
 oVM
 kIl
 jPG
@@ -72002,17 +72012,17 @@ jNo
 mbF
 sHe
 mbF
-kdB
+hOI
 axg
 aGv
 aGv
 aGv
 aGv
 aGv
-kdB
-uVX
-mUk
-kdB
+hOI
+mOR
+aMT
+hOI
 oVM
 kIl
 jPG
@@ -72260,17 +72270,17 @@ jNo
 mbF
 mbF
 mbF
-kdB
+hOI
 wKS
 aGv
 aGv
 aGv
 aGv
 nxY
-kdB
-kdB
-tbN
-kdB
+hOI
+hOI
+buS
+hOI
 tGE
 kIl
 jPG
@@ -72519,16 +72529,16 @@ mbF
 mbF
 sHe
 rom
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-aJc
-pGH
-kdB
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+tlv
+uVX
+hOI
 oVM
 dsG
 jPG
@@ -72776,17 +72786,17 @@ jNo
 mbF
 mbF
 mbF
-kdB
+hOI
 saD
 xRd
 lHF
 jFf
 jFf
-kdB
-kdB
-kdB
+hOI
+hOI
+hOI
 onX
-kdB
+hOI
 oVM
 kIl
 jPG
@@ -73034,13 +73044,13 @@ jNo
 mbF
 mKY
 mKY
-kdB
+hOI
 jFf
 xEl
 jIp
 kOw
 nrY
-kdB
+hOI
 oxT
 bTn
 hsD
@@ -73292,13 +73302,13 @@ jNo
 mbF
 mbF
 mbF
-kdB
+hOI
 tEr
 jFf
 jFf
 kOw
 uFH
-kdB
+hOI
 uMe
 hsD
 hsD
@@ -73550,17 +73560,17 @@ jNo
 mbF
 sHe
 mbF
-kdB
+hOI
 tEr
 lnS
 lnS
 kOw
 uRx
-kdB
+hOI
 pxI
 dFd
 eif
-kdB
+hOI
 oVM
 fGS
 jPG
@@ -73808,17 +73818,17 @@ eUL
 mKY
 mbF
 mbF
-kdB
-kdB
-kdB
-kdB
-kdB
-kdB
-kdB
-kdB
-kdB
-kdB
-kdB
+hOI
+hOI
+hOI
+hOI
+hOI
+hOI
+hOI
+hOI
+hOI
+hOI
+hOI
 oVM
 kIl
 jPG
@@ -81548,17 +81558,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
 oVM
 kIl
 jPG
@@ -81806,17 +81816,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+pGH
 uSd
 moh
 lRA
 hBZ
 jQx
 mhy
-epd
-mPJ
-iHV
-epd
+pGH
+oHr
+mII
+pGH
 oVM
 kIl
 jPG
@@ -82064,17 +82074,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+pGH
 ghV
 ePC
 ePC
 ePC
 ePC
 ePC
-epd
-mOR
-eKD
-epd
+pGH
+dMH
+rdT
+pGH
 oVM
 kIl
 jPG
@@ -82322,17 +82332,17 @@ wPM
 ftm
 nhm
 ajQ
-epd
+pGH
 qIn
 ePC
 ePC
 ePC
 ePC
 mkU
-epd
-epd
-jVS
-epd
+pGH
+pGH
+xSP
+pGH
 oVM
 vdd
 jPG
@@ -82581,16 +82591,16 @@ ycu
 nhm
 ajQ
 oAC
-aeS
-aeS
-aeS
-aeS
-aeS
-aeS
-aeS
-hfV
-aeS
-epd
+tGg
+tGg
+tGg
+tGg
+tGg
+tGg
+tGg
+xWW
+tGg
+pGH
 oVM
 kIl
 jPG
@@ -82838,17 +82848,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+pGH
 fwZ
 qan
-vwl
+aiP
 wEq
 wEq
-epd
-epd
-epd
+pGH
+pGH
+pGH
 sJh
-epd
+pGH
 oVM
 crG
 jPG
@@ -83096,13 +83106,13 @@ wPM
 ycu
 nhm
 ajQ
-epd
+pGH
 wEq
-xJs
-mqX
-nzP
-vdb
-epd
+mtk
+qLF
+iWc
+dzQ
+pGH
 bos
 uZT
 cqn
@@ -83311,7 +83321,7 @@ dES
 hqN
 qjX
 vpG
-gDd
+mhv
 vpG
 ivl
 iWh
@@ -83354,13 +83364,13 @@ wPM
 ycu
 nhm
 ajQ
-epd
+pGH
 kao
 wEq
 wEq
-nzP
+iWc
 tSw
-epd
+pGH
 hwS
 cqn
 cqn
@@ -83568,8 +83578,8 @@ dES
 dES
 dES
 qjX
-vin
-kLe
+kNz
+bgW
 vpG
 ivl
 oJW
@@ -83612,17 +83622,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+pGH
 kao
 uYn
 uYn
-nzP
+iWc
 qiH
-epd
+pGH
 gIm
 neC
 sNQ
-epd
+pGH
 tGE
 kIl
 jPG
@@ -83814,23 +83824,23 @@ tgj
 vrG
 fuy
 awD
-wPk
+iag
 xUp
 jxs
 ipC
-hOI
+gUF
 aUe
 uSA
 dTX
-pul
+vYc
 wTU
 pIO
 qjX
-pzL
+tJt
 ayz
 jPB
 ivl
-oae
+xPV
 aZi
 aZi
 diP
@@ -83870,17 +83880,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
 oVM
 kIl
 jPG
@@ -84128,17 +84138,17 @@ wPM
 ycu
 nhm
 ajQ
-sWf
+aLr
 hAQ
 hlj
 ffM
 ifX
 cHE
 qjp
-sWf
-rNo
-nDt
-sWf
+aLr
+eoO
+wUw
+aLr
 oVM
 kIl
 jPG
@@ -84337,7 +84347,7 @@ qbH
 qbH
 qbH
 qbH
-lcd
+pat
 qbH
 qbH
 qbH
@@ -84386,17 +84396,17 @@ wPM
 ycu
 nhm
 ajQ
-sWf
+aLr
 uXy
 hGy
 hGy
 hGy
 hGy
 hGy
-sWf
-fMZ
-vwn
-sWf
+aLr
+geC
+nwd
+aLr
 oVM
 kIl
 jPG
@@ -84604,7 +84614,7 @@ qbH
 qbH
 qbH
 qbH
-lcd
+pat
 qbH
 qbH
 qbH
@@ -84644,17 +84654,17 @@ wPM
 ftm
 nhm
 ajQ
-sWf
+aLr
 dCS
 hGy
 hGy
 hGy
 hGy
 ocj
-sWf
-sWf
-mqT
-sWf
+aLr
+aLr
+wvA
+aLr
 oVM
 crG
 jPG
@@ -84855,10 +84865,10 @@ gVF
 qbH
 qbH
 yhp
-aOK
+raz
 qfi
 uVx
-qbH
+cZL
 qbH
 qbH
 qbH
@@ -84903,16 +84913,16 @@ ycu
 nhm
 ajQ
 wrr
-dzQ
-dzQ
-dzQ
-dzQ
-dzQ
-dzQ
-dzQ
-kCv
-dzQ
-sWf
+dhl
+dhl
+dhl
+dhl
+dhl
+dhl
+dhl
+oVQ
+dhl
+aLr
 oVM
 kIl
 jPG
@@ -85105,21 +85115,21 @@ vrG
 fuy
 xuX
 qbH
-bNT
+rwl
 duU
 mky
 hGH
 gVF
 qbH
 yhp
-uqt
+jxw
 lhR
-wWt
+cKW
 cdC
 jdX
-kVm
+nIy
 fcO
-xKL
+eKD
 qfi
 xfq
 qfi
@@ -85160,17 +85170,17 @@ wPM
 ycu
 nhm
 ajQ
-sWf
+aLr
 wNS
 kGV
 fim
 dwH
 dwH
-sWf
-sWf
-sWf
+aLr
+aLr
+aLr
 hKT
-sWf
+aLr
 oVM
 kIl
 jPG
@@ -85371,7 +85381,7 @@ gVF
 qbH
 jWY
 lhR
-pqd
+ovJ
 lhR
 lhR
 lhR
@@ -85418,13 +85428,13 @@ wPM
 ycu
 nhm
 ajQ
-sWf
+aLr
 dwH
 jxe
 woJ
 ulc
 uqx
-sWf
+aLr
 wDy
 stq
 hFX
@@ -85629,13 +85639,13 @@ gVF
 qbH
 jWY
 lhR
-jbT
+kdB
 nzO
 lhR
 lhR
 lhR
 nzO
-jbT
+kdB
 lhR
 lhR
 lhR
@@ -85676,13 +85686,13 @@ wPM
 ycu
 nhm
 ajQ
-sWf
+aLr
 mVR
 dwH
 dwH
 ulc
 pDH
-sWf
+aLr
 uJK
 hFX
 hFX
@@ -85887,14 +85897,14 @@ soT
 qbH
 jWY
 lhR
-pXn
+xPs
 lhR
-sjg
-lhR
-lhR
+jdZ
 lhR
 lhR
-pqd
+lhR
+lhR
+ovJ
 lhR
 lhR
 lhR
@@ -85934,17 +85944,17 @@ wPM
 ycu
 nhm
 ajQ
-sWf
+aLr
 mVR
 kHq
 kHq
 ulc
 aon
-sWf
+aLr
 jGS
 wAv
 fDg
-sWf
+aLr
 oVM
 kIl
 jPG
@@ -86136,10 +86146,10 @@ tgj
 vrG
 fuy
 xuX
-oVy
-sAO
-sAO
-tyk
+kgD
+kkW
+kkW
+aCd
 lut
 syD
 qbH
@@ -86192,17 +86202,17 @@ wPM
 ycu
 nhm
 ajQ
-sWf
-sWf
-sWf
-sWf
-sWf
-sWf
-sWf
-sWf
-sWf
-sWf
-sWf
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
 oVM
 kIl
 jPG
@@ -86395,19 +86405,19 @@ vrG
 fuy
 xuX
 xTU
-dhl
-ugg
-oIG
+eCg
+kUr
+iXf
 lut
 qvq
 qbH
-ljQ
+xrL
 fSy
 dax
 dax
 dZc
 qbH
-qbH
+cZL
 qbH
 qbH
 qbH
@@ -86450,17 +86460,17 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+epd
 esR
 tFD
 vRU
 wWm
 kWn
 qfX
-iXf
-nyl
-pDR
-iXf
+epd
+rMG
+iHV
+epd
 oVM
 kIl
 jPG
@@ -86653,9 +86663,9 @@ vrG
 fuy
 xuX
 lFd
-dhl
-dhl
-oIG
+eCg
+eCg
+iXf
 rdj
 iMc
 qbH
@@ -86708,17 +86718,17 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+epd
 dEk
 wNb
 wNb
 wNb
 wNb
 wNb
-iXf
-dRn
-fDN
-iXf
+epd
+svw
+xJr
+epd
 oVM
 vdd
 jPG
@@ -86911,9 +86921,9 @@ vrG
 fuy
 xuX
 hIK
-dhl
-dhl
-oIG
+eCg
+eCg
+iXf
 lut
 qvq
 qbH
@@ -86923,7 +86933,7 @@ lhR
 lhR
 lhR
 lhR
-wUw
+ovv
 lhR
 lhR
 lhR
@@ -86966,17 +86976,17 @@ wPM
 ftm
 nhm
 ajQ
-iXf
+epd
 sBU
 wNb
 wNb
 wNb
 wNb
 kWY
-iXf
-iXf
-tGg
-iXf
+epd
+epd
+oBk
+epd
 oVM
 kIl
 jPG
@@ -87169,21 +87179,21 @@ vrG
 fuy
 xuX
 jRV
-dhl
-dhl
-oIG
-bbT
+eCg
+eCg
+iXf
+acm
 qdD
-nKT
+rbj
 jWY
 lhR
-jbT
+kdB
 nzO
 lhR
 lhR
 lhR
 nzO
-jbT
+kdB
 lhR
 lhR
 lhR
@@ -87225,16 +87235,16 @@ ycu
 nhm
 ajQ
 cRS
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-dHL
-dgT
-iXf
+rYA
+rYA
+rYA
+rYA
+rYA
+rYA
+rYA
+mIC
+rYA
+epd
 oVM
 kIl
 jPG
@@ -87427,9 +87437,9 @@ vrG
 fuy
 xuX
 jRV
-dhl
-dhl
-oIG
+eCg
+eCg
+iXf
 lut
 qvq
 qbH
@@ -87482,17 +87492,17 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+epd
 stn
 pmF
 oHb
 rWO
 rWO
-iXf
-iXf
-iXf
+epd
+epd
+epd
 iNx
-iXf
+epd
 tGE
 kIl
 jPG
@@ -87685,9 +87695,9 @@ vrG
 fuy
 xuX
 hIK
-dhl
-dhl
-oIG
+eCg
+eCg
+iXf
 rdj
 nzw
 dqU
@@ -87740,13 +87750,13 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+epd
 rWO
 bwN
 lMZ
 daE
 aDw
-iXf
+epd
 oYU
 ehz
 dED
@@ -87943,9 +87953,9 @@ vrG
 fuy
 xuX
 xTU
-dhl
-dhl
-oIG
+eCg
+eCg
+iXf
 lut
 qvq
 qbH
@@ -87954,9 +87964,9 @@ qbH
 nOE
 nOE
 aLS
+cZL
 qbH
-qbH
-blH
+enN
 qbH
 qbH
 qbH
@@ -87998,13 +88008,13 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+epd
 hTp
 rWO
 rWO
 daE
 cfX
-iXf
+epd
 oVX
 dED
 dED
@@ -88201,9 +88211,9 @@ vrG
 fuy
 xuX
 lFd
-dhl
-ugg
-oIG
+eCg
+kUr
+iXf
 lut
 fnu
 qbH
@@ -88256,17 +88266,17 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+epd
 hTp
 dxe
 dxe
 daE
 ckk
-iXf
+epd
 hAt
 erY
 bmm
-iXf
+epd
 oVM
 kIl
 jPG
@@ -88458,20 +88468,20 @@ tgj
 vrG
 fuy
 xuX
-ijc
-eCg
-eCg
-dbk
+oKR
+azq
+azq
+dGb
 lut
 qvq
 qbH
 qbH
-mfJ
+juK
 qbH
 qbH
 sbp
 qbH
-mfJ
+juK
 qbH
 qbH
 qbH
@@ -88514,17 +88524,17 @@ wPM
 ycu
 nhm
 ajQ
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
 oVM
 kIl
 jPG
@@ -88736,7 +88746,7 @@ sbp
 sbp
 sbp
 sbp
-vJD
+cQA
 kRJ
 kRJ
 ouN
@@ -88772,17 +88782,17 @@ wPM
 ycu
 nhm
 ajQ
-eoO
+nKT
 wAV
 xeP
 fMj
 oqE
 qQH
 jsx
-eoO
-lBI
-nJM
-eoO
+nKT
+qba
+tyP
+nKT
 oVM
 kIl
 jPG
@@ -88980,21 +88990,21 @@ qbH
 qbH
 qbH
 qbH
-spe
-fgs
+liN
+fLo
 qbH
-sJv
+rET
 sbp
 sbp
 sbp
 sbp
 sbp
-gla
+oeg
 sbp
 sbp
 sbp
 sbp
-vJD
+cQA
 kRJ
 kRJ
 ouN
@@ -89030,17 +89040,17 @@ wPM
 ycu
 nhm
 ajQ
-eoO
+nKT
 oFn
 wSj
 wSj
 wSj
 wSj
 wSj
-eoO
-aLr
-oOj
-eoO
+nKT
+ikQ
+ddW
+nKT
 tGE
 vdd
 jPG
@@ -89238,7 +89248,7 @@ qbH
 dqU
 dqU
 qbH
-iXX
+ltS
 qbH
 qbH
 qbH
@@ -89288,17 +89298,17 @@ wPM
 ftm
 nhm
 ajQ
-eoO
+nKT
 uEQ
 wSj
 wSj
 wSj
 wSj
 etN
-eoO
-eoO
-jxd
-eoO
+nKT
+nKT
+jVS
+nKT
 oVM
 kIl
 jPG
@@ -89491,7 +89501,7 @@ vrG
 fuy
 xuX
 soT
-sJv
+rET
 dqU
 poO
 snb
@@ -89505,7 +89515,7 @@ qbH
 qbH
 qbH
 qbH
-azq
+iFw
 qbH
 qbH
 sbp
@@ -89547,16 +89557,16 @@ ycu
 nhm
 ajQ
 kKz
-iag
-iag
-iag
-iag
-iag
-iag
-iag
-uYk
-iag
-eoO
+dgT
+dgT
+dgT
+dgT
+dgT
+dgT
+dgT
+aJc
+dgT
+nKT
 oVM
 kIl
 jPG
@@ -89760,9 +89770,9 @@ tZz
 tZz
 tZz
 rFt
-loW
+sWf
 qbH
-bpF
+rJH
 qbH
 qbH
 qbH
@@ -89804,17 +89814,17 @@ wPM
 ycu
 nhm
 ajQ
-eoO
+nKT
 nYd
 axn
 pNW
 nKG
 nKG
-eoO
-eoO
-eoO
+nKT
+nKT
+nKT
 rcW
-eoO
+nKT
 tGE
 kIl
 jPG
@@ -90062,13 +90072,13 @@ wPM
 ycu
 nhm
 ajQ
-eoO
+nKT
 nKG
 qEy
 erz
 uyc
 uhu
-eoO
+nKT
 aXy
 uPj
 uFT
@@ -90320,13 +90330,13 @@ wPM
 ycu
 nhm
 ajQ
-eoO
+nKT
 rDL
 nKG
 nKG
 uyc
 bvW
-eoO
+nKT
 hAV
 uFT
 uFT
@@ -90578,17 +90588,17 @@ wPM
 ycu
 nhm
 ajQ
-eoO
+nKT
 rDL
 dHv
 dHv
 uyc
 rCB
-eoO
+nKT
 anx
 utS
 cQx
-eoO
+nKT
 sKj
 kIl
 jPG
@@ -90836,17 +90846,17 @@ wPM
 ycu
 nhm
 ajQ
-eoO
-eoO
-eoO
-eoO
-eoO
-eoO
-eoO
-eoO
-eoO
-eoO
-eoO
+nKT
+nKT
+nKT
+nKT
+nKT
+nKT
+nKT
+nKT
+nKT
+nKT
+nKT
 tPv
 tPv
 tPv

--- a/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
+++ b/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
@@ -399,6 +399,14 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"att" = (
+/obj/structure/fence/hedge/corner{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "auQ" = (
 /obj/effect/floor_decal/milspec/color/silver,
 /obj/structure/simple_door/wood,
@@ -434,8 +442,13 @@
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
 "awD" = (
-/turf/simulated/wall/concrete,
-/area/vr/powered/mall/dorms/secondlife)
+/obj/structure/fence/hedge{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "awL" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_mob/vore/aggressive/lizardman,
@@ -1166,12 +1179,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/monkeysdelight,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
-"aZu" = (
-/obj/effect/landmark/virtual_reality{
-	name = "'Strip' Mall"
-	},
-/turf/simulated/floor/flock,
-/area/vr/powered/mall/secondlife)
 "aZv" = (
 /turf/unsimulated/wall,
 /area/vr/powered/material)
@@ -2534,6 +2541,13 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/whiteship)
+"cdY" = (
+/obj/machinery/light{
+	dir = 2;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "cem" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -4454,6 +4468,23 @@
 	},
 /turf/simulated/floor/lava,
 /area/vr/outdoors/powered/lava)
+"dMS" = (
+/obj/machinery/button/remote/airlock{
+	id = "QTstorage3";
+	name = "Bolt Control";
+	pixel_x = -10;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "dNs" = (
 /obj/structure/window/reinforced/survival_pod{
 	opacity = 1
@@ -5750,6 +5781,8 @@
 /obj/item/weapon/paper_bin{
 	color = "#8f7338"
 	},
+/obj/random/soap_common,
+/obj/random/soap_common,
 /turf/simulated/floor/tiled/old_tile,
 /area/vr/powered/mall)
 "eFH" = (
@@ -5769,6 +5802,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
+"eGb" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Restroom Stall";
+	id_tag = "QTstorage3"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "eGo" = (
 /obj/machinery/light{
 	dir = 8
@@ -6238,6 +6278,13 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"eZL" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Restroom Stall";
+	id_tag = "QTstorage1"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "fan" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/road,
@@ -7160,6 +7207,13 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/whiteship)
+"fIH" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Restroom Stall";
+	id_tag = "QTstorage4"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "fIM" = (
 /obj/structure/sign/painting/away_areas,
 /turf/simulated/wall/r_wall,
@@ -9569,6 +9623,23 @@
 /obj/effect/map_effect/perma_light/brighter,
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
+"hYZ" = (
+/obj/machinery/button/remote/airlock{
+	id = "QTstorage2";
+	name = "Bolt Control";
+	pixel_x = -10;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "hZc" = (
 /obj/structure/bed/pod,
 /obj/item/weapon/bedsheet/hos,
@@ -10558,6 +10629,14 @@
 /obj/item/weapon/storage/box/buns,
 /turf/simulated/floor/tiled/yellow,
 /area/vr/powered/mall)
+"iGz" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#4165ba";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "iGA" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 4
@@ -11492,6 +11571,12 @@
 	},
 /turf/simulated/shuttle/floor/purple,
 /area/vr/powered/space/whiteship)
+"jyG" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "jzh" = (
 /obj/structure/bed/chair/wood{
 	dir = 2;
@@ -13679,6 +13764,23 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/space/sciship)
+"lpl" = (
+/obj/machinery/button/remote/airlock{
+	id = "QTstorage1";
+	name = "Bolt Control";
+	pixel_x = -10;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "lpA" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod{
@@ -13717,6 +13819,11 @@
 "lqA" = (
 /obj/machinery/appliance/cooker/oven,
 /turf/simulated/floor/wood/alt,
+/area/vr/powered/mall)
+"lqN" = (
+/turf/simulated/wall/sandstone{
+	color = "purple"
+	},
 /area/vr/powered/mall)
 "lqP" = (
 /obj/structure/sink/kitchen{
@@ -14043,6 +14150,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
+"lxP" = (
+/obj/structure/fence/hedge/end{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "lyi" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 4
@@ -14098,6 +14213,11 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"lAg" = (
+/obj/item/weapon/reagent_containers/syringe,
+/obj/effect/decal/remains,
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "lAy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -14854,6 +14974,20 @@
 /obj/item/weapon/storage/box/donkpockets/teriyaki,
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
+"meE" = (
+/obj/machinery/button/remote/airlock{
+	id = "QTstorage5";
+	name = "Bolt Control";
+	pixel_x = -10;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "meP" = (
 /turf/simulated/floor/tiled{
 	outdoors = 1
@@ -16131,6 +16265,12 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/vr/powered/dungeon)
+"ngQ" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "nhm" = (
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
@@ -16218,6 +16358,13 @@
 /obj/item/clothing/head/shiny_hood,
 /turf/simulated/floor/carpet/bcarpet,
 /area/vr/powered/mall/dorms/secondlife5)
+"nlr" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Restroom Stall";
+	id_tag = "QTstorage2"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "nls" = (
 /obj/structure/curtain/black{
 	icon_state = "open";
@@ -16227,6 +16374,10 @@
 	},
 /turf/simulated/floor/wood/sif,
 /area/vr/powered/space/mechfactory)
+"nlG" = (
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "nlM" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
@@ -16369,6 +16520,14 @@
 /obj/structure/railing,
 /turf/simulated/floor/concrete{
 	outdoors = 1
+	},
+/area/vr/outdoors/powered)
+"nqf" = (
+/obj/structure/fence/hedge/end{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
 	},
 /area/vr/outdoors/powered)
 "nqH" = (
@@ -17815,6 +17974,14 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"ooV" = (
+/obj/machinery/door/airlock/multi_tile/metal{
+	dir = 2;
+	id_tag = "QTstorage5";
+	name = "Large Restroom Stall"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "oph" = (
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
@@ -18835,6 +19002,17 @@
 	outdoors = 1
 	},
 /area/vr/powered/vendor)
+"pcg" = (
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "pcp" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/tiled/steel_dirty,
@@ -19210,6 +19388,14 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
+"pqY" = (
+/obj/structure/fence/hedge{
+	dir = 2
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "prl" = (
 /obj/structure/table/rack/shelf,
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/coffee,
@@ -19902,6 +20088,9 @@
 	},
 /turf/simulated/shuttle/floor/purple,
 /area/vr/powered/space/whiteship)
+"pVm" = (
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "pVA" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/bodysnatcher,
@@ -20453,6 +20642,12 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"qnj" = (
+/obj/structure/sign/double/barsign,
+/turf/simulated/wall/sandstone{
+	color = "purple"
+	},
+/area/vr/powered/mall/secondlife)
 "qnD" = (
 /turf/unsimulated/fake_space,
 /area/vr/powered/mall/backrooms)
@@ -21243,6 +21438,14 @@
 	temperature = 311
 	},
 /area/vr/powered)
+"qTr" = (
+/obj/structure/fence/hedge/corner{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "qTw" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/light/small{
@@ -23737,6 +23940,14 @@
 /obj/item/weapon/storage/belt/utility,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/whiteship)
+"taN" = (
+/obj/structure/table/standard,
+/obj/random/soap_common,
+/obj/random/soap_common,
+/obj/random/soap_common,
+/obj/random/soap_common,
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "tbj" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -24038,6 +24249,12 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/vr/powered/mall)
+"tqn" = (
+/obj/effect/landmark/virtual_reality{
+	name = "'Strip' Mall"
+	},
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "tqo" = (
 /obj/machinery/vending/cola,
 /obj/structure/window/reinforced{
@@ -24617,6 +24834,10 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"tOM" = (
+/obj/random/trash,
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "tOX" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/fancy/candle_box,
@@ -25240,6 +25461,12 @@
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled,
 /area/vr/powered/dungeon)
+"uiQ" = (
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/outdoors/newdirt_nograss{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "ujg" = (
 /obj/structure/table/alien/blue,
 /obj/machinery/chemical_dispenser/ert/specialops{
@@ -26711,6 +26938,23 @@
 "vrb" = (
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/cult)
+"vrf" = (
+/obj/machinery/button/remote/airlock{
+	id = "QTstorage4";
+	name = "Bolt Control";
+	pixel_x = -10;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "vrG" = (
 /turf/unsimulated/wall/concrete/turfpack/station{
 	color = "#ebcd7c";
@@ -28540,7 +28784,7 @@
 /area/vr/powered/space/mechfactory)
 "wRz" = (
 /obj/structure/curtain/black,
-/obj/machinery/door/airlock/angled_bay/double/glass,
+/obj/machinery/door/airlock/multi_tile/metal,
 /turf/simulated/floor/flock,
 /area/vr/powered/mall/secondlife)
 "wRG" = (
@@ -29281,7 +29525,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/whiteship)
 "xuX" = (
-/turf/simulated/wall/concrete,
+/obj/machinery/door/airlock/freezer{
+	name = "Restrooms"
+	},
+/turf/simulated/floor/tiled/old_tile,
 /area/vr/powered/mall/secondlife)
 "xvh" = (
 /obj/machinery/vending/loadout{
@@ -29360,6 +29607,12 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"xzS" = (
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "xAp" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
@@ -81943,14 +82196,14 @@ gfv
 gfv
 wPM
 fyS
-wPM
-wPM
-wPM
-wPM
-wPM
-wPM
-wPM
-wPM
+lqN
+lqN
+lqN
+lqN
+lqN
+lqN
+lqN
+lqN
 mfD
 mfD
 mfD
@@ -82201,14 +82454,14 @@ wPM
 wPM
 wPM
 mfD
-wPM
+lqN
 cZD
 nkR
 uJo
 veM
 eIH
 aZi
-wPM
+lqN
 mfD
 mfD
 wPM
@@ -82459,14 +82712,14 @@ mfD
 mfD
 mfD
 mfD
-wPM
+lqN
 kss
 kss
 fKI
 vjd
 qpq
 aZi
-wPM
+lqN
 mfD
 mfD
 kkM
@@ -82717,14 +82970,14 @@ mfD
 mfD
 mfD
 mfD
-wPM
+lqN
 tOh
 bQG
 oRL
 jaw
 gVQ
 diP
-wPM
+lqN
 ihz
 mfD
 wPM
@@ -82969,20 +83222,20 @@ wPM
 wPM
 wPM
 wPM
-wPM
-wPM
-wPM
-wPM
-wPM
-wPM
-wPM
+lqN
+lqN
+lqN
+lqN
+lqN
+lqN
+lqN
 eRK
 eRK
 kss
 saj
 ugR
 kss
-wPM
+lqN
 mfD
 mfD
 wPM
@@ -83219,7 +83472,7 @@ tgj
 tgj
 vrG
 fuy
-awD
+ipC
 kIc
 yfs
 yfs
@@ -83240,7 +83493,7 @@ aZi
 oJW
 kss
 aZi
-wPM
+lqN
 mfD
 mfD
 wPM
@@ -83477,7 +83730,7 @@ tgj
 tgj
 vrG
 fuy
-awD
+ipC
 cXe
 cXe
 yfs
@@ -83498,7 +83751,7 @@ iWh
 aZi
 aZi
 aZi
-wPM
+lqN
 mfD
 ihz
 wPM
@@ -83735,7 +83988,7 @@ tgj
 tgj
 vrG
 fuy
-awD
+ipC
 agH
 yfs
 bKW
@@ -83756,7 +84009,7 @@ eWW
 aZi
 yiL
 hvR
-wPM
+lqN
 mfD
 xJF
 wPM
@@ -83993,7 +84246,7 @@ tgj
 tgj
 vrG
 fuy
-awD
+ipC
 hPO
 xUp
 jxs
@@ -84014,7 +84267,7 @@ rSM
 aZi
 aZi
 diP
-wPM
+lqN
 mfD
 mfD
 wPM
@@ -84251,7 +84504,7 @@ tgj
 tgj
 vrG
 fuy
-awD
+ipC
 dzT
 ipC
 ipC
@@ -84272,7 +84525,7 @@ eRK
 ivr
 eRK
 eRK
-wPM
+lqN
 mfD
 mfD
 wPM
@@ -84509,7 +84762,7 @@ tgj
 vrG
 vrG
 fuy
-xuX
+iyQ
 qbH
 qbH
 qbH
@@ -84530,7 +84783,7 @@ qbH
 qbH
 qbH
 qbH
-xuX
+iyQ
 ihz
 mfD
 pPo
@@ -84767,7 +85020,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 qbH
 gVF
 gVF
@@ -84788,7 +85041,7 @@ dnZ
 qbH
 qbH
 qbH
-xuX
+iyQ
 mfD
 mfD
 wPM
@@ -85025,7 +85278,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 qbH
 gVF
 eLf
@@ -85046,7 +85299,7 @@ qbH
 qbH
 qbH
 qbH
-xuX
+iyQ
 mfD
 mfD
 wPM
@@ -85283,7 +85536,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 qbH
 wTY
 duU
@@ -85304,7 +85557,7 @@ qfi
 xfq
 qfi
 qfi
-xuX
+iyQ
 mfD
 mfD
 wPM
@@ -85541,7 +85794,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 qbH
 gVF
 gHF
@@ -85562,7 +85815,7 @@ lhR
 lhR
 lhR
 lhR
-xuX
+iyQ
 mfD
 mfD
 wPM
@@ -85799,7 +86052,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 qbH
 gVF
 gVF
@@ -85820,7 +86073,7 @@ lhR
 lhR
 lhR
 lhR
-xuX
+iyQ
 mfD
 xJF
 wPM
@@ -86057,7 +86310,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 uzw
 uzw
 pTD
@@ -86078,7 +86331,7 @@ fxe
 lhR
 lhR
 lhR
-xuX
+iyQ
 ihR
 ihR
 wPM
@@ -86315,7 +86568,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 fQf
 jpy
 jpy
@@ -86336,7 +86589,7 @@ oCA
 nOE
 nOE
 nOE
-xuX
+iyQ
 wPM
 wPM
 wPM
@@ -86573,7 +86826,7 @@ tgj
 vrG
 vrG
 fuy
-xuX
+iyQ
 xTU
 eCg
 cPN
@@ -86831,7 +87084,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 lFd
 eCg
 eCg
@@ -87089,7 +87342,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 hIK
 eCg
 eCg
@@ -87347,7 +87600,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 dLk
 eCg
 eCg
@@ -87605,7 +87858,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 jRV
 eCg
 eCg
@@ -87863,7 +88116,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 ydc
 eCg
 eCg
@@ -88121,7 +88374,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 xTU
 eCg
 eCg
@@ -88142,7 +88395,7 @@ qbH
 qbH
 qbH
 qbH
-iyQ
+qnj
 ouN
 ouN
 ouN
@@ -88379,7 +88632,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 lFd
 eCg
 cPN
@@ -88637,7 +88890,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 pZh
 fnx
 fnx
@@ -88895,7 +89148,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 rgm
 sOV
 xma
@@ -89153,7 +89406,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 qbH
 qbH
 qbH
@@ -89172,7 +89425,7 @@ sbp
 gEm
 sbp
 sbp
-aZu
+tqn
 sbp
 tGg
 kRJ
@@ -89411,7 +89664,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 ujo
 dqU
 qbH
@@ -89669,7 +89922,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 soT
 frI
 dqU
@@ -89927,7 +90180,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 gVN
 qbH
 dqU
@@ -90185,7 +90438,7 @@ tgj
 tgj
 vrG
 fuy
-xuX
+iyQ
 clV
 qbH
 qbH
@@ -90443,28 +90696,28 @@ tgj
 tgj
 vrG
 fuy
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
 xuX
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
 xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
-xuX
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
 jiV
 ouN
 ouN
@@ -90701,23 +90954,23 @@ tgj
 vrG
 vrG
 fuy
+lxP
 kIl
 kIl
 kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+iyQ
+pVm
+pVm
+tOM
+taN
+pcg
+pcg
+pcg
+pcg
+tOM
+pVm
+iyQ
+lxP
 kIl
 kIl
 kIl
@@ -90959,23 +91212,23 @@ tgj
 tgj
 vrG
 fuy
+awD
 kIl
 kIl
 kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+iyQ
+tOM
+pVm
+iGz
+pVm
+nlG
+pVm
+tOM
+iGz
+lAg
+cdY
+iyQ
+awD
 kIl
 kIl
 kIl
@@ -91217,25 +91470,25 @@ tgj
 tgj
 vrG
 fuy
+awD
 kIl
 kIl
 kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+iyQ
+nlG
+pVm
+pVm
+pVm
+pVm
+tOM
+pVm
+iyQ
+pVm
+ooV
+iyQ
+awD
+xzS
+ngQ
 kIl
 jLr
 ebN
@@ -91475,23 +91728,23 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-dLz
+awD
 kIl
 dLz
 kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+iyQ
+eZL
+iyQ
+nlr
+iyQ
+eGb
+iyQ
+fIH
+iyQ
+pVm
+pVm
+iyQ
+awD
 kIl
 kIl
 jPG
@@ -91733,26 +91986,26 @@ tgj
 tgj
 vrG
 fuy
+awD
 kIl
 kIl
 kIl
+iyQ
+lpl
+iyQ
+hYZ
+iyQ
+dMS
+iyQ
+vrf
+iyQ
+meE
+jyG
+iyQ
+awD
 kIl
 kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-jPG
+uiQ
 jLr
 ebN
 geo
@@ -91991,25 +92244,25 @@ tgj
 tgj
 vrG
 fuy
+awD
 kIl
 kIl
 kIl
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+iyQ
+awD
 kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+ngQ
 jPG
 cuJ
 ebN
@@ -92249,7 +92502,7 @@ tgj
 tgj
 vrG
 fuy
-kIl
+awD
 kIl
 kIl
 kIl
@@ -92265,7 +92518,7 @@ kIl
 kIl
 dLz
 kIl
-kIl
+awD
 kIl
 kIl
 kIl
@@ -92507,14 +92760,14 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+att
+pqY
+pqY
+pqY
+pqY
+pqY
+pqY
+qTr
 kIl
 dLz
 kIl
@@ -92523,7 +92776,7 @@ kIl
 kIl
 kIl
 kIl
-kIl
+nqf
 kIl
 kIl
 kIl
@@ -92772,7 +93025,7 @@ fuy
 fuy
 fuy
 fuy
-kIl
+awD
 kIl
 kIl
 kIl
@@ -93030,7 +93283,7 @@ vrG
 vrG
 vrG
 fuy
-kIl
+awD
 kIl
 kIl
 kIl
@@ -93288,7 +93541,7 @@ tgj
 tgj
 vrG
 fuy
-kIl
+awD
 kIl
 dLz
 kIl
@@ -93546,8 +93799,8 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
+att
+qTr
 kIl
 kIl
 kIl
@@ -93805,7 +94058,7 @@ tgj
 vrG
 fuy
 fuy
-kIl
+awD
 kIl
 kIl
 kIl
@@ -94063,7 +94316,7 @@ vrG
 vrG
 vrG
 fuy
-kIl
+awD
 kIl
 kIl
 kIl
@@ -94321,7 +94574,7 @@ tgj
 vrG
 vrG
 fuy
-kIl
+awD
 kIl
 kIl
 kIl
@@ -94579,7 +94832,7 @@ tgj
 vrG
 vrG
 fuy
-kIl
+awD
 kIl
 kIl
 kIl
@@ -94837,7 +95090,7 @@ tgj
 vrG
 vrG
 fuy
-kIl
+awD
 kIl
 dLz
 kIl
@@ -95095,7 +95348,7 @@ tgj
 vrG
 vrG
 fuy
-kIl
+awD
 kIl
 kIl
 kIl
@@ -95353,7 +95606,7 @@ tgj
 vrG
 vrG
 fuy
-kIl
+awD
 kIl
 kIl
 kIl
@@ -95611,7 +95864,7 @@ tgj
 vrG
 vrG
 fuy
-kIl
+nqf
 kIl
 kIl
 kIl
@@ -95869,64 +96122,64 @@ vrG
 vrG
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
+xuH
 xuH
 xuH
 xuH

--- a/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
+++ b/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
@@ -399,14 +399,6 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
-"att" = (
-/obj/structure/fence/hedge/corner{
-	dir = 1
-	},
-/turf/simulated/floor/outdoors/grass{
-	temperature = 293.15
-	},
-/area/vr/outdoors/powered)
 "auQ" = (
 /obj/effect/floor_decal/milspec/color/silver,
 /obj/structure/simple_door/wood,
@@ -442,13 +434,9 @@
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
 "awD" = (
-/obj/structure/fence/hedge{
-	dir = 4
-	},
-/turf/simulated/floor/outdoors/grass{
-	temperature = 293.15
-	},
-/area/vr/outdoors/powered)
+/obj/random/trash,
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "awL" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_mob/vore/aggressive/lizardman,
@@ -745,6 +733,12 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"aHH" = (
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "aHI" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -847,6 +841,23 @@
 	temperature = 311
 	},
 /area/vr/powered)
+"aLl" = (
+/obj/machinery/button/remote/airlock{
+	id = "QTstorage3";
+	name = "Bolt Control";
+	pixel_x = -10;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "aLr" = (
 /obj/effect/floor_decal/corner/purple/border{
 	color = "#f700ff";
@@ -934,6 +945,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cult)
+"aPd" = (
+/obj/structure/fence/hedge/corner{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "aPz" = (
 /obj/machinery/disperser/back{
 	dir = 1
@@ -1438,6 +1457,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
+"bky" = (
+/obj/machinery/button/remote/airlock{
+	id = "QTstorage4";
+	name = "Bolt Control";
+	pixel_x = -10;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "bkS" = (
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 5
@@ -1810,6 +1846,13 @@
 	},
 /turf/simulated/shuttle/floor/darkred,
 /area/vr/powered/armory)
+"bDN" = (
+/obj/machinery/light{
+	dir = 2;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "bDQ" = (
 /obj/effect/floor_decal/arrow{
 	dir = 4
@@ -2541,13 +2584,6 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/whiteship)
-"cdY" = (
-/obj/machinery/light{
-	dir = 2;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "cem" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -4015,6 +4051,23 @@
 	temperature = 311
 	},
 /area/vr/powered)
+"drt" = (
+/obj/machinery/button/remote/airlock{
+	id = "QTstorage5";
+	name = "Bolt Control";
+	pixel_x = -10;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "dry" = (
 /turf/unsimulated/wall/seperator,
 /area/vr/space)
@@ -4468,23 +4521,6 @@
 	},
 /turf/simulated/floor/lava,
 /area/vr/outdoors/powered/lava)
-"dMS" = (
-/obj/machinery/button/remote/airlock{
-	id = "QTstorage3";
-	name = "Bolt Control";
-	pixel_x = -10;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "dNs" = (
 /obj/structure/window/reinforced/survival_pod{
 	opacity = 1
@@ -4558,6 +4594,10 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"dOc" = (
+/obj/effect/decal/cleanable/filth,
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "dOg" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/light/floortube/flicker{
@@ -5519,6 +5559,10 @@
 	pixel_y = 2;
 	pixel_x = 6
 	},
+/obj/item/trash/cigbutt{
+	pixel_y = 2;
+	pixel_x = -9
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "evY" = (
@@ -5802,13 +5846,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
-"eGb" = (
-/obj/machinery/door/airlock/freezer{
-	name = "Restroom Stall";
-	id_tag = "QTstorage3"
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "eGo" = (
 /obj/machinery/light{
 	dir = 8
@@ -5836,6 +5873,13 @@
 	},
 /turf/unsimulated/floor/tiled/techfloor,
 /area/vr/powered/mall)
+"eGQ" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Restroom Stall";
+	id_tag = "QTstorage4"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "eHc" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/drinks/cup{
@@ -6278,13 +6322,6 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
-"eZL" = (
-/obj/machinery/door/airlock/freezer{
-	name = "Restroom Stall";
-	id_tag = "QTstorage1"
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "fan" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/road,
@@ -6770,6 +6807,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
+"frM" = (
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "frW" = (
 /obj/machinery/light{
 	dir = 4
@@ -7207,13 +7247,6 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/whiteship)
-"fIH" = (
-/obj/machinery/door/airlock/freezer{
-	name = "Restroom Stall";
-	id_tag = "QTstorage4"
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "fIM" = (
 /obj/structure/sign/painting/away_areas,
 /turf/simulated/wall/r_wall,
@@ -7817,6 +7850,14 @@
 "gjB" = (
 /turf/simulated/wall/r_wall,
 /area/vr/powered/bluebase)
+"gjP" = (
+/obj/structure/fence/hedge/corner{
+	dir = 1
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "glK" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -8085,6 +8126,13 @@
 	},
 /turf/simulated/floor/redgrid/animated,
 /area/vr/powered/cult)
+"gBw" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Restroom Stall";
+	id_tag = "QTstorage1"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "gBz" = (
 /obj/machinery/door/airlock/sandstone{
 	id_tag = "VRmall5"
@@ -8207,6 +8255,12 @@
 /obj/item/weapon/storage/fancy/egg_box,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/dorms/dorms1)
+"gGa" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "gGj" = (
 /obj/structure/fence/door/opened{
 	dir = 4
@@ -8439,6 +8493,14 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/concrete,
 /area/vr/powered/mall)
+"gRn" = (
+/obj/structure/fence/hedge{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "gRT" = (
 /obj/machinery/light{
 	layer = 3
@@ -8876,6 +8938,14 @@
 "hoq" = (
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/whiteship)
+"hot" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#4165ba";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "hou" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
@@ -9623,23 +9693,6 @@
 /obj/effect/map_effect/perma_light/brighter,
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
-"hYZ" = (
-/obj/machinery/button/remote/airlock{
-	id = "QTstorage2";
-	name = "Bolt Control";
-	pixel_x = -10;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "hZc" = (
 /obj/structure/bed/pod,
 /obj/item/weapon/bedsheet/hos,
@@ -10629,14 +10682,6 @@
 /obj/item/weapon/storage/box/buns,
 /turf/simulated/floor/tiled/yellow,
 /area/vr/powered/mall)
-"iGz" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#4165ba";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "iGA" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 4
@@ -11289,6 +11334,12 @@
 /obj/item/weapon/storage/fancy/cigar/havana,
 /turf/simulated/floor/tiled,
 /area/vr/powered/constore)
+"jmD" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "jmG" = (
 /obj/structure/table/marble,
 /obj/item/weapon/storage/box/donkpockets/teriyaki,
@@ -11368,6 +11419,23 @@
 /obj/item/weapon/pen/fountain,
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"joY" = (
+/obj/machinery/button/remote/airlock{
+	id = "QTstorage1";
+	name = "Bolt Control";
+	pixel_x = -10;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "jpu" = (
 /obj/machinery/sleep_console{
 	dir = 4
@@ -11571,12 +11639,6 @@
 	},
 /turf/simulated/shuttle/floor/purple,
 /area/vr/powered/space/whiteship)
-"jyG" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "jzh" = (
 /obj/structure/bed/chair/wood{
 	dir = 2;
@@ -12147,6 +12209,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"jVb" = (
+/obj/machinery/door/airlock/multi_tile/metal{
+	dir = 2;
+	id_tag = "QTstorage5";
+	name = "Large Restroom Stall"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "jVS" = (
 /obj/effect/floor_decal/milspec/color/silver,
 /obj/structure/simple_door/wood,
@@ -12994,6 +13064,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/cult)
+"kJo" = (
+/obj/structure/sign/double/barsign,
+/turf/simulated/wall/sandstone{
+	color = "purple"
+	},
+/area/vr/powered/mall/secondlife)
 "kJp" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
@@ -13764,23 +13840,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/space/sciship)
-"lpl" = (
-/obj/machinery/button/remote/airlock{
-	id = "QTstorage1";
-	name = "Bolt Control";
-	pixel_x = -10;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "lpA" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod{
@@ -13819,11 +13878,6 @@
 "lqA" = (
 /obj/machinery/appliance/cooker/oven,
 /turf/simulated/floor/wood/alt,
-/area/vr/powered/mall)
-"lqN" = (
-/turf/simulated/wall/sandstone{
-	color = "purple"
-	},
 /area/vr/powered/mall)
 "lqP" = (
 /obj/structure/sink/kitchen{
@@ -14006,6 +14060,23 @@
 /obj/structure/table/darkglass,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/vr/powered/mall/secondlife)
+"luQ" = (
+/obj/machinery/button/remote/airlock{
+	id = "QTstorage2";
+	name = "Bolt Control";
+	pixel_x = -10;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "lvj" = (
 /obj/structure/table/rack/wood,
 /obj/item/clothing/under/color/grey{
@@ -14150,14 +14221,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
-"lxP" = (
-/obj/structure/fence/hedge/end{
-	dir = 4
-	},
-/turf/simulated/floor/outdoors/grass{
-	temperature = 293.15
-	},
-/area/vr/outdoors/powered)
 "lyi" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 4
@@ -14213,11 +14276,6 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
-"lAg" = (
-/obj/item/weapon/reagent_containers/syringe,
-/obj/effect/decal/remains,
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "lAy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -14824,6 +14882,14 @@
 	},
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/dungeon)
+"lXB" = (
+/obj/structure/table/standard,
+/obj/random/soap_common,
+/obj/random/soap_common,
+/obj/random/soap_common,
+/obj/random/soap_common,
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "lYd" = (
 /turf/simulated/mineral/sif,
 /area/vr/outdoors/powered)
@@ -14974,20 +15040,6 @@
 /obj/item/weapon/storage/box/donkpockets/teriyaki,
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
-"meE" = (
-/obj/machinery/button/remote/airlock{
-	id = "QTstorage5";
-	name = "Bolt Control";
-	pixel_x = -10;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "meP" = (
 /turf/simulated/floor/tiled{
 	outdoors = 1
@@ -15323,6 +15375,11 @@
 "mso" = (
 /turf/simulated/floor/beach/sand/desert,
 /area/vr/powered/mall/vw)
+"msp" = (
+/obj/item/weapon/reagent_containers/syringe,
+/obj/effect/decal/remains,
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "mss" = (
 /obj/structure/railing,
 /obj/effect/step_trigger/teleporter/bridge/north_to_south,
@@ -16265,12 +16322,6 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/vr/powered/dungeon)
-"ngQ" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/outdoors/grass{
-	temperature = 293.15
-	},
-/area/vr/outdoors/powered)
 "nhm" = (
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
@@ -16358,13 +16409,6 @@
 /obj/item/clothing/head/shiny_hood,
 /turf/simulated/floor/carpet/bcarpet,
 /area/vr/powered/mall/dorms/secondlife5)
-"nlr" = (
-/obj/machinery/door/airlock/freezer{
-	name = "Restroom Stall";
-	id_tag = "QTstorage2"
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "nls" = (
 /obj/structure/curtain/black{
 	icon_state = "open";
@@ -16374,10 +16418,6 @@
 	},
 /turf/simulated/floor/wood/sif,
 /area/vr/powered/space/mechfactory)
-"nlG" = (
-/obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "nlM" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
@@ -16520,14 +16560,6 @@
 /obj/structure/railing,
 /turf/simulated/floor/concrete{
 	outdoors = 1
-	},
-/area/vr/outdoors/powered)
-"nqf" = (
-/obj/structure/fence/hedge/end{
-	dir = 8
-	},
-/turf/simulated/floor/outdoors/grass{
-	temperature = 293.15
 	},
 /area/vr/outdoors/powered)
 "nqH" = (
@@ -17974,14 +18006,6 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
-"ooV" = (
-/obj/machinery/door/airlock/multi_tile/metal{
-	dir = 2;
-	id_tag = "QTstorage5";
-	name = "Large Restroom Stall"
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "oph" = (
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
@@ -19002,17 +19026,6 @@
 	outdoors = 1
 	},
 /area/vr/powered/vendor)
-"pcg" = (
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "pcp" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/tiled/steel_dirty,
@@ -19059,6 +19072,12 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"peZ" = (
+/obj/structure/flora/ausbushes,
+/turf/simulated/floor/outdoors/newdirt_nograss{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "pfa" = (
 /obj/machinery/vending/wallmed1{
 	name = "NanoMed Wall";
@@ -19264,6 +19283,14 @@
 "pmG" = (
 /turf/simulated/floor/carpet,
 /area/vr/powered/mall)
+"pmQ" = (
+/obj/structure/fence/hedge/end{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "pnq" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -19388,14 +19415,6 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
-"pqY" = (
-/obj/structure/fence/hedge{
-	dir = 2
-	},
-/turf/simulated/floor/outdoors/grass{
-	temperature = 293.15
-	},
-/area/vr/outdoors/powered)
 "prl" = (
 /obj/structure/table/rack/shelf,
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/coffee,
@@ -20088,9 +20107,6 @@
 	},
 /turf/simulated/shuttle/floor/purple,
 /area/vr/powered/space/whiteship)
-"pVm" = (
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "pVA" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/bodysnatcher,
@@ -20642,12 +20658,6 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
-"qnj" = (
-/obj/structure/sign/double/barsign,
-/turf/simulated/wall/sandstone{
-	color = "purple"
-	},
-/area/vr/powered/mall/secondlife)
 "qnD" = (
 /turf/unsimulated/fake_space,
 /area/vr/powered/mall/backrooms)
@@ -21438,14 +21448,6 @@
 	temperature = 311
 	},
 /area/vr/powered)
-"qTr" = (
-/obj/structure/fence/hedge/corner{
-	dir = 8
-	},
-/turf/simulated/floor/outdoors/grass{
-	temperature = 293.15
-	},
-/area/vr/outdoors/powered)
 "qTw" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/light/small{
@@ -22153,6 +22155,13 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"rCf" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Restroom Stall";
+	id_tag = "QTstorage3"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "rCh" = (
 /turf/simulated/floor/gorefloor,
 /area/vr/powered/cult)
@@ -22382,6 +22391,11 @@
 /obj/effect/zone_divider,
 /turf/unsimulated/wall,
 /area/vr/powered/cult)
+"rMS" = (
+/turf/simulated/wall/sandstone{
+	color = "purple"
+	},
+/area/vr/powered/mall)
 "rOk" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod{
@@ -23021,6 +23035,14 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"spL" = (
+/obj/structure/fence/hedge/end{
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "squ" = (
 /turf/simulated/floor/wood/alt/panel/broken{
 	temperature = 311
@@ -23940,14 +23962,6 @@
 /obj/item/weapon/storage/belt/utility,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/whiteship)
-"taN" = (
-/obj/structure/table/standard,
-/obj/random/soap_common,
-/obj/random/soap_common,
-/obj/random/soap_common,
-/obj/random/soap_common,
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "tbj" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -24249,12 +24263,6 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/vr/powered/mall)
-"tqn" = (
-/obj/effect/landmark/virtual_reality{
-	name = "'Strip' Mall"
-	},
-/turf/simulated/floor/flock,
-/area/vr/powered/mall/secondlife)
 "tqo" = (
 /obj/machinery/vending/cola,
 /obj/structure/window/reinforced{
@@ -24320,6 +24328,12 @@
 /obj/structure/shuttle/engine/router,
 /turf/simulated/shuttle/wall,
 /area/vr/powered/space/whiteship)
+"ttD" = (
+/obj/effect/landmark/virtual_reality{
+	name = "'Strip' Mall"
+	},
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "tui" = (
 /obj/structure/salvageable/console_broken_os,
 /obj/effect/floor_decal/techfloor{
@@ -24834,10 +24848,6 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
-"tOM" = (
-/obj/random/trash,
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "tOX" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/fancy/candle_box,
@@ -25461,12 +25471,6 @@
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled,
 /area/vr/powered/dungeon)
-"uiQ" = (
-/obj/structure/flora/ausbushes,
-/turf/simulated/floor/outdoors/newdirt_nograss{
-	temperature = 293.15
-	},
-/area/vr/outdoors/powered)
 "ujg" = (
 /obj/structure/table/alien/blue,
 /obj/machinery/chemical_dispenser/ert/specialops{
@@ -26938,23 +26942,6 @@
 "vrb" = (
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/cult)
-"vrf" = (
-/obj/machinery/button/remote/airlock{
-	id = "QTstorage4";
-	name = "Bolt Control";
-	pixel_x = -10;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/vr/powered/mall/secondlife)
 "vrG" = (
 /turf/unsimulated/wall/concrete/turfpack/station{
 	color = "#ebcd7c";
@@ -28260,6 +28247,13 @@
 "wxv" = (
 /turf/simulated/wall/concrete,
 /area/vr/outdoors/powered/mall)
+"wxC" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Restroom Stall";
+	id_tag = "QTstorage2"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "wxF" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/item/weapon/stool{
@@ -28863,6 +28857,17 @@
 /obj/item/weapon/pen/blade/blue,
 /turf/simulated/floor/carpet/oracarpet,
 /area/vr/powered/mall/dorms/dorms3)
+"wTQ" = (
+/obj/structure/mirror{
+	pixel_x = -28
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/vr/powered/mall/secondlife)
 "wTU" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29607,8 +29612,10 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
-"xzS" = (
-/obj/structure/flora/ausbushes,
+"xAg" = (
+/obj/structure/fence/hedge{
+	dir = 2
+	},
 /turf/simulated/floor/outdoors/grass{
 	temperature = 293.15
 	},
@@ -82196,14 +82203,14 @@ gfv
 gfv
 wPM
 fyS
-lqN
-lqN
-lqN
-lqN
-lqN
-lqN
-lqN
-lqN
+rMS
+rMS
+rMS
+rMS
+rMS
+rMS
+rMS
+rMS
 mfD
 mfD
 mfD
@@ -82454,14 +82461,14 @@ wPM
 wPM
 wPM
 mfD
-lqN
+rMS
 cZD
 nkR
 uJo
 veM
 eIH
 aZi
-lqN
+rMS
 mfD
 mfD
 wPM
@@ -82712,14 +82719,14 @@ mfD
 mfD
 mfD
 mfD
-lqN
+rMS
 kss
 kss
 fKI
 vjd
 qpq
 aZi
-lqN
+rMS
 mfD
 mfD
 kkM
@@ -82970,14 +82977,14 @@ mfD
 mfD
 mfD
 mfD
-lqN
+rMS
 tOh
 bQG
 oRL
 jaw
 gVQ
 diP
-lqN
+rMS
 ihz
 mfD
 wPM
@@ -83222,20 +83229,20 @@ wPM
 wPM
 wPM
 wPM
-lqN
-lqN
-lqN
-lqN
-lqN
-lqN
-lqN
+rMS
+rMS
+rMS
+rMS
+rMS
+rMS
+rMS
 eRK
 eRK
 kss
 saj
 ugR
 kss
-lqN
+rMS
 mfD
 mfD
 wPM
@@ -83493,7 +83500,7 @@ aZi
 oJW
 kss
 aZi
-lqN
+rMS
 mfD
 mfD
 wPM
@@ -83751,7 +83758,7 @@ iWh
 aZi
 aZi
 aZi
-lqN
+rMS
 mfD
 ihz
 wPM
@@ -84009,7 +84016,7 @@ eWW
 aZi
 yiL
 hvR
-lqN
+rMS
 mfD
 xJF
 wPM
@@ -84267,7 +84274,7 @@ rSM
 aZi
 aZi
 diP
-lqN
+rMS
 mfD
 mfD
 wPM
@@ -84525,7 +84532,7 @@ eRK
 ivr
 eRK
 eRK
-lqN
+rMS
 mfD
 mfD
 wPM
@@ -88395,7 +88402,7 @@ qbH
 qbH
 qbH
 qbH
-qnj
+kJo
 ouN
 ouN
 ouN
@@ -89425,7 +89432,7 @@ sbp
 gEm
 sbp
 sbp
-tqn
+ttD
 sbp
 tGg
 kRJ
@@ -90954,23 +90961,23 @@ tgj
 vrG
 vrG
 fuy
-lxP
+pmQ
 kIl
 kIl
 kIl
 iyQ
-pVm
-pVm
-tOM
-taN
-pcg
-pcg
-pcg
-pcg
-tOM
-pVm
+frM
+frM
+awD
+lXB
+wTQ
+wTQ
+wTQ
+wTQ
+awD
+frM
 iyQ
-lxP
+pmQ
 kIl
 kIl
 kIl
@@ -91212,23 +91219,23 @@ tgj
 tgj
 vrG
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
 iyQ
-tOM
-pVm
-iGz
-pVm
-nlG
-pVm
-tOM
-iGz
-lAg
-cdY
-iyQ
 awD
+frM
+hot
+frM
+dOc
+frM
+awD
+hot
+msp
+bDN
+iyQ
+gRn
 kIl
 kIl
 kIl
@@ -91470,25 +91477,25 @@ tgj
 tgj
 vrG
 fuy
+gRn
+kIl
+kIl
+kIl
+iyQ
+dOc
+frM
+frM
+frM
+frM
 awD
-kIl
-kIl
-kIl
+frM
 iyQ
-nlG
-pVm
-pVm
-pVm
-pVm
-tOM
-pVm
+frM
+jVb
 iyQ
-pVm
-ooV
-iyQ
-awD
-xzS
-ngQ
+gRn
+aHH
+jmD
 kIl
 jLr
 ebN
@@ -91728,23 +91735,23 @@ tgj
 tgj
 vrG
 fuy
-awD
+gRn
 kIl
 dLz
 kIl
 iyQ
-eZL
+gBw
 iyQ
-nlr
+wxC
 iyQ
-eGb
+rCf
 iyQ
-fIH
+eGQ
 iyQ
-pVm
-pVm
+frM
+frM
 iyQ
-awD
+gRn
 kIl
 kIl
 jPG
@@ -91986,26 +91993,26 @@ tgj
 tgj
 vrG
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
 iyQ
-lpl
+joY
 iyQ
-hYZ
+luQ
 iyQ
-dMS
+aLl
 iyQ
-vrf
+bky
 iyQ
-meE
-jyG
+drt
+gGa
 iyQ
-awD
+gRn
 kIl
 kIl
-uiQ
+peZ
 jLr
 ebN
 geo
@@ -92244,7 +92251,7 @@ tgj
 tgj
 vrG
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
@@ -92260,9 +92267,9 @@ iyQ
 iyQ
 iyQ
 iyQ
-awD
+gRn
 kIl
-ngQ
+jmD
 jPG
 cuJ
 ebN
@@ -92502,7 +92509,7 @@ tgj
 tgj
 vrG
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
@@ -92518,7 +92525,7 @@ kIl
 kIl
 dLz
 kIl
-awD
+gRn
 kIl
 kIl
 kIl
@@ -92760,14 +92767,14 @@ tgj
 tgj
 vrG
 fuy
-att
-pqY
-pqY
-pqY
-pqY
-pqY
-pqY
-qTr
+gjP
+xAg
+xAg
+xAg
+xAg
+xAg
+xAg
+aPd
 kIl
 dLz
 kIl
@@ -92776,7 +92783,7 @@ kIl
 kIl
 kIl
 kIl
-nqf
+spL
 kIl
 kIl
 kIl
@@ -93025,7 +93032,7 @@ fuy
 fuy
 fuy
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
@@ -93283,7 +93290,7 @@ vrG
 vrG
 vrG
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
@@ -93541,7 +93548,7 @@ tgj
 tgj
 vrG
 fuy
-awD
+gRn
 kIl
 dLz
 kIl
@@ -93799,8 +93806,8 @@ tgj
 tgj
 vrG
 fuy
-att
-qTr
+gjP
+aPd
 kIl
 kIl
 kIl
@@ -94058,7 +94065,7 @@ tgj
 vrG
 fuy
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
@@ -94316,7 +94323,7 @@ vrG
 vrG
 vrG
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
@@ -94574,7 +94581,7 @@ tgj
 vrG
 vrG
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
@@ -94832,7 +94839,7 @@ tgj
 vrG
 vrG
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
@@ -95090,7 +95097,7 @@ tgj
 vrG
 vrG
 fuy
-awD
+gRn
 kIl
 dLz
 kIl
@@ -95348,7 +95355,7 @@ tgj
 vrG
 vrG
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
@@ -95606,7 +95613,7 @@ tgj
 vrG
 vrG
 fuy
-awD
+gRn
 kIl
 kIl
 kIl
@@ -95864,7 +95871,7 @@ tgj
 vrG
 vrG
 fuy
-nqf
+spL
 kIl
 kIl
 kIl

--- a/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
+++ b/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
@@ -31,11 +31,6 @@
 /obj/item/weapon/storage/firstaid/adv,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/building2)
-"acm" = (
-/obj/structure/table/darkglass,
-/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
-/turf/simulated/floor/tiled/milspec/raised,
-/area/vr/powered/mall/secondlife)
 "acC" = (
 /obj/effect/landmark/virtual_reality{
 	name = "Cultist Base"
@@ -128,15 +123,6 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/flock,
 /area/vr/powered/rocks)
-"aiP" = (
-/obj/structure/bed/chair/sofa/right/beige{
-	dir = 4
-	},
-/obj/machinery/light/floortube{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "ajk" = (
 /obj/structure/barricade,
 /obj/effect/floor_decal/rust,
@@ -388,6 +374,12 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"asY" = (
+/obj/structure/bed/chair/sofa/left/beige{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "ate" = (
 /obj/item/weapon/reagent_containers/food/snacks/badrecipe,
 /obj/effect/map_effect/perma_light/brighter,
@@ -395,6 +387,15 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"ato" = (
+/obj/structure/table/bench/wooden,
+/obj/item/weapon/pen/blade/blue,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
+"aty" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "avf" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
@@ -485,11 +486,8 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
 "azq" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/turf/unsimulated/shuttle/floor/purple,
+/obj/item/weapon/tape_roll,
+/turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "azz" = (
 /obj/machinery/vending/dinnerware{
@@ -598,13 +596,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/dungeon)
-"aCd" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 10
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "aCM" = (
 /obj/structure/table/marble{
 	pixel_y = 0
@@ -768,7 +759,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms6)
+/area/vr/powered/mall/dorms/dorms4)
 "aJB" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/item/clothing/under/teshari/undercoat/standard/black_grey,
@@ -824,7 +815,7 @@
 /area/vr/powered)
 "aLr" = (
 /turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms4)
+/area/vr/powered/mall/dorms/dorms2)
 "aLx" = (
 /obj/item/weapon/pickaxe,
 /obj/structure/table/rack/shelf/steel,
@@ -860,17 +851,6 @@
 /obj/structure/table/alien/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
-"aMT" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "aNd" = (
 /obj/structure/table/fancyblack,
 /turf/simulated/floor/wood,
@@ -1059,6 +1039,22 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/bmarble,
 /area/vr/powered/cult)
+"aVP" = (
+/obj/structure/table/darkglass,
+/obj/item/device/mindbinder{
+	pixel_y = 4;
+	pixel_x = -2
+	},
+/obj/item/device/mindbinder{
+	pixel_y = -4;
+	pixel_x = -3
+	},
+/obj/item/device/mindbinder{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "aWu" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/condiment/small/saltshaker,
@@ -1325,14 +1321,6 @@
 	outdoors = 0
 	},
 /area/vr/powered/dungeon)
-"bgW" = (
-/obj/item/weapon/digestion_remains/skull/teshari,
-/obj/effect/decal/cleanable/fruit_smudge,
-/obj/item/clothing/mask/muzzle/ballgag{
-	pixel_y = -7
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "bhs" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
@@ -1423,6 +1411,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
+"bkg" = (
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual,
+/obj/item/weapon/book/manual,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "bkS" = (
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 5
@@ -1596,6 +1590,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
+"btR" = (
+/obj/structure/bed/chair/sofa/right/beige{
+	dir = 4
+	},
+/obj/machinery/light/floortube{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "bue" = (
 /obj/effect/map_effect/portal/master/side_a{
 	dir = 4;
@@ -1603,11 +1606,6 @@
 	},
 /turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
-"buS" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "bvk" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/foodcart,
@@ -1866,6 +1864,14 @@
 	},
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/dungeon)
+"bHn" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "bHz" = (
 /obj/structure/sign/periodic,
 /turf/simulated/wall/wood,
@@ -2035,6 +2041,11 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"bNz" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/stripper_pink,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "bOh" = (
 /turf/simulated/wall/durasteel,
 /area/vr/powered/mall/backrooms)
@@ -2257,6 +2268,15 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"bTr" = (
+/obj/machinery/vending/deluxe_boozeomat,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "bTy" = (
 /obj/structure/flora/tree/jungle,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -2281,6 +2301,14 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/sciship)
+"bUE" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/item/clothing/under/swimsuit/purple,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "bVz" = (
 /obj/machinery/door/airlock/multi_tile/metal/mait{
 	icon_state = "door_locked";
@@ -2901,6 +2929,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/dungeon)
+"cvP" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "cvQ" = (
 /turf/simulated/floor/plating,
 /area/vr/powered/vendor)
@@ -3040,6 +3072,10 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"cDf" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "cDl" = (
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -3210,11 +3246,6 @@
 "cKr" = (
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/building1)
-"cKW" = (
-/obj/structure/table/darkglass,
-/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "cLi" = (
 /obj/structure/table/fancyblack,
 /obj/item/weapon/reagent_containers/food/snacks/ribplate,
@@ -3295,10 +3326,6 @@
 /obj/item/weapon/bedsheet/hosdouble,
 /turf/simulated/floor/carpet/purple,
 /area/vr/powered/mall/dorms/dorms6)
-"cQA" = (
-/obj/structure/curtain/black,
-/turf/simulated/floor/flock,
-/area/vr/powered/mall/secondlife)
 "cQR" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/light/poi,
@@ -3504,10 +3531,6 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
-"cZL" = (
-/obj/item/toy/balloon,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "cZN" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -3614,17 +3637,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/space/whiteship)
-"ddW" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "des" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/beach/sand/desert{
@@ -3681,14 +3693,14 @@
 /area/vr/powered/mall)
 "dgT" = (
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms6)
+/area/vr/powered/mall/dorms/dorms2)
 "dha" = (
 /obj/item/toy/plushie/susred,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
 "dhl" = (
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms4)
+/area/vr/powered/mall/dorms/dorms3)
 "dhv" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/reagent_containers/food/drinks/soymilk,
@@ -4094,10 +4106,14 @@
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/whiteship)
 "dzQ" = (
-/obj/structure/table/hardwoodtable,
-/obj/item/device/flashlight/lamp/green,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 9
+	},
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "dzT" = (
 /obj/machinery/door/airlock/gold{
 	id_tag = "VRmallSL1"
@@ -4271,13 +4287,6 @@
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/vr/powered/mall/dorms/dorms2)
-"dGb" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 6
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "dGC" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -4393,14 +4402,6 @@
 	},
 /turf/simulated/floor/lava,
 /area/vr/outdoors/powered/lava)
-"dMH" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "dNs" = (
 /obj/structure/window/reinforced/survival_pod{
 	opacity = 1
@@ -5256,7 +5257,7 @@
 	},
 /area/vr/powered/rocks)
 "enN" = (
-/obj/item/clothing/under/shiny/catsuit/poly,
+/obj/item/toy/balloon,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "eoA" = (
@@ -5278,12 +5279,12 @@
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/sciship)
 "eoO" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "epd" = (
 /turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms5)
+/area/vr/powered/mall/dorms/dorms6)
 "epk" = (
 /obj/structure/table/marble{
 	pixel_y = 0
@@ -5509,6 +5510,11 @@
 /turf/simulated/floor/wood,
 /area/vr/powered)
 "eCg" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 2;
+	pixel_y = 0
+	},
 /turf/unsimulated/shuttle/floor/purple,
 /area/vr/powered/mall/secondlife)
 "eCs" = (
@@ -5647,6 +5653,20 @@
 /obj/item/clothing/accessory/fluff/zeta_blackwell_1,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"eFa" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "eFl" = (
 /obj/effect/decal/cleanable/blood/gibs{
 	color = "red";
@@ -5841,17 +5861,16 @@
 /turf/simulated/floor/carpet/geo,
 /area/vr/powered/mall)
 "eKD" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
 	},
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "eKF" = (
 /obj/structure/bed/chair/sofa/brown{
 	dir = 8
@@ -6076,6 +6095,12 @@
 /obj/item/weapon/storage/firstaid/surgery,
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/cult)
+"eVj" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms3)
 "eVV" = (
 /obj/structure/table/marble{
 	color = "grey"
@@ -6286,6 +6311,11 @@
 /obj/structure/salvageable/console_broken_os,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/sciship)
+"ffx" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "ffA" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
@@ -6599,6 +6629,17 @@
 	},
 /turf/space,
 /area/vr/space)
+"frB" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "frW" = (
 /obj/machinery/light{
 	dir = 4
@@ -6657,6 +6698,10 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/redgrid/animated,
 /area/vr/powered/cult)
+"ftE" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "ftQ" = (
 /obj/structure/railing,
 /obj/effect/step_trigger/teleporter/bridge/north_to_south,
@@ -6856,6 +6901,14 @@
 /obj/item/weapon/reagent_containers/glass/beaker,
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"fAX" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "fAY" = (
 /obj/machinery/access_button{
 	master_tag = null;
@@ -6886,6 +6939,10 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/medigun,
 /turf/simulated/floor/airless,
 /area/vr/space)
+"fBV" = (
+/obj/item/weapon/digestion_remains/variant2,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "fBZ" = (
 /obj/item/clothing/accessory/fluff/zeta_blackwell_1,
 /turf/simulated/floor/cult,
@@ -7058,19 +7115,6 @@
 /obj/item/toy/plushie/otter,
 /turf/simulated/floor/carpet/bcarpet,
 /area/vr/powered/mall/dorms/secondlife5)
-"fKO" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 31
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
-"fLo" = (
-/obj/item/toy/plushie/black_fox{
-	pixel_y = 0;
-	name = "latex black fox"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "fLs" = (
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 5
@@ -7513,14 +7557,6 @@
 /obj/structure/bed/chair/sofa/black,
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/mall)
-"geC" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "geP" = (
 /obj/structure/cliff/automatic{
 	dir = 5
@@ -8265,17 +8301,6 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
-"gUF" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL2";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms/secondlife2)
 "gVk" = (
 /obj/structure/table/alien/blue,
 /obj/structure/window/reinforced/survival_pod{
@@ -8337,6 +8362,9 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered)
+"gZX" = (
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "hcc" = (
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_x = -25;
@@ -8619,6 +8647,13 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor,
 /area/vr/powered)
+"hlR" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 10
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "hmv" = (
 /obj/machinery/conveyor{
 	id = "vrsushitrain";
@@ -8929,14 +8964,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/donerkebab,
 /turf/simulated/floor/wood/alt,
 /area/vr/powered/mall)
-"hzt" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "hzJ" = (
 /obj/machinery/fitness/heavy/lifter,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -9127,6 +9154,14 @@
 	dir = 1;
 	pixel_y = 0
 	},
+/obj/item/weapon/storage/box/glasses/rocks{
+	pixel_y = -2;
+	pixel_x = -10
+	},
+/obj/item/weapon/storage/box/glasses/square{
+	pixel_y = -2;
+	pixel_x = 12
+	},
 /turf/unsimulated/shuttle/floor/purple,
 /area/vr/powered/mall/secondlife)
 "hIL" = (
@@ -9175,8 +9210,8 @@
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/dungeon)
 "hOI" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms2)
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "hPd" = (
 /obj/structure/railing/grey{
 	pixel_y = 0;
@@ -9287,6 +9322,11 @@
 /obj/mecha/combat/marauder/seraph,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/mechfactory)
+"hTA" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "hTV" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/pancakes{
@@ -9335,6 +9375,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
+"hVL" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL3";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "hVP" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/storage/briefcase/inflatable{
@@ -9343,6 +9394,18 @@
 /obj/item/weapon/storage/toolbox/syndicate/powertools,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
+"hVQ" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "hWB" = (
 /obj/structure/table/marble{
 	pixel_y = 0
@@ -9503,16 +9566,8 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/constore)
 "iag" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL1";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms/secondlife)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms4)
 "iam" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -9548,10 +9603,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/dungeon)
-"ibm" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "icz" = (
 /obj/structure/sign/warning/vacuum,
 /turf/unsimulated/wall,
@@ -9605,7 +9656,7 @@
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
+/area/vr/powered/mall/dorms/dorms3)
 "ifF" = (
 /obj/machinery/smartfridge/survival_pod{
 	icon = 'icons/obj/vending.dmi';
@@ -9831,14 +9882,6 @@
 "ikE" = (
 /turf/unsimulated/floor/tiled/techfloor,
 /area/vr/powered/mall)
-"ikQ" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "ilo" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/mech_toy,
@@ -9860,6 +9903,14 @@
 	},
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/cult)
+"imT" = (
+/obj/structure/table/darkglass,
+/obj/structure/stripper_pole{
+	icon_scale_x = 0.5;
+	icon_scale_y = 0.5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "imW" = (
 /obj/item/weapon/photo,
 /obj/item/weapon/photo{
@@ -9967,6 +10018,14 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
+"iqP" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "irA" = (
 /turf/simulated/floor/tiled/neutral,
 /area/vr/powered)
@@ -10351,11 +10410,6 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
-"iFw" = (
-/obj/item/weapon/material/twohanded/riding_crop,
-/obj/effect/decal/cleanable/blood/oil/streak,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "iGx" = (
 /obj/structure/table/marble,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -10440,6 +10494,11 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/whiteship)
+"iKM" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "iLp" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -10472,6 +10531,12 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
+"iMO" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms2)
 "iMU" = (
 /obj/machinery/door/window/survival_pod{
 	dir = 8
@@ -10534,6 +10599,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/dungeon)
+"iRC" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "iSq" = (
 /obj/random/trash,
 /obj/random/trash,
@@ -10627,12 +10700,12 @@
 	},
 /area/vr/outdoors/powered)
 "iXf" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 2;
-	pixel_y = 0
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
 	},
-/turf/unsimulated/shuttle/floor/purple,
+/turf/simulated/floor/flock,
 /area/vr/powered/mall/secondlife)
 "iXg" = (
 /obj/structure/table/hardwoodtable,
@@ -10827,11 +10900,6 @@
 	color = "#f700ff";
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
-"jdZ" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/stripper_green,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "jem" = (
@@ -11127,12 +11195,6 @@
 /obj/machinery/vending/loadout/uniform,
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
-"jrm" = (
-/obj/structure/bed/chair/sofa/left/beige{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "jrC" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/lime/border,
@@ -11247,10 +11309,6 @@
 /obj/structure/reagent_dispensers/beerkeg/fakenuke,
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
-"juK" = (
-/obj/item/clothing/mask/muzzle/ballgag,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "juM" = (
 /obj/structure/table/marble,
 /obj/item/weapon/storage/box/glasses/meta/metapint{
@@ -11311,18 +11369,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/vet)
-"jxw" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 6
-	},
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "jxO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -11852,9 +11898,7 @@
 /turf/simulated/floor/bmarble,
 /area/vr/powered/mall)
 "jRV" = (
-/obj/machinery/vending/boozeomat{
-	req_access = null
-	},
+/obj/machinery/vending/deluxe_dinner,
 /obj/effect/floor_decal/corner/purple/border{
 	color = "#f700ff";
 	dir = 1;
@@ -11905,7 +11949,7 @@
 /obj/effect/floor_decal/milspec/color/silver,
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
+/area/vr/powered/mall/dorms/dorms4)
 "jWs" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -11972,6 +12016,25 @@
 	movement_cost = 0
 	},
 /area/vr/outdoors/powered)
+"jYq" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
+"jYy" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/mask/muzzle/ballgag,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "jYM" = (
 /turf/simulated/floor/wood/broken,
 /area/vr/powered/space/whiteship)
@@ -12160,14 +12223,6 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
-"kgD" = (
-/obj/structure/table/darkglass,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 9
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "khm" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -12300,13 +12355,6 @@
 /obj/mecha/combat/gygax/old,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/mechfactory)
-"kkW" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 8
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "kls" = (
 /obj/effect/overlay/palmtree_l,
 /obj/effect/overlay/coconut,
@@ -12912,10 +12960,6 @@
 /obj/item/weapon/material/knife/machete,
 /turf/simulated/floor/reinforced,
 /area/vr/powered/redbase)
-"kNz" = (
-/obj/item/weapon/digestion_remains/variant2,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "kNU" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small,
@@ -13096,14 +13140,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
-"kUr" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "kUt" = (
 /obj/machinery/light{
 	dir = 4
@@ -13315,6 +13351,17 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/space/whiteship)
+"ley" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "leB" = (
 /obj/machinery/light{
 	layer = 3
@@ -13388,22 +13435,6 @@
 /area/vr/powered/mall)
 "lhR" = (
 /obj/structure/table/darkglass,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
-"liN" = (
-/obj/structure/table/darkglass,
-/obj/item/device/mindbinder{
-	pixel_y = 4;
-	pixel_x = -2
-	},
-/obj/item/device/mindbinder{
-	pixel_y = -4;
-	pixel_x = -3
-	},
-/obj/item/device/mindbinder{
-	pixel_y = 2;
-	pixel_x = 5
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "liP" = (
@@ -13734,22 +13765,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/whiteship)
-"ltS" = (
-/obj/structure/table/darkglass,
-/obj/item/device/bodysnatcher{
-	pixel_y = 4;
-	pixel_x = 3
-	},
-/obj/item/device/bodysnatcher{
-	pixel_y = -2;
-	pixel_x = -2
-	},
-/obj/item/device/bodysnatcher{
-	pixel_y = -4;
-	pixel_x = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "lub" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -13771,6 +13786,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/vet)
+"lur" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/stripper_green,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "lut" = (
 /obj/structure/table/darkglass,
 /turf/simulated/floor/tiled/milspec/raised,
@@ -14417,6 +14437,14 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
+"lRy" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "lRA" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
@@ -14557,6 +14585,17 @@
 /obj/random/unidentified_medicine,
 /turf/simulated/floor/tiled,
 /area/vr/powered)
+"lXe" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "lXA" = (
 /obj/structure/bed/alien,
 /obj/structure/curtain/open/privacy,
@@ -14747,11 +14786,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/sciship)
 "mfJ" = (
-/obj/structure/bookcase,
-/obj/item/weapon/book/manual,
-/obj/item/weapon/book/manual,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms3)
 "mgc" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/wood,
@@ -14788,10 +14824,6 @@
 /obj/item/ammo_magazine/s357,
 /turf/simulated/floor/tiled,
 /area/vr/powered/gunshop)
-"mhv" = (
-/obj/item/weapon/digestion_remains/variant3,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "mhy" = (
 /obj/structure/table/marble,
 /obj/structure/sink/countertop{
@@ -14943,6 +14975,12 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
+"mmf" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms5)
 "mmV" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/department/robo{
@@ -15083,10 +15121,6 @@
 	},
 /turf/simulated/floor/weird_things/dark,
 /area/vr/powered/mall/backrooms)
-"mtk" = (
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "mtx" = (
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/tiled,
@@ -15159,6 +15193,20 @@
 /obj/item/weapon/storage/box/matches,
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"mwD" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "mwO" = (
 /turf/simulated/floor/plating,
 /area/vr/powered/cafe)
@@ -15212,6 +15260,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
+"mAJ" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL4";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "mBa" = (
 /obj/fiftyspawner/glass,
 /obj/fiftyspawner/glass,
@@ -15426,26 +15485,6 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/clusterbang,
 /turf/simulated/floor/airless,
 /area/vr/space)
-"mIC" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms5)
-"mII" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "mIK" = (
 /obj/machinery/light{
 	dir = 8
@@ -15708,13 +15747,18 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
+/area/vr/powered/mall/dorms/dorms3)
 "mUR" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack,
 /area/vr/powered/mall)
+"mVk" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "mVy" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/action_figure{
@@ -16009,12 +16053,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/pineapple,
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
-"nhK" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms1)
 "nie" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/dip/salsa,
@@ -16176,6 +16214,10 @@
 /obj/fruitspawner/rice,
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
+"nmX" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "nng" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1
@@ -16232,6 +16274,10 @@
 "npj" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/cult)
+"npn" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "npD" = (
 /obj/structure/railing,
 /turf/simulated/floor/concrete{
@@ -16376,17 +16422,6 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/vr/powered/mall/secondlife)
-"nwd" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "nwE" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/contraband/nofail,
@@ -16756,14 +16791,6 @@
 /obj/item/weapon/reagent_containers/glass/rag,
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
-"nIy" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/obj/item/clothing/accessory/shiny/gloves/poly,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "nIW" = (
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
@@ -16802,8 +16829,10 @@
 	},
 /area/vr/outdoors/powered)
 "nJM" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms1)
+/obj/item/weapon/material/twohanded/riding_crop,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "nJZ" = (
 /obj/item/weapon/material/twohanded/baseballbat/gold,
 /obj/item/stack/material/gold,
@@ -16854,8 +16883,8 @@
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/dungeon)
 "nKT" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms6)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms4)
 "nLa" = (
 /obj/structure/bed/pillowpile/orange,
 /obj/effect/floor_decal/corner/purple/border{
@@ -17351,14 +17380,6 @@
 /obj/item/weapon/material/knife/machete/deluxe,
 /turf/simulated/floor/tiled,
 /area/vr/powered/gunshop)
-"oeg" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/flock,
-/area/vr/powered/mall/secondlife)
 "oeP" = (
 /obj/structure/prop/statue,
 /turf/simulated/floor/water/pool{
@@ -17713,6 +17734,10 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/cult)
+"opB" = (
+/obj/item/clothing/mask/muzzle/ballgag,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "opG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17882,16 +17907,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vr/outdoors/powered)
-"ovv" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/stripper_pink,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
-"ovJ" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/mask/muzzle/ballgag,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "ovM" = (
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
@@ -18055,11 +18070,6 @@
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/dungeon)
-"oBk" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "oBA" = (
 /obj/random/maintenance,
 /obj/machinery/light/small{
@@ -18229,10 +18239,6 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/vr/powered/mall/dorms/dorms5)
-"oHr" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "oHz" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/storage/toolbox/electrical,
@@ -18247,6 +18253,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/space/whiteship)
+"oHI" = (
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "oHJ" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/item/clothing/under/teshari/undercoat/standard/black_grey,
@@ -18280,8 +18290,26 @@
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
 "oIG" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms1)
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/box/glasses/meta/metapint{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/weapon/storage/box/glasses/meta/metapint{
+	pixel_y = 9;
+	pixel_x = 9
+	},
+/obj/item/weapon/storage/box/glasses/meta/metapint{
+	pixel_y = 6;
+	pixel_x = 7
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "oJb" = (
 /obj/machinery/light{
 	dir = 1
@@ -18334,14 +18362,6 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
-"oKR" = (
-/obj/structure/table/darkglass,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 5
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "oLe" = (
 /obj/structure/window/basic,
 /obj/structure/table/rack/wood,
@@ -18441,15 +18461,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/whiteship)
-"oPm" = (
-/obj/structure/table/hardwoodtable,
-/obj/machinery/light/small{
-	dir = 4;
-	nightshift_enabled = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "oPY" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/fishing,
@@ -18538,12 +18549,6 @@
 	outdoors = 1
 	},
 /area/vr/outdoors/powered)
-"oVQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms4)
 "oVV" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -18589,10 +18594,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/blue,
 /area/vr/powered/motel)
-"pat" = (
-/obj/item/weapon/tape_roll,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "paD" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wmarble,
@@ -18719,6 +18720,10 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"pcJ" = (
+/obj/item/weapon/digestion_remains/variant3,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "pdu" = (
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled,
@@ -18742,6 +18747,18 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"pee" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL5";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "pen" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 8
@@ -18806,6 +18823,14 @@
 /obj/item/weapon/cell/slime,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
+"pgz" = (
+/obj/structure/table/darkglass,
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/item/weapon/material/whip,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "pgH" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/carpet,
@@ -19245,6 +19270,10 @@
 /obj/item/clothing/shoes/boots/marine,
 /turf/simulated/floor/tiled,
 /area/vr/powered/gunshop)
+"pAQ" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "pBf" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
@@ -19398,8 +19427,21 @@
 	},
 /area/vr/powered/rocks)
 "pGH" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms3)
+/obj/structure/table/darkglass,
+/obj/item/device/bodysnatcher{
+	pixel_y = 4;
+	pixel_x = 3
+	},
+/obj/item/device/bodysnatcher{
+	pixel_y = -2;
+	pixel_x = -2
+	},
+/obj/item/device/bodysnatcher{
+	pixel_y = -4;
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "pGO" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -19565,6 +19607,10 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_grid,
 /area/vr/powered/space/whiteship)
+"pMg" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "pMW" = (
 /obj/structure/table/woodentable,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -19673,7 +19719,7 @@
 "pRJ" = (
 /obj/effect/floor_decal/milspec/color/silver,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
+/area/vr/powered/mall/dorms/dorms3)
 "pRN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -19851,7 +19897,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms1)
 "qaJ" = (
 /obj/machinery/chemical_dispenser/ert/specialops{
 	pixel_y = 7
@@ -19893,9 +19939,8 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
 "qba" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms5)
 "qbf" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/cult{
@@ -20264,6 +20309,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
+"qlq" = (
+/obj/item/weapon/digestion_remains/skull/teshari,
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/item/clothing/mask/muzzle/ballgag{
+	pixel_y = -7
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "qlF" = (
 /obj/machinery/gateway/brass{
 	dir = 8
@@ -20889,6 +20942,18 @@
 	},
 /turf/simulated/floor/airless,
 /area/vr/space)
+"qKj" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 6
+	},
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "qKo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
@@ -20932,7 +20997,7 @@
 /obj/structure/table/bench/wooden,
 /obj/item/weapon/pen/blade/blue,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms1)
 "qMa" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -20946,20 +21011,6 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
-"qMW" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "qMX" = (
 /obj/machinery/sleeper{
 	dir = 4;
@@ -21204,14 +21255,6 @@
 "qZX" = (
 /turf/simulated/floor/carpet/blue,
 /area/vr/powered/motel)
-"raz" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/obj/item/clothing/under/swimsuit/purple,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "raK" = (
 /obj/item/weapon/pack/cardemon,
 /turf/simulated/floor/wood,
@@ -21222,10 +21265,6 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/space/sciship)
-"rbj" = (
-/obj/item/clothing/accessory/shiny/gloves/poly,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "rbq" = (
 /obj/machinery/disperser/front{
 	dir = 1
@@ -21300,17 +21339,6 @@
 /obj/item/weapon/storage/backpack/dufflebag/syndie,
 /turf/simulated/floor/wmarble,
 /area/vr/powered/motel)
-"rdT" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "reW" = (
 /obj/structure/flora/rocks2,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -21704,14 +21732,6 @@
 	},
 /turf/unsimulated/elevator_shaft,
 /area/vr/outdoors/powered)
-"rwl" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/secondlife)
 "rwn" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -21845,6 +21865,20 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/vr/powered/mall/dorms/dorms6)
+"rCI" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "rCZ" = (
 /obj/machinery/light/small,
 /obj/structure/table/woodentable,
@@ -21881,14 +21915,6 @@
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
-"rET" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "rFf" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/gear_dispenser/suit/ert{
@@ -21927,8 +21953,10 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
 "rHw" = (
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "rHO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -21954,10 +21982,6 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered)
-"rJH" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "rKk" = (
 /obj/structure/table/rack/shelf,
 /obj/item/ammo_magazine/m45,
@@ -22046,10 +22070,6 @@
 /obj/structure/salvageable/computer_os,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/sciship)
-"rMG" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "rMK" = (
 /obj/effect/zone_divider,
 /obj/effect/zone_divider,
@@ -22301,9 +22321,6 @@
 	},
 /turf/space,
 /area/vr/space)
-"rYA" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms5)
 "rYV" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -22425,6 +22442,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
+"sdb" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/light/small{
+	dir = 4;
+	nightshift_enabled = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "sdc" = (
 /obj/structure/salvageable/console_os,
 /obj/effect/floor_decal/techfloor{
@@ -22823,14 +22849,6 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/space/mechfactory)
-"svw" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "svz" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -23145,6 +23163,17 @@
 /obj/item/weapon/pen,
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
+"sFW" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL2";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "sGC" = (
 /obj/machinery/vending/wallmed1/public{
 	pixel_y = 32
@@ -23352,6 +23381,7 @@
 /obj/structure/window/basic{
 	dir = 4
 	},
+/obj/item/weapon/material/twohanded/riding_crop,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/vr/powered/mall/secondlife)
 "sPT" = (
@@ -23507,8 +23537,12 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/vr/powered/mall)
 "sWf" = (
-/obj/item/weapon/handcuffs/legcuffs/fuzzy,
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/carpet/gaycarpet,
 /area/vr/powered/mall/secondlife)
 "sWx" = (
 /turf/simulated/shuttle/floor/darkred,
@@ -23565,6 +23599,10 @@
 	icon_state = "cult-narsie"
 	},
 /area/vr/powered/cult)
+"tbM" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "tcB" = (
 /obj/structure/table/woodentable,
 /obj/item/stack/cable_coil{
@@ -23654,6 +23692,10 @@
 "tgD" = (
 /turf/simulated/wall/r_wall,
 /area/vr/powered/building2)
+"tgH" = (
+/obj/item/clothing/under/shiny/catsuit/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "tgJ" = (
 /obj/machinery/gear_dispenser/suit/autolok,
 /turf/simulated/shuttle/floor/voidcraft/dark,
@@ -23755,12 +23797,6 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered)
-"tlv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms2)
 "tlY" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
@@ -24051,20 +24087,6 @@
 "tyN" = (
 /turf/simulated/wall,
 /area/vr/powered/material)
-"tyP" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "tyX" = (
 /obj/structure/salvageable/console_os{
 	name = "Turret control console"
@@ -24258,7 +24280,18 @@
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
 "tGg" = (
-/turf/simulated/floor/wood/alt/parquet,
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
 /area/vr/powered/mall/dorms/dorms3)
 "tGi" = (
 /obj/machinery/light{
@@ -24340,17 +24373,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
-"tJt" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL4";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "tJU" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/snacks/enchiladas{
@@ -24376,6 +24398,11 @@
 /obj/item/weapon/fossil/skull/horned,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"tKI" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "tLr" = (
 /obj/effect/landmark/virtual_reality{
 	name = "City"
@@ -24388,6 +24415,17 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/cult)
+"tLD" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
+"tLL" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms1)
 "tLM" = (
 /obj/machinery/light/floortube/flicker{
 	pixel_y = -2
@@ -24569,7 +24607,7 @@
 "tSw" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms1)
 "tSB" = (
 /turf/simulated/floor/lava,
 /area/vr/powered/mall/backrooms)
@@ -24609,6 +24647,12 @@
 /obj/random/maintenance/morestuff,
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
+"tTK" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 31
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "tTT" = (
 /obj/item/trash/rkibble{
 	pixel_x = 8;
@@ -24641,6 +24685,13 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/space/sciship)
+"tUk" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "tUm" = (
 /obj/machinery/optable,
 /turf/simulated/shuttle/floor/white,
@@ -24737,6 +24788,10 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"tYA" = (
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "tYP" = (
 /obj/structure/prop/dominator/blue,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -26004,6 +26059,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
+"uUN" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 6
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "uUX" = (
 /turf/simulated/floor/outdoors/sidewalk/slab{
 	movement_cost = 0;
@@ -26032,8 +26094,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "uVX" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms2)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms1)
 "uWc" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/sign/department/cargo_dock{
@@ -26140,9 +26202,8 @@
 /turf/simulated/floor/plating,
 /area/vr/outdoors/powered)
 "vdb" = (
-/obj/structure/table/hardwoodtable,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms5)
 "vdd" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/outdoors/grass{
@@ -26514,6 +26575,14 @@
 	temperature = 293.15
 	},
 /area/vr/powered/dungeon)
+"vqJ" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "vrb" = (
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/cult)
@@ -26558,6 +26627,14 @@
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/vr/powered/space/sciship)
+"vsS" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "vtf" = (
 /obj/item/weapon/material/twohanded/baseballbat/gold,
 /obj/item/clothing/gloves/ring/material/gold,
@@ -26650,11 +26727,6 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
-"vwK" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
 /area/vr/powered/mall/dorms/dorms1)
 "vwT" = (
 /obj/structure/bed/chair/sofa/left/black,
@@ -26972,6 +27044,13 @@
 /obj/effect/decal/remains,
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/dungeon)
+"vLa" = (
+/obj/item/toy/plushie/black_fox{
+	pixel_y = 0;
+	name = "latex black fox"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "vLG" = (
 /obj/machinery/button/remote/blast_door{
 	id = "vrgunshop";
@@ -27159,20 +27238,6 @@
 "vTF" = (
 /turf/simulated/floor/lava,
 /area/vr/powered/cult)
-"vTM" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "vTN" = (
 /obj/machinery/light{
 	dir = 8
@@ -27210,6 +27275,17 @@
 /obj/random/maintenance/morestuff,
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
+"vVL" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL1";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "vWm" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
@@ -27235,6 +27311,15 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"vXa" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 5
+	},
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "vXA" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/grenade/box,
@@ -27266,17 +27351,6 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
-"vYc" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL3";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/vr/powered/mall/dorms/secondlife3)
 "vYq" = (
 /obj/structure/grille/cult,
 /obj/structure/window/phoronreinforced/full,
@@ -27488,6 +27562,13 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"wfY" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "wgq" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/wood,
@@ -27823,11 +27904,6 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
-"wvA" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "wwm" = (
 /obj/structure/reagent_dispensers/foam,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -28029,7 +28105,7 @@
 /area/vr/powered/rocks)
 "wEq" = (
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms1)
 "wEB" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 4
@@ -28452,19 +28528,8 @@
 /turf/unsimulated/floor/tiled/techfloor,
 /area/vr/powered/mall)
 "wUw" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms1)
 "wUx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -28584,9 +28649,8 @@
 /turf/simulated/floor/tiled/red,
 /area/vr/powered/mall/dorms/dorms5)
 "wWt" = (
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms6)
 "wWC" = (
 /obj/machinery/light{
 	dir = 8
@@ -28907,6 +28971,12 @@
 /obj/machinery/door/window/eastleft,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/vr/powered/mall/secondlife)
+"xmj" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms6)
 "xnt" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -29000,14 +29070,6 @@
 	},
 /turf/simulated/floor/weird_things/dark,
 /area/vr/powered/mall/backrooms)
-"xrL" = (
-/obj/structure/table/darkglass,
-/obj/structure/stripper_pole{
-	icon_scale_x = 0.5;
-	icon_scale_y = 0.5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "xsb" = (
 /obj/structure/table/marble,
 /obj/structure/window/reinforced{
@@ -29058,6 +29120,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
+"xsz" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "xtQ" = (
 /obj/machinery/light{
 	layer = 3
@@ -29187,6 +29257,11 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"xAk" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "xAp" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
@@ -29427,17 +29502,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
-"xJr" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "xJF" = (
 /obj/machinery/light,
 /turf/simulated/floor/concrete,
@@ -29490,6 +29554,17 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/vr/powered/mall)
+"xLP" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "xLW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -29559,11 +29634,6 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
-"xPs" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/mankini,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "xPH" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -29577,18 +29647,6 @@
 /obj/machinery/floorlayer,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
-"xPV" = (
-/obj/effect/decal/cleanable/fruit_smudge,
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL5";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/vr/powered/mall/dorms/secondlife5)
 "xQB" = (
 /obj/machinery/light{
 	dir = 1
@@ -29628,11 +29686,6 @@
 /obj/structure/window/plastitanium,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
-"xSP" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "xTe" = (
 /obj/machinery/vending/wardrobe/clowndrobe{
 	req_access = null
@@ -29674,7 +29727,7 @@
 /area/vr/outdoors/powered/lava)
 "xTU" = (
 /obj/structure/table/darkglass,
-/obj/machinery/chemical_dispenser/bar_alc/full,
+/obj/machinery/chemical_dispenser/deluxe/full,
 /obj/effect/floor_decal/corner/purple/border{
 	color = "#f700ff";
 	dir = 1;
@@ -29708,6 +29761,11 @@
 /obj/item/weapon/grenade/explosive,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
+"xVL" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/mankini,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "xVV" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/machinery/light{
@@ -29724,12 +29782,6 @@
 /obj/item/weapon/cell/slime,
 /turf/simulated/floor/reinforced,
 /area/vr/powered/redbase)
-"xWW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms3)
 "xXa" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -29775,11 +29827,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube,
 /turf/simulated/floor/wood,
 /area/vr/powered/dungeon)
-"xYt" = (
-/obj/structure/table/bench/wooden,
-/obj/item/weapon/pen/blade/blue,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "xYu" = (
 /obj/machinery/light/floortube{
 	dir = 2
@@ -69174,17 +69221,17 @@ jNo
 mbF
 mbF
 mbF
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
 oVM
 kIl
 jPG
@@ -69432,17 +69479,17 @@ jNo
 mbF
 mbF
 mbF
-oIG
+uVX
 gFH
 avf
 wkd
 rGJ
 rbF
 pYB
-oIG
-ibm
-qMW
-oIG
+uVX
+tbM
+jYq
+uVX
 oVM
 hSI
 jPG
@@ -69690,17 +69737,17 @@ jNo
 mbF
 sHe
 mbF
-oIG
+uVX
 ixQ
 cTE
 cTE
 cTE
 cTE
 cTE
-oIG
-hzt
-mUk
-oIG
+uVX
+vsS
+frB
+uVX
 oVM
 kIl
 jPG
@@ -69948,17 +69995,17 @@ jNo
 mbF
 mbF
 sHe
-oIG
+uVX
 wSm
 cTE
 cTE
 cTE
 cTE
 qAG
-oIG
-oIG
-vwK
-oIG
+uVX
+uVX
+iKM
+uVX
 tGE
 kIl
 jPG
@@ -70207,16 +70254,16 @@ mbF
 sHe
 mbF
 gBz
-nJM
-nJM
-nJM
-nJM
-nJM
-nJM
-nJM
-nhK
-nJM
-oIG
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+tLL
+wUw
+uVX
 oVM
 kIl
 jPG
@@ -70464,17 +70511,17 @@ jNo
 mbF
 mbF
 mbF
-oIG
+uVX
 rQv
-jrm
+qan
 vwl
-rHw
-rHw
-oIG
-oIG
-oIG
+wEq
+wEq
+uVX
+uVX
+uVX
 mYs
-oIG
+uVX
 oVM
 dsG
 jPG
@@ -70722,13 +70769,13 @@ jNo
 mKY
 mbF
 mKY
-oIG
-rHw
+uVX
+wEq
 pBo
-xYt
-wWt
-ifd
-oIG
+qLF
+pAQ
+xAk
+uVX
 qxv
 iVO
 aHs
@@ -70980,13 +71027,13 @@ jNo
 mbF
 mbF
 mbF
-oIG
-mfJ
-rHw
-rHw
-wWt
-vdb
-oIG
+uVX
+bkg
+wEq
+wEq
+pAQ
+tSw
+uVX
 aJP
 aHs
 aHs
@@ -71238,17 +71285,17 @@ jNo
 mbF
 mKY
 nrp
-oIG
-mfJ
-fKO
-fKO
-wWt
-oPm
-oIG
+uVX
+bkg
+tTK
+tTK
+pAQ
+sdb
+uVX
 khJ
 uqE
 cWw
-oIG
+uVX
 oVM
 kIl
 jPG
@@ -71496,17 +71543,17 @@ jNo
 mbF
 mbF
 nrp
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
+uVX
 oVM
 kIl
 jPG
@@ -71754,17 +71801,17 @@ jNo
 mbF
 mbF
 nrp
-hOI
+aLr
 iDr
 ane
 joA
 qRP
 dFF
 jSK
-hOI
-pRJ
-vTM
-hOI
+aLr
+cvP
+rCI
+aLr
 oVM
 kIl
 jPG
@@ -72012,17 +72059,17 @@ jNo
 mbF
 sHe
 mbF
-hOI
+aLr
 axg
 aGv
 aGv
 aGv
 aGv
 aGv
-hOI
+aLr
 mOR
-aMT
-hOI
+ley
+aLr
 oVM
 kIl
 jPG
@@ -72270,17 +72317,17 @@ jNo
 mbF
 mbF
 mbF
-hOI
+aLr
 wKS
 aGv
 aGv
 aGv
 aGv
 nxY
-hOI
-hOI
-buS
-hOI
+aLr
+aLr
+tKI
+aLr
 tGE
 kIl
 jPG
@@ -72529,16 +72576,16 @@ mbF
 mbF
 sHe
 rom
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-tlv
-uVX
-hOI
+dgT
+dgT
+dgT
+dgT
+dgT
+dgT
+dgT
+iMO
+dgT
+aLr
 oVM
 dsG
 jPG
@@ -72786,17 +72833,17 @@ jNo
 mbF
 mbF
 mbF
-hOI
+aLr
 saD
 xRd
 lHF
 jFf
 jFf
-hOI
-hOI
-hOI
+aLr
+aLr
+aLr
 onX
-hOI
+aLr
 oVM
 kIl
 jPG
@@ -73044,13 +73091,13 @@ jNo
 mbF
 mKY
 mKY
-hOI
+aLr
 jFf
 xEl
 jIp
 kOw
 nrY
-hOI
+aLr
 oxT
 bTn
 hsD
@@ -73302,13 +73349,13 @@ jNo
 mbF
 mbF
 mbF
-hOI
+aLr
 tEr
 jFf
 jFf
 kOw
 uFH
-hOI
+aLr
 uMe
 hsD
 hsD
@@ -73560,17 +73607,17 @@ jNo
 mbF
 sHe
 mbF
-hOI
+aLr
 tEr
 lnS
 lnS
 kOw
 uRx
-hOI
+aLr
 pxI
 dFd
 eif
-hOI
+aLr
 oVM
 fGS
 jPG
@@ -73818,17 +73865,17 @@ eUL
 mKY
 mbF
 mbF
-hOI
-hOI
-hOI
-hOI
-hOI
-hOI
-hOI
-hOI
-hOI
-hOI
-hOI
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
+aLr
 oVM
 kIl
 jPG
@@ -81558,17 +81605,17 @@ wPM
 ycu
 nhm
 ajQ
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
 oVM
 kIl
 jPG
@@ -81816,17 +81863,17 @@ wPM
 ycu
 nhm
 ajQ
-pGH
+mfJ
 uSd
 moh
 lRA
 hBZ
 jQx
 mhy
-pGH
-oHr
-mII
-pGH
+mfJ
+pRJ
+tGg
+mfJ
 oVM
 kIl
 jPG
@@ -82074,17 +82121,17 @@ wPM
 ycu
 nhm
 ajQ
-pGH
+mfJ
 ghV
 ePC
 ePC
 ePC
 ePC
 ePC
-pGH
-dMH
-rdT
-pGH
+mfJ
+lRy
+mUk
+mfJ
 oVM
 kIl
 jPG
@@ -82332,17 +82379,17 @@ wPM
 ftm
 nhm
 ajQ
-pGH
+mfJ
 qIn
 ePC
 ePC
 ePC
 ePC
 mkU
-pGH
-pGH
-xSP
-pGH
+mfJ
+mfJ
+ffx
+mfJ
 oVM
 vdd
 jPG
@@ -82591,16 +82638,16 @@ ycu
 nhm
 ajQ
 oAC
-tGg
-tGg
-tGg
-tGg
-tGg
-tGg
-tGg
-xWW
-tGg
-pGH
+dhl
+dhl
+dhl
+dhl
+dhl
+dhl
+dhl
+eVj
+dhl
+mfJ
 oVM
 kIl
 jPG
@@ -82848,17 +82895,17 @@ wPM
 ycu
 nhm
 ajQ
-pGH
+mfJ
 fwZ
-qan
-aiP
-wEq
-wEq
-pGH
-pGH
-pGH
+asY
+btR
+gZX
+gZX
+mfJ
+mfJ
+mfJ
 sJh
-pGH
+mfJ
 oVM
 crG
 jPG
@@ -83106,13 +83153,13 @@ wPM
 ycu
 nhm
 ajQ
-pGH
-wEq
-mtk
-qLF
+mfJ
+gZX
+nmX
+ato
 iWc
-dzQ
-pGH
+ifd
+mfJ
 bos
 uZT
 cqn
@@ -83321,7 +83368,7 @@ dES
 hqN
 qjX
 vpG
-mhv
+pcJ
 vpG
 ivl
 iWh
@@ -83364,13 +83411,13 @@ wPM
 ycu
 nhm
 ajQ
-pGH
+mfJ
 kao
-wEq
-wEq
+gZX
+gZX
 iWc
-tSw
-pGH
+eoO
+mfJ
 hwS
 cqn
 cqn
@@ -83578,8 +83625,8 @@ dES
 dES
 dES
 qjX
-kNz
-bgW
+fBV
+qlq
 vpG
 ivl
 oJW
@@ -83622,17 +83669,17 @@ wPM
 ycu
 nhm
 ajQ
-pGH
+mfJ
 kao
 uYn
 uYn
 iWc
 qiH
-pGH
+mfJ
 gIm
 neC
 sNQ
-pGH
+mfJ
 tGE
 kIl
 jPG
@@ -83824,23 +83871,23 @@ tgj
 vrG
 fuy
 awD
-iag
+vVL
 xUp
 jxs
 ipC
-gUF
+sFW
 aUe
 uSA
 dTX
-vYc
+hVL
 wTU
 pIO
 qjX
-tJt
+mAJ
 ayz
 jPB
 ivl
-xPV
+pee
 aZi
 aZi
 diP
@@ -83880,17 +83927,17 @@ wPM
 ycu
 nhm
 ajQ
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
-pGH
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
 oVM
 kIl
 jPG
@@ -84138,17 +84185,17 @@ wPM
 ycu
 nhm
 ajQ
-aLr
+iag
 hAQ
 hlj
 ffM
 ifX
 cHE
 qjp
-aLr
-eoO
-wUw
-aLr
+iag
+pMg
+eFa
+iag
 oVM
 kIl
 jPG
@@ -84347,7 +84394,7 @@ qbH
 qbH
 qbH
 qbH
-pat
+azq
 qbH
 qbH
 qbH
@@ -84396,17 +84443,17 @@ wPM
 ycu
 nhm
 ajQ
-aLr
+iag
 uXy
 hGy
 hGy
 hGy
 hGy
 hGy
-aLr
-geC
-nwd
-aLr
+iag
+xsz
+lXe
+iag
 oVM
 kIl
 jPG
@@ -84614,7 +84661,7 @@ qbH
 qbH
 qbH
 qbH
-pat
+azq
 qbH
 qbH
 qbH
@@ -84654,17 +84701,17 @@ wPM
 ftm
 nhm
 ajQ
-aLr
+iag
 dCS
 hGy
 hGy
 hGy
 hGy
 ocj
-aLr
-aLr
-wvA
-aLr
+iag
+iag
+jVS
+iag
 oVM
 crG
 jPG
@@ -84865,10 +84912,10 @@ gVF
 qbH
 qbH
 yhp
-raz
+bUE
 qfi
 uVx
-cZL
+enN
 qbH
 qbH
 qbH
@@ -84913,16 +84960,16 @@ ycu
 nhm
 ajQ
 wrr
-dhl
-dhl
-dhl
-dhl
-dhl
-dhl
-dhl
-oVQ
-dhl
-aLr
+nKT
+nKT
+nKT
+nKT
+nKT
+nKT
+nKT
+aJc
+nKT
+iag
 oVM
 kIl
 jPG
@@ -85115,21 +85162,21 @@ vrG
 fuy
 xuX
 qbH
-rwl
+sWf
 duU
 mky
 hGH
 gVF
 qbH
 yhp
-jxw
+qKj
 lhR
-cKW
+hTA
 cdC
 jdX
-nIy
+bHn
 fcO
-eKD
+hVQ
 qfi
 xfq
 qfi
@@ -85170,17 +85217,17 @@ wPM
 ycu
 nhm
 ajQ
-aLr
+iag
 wNS
 kGV
 fim
 dwH
 dwH
-aLr
-aLr
-aLr
+iag
+iag
+iag
 hKT
-aLr
+iag
 oVM
 kIl
 jPG
@@ -85381,7 +85428,7 @@ gVF
 qbH
 jWY
 lhR
-ovJ
+jYy
 lhR
 lhR
 lhR
@@ -85428,13 +85475,13 @@ wPM
 ycu
 nhm
 ajQ
-aLr
+iag
 dwH
 jxe
 woJ
 ulc
 uqx
-aLr
+iag
 wDy
 stq
 hFX
@@ -85686,13 +85733,13 @@ wPM
 ycu
 nhm
 ajQ
-aLr
+iag
 mVR
 dwH
 dwH
 ulc
 pDH
-aLr
+iag
 uJK
 hFX
 hFX
@@ -85897,14 +85944,14 @@ soT
 qbH
 jWY
 lhR
-xPs
+xVL
 lhR
-jdZ
-lhR
-lhR
+lur
 lhR
 lhR
-ovJ
+lhR
+lhR
+jYy
 lhR
 lhR
 lhR
@@ -85944,17 +85991,17 @@ wPM
 ycu
 nhm
 ajQ
-aLr
+iag
 mVR
 kHq
 kHq
 ulc
 aon
-aLr
+iag
 jGS
 wAv
 fDg
-aLr
+iag
 oVM
 kIl
 jPG
@@ -86146,10 +86193,10 @@ tgj
 vrG
 fuy
 xuX
-kgD
-kkW
-kkW
-aCd
+dzQ
+tUk
+tUk
+hlR
 lut
 syD
 qbH
@@ -86202,17 +86249,17 @@ wPM
 ycu
 nhm
 ajQ
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
+iag
+iag
+iag
+iag
+iag
+iag
+iag
+iag
+iag
+iag
+iag
 oVM
 kIl
 jPG
@@ -86405,19 +86452,19 @@ vrG
 fuy
 xuX
 xTU
+hOI
+fAX
 eCg
-kUr
-iXf
 lut
 qvq
 qbH
-xrL
+imT
 fSy
 dax
 dax
 dZc
 qbH
-cZL
+enN
 qbH
 qbH
 qbH
@@ -86460,17 +86507,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+vdb
 esR
 tFD
 vRU
 wWm
 kWn
 qfX
-epd
-rMG
+vdb
+npn
 iHV
-epd
+vdb
 oVM
 kIl
 jPG
@@ -86663,9 +86710,9 @@ vrG
 fuy
 xuX
 lFd
+hOI
+hOI
 eCg
-eCg
-iXf
 rdj
 iMc
 qbH
@@ -86718,17 +86765,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+vdb
 dEk
 wNb
 wNb
 wNb
 wNb
 wNb
-epd
-svw
-xJr
-epd
+vdb
+vqJ
+eKD
+vdb
 oVM
 vdd
 jPG
@@ -86920,10 +86967,10 @@ tgj
 vrG
 fuy
 xuX
-hIK
+oIG
+hOI
+hOI
 eCg
-eCg
-iXf
 lut
 qvq
 qbH
@@ -86933,7 +86980,7 @@ lhR
 lhR
 lhR
 lhR
-ovv
+bNz
 lhR
 lhR
 lhR
@@ -86976,17 +87023,17 @@ wPM
 ftm
 nhm
 ajQ
-epd
+vdb
 sBU
 wNb
 wNb
 wNb
 wNb
 kWY
-epd
-epd
-oBk
-epd
+vdb
+vdb
+tLD
+vdb
 oVM
 kIl
 jPG
@@ -87178,13 +87225,13 @@ tgj
 vrG
 fuy
 xuX
-jRV
+bTr
+hOI
+hOI
 eCg
-eCg
-iXf
-acm
+rHw
 qdD
-rbj
+tYA
 jWY
 lhR
 kdB
@@ -87235,16 +87282,16 @@ ycu
 nhm
 ajQ
 cRS
-rYA
-rYA
-rYA
-rYA
-rYA
-rYA
-rYA
-mIC
-rYA
-epd
+qba
+qba
+qba
+qba
+qba
+qba
+qba
+mmf
+qba
+vdb
 oVM
 kIl
 jPG
@@ -87437,9 +87484,9 @@ vrG
 fuy
 xuX
 jRV
+hOI
+hOI
 eCg
-eCg
-iXf
 lut
 qvq
 qbH
@@ -87492,17 +87539,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+vdb
 stn
 pmF
 oHb
 rWO
 rWO
-epd
-epd
-epd
+vdb
+vdb
+vdb
 iNx
-epd
+vdb
 tGE
 kIl
 jPG
@@ -87695,9 +87742,9 @@ vrG
 fuy
 xuX
 hIK
+hOI
+hOI
 eCg
-eCg
-iXf
 rdj
 nzw
 dqU
@@ -87750,13 +87797,13 @@ wPM
 ycu
 nhm
 ajQ
-epd
+vdb
 rWO
 bwN
 lMZ
 daE
 aDw
-epd
+vdb
 oYU
 ehz
 dED
@@ -87953,9 +88000,9 @@ vrG
 fuy
 xuX
 xTU
+hOI
+hOI
 eCg
-eCg
-iXf
 lut
 qvq
 qbH
@@ -87964,9 +88011,9 @@ qbH
 nOE
 nOE
 aLS
-cZL
-qbH
 enN
+qbH
+tgH
 qbH
 qbH
 qbH
@@ -88008,13 +88055,13 @@ wPM
 ycu
 nhm
 ajQ
-epd
+vdb
 hTp
 rWO
 rWO
 daE
 cfX
-epd
+vdb
 oVX
 dED
 dED
@@ -88211,9 +88258,9 @@ vrG
 fuy
 xuX
 lFd
+hOI
+fAX
 eCg
-kUr
-iXf
 lut
 fnu
 qbH
@@ -88266,17 +88313,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+vdb
 hTp
 dxe
 dxe
 daE
 ckk
-epd
+vdb
 hAt
 erY
 bmm
-epd
+vdb
 oVM
 kIl
 jPG
@@ -88468,20 +88515,20 @@ tgj
 vrG
 fuy
 xuX
-oKR
-azq
-azq
-dGb
+vXa
+wfY
+wfY
+uUN
 lut
 qvq
 qbH
 qbH
-juK
+opB
 qbH
 qbH
 sbp
 qbH
-juK
+opB
 qbH
 qbH
 qbH
@@ -88524,17 +88571,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
+vdb
+vdb
+vdb
+vdb
+vdb
+vdb
+vdb
+vdb
+vdb
+vdb
+vdb
 oVM
 kIl
 jPG
@@ -88727,7 +88774,7 @@ vrG
 fuy
 xuX
 sOV
-sOV
+pgz
 xma
 lut
 lut
@@ -88746,7 +88793,7 @@ sbp
 sbp
 sbp
 sbp
-cQA
+aty
 kRJ
 kRJ
 ouN
@@ -88782,17 +88829,17 @@ wPM
 ycu
 nhm
 ajQ
-nKT
+epd
 wAV
 xeP
 fMj
 oqE
 qQH
 jsx
-nKT
-qba
-tyP
-nKT
+epd
+ftE
+mwD
+epd
 oVM
 kIl
 jPG
@@ -88990,21 +89037,21 @@ qbH
 qbH
 qbH
 qbH
-liN
-fLo
+aVP
+vLa
 qbH
-rET
+iRC
 sbp
 sbp
 sbp
 sbp
 sbp
-oeg
+iXf
 sbp
 sbp
 sbp
 sbp
-cQA
+aty
 kRJ
 kRJ
 ouN
@@ -89040,17 +89087,17 @@ wPM
 ycu
 nhm
 ajQ
-nKT
+epd
 oFn
 wSj
 wSj
 wSj
 wSj
 wSj
-nKT
-ikQ
-ddW
-nKT
+epd
+iqP
+xLP
+epd
 tGE
 vdd
 jPG
@@ -89248,7 +89295,7 @@ qbH
 dqU
 dqU
 qbH
-ltS
+pGH
 qbH
 qbH
 qbH
@@ -89298,17 +89345,17 @@ wPM
 ftm
 nhm
 ajQ
-nKT
+epd
 uEQ
 wSj
 wSj
 wSj
 wSj
 etN
-nKT
-nKT
-jVS
-nKT
+epd
+epd
+mVk
+epd
 oVM
 kIl
 jPG
@@ -89501,7 +89548,7 @@ vrG
 fuy
 xuX
 soT
-rET
+iRC
 dqU
 poO
 snb
@@ -89515,7 +89562,7 @@ qbH
 qbH
 qbH
 qbH
-iFw
+nJM
 qbH
 qbH
 sbp
@@ -89557,16 +89604,16 @@ ycu
 nhm
 ajQ
 kKz
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-aJc
-dgT
-nKT
+wWt
+wWt
+wWt
+wWt
+wWt
+wWt
+wWt
+xmj
+wWt
+epd
 oVM
 kIl
 jPG
@@ -89770,9 +89817,9 @@ tZz
 tZz
 tZz
 rFt
-sWf
+oHI
 qbH
-rJH
+cDf
 qbH
 qbH
 qbH
@@ -89814,17 +89861,17 @@ wPM
 ycu
 nhm
 ajQ
-nKT
+epd
 nYd
 axn
 pNW
 nKG
 nKG
-nKT
-nKT
-nKT
+epd
+epd
+epd
 rcW
-nKT
+epd
 tGE
 kIl
 jPG
@@ -90072,13 +90119,13 @@ wPM
 ycu
 nhm
 ajQ
-nKT
+epd
 nKG
 qEy
 erz
 uyc
 uhu
-nKT
+epd
 aXy
 uPj
 uFT
@@ -90330,13 +90377,13 @@ wPM
 ycu
 nhm
 ajQ
-nKT
+epd
 rDL
 nKG
 nKG
 uyc
 bvW
-nKT
+epd
 hAV
 uFT
 uFT
@@ -90588,17 +90635,17 @@ wPM
 ycu
 nhm
 ajQ
-nKT
+epd
 rDL
 dHv
 dHv
 uyc
 rCB
-nKT
+epd
 anx
 utS
 cQx
-nKT
+epd
 sKj
 kIl
 jPG
@@ -90846,17 +90893,17 @@ wPM
 ycu
 nhm
 ajQ
-nKT
-nKT
-nKT
-nKT
-nKT
-nKT
-nKT
-nKT
-nKT
-nKT
-nKT
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
 tPv
 tPv
 tPv

--- a/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
+++ b/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
@@ -82,6 +82,9 @@
 	movement_cost = 0
 	},
 /area/vr/outdoors/powered)
+"aeS" = (
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms3)
 "afn" = (
 /obj/structure/window/phoronreinforced{
 	dir = 1
@@ -106,6 +109,13 @@
 /obj/structure/salvageable/bliss,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
+"aiv" = (
+/obj/structure/table/gamblingtable,
+/obj/item/weapon/gun/projectile/revolver,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "aiI" = (
 /obj/item/weapon/coin/gold,
 /obj/item/clothing/ears/earring/dangle/gold,
@@ -138,6 +148,10 @@
 "ajP" = (
 /obj/effect/floor_decal/stairs/dark_stairs,
 /turf/simulated/floor/bmarble,
+/area/vr/powered/mall)
+"ajQ" = (
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/wood,
 /area/vr/powered/mall)
 "ajZ" = (
 /turf/simulated/floor/water/indoors{
@@ -250,7 +264,7 @@
 	},
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "ang" = (
 /obj/machinery/light/lamppost,
 /turf/simulated/floor/outdoors/sidewalk/side{
@@ -268,7 +282,7 @@
 /obj/item/weapon/book/bundle/custom_library/nonfiction/riseandfallofpersianempire,
 /obj/item/weapon/book/bundle/custom_library/nonfiction/skrelliancastesystem,
 /turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "aon" = (
 /obj/structure/table/hardwoodtable,
 /obj/machinery/light/small{
@@ -277,7 +291,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "aoo" = (
 /obj/structure/table/standard,
 /obj/item/stack/medical/advanced/bruise_pack,
@@ -384,7 +398,7 @@
 	},
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "avD" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/structure/railing/overhang/waterless/under,
@@ -399,6 +413,9 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
+"awD" = (
+/turf/simulated/wall/concrete,
+/area/vr/powered/mall/dorms/secondlife)
 "awL" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_mob/vore/aggressive/lizardman,
@@ -413,7 +430,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "axm" = (
 /obj/machinery/chemical_analyzer,
 /turf/simulated/shuttle/floor/voidcraft/light,
@@ -423,7 +440,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "axv" = (
 /obj/structure/cult/pylon,
 /obj/effect/floor_decal/spline/fancy{
@@ -444,12 +461,23 @@
 "axG" = (
 /turf/simulated/mineral/ignore_oregen,
 /area/vr/powered/dungeon)
+"ayz" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "ayP" = (
 /obj/machinery/vending/loadout/accessory{
 	prices = list(/obj/item/clothing/accessory=0,/obj/item/clothing/accessory/armband/med/color=0,/obj/item/clothing/accessory/asymmetric=0,/obj/item/clothing/accessory/asymmetric/purple=0,/obj/item/clothing/accessory/asymmetric/green=0,/obj/item/clothing/accessory/bracelet=0,/obj/item/clothing/accessory/bracelet/material=0,/obj/item/clothing/accessory/bracelet/friendship=0,/obj/item/clothing/accessory/chaps=0,/obj/item/clothing/accessory/chaps/black=0,/obj/item/weapon/storage/briefcase/clutch=0,/obj/item/clothing/accessory/collar=0,/obj/item/clothing/accessory/collar/bell=0,/obj/item/clothing/accessory/collar/spike=0,/obj/item/clothing/accessory/collar/pink=0,/obj/item/clothing/accessory/collar/holo=0,/obj/item/clothing/accessory/collar/shock=0,/obj/item/weapon/storage/belt/fannypack=0,/obj/item/weapon/storage/belt/fannypack/white=0,/obj/item/clothing/accessory/fullcape=0,/obj/item/clothing/accessory/halfcape=0,/obj/item/clothing/accessory/hawaiian=0,/obj/item/clothing/accessory/hawaiian/blue=0,/obj/item/clothing/accessory/hawaiian/pink=0,/obj/item/clothing/accessory/hawaiian/red=0,/obj/item/clothing/accessory/hawaiian/yellow=0,/obj/item/clothing/accessory/tropical=0,/obj/item/clothing/accessory/tropical/green=0,/obj/item/clothing/accessory/tropical/pink=0,/obj/item/clothing/accessory/tropical/blue=0,/obj/item/clothing/accessory/locket=0,/obj/item/weapon/storage/backpack/purse=0,/obj/item/clothing/accessory/sash=0,/obj/item/clothing/accessory/scarf=5,/obj/item/clothing/accessory/scarf/red=0,/obj/item/clothing/accessory/scarf/darkblue=0,/obj/item/clothing/accessory/scarf/purple=0,/obj/item/clothing/accessory/scarf/yellow=100,/obj/item/clothing/accessory/scarf/orange=0,/obj/item/clothing/accessory/scarf/lightblue=0,/obj/item/clothing/accessory/scarf/white=0,/obj/item/clothing/accessory/scarf/black=0,/obj/item/clothing/accessory/scarf/zebra=0,/obj/item/clothing/accessory/scarf/christmas=0,/obj/item/clothing/accessory/scarf/stripedred=0,/obj/item/clothing/accessory/scarf/stripedgreen=0,/obj/item/clothing/accessory/scarf/stripedblue=0,/obj/item/clothing/accessory/jacket=0,/obj/item/clothing/accessory/jacket/checkered=0,/obj/item/clothing/accessory/jacket/burgundy=0,/obj/item/clothing/accessory/jacket/navy=0,/obj/item/clothing/accessory/jacket/charcoal=0,/obj/item/clothing/accessory/vest=0,/obj/item/clothing/accessory/sweater=0,/obj/item/clothing/accessory/sweater/pink=0,/obj/item/clothing/accessory/sweater/mint=0,/obj/item/clothing/accessory/sweater/blue=0,/obj/item/clothing/accessory/sweater/heart=0,/obj/item/clothing/accessory/sweater/nt=5,/obj/item/clothing/accessory/sweater/keyhole=0,/obj/item/clothing/accessory/sweater/winterneck=0,/obj/item/clothing/accessory/sweater/uglyxmas=5,/obj/item/clothing/accessory/sweater/flowersweater=0,/obj/item/clothing/accessory/sweater/redneck=0,/obj/item/clothing/accessory/tie=0,/obj/item/clothing/accessory/tie/horrible=0,/obj/item/clothing/accessory/tie/white=0,/obj/item/clothing/accessory/tie/navy=0,/obj/item/clothing/accessory/tie/yellow=0,/obj/item/clothing/accessory/tie/darkgreen=0,/obj/item/clothing/accessory/tie/black=0,/obj/item/clothing/accessory/tie/red_long=0,/obj/item/clothing/accessory/tie/red_clip=0,/obj/item/clothing/accessory/tie/blue_long=0,/obj/item/clothing/accessory/tie/blue_clip=0,/obj/item/clothing/accessory/tie/red=0,/obj/item/clothing/accessory/wcoat=0,/obj/item/clothing/accessory/wcoat/red=0,/obj/item/clothing/accessory/wcoat/grey=0,/obj/item/clothing/accessory/wcoat/brown=0,/obj/item/clothing/accessory/wcoat/gentleman=0,/obj/item/clothing/accessory/wcoat/swvest=0,/obj/item/clothing/accessory/wcoat/swvest/blue=0,/obj/item/clothing/accessory/wcoat/swvest/red=0,/obj/item/weapon/storage/wallet=0,/obj/item/weapon/storage/wallet/poly=0,/obj/item/weapon/storage/wallet/womens=0,/obj/item/weapon/lipstick=0,/obj/item/weapon/lipstick/purple=0,/obj/item/weapon/lipstick/jade=0,/obj/item/weapon/lipstick/black=0,/obj/item/clothing/ears/earmuffs=0,/obj/item/clothing/ears/earmuffs/headphones=0,/obj/item/clothing/ears/earring/stud=0,/obj/item/clothing/ears/earring/dangle=0,/obj/item/clothing/gloves/ring/mariner=0,/obj/item/clothing/gloves/ring/engagement=0,/obj/item/clothing/gloves/ring/seal/signet=0,/obj/item/clothing/gloves/ring/seal/mason=0,/obj/item/clothing/gloves/ring/material/plastic=0,/obj/item/clothing/gloves/ring/material/steel=0,/obj/item/clothing/gloves/ring/material/gold=100,/obj/item/clothing/glasses/eyepatch=0,/obj/item/clothing/glasses/gglasses=0,/obj/item/clothing/glasses/regular/hipster=0,/obj/item/clothing/glasses/rimless=0,/obj/item/clothing/glasses/thin=0,/obj/item/clothing/glasses/monocle=0,/obj/item/clothing/glasses/goggles=0,/obj/item/clothing/glasses/fluff/spiffygogs=0,/obj/item/clothing/glasses/fakesunglasses=0,/obj/item/clothing/glasses/fakesunglasses/aviator=0,/obj/item/clothing/mask/bandana/blue=0,/obj/item/clothing/mask/bandana/gold=0,/obj/item/clothing/mask/bandana/green=0,/obj/item/clothing/mask/bandana/red=0,/obj/item/clothing/mask/surgical=0,/obj/item/clothing/accessory/pride/bi=0,/obj/item/clothing/accessory/pride/trans=0,/obj/item/clothing/accessory/pride/ace=0,/obj/item/clothing/accessory/pride/enby=0,/obj/item/clothing/accessory/pride/pan=0,/obj/item/clothing/accessory/pride/lesbian=0,/obj/item/clothing/accessory/pride/intersex=0,/obj/item/clothing/accessory/pride/vore=0)
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
+"azq" = (
+/obj/item/weapon/material/twohanded/riding_crop,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "azz" = (
 /obj/machinery/vending/dinnerware{
 	dir = 4;
@@ -511,6 +539,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
+"aAH" = (
+/obj/item/weapon/bedsheet/pillow/orange,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
 "aAU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -599,7 +631,7 @@
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "aDE" = (
 /obj/item/weapon/digestion_remains/ribcage,
 /turf/simulated/shuttle/floor/voidcraft,
@@ -666,10 +698,10 @@
 "aGv" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "aHs" = (
 /turf/simulated/floor/carpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "aHt" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood,
@@ -716,7 +748,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "aJB" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/item/clothing/under/teshari/undercoat/standard/black_grey,
@@ -741,7 +773,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/carpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "aKH" = (
 /obj/structure/salvageable/autolathe,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -770,6 +802,14 @@
 	temperature = 311
 	},
 /area/vr/powered)
+"aLr" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "aLx" = (
 /obj/item/weapon/pickaxe,
 /obj/structure/table/rack/shelf/steel,
@@ -782,15 +822,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
-"aLN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+"aLS" = (
+/obj/effect/floor_decal/corner/purple/bordercorner{
+	color = "#f700ff";
+	dir = 1
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "aMp" = (
 /obj/machinery/conveyor{
 	id = "vrsushitrain";
@@ -847,6 +885,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cult)
+"aOK" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/item/clothing/under/swimsuit/purple,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "aPz" = (
 /obj/machinery/disperser/back{
 	dir = 1
@@ -917,10 +963,7 @@
 	},
 /area/vr/outdoors/powered/lava)
 "aTx" = (
-/obj/structure/flora/ausbushes/leafybush,
-/turf/simulated/floor/outdoors/newdirt_nograss{
-	temperature = 293.15
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/outdoors/powered)
 "aTO" = (
 /obj/structure/table/standard,
@@ -952,6 +995,12 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"aUe" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "aUr" = (
 /obj/structure/closet/walllocker_double/kitchen/north{
 	dir = 8;
@@ -1001,17 +1050,11 @@
 /turf/simulated/floor/wood/alt,
 /area/vr/powered/mall)
 "aWG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/item/clothing/shoes/bhop,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
 	},
-/obj/effect/floor_decal/corner/green/border{
-	dir = 6
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
+/area/vr/powered/mall/backrooms)
 "aWK" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/item/clothing/under/teshari/undercoat/standard/black_grey,
@@ -1043,14 +1086,12 @@
 /obj/structure/table/rack/shelf/wood,
 /obj/random/plushie,
 /turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "aYc" = (
 /obj/effect/map_effect/portal/line/side_b{
 	dir = 8
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 0
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/outdoors/powered)
 "aYm" = (
 /obj/item/weapon/weldingtool/largetank,
@@ -1089,6 +1130,9 @@
 	},
 /turf/simulated/floor/bmarble,
 /area/vr/powered/mall)
+"aZi" = (
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "aZt" = (
 /obj/structure/table/fancyblack,
 /obj/item/weapon/reagent_containers/food/snacks/monkeysdelight,
@@ -1104,7 +1148,13 @@
 /turf/simulated/floor/carpet/blucarpet,
 /area/vr/powered)
 "aZS" = (
-/obj/machinery/light/floortube,
+/obj/machinery/light/floortube{
+	overlay_color = "#e060e0";
+	brightness_color_ns = "#9C439C";
+	light_color = "#e060e0";
+	brightness_color = "#e060e0";
+	name = "tinted light fixture"
+	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
 "aZV" = (
@@ -1156,6 +1206,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
+"bbT" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "bcC" = (
 /obj/structure/table/hardwoodtable,
 /obj/random/drinkbottle,
@@ -1356,6 +1411,10 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
+"blH" = (
+/obj/item/clothing/under/shiny/catsuit/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "bmi" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/under/pants/camo,
@@ -1366,20 +1425,16 @@
 /obj/structure/bed/double,
 /obj/item/weapon/bedsheet/hosdouble,
 /turf/simulated/floor/carpet/retro,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "bmZ" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
 "bne" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/green/border{
-	dir = 8
+/turf/unsimulated/wall/fakeglass{
+	dir = 2
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
+/area/vr/powered/mall/backrooms)
 "bnj" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -1416,7 +1471,13 @@
 /obj/structure/table/rack/shelf/wood,
 /obj/random/plushie,
 /turf/simulated/floor/carpet/turcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
+"boF" = (
+/obj/structure/bed/chair/sofa/left/beige{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "boL" = (
 /obj/effect/floor_decal/corner/white/border{
 	dir = 5
@@ -1427,6 +1488,10 @@
 	outdoors = 0
 	},
 /area/vr/powered/dungeon)
+"bpF" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "bpP" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod{
@@ -1519,7 +1584,8 @@
 	equip_body = 1;
 	name = "VR Ghost Cafe Spawn";
 	desc = "Clicking on this as a ghost will spawn you in as a NPC exclusive to the VR world loaded into the station.";
-	ghost_spawns = 1
+	ghost_spawns = 1;
+	default_job = "VR Avatar"
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
@@ -1528,9 +1594,7 @@
 	dir = 4;
 	portal_id = "vrmall"
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
 "bvk" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1562,13 +1626,15 @@
 /turf/space,
 /area/vr/space)
 "bvN" = (
-/obj/effect/floor_decal/corner/purple/diagonal,
+/obj/effect/floor_decal/corner/purple/diagonal{
+	color = "#f700ff"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/vr/outdoors/powered)
 "bvW" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "bws" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -1584,7 +1650,7 @@
 "bwN" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "bwW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/light/small{
@@ -1951,6 +2017,20 @@
 "bNe" = (
 /turf/simulated/wall/r_wall,
 /area/vr/powered/vendor)
+"bNs" = (
+/obj/structure/safe,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
+"bNT" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
 "bOh" = (
 /turf/simulated/wall/durasteel,
 /area/vr/powered/mall/backrooms)
@@ -1974,10 +2054,15 @@
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
 "bOr" = (
-/turf/simulated/floor/concrete{
-	outdoors = 1
+/obj/structure/railing/grey,
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
+"bOB" = (
+/obj/effect/floor_decal/corner/lightgrey/border/shifted,
+/turf/simulated/floor/outdoors/road,
+/area/vr/outdoors/powered)
 "bOO" = (
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/dirt,
@@ -2030,6 +2115,29 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"bQG" = (
+/obj/item/weapon/material/twohanded/riding_crop,
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/skinsuit/leotard/gray,
+/obj/item/clothing/under/skinsuit/fem/leotard/gray,
+/obj/item/clothing/under/skinsuit{
+	pixel_y = 0;
+	pixel_x = 8
+	},
+/obj/item/clothing/accessory/collar/shock,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/weapon/melee/fluff/holochain/mass,
+/obj/machinery/light{
+	dir = 4;
+	nightshift_enabled = 1;
+	brightness_color = "#e060e0";
+	light_color = "#e060e0";
+	overlay_color = "#e060e0";
+	brightness_color_ns = "#9C439C";
+	name = "tinted light fixture"
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "bQS" = (
 /obj/item/weapon/reagent_containers/food/snacks/sausage,
 /turf/simulated/floor/outdoors/newdirt_nograss{
@@ -2134,7 +2242,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "bTp" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/beach/sand/desert{
@@ -2220,6 +2328,15 @@
 "bYn" = (
 /turf/simulated/floor/beach/sand/desert,
 /area/vr/outdoors/powered/mall)
+"bYA" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/bluespace_harpoon,
+/obj/item/weapon/stock_parts/scanning_module/omni,
+/obj/item/weapon/tool/screwdriver,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "bZo" = (
 /obj/structure/table/fancyblack,
 /obj/item/weapon/bikehorn/tinytether{
@@ -2241,6 +2358,28 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
+"bZJ" = (
+/obj/structure/bed/chair/sofa/right/beige{
+	dir = 4
+	},
+/obj/machinery/light/floortube{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
+"cag" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "caK" = (
 /obj/effect/floor_decal/techfloor/corner,
 /turf/simulated/floor/cult{
@@ -2349,6 +2488,13 @@
 /obj/item/weapon/grenade/spawnergrenade/casino/yithian,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/building2)
+"cdC" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "cdH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -2398,7 +2544,7 @@
 "cfX" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "cgm" = (
 /turf/simulated/floor/airless,
 /area/vr/powered/space/sciship)
@@ -2406,15 +2552,6 @@
 /obj/item/weapon/stool/padded,
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/sciship)
-"cgv" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "cgB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -2492,7 +2629,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "cks" = (
 /obj/structure/prop/rock/small/water,
 /turf/simulated/floor/water{
@@ -2659,7 +2796,7 @@
 /area/vr/outdoors/powered/cult)
 "cqn" = (
 /turf/simulated/floor/carpet/turcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "cqv" = (
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/sciship)
@@ -2758,8 +2895,8 @@
 	},
 /obj/structure/railing/grey,
 /obj/machinery/light/lamppost,
-/turf/simulated/floor/concrete{
-	outdoors = 1
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
 "cuW" = (
@@ -2925,7 +3062,13 @@
 /turf/simulated/floor/tiled/yellow,
 /area/vr/powered/mall)
 "cFc" = (
-/obj/machinery/light/floortube,
+/obj/machinery/light/floortube{
+	overlay_color = "#e060e0";
+	brightness_color_ns = "#9C439C";
+	light_color = "#e060e0";
+	brightness_color = "#e060e0";
+	name = "tinted light fixture"
+	},
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 24
 	},
@@ -2984,6 +3127,12 @@
 /obj/item/canvas/twentythree_nineteen,
 /turf/simulated/floor/wood,
 /area/vr/powered/art)
+"cGy" = (
+/obj/structure/table/gamblingtable,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "cGB" = (
 /obj/structure/bonfire,
 /turf/simulated/floor/outdoors/newdirt_nograss{
@@ -3009,7 +3158,7 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "cIa" = (
 /obj/structure/cult/pylon,
 /obj/effect/floor_decal/spline/fancy{
@@ -3074,15 +3223,6 @@
 "cLE" = (
 /turf/simulated/shuttle/floor/darkred,
 /area/vr/powered/armory)
-"cLV" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/green/border{
-	dir = 4
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "cME" = (
 /obj/item/weapon/coin/gold,
 /obj/item/weapon/coin/diamond,
@@ -3154,7 +3294,7 @@
 /obj/structure/bed/double,
 /obj/item/weapon/bedsheet/hosdouble,
 /turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "cQR" = (
 /obj/effect/floor_decal/techfloor,
 /obj/machinery/light/poi,
@@ -3189,7 +3329,7 @@
 	id_tag = "VRmall3"
 	},
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "cSy" = (
 /obj/structure/table/glass,
 /obj/item/weapon/towel,
@@ -3208,20 +3348,14 @@
 "cTE" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "cUn" = (
 /obj/item/toy/cat_toy,
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/vet)
 "cUz" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/green/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
+/turf/unsimulated/wall/fakeglass2,
+/area/vr/powered/mall/backrooms)
 "cUG" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
@@ -3276,7 +3410,7 @@
 /obj/structure/bed/double,
 /obj/item/weapon/bedsheet/hosdouble,
 /turf/simulated/floor/carpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "cWG" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
@@ -3288,6 +3422,10 @@
 /obj/random/soap,
 /turf/simulated/floor/tiled/freezer,
 /area/vr/powered/space/whiteship)
+"cXe" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "cXr" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -3324,6 +3462,36 @@
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
+"cZD" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/handcuffs/fuzzy{
+	pixel_y = 9
+	},
+/obj/item/weapon/handcuffs/legcuffs/fuzzy{
+	pixel_y = 12;
+	pixel_x = -3
+	},
+/obj/item/clothing/under/fluff/latexmaid{
+	pixel_y = -4;
+	pixel_x = -8
+	},
+/obj/item/clothing/mask/muzzle/ballgag{
+	pixel_y = -9;
+	pixel_x = 9
+	},
+/obj/item/clothing/mask/muzzle/ballgag/ringgag{
+	pixel_y = -1;
+	pixel_x = 9
+	},
+/obj/item/weapon/handcuffs/fuzzy{
+	pixel_y = 9
+	},
+/obj/item/weapon/handcuffs/legcuffs/fuzzy{
+	pixel_y = 12;
+	pixel_x = -3
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "cZE" = (
 /obj/machinery/appliance/cooker/oven,
 /obj/machinery/light{
@@ -3339,10 +3507,28 @@
 /obj/structure/table/rack/shelf/steel,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
+"dax" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "daE" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
+"dbk" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 6
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "dcB" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/door/airlock/medical{
@@ -3453,6 +3639,14 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
+"dfx" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/cell/giga,
+/obj/item/weapon/cell/giga,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "dfJ" = (
 /turf/unsimulated/floor{
 	dir = 1;
@@ -3475,11 +3669,14 @@
 /area/vr/powered/mall)
 "dgT" = (
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "dha" = (
 /obj/item/toy/plushie/susred,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"dhl" = (
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "dhv" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/reagent_containers/food/drinks/soymilk,
@@ -3509,6 +3706,18 @@
 /turf/simulated/wall/titanium,
 /turf/simulated/wall/titanium,
 /area/vr/powered/dungeon)
+"diP" = (
+/obj/machinery/light{
+	dir = 2;
+	nightshift_enabled = 1;
+	brightness_color = "#e060e0";
+	light_color = "#e060e0";
+	overlay_color = "#e060e0";
+	brightness_color_ns = "#9C439C";
+	name = "tinted light fixture"
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "diT" = (
 /obj/structure/table/marble,
 /obj/machinery/light{
@@ -3716,6 +3925,10 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
+"dqU" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "drk" = (
 /obj/structure/closet/athletic_mixed,
 /obj/item/clothing/shoes/sandal,
@@ -3739,15 +3952,20 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"dsG" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "dsS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
 	},
 /turf/simulated/floor/concrete{
 	outdoors = 1
 	},
-/area/vr/outdoors/powered/mall)
+/area/vr/outdoors/powered)
 "duE" = (
 /obj/machinery/light/floortube/flicker{
 	dir = 8;
@@ -3755,6 +3973,27 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"duU" = (
+/obj/structure/bed/pillowpile/red,
+/obj/item/toy/plushie/foxbear,
+/obj/item/toy/plushie/marble_fox{
+	pixel_x = -17;
+	pixel_y = -8
+	},
+/obj/item/toy/plushie/teshari/y_yw{
+	pixel_y = -5;
+	pixel_x = 7
+	},
+/obj/item/toy/plushie/snakeplushie{
+	pixel_y = -21
+	},
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
 "dvd" = (
 /obj/structure/low_wall/bay/white,
 /turf/simulated/floor/outdoors/sidewalk/slab{
@@ -3777,7 +4016,7 @@
 /area/vr/powered/rocks)
 "dwH" = (
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "dwP" = (
 /obj/effect/floor_decal/rust,
 /mob/living/simple_mob/animal/giant_spider/lurker,
@@ -3788,7 +4027,7 @@
 	pixel_x = 31
 	},
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "dxk" = (
 /obj/effect/map_effect/perma_light{
 	light_color = "#5e4d26";
@@ -3842,6 +4081,15 @@
 	},
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/whiteship)
+"dzQ" = (
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms4)
+"dzT" = (
+/obj/machinery/door/airlock/gold{
+	id_tag = "VRmallSL1"
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "dzW" = (
 /obj/machinery/suit_cycler/refit_only,
 /turf/simulated/floor/cult,
@@ -3939,7 +4187,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "dCT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3976,7 +4224,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/red,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "dEs" = (
 /obj/structure/bed/chair/oldsofa/left,
 /obj/structure/window/phoronreinforced{
@@ -3986,16 +4234,20 @@
 /area/vr/powered/cult)
 "dED" = (
 /turf/simulated/floor/carpet/retro,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "dEG" = (
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
+"dES" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "dFd" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "dFF" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
@@ -4004,7 +4256,7 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "dGC" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -4041,10 +4293,16 @@
 	pixel_x = 31
 	},
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "dHI" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/vr/powered/cult)
+"dHL" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms5)
 "dKF" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -4241,6 +4499,13 @@
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/coffee,
 /turf/simulated/floor/concrete,
 /area/vr/powered/mall)
+"dQA" = (
+/obj/structure/sign/warning/falling,
+/turf/unsimulated/wall/concrete/turfpack/station{
+	color = "#ebcd7c";
+	icon = 'icons/turf/wall_masks.dmi'
+	},
+/area/vr/powered/mall/backrooms)
 "dQM" = (
 /obj/structure/table/marble,
 /obj/machinery/reagentgrinder,
@@ -4416,6 +4681,14 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/sciship)
+"dRn" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "dRJ" = (
 /obj/structure/curtain/black,
 /obj/random/junk,
@@ -4456,6 +4729,14 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
+"dTK" = (
+/obj/structure/bed/pillowpile/teal,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "dTL" = (
 /obj/structure/salvageable/console,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -4470,6 +4751,11 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
+"dTX" = (
+/turf/simulated/wall/stonebricks{
+	color = "pink"
+	},
+/area/vr/powered/mall/dorms/secondlife2)
 "dUZ" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -4580,6 +4866,17 @@
 	outdoors = 0
 	},
 /area/vr/outdoors/powered)
+"dZc" = (
+/obj/effect/floor_decal/corner/purple/bordercorner{
+	color = "#f700ff";
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/bordercorner{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "dZm" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -4629,6 +4926,22 @@
 /obj/structure/flora/pottedplant/fern,
 /turf/simulated/floor/wood,
 /area/vr/powered/art)
+"eag" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/obj/item/weapon/handcuffs/fuzzy,
+/obj/item/weapon/handcuffs/fuzzy,
+/obj/item/weapon/handcuffs/fuzzy,
+/obj/item/weapon/handcuffs/fuzzy,
+/obj/item/weapon/handcuffs/fuzzy,
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "eas" = (
 /turf/simulated/floor/wood,
 /area/vr/powered/space/whiteship)
@@ -4783,7 +5096,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/retro,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "ehT" = (
 /obj/structure/table/alien/blue,
 /obj/item/weapon/reagent_containers/spray/cleaner{
@@ -4816,7 +5129,7 @@
 /obj/structure/bed/double,
 /obj/item/weapon/bedsheet/hosdouble,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "ein" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod{
@@ -4847,7 +5160,7 @@
 	id = "vrmalltint4"
 	},
 /turf/simulated/floor/plating,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "eiL" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/cult/pylon,
@@ -4926,6 +5239,9 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"enN" = (
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms1)
 "eoA" = (
 /obj/machinery/light{
 	dir = 8
@@ -4944,9 +5260,12 @@
 /obj/structure/closet/walllocker/medical/east,
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/sciship)
+"eoO" = (
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms6)
 "epd" = (
 /turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "epk" = (
 /obj/structure/table/marble{
 	pixel_y = 0
@@ -5006,12 +5325,12 @@
 /obj/structure/table/bench/wooden,
 /obj/item/weapon/pen/blade/blue,
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "erY" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/retro,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "esR" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/random/meat,
@@ -5023,7 +5342,7 @@
 /obj/item/weapon/storage/fancy/egg_box,
 /obj/item/weapon/storage/fancy/egg_box,
 /turf/simulated/floor/tiled/red,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "esS" = (
 /obj/structure/window/phoronreinforced,
 /turf/simulated/shuttle/floor/black,
@@ -5042,7 +5361,7 @@
 	},
 /obj/structure/curtain,
 /turf/simulated/floor/tiled/old_cargo,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "eux" = (
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/cult{
@@ -5089,7 +5408,7 @@
 	id = "vrmalltint2"
 	},
 /turf/simulated/floor/plating,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "exd" = (
 /obj/structure/salvageable/slotmachine2,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -5110,17 +5429,6 @@
 /obj/item/weapon/miscdisc,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
-"ezi" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "ezz" = (
 /obj/machinery/door/firedoor/glass,
 /obj/structure/shuttle/window,
@@ -5182,6 +5490,13 @@
 /obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"eCg" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "eCs" = (
 /turf/simulated/floor/water/pool{
 	temperature = 293.15;
@@ -5471,6 +5786,13 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
+"eIH" = (
+/obj/item/toy/plushie/white_cat{
+	pixel_y = 4;
+	pixel_x = 15
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "eIW" = (
 /obj/structure/easel,
 /obj/item/canvas/twentyfour_twentyfour,
@@ -5504,12 +5826,33 @@
 /obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/carpet/geo,
 /area/vr/powered/mall)
+"eKD" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "eKF" = (
 /obj/structure/bed/chair/sofa/brown{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
+"eLf" = (
+/obj/structure/bed/pillowpile/green,
+/obj/item/toy/plushie/pink_fox{
+	pixel_x = -5;
+	pixel_y = -13
+	},
+/obj/item/weapon/bedsheet/pillow/teal,
+/obj/item/toy/plushie/borgplushie/drake/med,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
 "eLS" = (
 /obj/machinery/door/airlock/multi_tile/metal/mait{
 	dir = 1;
@@ -5599,7 +5942,7 @@
 "ePC" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "eQe" = (
 /obj/item/weapon/coin/gold,
 /obj/item/weapon/coin/gold,
@@ -5650,6 +5993,11 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"eRK" = (
+/turf/simulated/wall/stonebricks{
+	color = "pink"
+	},
+/area/vr/powered/mall/dorms/secondlife5)
 "eRP" = (
 /obj/structure/railing/grey{
 	pixel_y = 0;
@@ -5674,6 +6022,12 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/vr/powered/motel)
+"eTu" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/vr/powered/mall)
 "eTA" = (
 /turf/simulated/floor/water/deep{
 	outdoors = 0;
@@ -5697,15 +6051,9 @@
 /turf/unsimulated/wall,
 /area/vr/outdoors/powered)
 "eUL" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/disposaloutlet,
-/obj/effect/floor_decal/corner/green/border{
-	dir = 9
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
+/obj/machinery/light/lamppost,
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
 "eUO" = (
@@ -5780,6 +6128,10 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"fan" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/outdoors/road,
+/area/vr/outdoors/powered)
 "faC" = (
 /obj/item/clothing/shoes/cult,
 /obj/item/clothing/suit/cultrobes/alt,
@@ -5833,6 +6185,22 @@
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
+"fcO" = (
+/obj/structure/bed/pillowpile,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/machinery/light/floortube{
+	overlay_color = "#e060e0";
+	brightness_color_ns = "#9C439C";
+	light_color = "#e060e0";
+	brightness_color = "#e060e0";
+	name = "tinted light fixture";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "fcS" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -5936,7 +6304,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "ffN" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/ammo_magazine/awp,
@@ -5979,6 +6347,13 @@
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"fgs" = (
+/obj/item/toy/plushie/black_fox{
+	pixel_y = 0;
+	name = "latex black fox"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "fgP" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/wormcan,
@@ -6006,7 +6381,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "fiJ" = (
 /turf/simulated/floor/water/beach{
 	dir = 8;
@@ -6044,9 +6419,7 @@
 /obj/effect/map_effect/portal/line/side_a{
 	dir = 4
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
 "fki" = (
 /obj/structure/closet/walllocker/emerglocker/south,
@@ -6076,6 +6449,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"flB" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "flS" = (
 /turf/space,
 /turf/simulated/floor/beach/sand/desert{
@@ -6108,7 +6495,11 @@
 	id = "vrmalltint5"
 	},
 /turf/simulated/floor/plating,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
+"fnu" = (
+/obj/structure/bed/pillowpile,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "fnC" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -6122,10 +6513,6 @@
 "fof" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/reagent_containers/food/snacks/chips{
-	pixel_y = 7;
-	pixel_x = 9
-	},
-/obj/item/weapon/reagent_containers/food/snacks/chips{
 	pixel_y = 2;
 	pixel_x = 2
 	},
@@ -6136,14 +6523,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/chips{
 	pixel_y = 2;
 	pixel_x = 9
-	},
-/obj/item/weapon/reagent_containers/food/snacks/chips{
-	pixel_y = 7;
-	pixel_x = -7
-	},
-/obj/item/weapon/reagent_containers/food/snacks/chips{
-	pixel_y = 7;
-	pixel_x = 1
 	},
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
@@ -6268,7 +6647,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wmarble,
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
 /area/vr/powered/mall)
 "fts" = (
 /obj/structure/window/phoronreinforced{
@@ -6350,6 +6732,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/whiteship)
+"fur" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "fuy" = (
 /turf/unsimulated/wall/seperator,
 /area/vr/powered/mall/backrooms)
@@ -6406,7 +6795,7 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "fxa" = (
 /obj/structure/salvageable/machine_os,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -6533,7 +6922,18 @@
 /obj/structure/bed/double,
 /obj/item/weapon/bedsheet/hosdouble,
 /turf/simulated/floor/carpet/brown,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
+"fDN" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "fDV" = (
 /obj/structure/cliff/automatic{
 	dir = 8
@@ -6607,10 +7007,11 @@
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/dungeon)
 "fGS" = (
-/turf/simulated/floor/concrete{
-	outdoors = 1
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
 	},
-/area/vr/powered/rocks)
+/area/vr/outdoors/powered)
 "fHm" = (
 /obj/structure/table/standard,
 /obj/item/weapon/surgical/FixOVein{
@@ -6662,6 +7063,18 @@
 "fJm" = (
 /turf/simulated/shuttle/floor/yellow,
 /area/vr/powered/space/sciship)
+"fKg" = (
+/obj/structure/sign/directions/dorms{
+	pixel_y = -6;
+	dir = 4
+	},
+/turf/simulated/wall/concrete,
+/area/vr/powered/mall)
+"fKI" = (
+/obj/structure/bed/pillowpile/red,
+/obj/item/toy/plushie/otter,
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "fLs" = (
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 5
@@ -6683,7 +7096,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/old_cargo,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "fMF" = (
 /obj/structure/table/marble,
 /obj/structure/window/reinforced{
@@ -6759,6 +7172,14 @@
 /obj/item/weapon/reagent_containers/food/condiment/small/packet/crayon/grey,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"fMZ" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "fNa" = (
 /obj/structure/lattice,
 /turf/space,
@@ -6848,6 +7269,17 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/vr/powered/mall)
+"fSy" = (
+/obj/effect/floor_decal/corner/purple/bordercorner{
+	color = "#f700ff";
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/purple/bordercorner{
+	color = "#f700ff";
+	dir = 2
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "fSz" = (
 /obj/structure/bed/chair/oldsofa/right{
 	dir = 1
@@ -7151,7 +7583,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "ghY" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/engineering,
@@ -7201,6 +7633,14 @@
 "gjB" = (
 /turf/simulated/wall/r_wall,
 /area/vr/powered/bluebase)
+"gla" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "glK" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -7240,15 +7680,6 @@
 /mob/living/simple_mob/vore/rabbit/killer,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/dungeon)
-"gmY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "gnm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/floor_decal/techfloor{
@@ -7468,7 +7899,7 @@
 	id_tag = "VRmall5"
 	},
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "gBD" = (
 /obj/structure/cliff/automatic{
 	dir = 4
@@ -7496,16 +7927,17 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/whiteship)
 "gBR" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/deliveryChute{
-	dir = 2
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 4
 	},
 /turf/simulated/floor/concrete{
 	outdoors = 1
 	},
-/area/vr/outdoors/powered/mall)
+/area/vr/outdoors/powered)
+"gDd" = (
+/obj/item/weapon/digestion_remains/variant3,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "gDe" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
@@ -7579,7 +8011,7 @@
 /obj/item/weapon/storage/fancy/egg_box,
 /obj/item/weapon/storage/fancy/egg_box,
 /turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "gGj" = (
 /obj/structure/fence/door/opened{
 	dir = 4
@@ -7612,6 +8044,10 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"gHF" = (
+/obj/item/weapon/bedsheet/pillow,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
 "gIm" = (
 /obj/structure/bookcase,
 /obj/item/weapon/book/bundle/custom_library/fiction/coldmountain,
@@ -7621,7 +8057,7 @@
 /obj/item/weapon/book/bundle/custom_library/nonfiction/riseandfallofpersianempire,
 /obj/item/weapon/book/bundle/custom_library/nonfiction/skrelliancastesystem,
 /turf/simulated/floor/carpet/turcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "gIs" = (
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
@@ -7748,6 +8184,13 @@
 	temperature = 293.15
 	},
 /area/vr/powered/cult)
+"gPA" = (
+/obj/effect/floor_decal/corner/purple/bordercorner{
+	color = "#f700ff";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "gPK" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/item/clothing/under/permit,
@@ -7766,6 +8209,12 @@
 /obj/item/device/radio/headset,
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
+"gPR" = (
+/obj/machinery/door/airlock/gold{
+	id_tag = "VRmallSL3"
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "gPX" = (
 /obj/structure/window/basic,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -7852,6 +8301,23 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"gVF" = (
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
+"gVN" = (
+/obj/machinery/vending/loadout/loadout_misc{
+	emagged = 1
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
+"gVQ" = (
+/obj/structure/bed/pillowpile/orange,
+/obj/item/toy/plushie/purple_fox{
+	pixel_y = -5;
+	pixel_x = 5
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "gWl" = (
 /mob/living/simple_mob/animal/passive/lizard,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -7863,9 +8329,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
 "gXF" = (
 /mob/living/simple_mob/clowns/big/c_shift/chlown,
@@ -8015,6 +8479,12 @@
 	outdoors = 1
 	},
 /area/vr/outdoors/powered)
+"hfV" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms3)
 "hgg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -8147,7 +8617,7 @@
 	},
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/tiled/yellow,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "hll" = (
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -8208,6 +8678,12 @@
 "hoq" = (
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/whiteship)
+"hou" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 5
+	},
+/turf/simulated/floor/wood,
+/area/vr/powered/mall)
 "hoO" = (
 /obj/machinery/light/poi{
 	dir = 1
@@ -8243,6 +8719,9 @@
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
+"hqN" = (
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "hqT" = (
 /obj/structure/sign/warning/caution{
 	name = "\improper CAUTION: 4th WALL BREAKS"
@@ -8318,7 +8797,7 @@
 /area/vr/powered/space/whiteship)
 "hsD" = (
 /turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "hsQ" = (
 /obj/structure/closet/walllocker_double/kitchen/north{
 	dir = 8;
@@ -8352,7 +8831,9 @@
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
 "htD" = (
-/obj/effect/floor_decal/corner/purple/diagonal,
+/obj/effect/floor_decal/corner/purple/diagonal{
+	color = "#f700ff"
+	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/dark,
 /area/vr/powered/mall/vw)
@@ -8423,7 +8904,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/carpet/turcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "hxG" = (
 /obj/machinery/vending/deluxe_boozeomat{
 	req_access = null;
@@ -8462,6 +8943,9 @@
 /obj/machinery/fitness/heavy/lifter,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
+"hzU" = (
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "hAl" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -8479,7 +8963,7 @@
 /obj/item/weapon/book/bundle/custom_library/nonfiction/riseandfallofpersianempire,
 /obj/item/weapon/book/bundle/custom_library/nonfiction/skrelliancastesystem,
 /turf/simulated/floor/carpet/retro,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "hAQ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/random/meat,
@@ -8491,14 +8975,14 @@
 /obj/item/weapon/storage/fancy/egg_box,
 /obj/item/weapon/storage/fancy/egg_box,
 /turf/simulated/floor/tiled/yellow,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "hAV" = (
 /obj/machinery/light/small{
 	dir = 1;
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "hBa" = (
 /obj/structure/flora/pottedplant/fern,
 /obj/effect/floor_decal/carpet,
@@ -8521,7 +9005,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "hCn" = (
 /obj/machinery/appliance/cooker/grill,
 /turf/simulated/floor/wood/alt,
@@ -8596,7 +9080,7 @@
 /area/vr/powered/cult)
 "hFX" = (
 /turf/simulated/floor/carpet/brown,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "hGg" = (
 /obj/effect/floor_decal/corner/paleblue/full{
 	dir = 4
@@ -8609,13 +9093,17 @@
 "hGy" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/yellow,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "hGB" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/dungeon)
+"hGH" = (
+/obj/item/weapon/bedsheet/pillow/teal,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
 "hHa" = (
 /turf/unsimulated/wall,
 /area/vr/outdoors/powered)
@@ -8634,6 +9122,15 @@
 /obj/effect/catwalk_plated/white,
 /turf/space,
 /area/vr/space)
+"hIK" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "hIL" = (
 /obj/machinery/chemical_dispenser/bar_soft/full{
 	pixel_y = 8;
@@ -8651,7 +9148,7 @@
 "hKT" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/carpet/brown,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "hNG" = (
 /turf/simulated/floor/outdoors/dirt{
 	temperature = 311;
@@ -8679,13 +9176,24 @@
 	},
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/dungeon)
+"hOI" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL2";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "hPd" = (
 /obj/structure/railing/grey{
 	pixel_y = 0;
 	dir = 8
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
 "hPe" = (
@@ -8758,6 +9266,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/mineral/sif,
 /area/vr/powered/rocks)
+"hSI" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "hSS" = (
 /obj/structure/fans,
 /turf/simulated/shuttle/plating,
@@ -8776,7 +9290,7 @@
 /obj/item/weapon/book/manual,
 /obj/item/weapon/book/manual,
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "hTq" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -8856,12 +9370,8 @@
 /area/vr/powered/bar)
 "hXy" = (
 /obj/structure/railing/grey,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
+/turf/simulated/floor/outdoors/newdirt_nograss{
+	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
 "hXB" = (
@@ -9002,6 +9512,9 @@
 /obj/random/cigarettes,
 /turf/simulated/floor/tiled,
 /area/vr/powered/constore)
+"iag" = (
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms6)
 "iam" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -9090,7 +9603,7 @@
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "ifF" = (
 /obj/machinery/smartfridge/survival_pod{
 	icon = 'icons/obj/vending.dmi';
@@ -9193,7 +9706,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "igf" = (
 /obj/structure/closet/secure_closet/engineering_electrical{
 	req_access = null
@@ -9246,6 +9759,14 @@
 /obj/structure/closet/crate/trashcart,
 /turf/simulated/floor/concrete,
 /area/vr/powered/mall)
+"ijc" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 5
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "ijw" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/snacks/slice/sushi/filled/filled{
@@ -9427,6 +9948,11 @@
 /obj/random/maintenance/security,
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"ipC" = (
+/turf/simulated/wall/stonebricks{
+	color = "pink"
+	},
+/area/vr/powered/mall/dorms/secondlife)
 "ipY" = (
 /turf/space,
 /area/vr/space)
@@ -9596,10 +10122,21 @@
 /area/vr/powered/mall)
 "ivc" = (
 /obj/structure/prop/statue/pillar,
-/turf/simulated/floor/concrete{
-	outdoors = 1
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
+"ivl" = (
+/turf/simulated/wall/stonebricks{
+	color = "pink"
+	},
+/area/vr/powered/mall/dorms/secondlife4)
+"ivr" = (
+/obj/machinery/door/airlock/gold{
+	id_tag = "VRmallSL5"
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "ivx" = (
 /obj/structure/bed/chair/sofa/bench/marble{
 	pixel_y = 0;
@@ -9667,7 +10204,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "ixS" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8
@@ -9771,7 +10308,7 @@
 /obj/item/weapon/storage/fancy/egg_box,
 /obj/item/weapon/storage/fancy/egg_box,
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "iDR" = (
 /obj/structure/table/rack/shelf,
 /obj/item/ammo_magazine/m9mm,
@@ -9791,9 +10328,7 @@
 /area/vr/powered/vendor)
 "iEH" = (
 /obj/item/weapon/beach_ball/holoball,
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/outdoors/powered)
 "iET" = (
 /obj/effect/overlay/palmtree_r,
@@ -9857,7 +10392,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "iIl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -9869,9 +10404,7 @@
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/vet)
 "iIT" = (
-/turf/simulated/floor/concrete{
-	outdoors = 0
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
 "iIY" = (
 /obj/item/weapon/gun/projectile/automatic/serdy/hunter,
@@ -9900,6 +10433,12 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/whiteship)
+"iKR" = (
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual,
+/obj/item/weapon/book/manual,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "iLp" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -9916,6 +10455,10 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/space/mechfactory)
+"iMc" = (
+/obj/structure/bed/pillowpile/teal,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "iMi" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9949,7 +10492,7 @@
 "iNx" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/carpet/retro,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "iNM" = (
 /obj/structure/table/alien/blue,
 /obj/item/weapon/surgical/bonegel,
@@ -10039,7 +10582,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "iVQ" = (
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
@@ -10055,7 +10598,11 @@
 "iWc" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
+"iWh" = (
+/obj/item/toy/plushie/possum,
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "iWn" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -10078,6 +10625,9 @@
 	outdoors = 0
 	},
 /area/vr/outdoors/powered)
+"iXf" = (
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms5)
 "iXg" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/device/communicator,
@@ -10108,6 +10658,22 @@
 	},
 /turf/space,
 /area/vr/space)
+"iXX" = (
+/obj/structure/table/darkglass,
+/obj/item/device/bodysnatcher{
+	pixel_y = 4;
+	pixel_x = 3
+	},
+/obj/item/device/bodysnatcher{
+	pixel_y = -2;
+	pixel_x = -2
+	},
+/obj/item/device/bodysnatcher{
+	pixel_y = -4;
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "iYh" = (
 /obj/machinery/vending/giftvendor,
 /turf/simulated/floor/tiled,
@@ -10164,6 +10730,25 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/vr/powered/mall)
+"jaw" = (
+/obj/structure/bed/pillowpile,
+/obj/item/toy/plushie/shark{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/obj/item/toy/plushie/kitten{
+	pixel_y = -3
+	},
+/obj/item/toy/plushie/bigcat{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/item/toy/plushie/marble_fox{
+	pixel_y = -13;
+	pixel_x = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "jay" = (
 /obj/machinery/door/window/brigdoor/westleft{
 	req_access = null
@@ -10197,6 +10782,15 @@
 /obj/item/weapon/gun/energy/locked/frontier/unlocked,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
+"jbT" = (
+/obj/structure/table/darkglass,
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "jbY" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -10222,8 +10816,9 @@
 /area/vr/powered/shop)
 "jcI" = (
 /obj/structure/railing/grey,
-/turf/simulated/floor/concrete{
-	outdoors = 1
+/obj/machinery/light/lamppost,
+/turf/simulated/floor/outdoors/newdirt_nograss{
+	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
 "jcO" = (
@@ -10245,6 +10840,14 @@
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/carpet/blue,
 /area/vr/powered/motel)
+"jdX" = (
+/obj/structure/bed/pillowpile/black,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "jem" = (
 /obj/machinery/light{
 	dir = 8
@@ -10289,6 +10892,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/nuke)
+"jfo" = (
+/obj/structure/bed/pillowpile,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "jft" = (
 /obj/structure/cult/tome,
 /turf/simulated/floor/wood,
@@ -10501,7 +11112,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "joP" = (
 /obj/machinery/light{
 	dir = 8
@@ -10517,6 +11128,9 @@
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
+"jpy" = (
+/turf/simulated/wall/concrete,
+/area/vr/powered/mall/dorms/secondlife5)
 "jpL" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -10596,7 +11210,7 @@
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/old_cargo,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "jsF" = (
 /obj/machinery/vending/boozeomat{
 	req_access = null
@@ -10661,14 +11275,13 @@
 	},
 /area/vr/outdoors/powered)
 "jvT" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/railing/grey{
+	pixel_y = 0;
+	dir = 8
 	},
-/obj/machinery/disposal/deliveryChute{
-	dir = 2
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
 "jwx" = (
@@ -10681,10 +11294,20 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/unsimulated/wall,
 /area/vr/outdoors/powered)
+"jxd" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "jxe" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
+"jxs" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/structure/bed/double/padded,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "jxv" = (
 /obj/structure/table/standard,
 /obj/item/device/taperecorder,
@@ -10770,6 +11393,10 @@
 	},
 /turf/simulated/floor/carpet/geo,
 /area/vr/powered/mall)
+"jCa" = (
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "jCk" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/mimedouble,
@@ -10865,16 +11492,12 @@
 /area/vr/powered/art)
 "jFf" = (
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "jFD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/turf/unsimulated/wall/fakeglass{
+	dir = 1
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
+/area/vr/powered/conspawn)
 "jFH" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/shuttle/floor/black,
@@ -10898,7 +11521,7 @@
 /obj/item/weapon/book/bundle/custom_library/nonfiction/riseandfallofpersianempire,
 /obj/item/weapon/book/bundle/custom_library/nonfiction/skrelliancastesystem,
 /turf/simulated/floor/carpet/brown,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "jGX" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 1
@@ -10947,7 +11570,7 @@
 /obj/structure/table/bench/wooden,
 /obj/item/weapon/pen/blade/blue,
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "jIV" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
@@ -10956,12 +11579,6 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/vr/powered/mall)
-"jIZ" = (
-/obj/machinery/light/lamppost,
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "jJx" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -11011,6 +11628,15 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
+"jKc" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/light/small{
+	dir = 4;
+	nightshift_enabled = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "jKl" = (
 /obj/effect/landmark/button_mob_spawner_landmark/second,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -11136,6 +11762,10 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/vr/powered/mall)
+"jPB" = (
+/obj/structure/bed/double/padded,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "jPG" = (
 /turf/simulated/floor/outdoors/newdirt_nograss{
 	temperature = 293.15
@@ -11162,7 +11792,7 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "jQC" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/weapon/storage/box/glasses/square{
@@ -11231,6 +11861,17 @@
 	},
 /turf/simulated/floor/bmarble,
 /area/vr/powered/mall)
+"jRV" = (
+/obj/machinery/vending/boozeomat{
+	req_access = null
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "jSK" = (
 /obj/structure/table/marble,
 /obj/structure/sink/countertop{
@@ -11240,7 +11881,7 @@
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "jST" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -11274,7 +11915,7 @@
 /obj/effect/floor_decal/milspec/color/silver,
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "jWs" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -11286,6 +11927,14 @@
 /obj/item/device/ticket_printer/train,
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
+"jWY" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 2;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "jXf" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -11366,7 +12015,7 @@
 /obj/item/weapon/book/manual,
 /obj/item/weapon/book/manual,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "kaK" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled,
@@ -11375,9 +12024,7 @@
 /obj/structure/holohoop{
 	dir = 1
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/outdoors/powered)
 "kby" = (
 /turf/simulated/floor/wood/alt/parquet/turfpack,
@@ -11397,12 +12044,16 @@
 /area/vr/outdoors/powered)
 "kck" = (
 /obj/structure/window/phoronbasic,
-/obj/item/device/camerabug,
 /obj/machinery/flasher{
 	pixel_y = -7
 	},
 /obj/machinery/door/window/westleft{
 	dir = 1
+	},
+/obj/item/device/camera{
+	anchored = 1;
+	name = "projector";
+	desc = "Hope theres good movies this year."
 	},
 /turf/simulated/floor/bmarble,
 /area/vr/powered/mall)
@@ -11426,6 +12077,9 @@
 "kcZ" = (
 /turf/simulated/wall/solidrock,
 /area/vr/powered/rocks)
+"kdB" = (
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms2)
 "kdJ" = (
 /mob/living/simple_mob/animal/passive/pillbug,
 /turf/simulated/floor/wood{
@@ -11537,7 +12191,7 @@
 /obj/item/weapon/book/bundle/custom_library/nonfiction/riseandfallofpersianempire,
 /obj/item/weapon/book/bundle/custom_library/nonfiction/skrelliancastesystem,
 /turf/simulated/floor/carpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "khN" = (
 /obj/structure/cult/pylon,
 /obj/effect/floor_decal/spline/fancy{
@@ -11558,14 +12212,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
 "khU" = (
-/obj/structure/disposalpipe/segment{
+/turf/unsimulated/wall/fakeglass2{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/beige/border/shifted,
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
+/area/vr/powered/mall/backrooms)
 "kiv" = (
 /obj/machinery/fusion_fuel_compressor,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -11772,6 +12422,10 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"kss" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "ksP" = (
 /obj/machinery/light/floortube/flicker{
 	pixel_y = 5
@@ -11900,7 +12554,8 @@
 	equip_body = 1;
 	name = "VR Ghost Cafe Spawn";
 	desc = "Clicking on this as a ghost will spawn you in as a NPC exclusive to the VR world loaded into the station.";
-	ghost_spawns = 1
+	ghost_spawns = 1;
+	default_job = "VR Avatar"
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
@@ -11930,6 +12585,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/space/mechfactory)
+"kBb" = (
+/obj/structure/window/plastitanium{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "kBH" = (
 /obj/structure/table/marble,
 /obj/structure/sink/countertop{
@@ -11954,6 +12615,12 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
+"kCv" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms4)
 "kCO" = (
 /mob/living/simple_mob/animal/giant_spider/hunter,
 /turf/simulated/floor/outdoors/mud{
@@ -11993,7 +12660,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "kHl" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled,
@@ -12003,7 +12670,7 @@
 	pixel_x = 31
 	},
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "kHA" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -12017,6 +12684,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/vr/powered/dungeon)
+"kIc" = (
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/handcuffs/fuzzy,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "kIl" = (
 /turf/simulated/floor/outdoors/grass{
 	temperature = 293.15
@@ -12133,11 +12812,19 @@
 	id_tag = "VRmall4"
 	},
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "kKK" = (
 /obj/effect/landmark/button_mob_spawner_landmark,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/building2)
+"kLe" = (
+/obj/item/weapon/digestion_remains/skull/teshari,
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/item/clothing/mask/muzzle/ballgag{
+	pixel_y = -7
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "kLz" = (
 /obj/machinery/power/emitter/antique,
 /obj/structure/cable/green,
@@ -12256,7 +12943,7 @@
 "kOw" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "kOx" = (
 /obj/structure/table/standard,
 /obj/item/weapon/surgical/scalpel{
@@ -12359,6 +13046,9 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/unsimulated/wall,
 /area/vr/outdoors/powered)
+"kRJ" = (
+/turf/simulated/floor/flock,
+/area/vr/powered/mall)
 "kSG" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -12411,6 +13101,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
+"kVm" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "kVX" = (
 /obj/machinery/door/window/northright{
 	name = "Server Room";
@@ -12439,7 +13137,7 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/red,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "kWY" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/closet/secure_closet/freezer/kitchen{
@@ -12450,16 +13148,7 @@
 	},
 /obj/structure/curtain,
 /turf/simulated/floor/tiled/red,
-/area/vr/powered/mall/dorms)
-"kXB" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/disposaloutlet,
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
+/area/vr/powered/mall/dorms/dorms5)
 "kXJ" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -12583,6 +13272,10 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"lcd" = (
+/obj/item/weapon/tape_roll,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "lcF" = (
 /turf/simulated/wall/skipjack,
 /area/vr/powered/space/sciship)
@@ -12696,6 +13389,10 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
+"lhR" = (
+/obj/structure/table/darkglass,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "liP" = (
 /obj/structure/window/phoronreinforced{
 	dir = 4
@@ -12720,6 +13417,14 @@
 /obj/item/weapon/grenade/confetti/party_ball,
 /turf/simulated/floor/tiled,
 /area/vr/powered/dungeon)
+"ljQ" = (
+/obj/structure/table/darkglass,
+/obj/structure/stripper_pole{
+	icon_scale_x = 0.5;
+	icon_scale_y = 0.5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "lkk" = (
 /obj/effect/map_effect/perma_light/brighter{
 	light_color = "#d817ff"
@@ -12799,7 +13504,7 @@
 	pixel_x = 31
 	},
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "log" = (
 /obj/machinery/light{
 	dir = 8
@@ -12814,6 +13519,10 @@
 	},
 /turf/simulated/floor/bmarble,
 /area/vr/powered/mall)
+"loW" = (
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "lpe" = (
 /obj/machinery/light{
 	dir = 8
@@ -13045,6 +13754,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/vet)
+"lut" = (
+/obj/structure/table/darkglass,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
+"luH" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "lvj" = (
 /obj/structure/table/rack/wood,
 /obj/item/clothing/under/color/grey{
@@ -13249,6 +13973,9 @@
 /obj/machinery/cell_charger,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/space/mechfactory)
+"lAT" = (
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "lBi" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/wmarble,
@@ -13263,6 +13990,10 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
+"lBI" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "lBL" = (
 /obj/structure/table/fancyblack,
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/excitingsuppermatter,
@@ -13343,6 +14074,16 @@
 /obj/item/weapon/storage/fancy/cigar/cohiba,
 /turf/simulated/floor/tiled,
 /area/vr/powered/constore)
+"lFd" = (
+/obj/structure/table/darkglass,
+/obj/machinery/chemical_dispenser/bar_soft,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "lFo" = (
 /obj/structure/table/marble{
 	color = "grey"
@@ -13412,7 +14153,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "lIn" = (
 /turf/simulated/mineral/ignore_oregen,
 /area/vr/powered/rocks)
@@ -13513,7 +14254,7 @@
 /obj/structure/table/bench/wooden,
 /obj/item/weapon/pen/blade/blue,
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "lNm" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/drinks/shaker{
@@ -13689,7 +14430,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "lSc" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/beach/sand/desert,
@@ -13769,6 +14510,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/dungeon)
+"lUR" = (
+/obj/machinery/telecomms/processor,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "lVg" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
@@ -14000,6 +14747,10 @@
 /obj/mecha/combat/durand/old,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/sciship)
+"mfJ" = (
+/obj/item/clothing/mask/muzzle/ballgag,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "mgc" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/wood,
@@ -14045,7 +14796,7 @@
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "mhK" = (
 /obj/machinery/holoplant,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -14121,6 +14872,20 @@
 /obj/item/weapon/flame/candle/candelabra/everburn,
 /turf/simulated/floor/carpet/blucarpet,
 /area/vr/powered)
+"mky" = (
+/obj/structure/bed/pillowpile/teal,
+/obj/item/toy/plushie/borgplushie/drake/trauma{
+	pixel_y = -5;
+	pixel_x = 5
+	},
+/obj/item/weapon/bedsheet/pillow/white,
+/obj/item/toy/plushie/teshari/w_yw,
+/obj/item/toy/plushie/shark{
+	pixel_y = 3;
+	pixel_x = -15
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
 "mkG" = (
 /obj/machinery/vending/fishing,
 /turf/simulated/floor/tiled,
@@ -14135,7 +14900,7 @@
 	},
 /obj/structure/curtain,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "mkV" = (
 /obj/machinery/door/airlock/alien{
 	req_one_access = null
@@ -14217,7 +14982,7 @@
 	},
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "mon" = (
 /obj/machinery/light{
 	dir = 4
@@ -14269,6 +15034,16 @@
 	outdoors = -1
 	},
 /area/vr/powered/mall)
+"mqT" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
+"mqX" = (
+/obj/structure/table/bench/wooden,
+/obj/item/weapon/pen/blade/blue,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "msk" = (
 /obj/structure/closet/walllocker_double/medical/west,
 /obj/item/weapon/storage/firstaid,
@@ -14438,18 +15213,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
-"mAG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/corner/green/border{
-	dir = 10
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "mBa" = (
 /obj/fiftyspawner/glass,
 /obj/fiftyspawner/glass,
@@ -14819,7 +15582,7 @@
 	pixel_x = -5
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "mOS" = (
 /obj/structure/bed/chair/backed_red{
 	dir = 4
@@ -14846,6 +15609,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
+"mPJ" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "mQL" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/outdoors/rocks{
@@ -14926,7 +15693,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "mUR" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -14953,9 +15720,11 @@
 /obj/item/weapon/book/manual,
 /obj/item/weapon/book/manual,
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "mWb" = (
-/obj/effect/floor_decal/corner/purple/diagonal,
+/obj/effect/floor_decal/corner/purple/diagonal{
+	color = "#f700ff"
+	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/effect/map_effect/perma_light/brighter{
 	light_color = "#d817ff"
@@ -15013,7 +15782,7 @@
 "mYs" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/carpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "mZw" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/fancy/cigar/choiba,
@@ -15170,7 +15939,7 @@
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/turcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "neM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/sidewalk/side{
@@ -15285,6 +16054,16 @@
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"nkR" = (
+/obj/item/weapon/melee/chainofcommand/curator_whip,
+/obj/structure/table/darkglass,
+/obj/item/clothing/accessory/shiny/socks/poly,
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/obj/item/clothing/under/shiny/catsuit,
+/obj/item/clothing/head/shiny_hood/closed,
+/obj/item/clothing/head/shiny_hood,
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "nls" = (
 /obj/structure/curtain/black{
 	icon_state = "open";
@@ -15417,6 +16196,14 @@
 	},
 /turf/simulated/shuttle/floor/purple,
 /area/vr/powered/dungeon)
+"nog" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "noI" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
@@ -15493,11 +16280,19 @@
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/vr/powered)
+"nrU" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/obj/structure/bed/pillowpile/green,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "nrY" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/clown,
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "nsO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chemical_dispenser/bar_coffee/full{
@@ -15559,6 +16354,15 @@
 /obj/item/weapon/weldingtool/largetank,
 /turf/simulated/floor/tiled,
 /area/vr/powered/nuke)
+"nvu" = (
+/obj/structure/bed/pillowpile/yellow,
+/obj/item/toy/plushie/borgplushie/drake/jani,
+/obj/item/toy/plushie/red_fox{
+	pixel_y = -8;
+	pixel_x = 7
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
 "nwE" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/contraband/nofail,
@@ -15577,9 +16381,7 @@
 	dir = 8;
 	portal_id = "vrmall"
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 0
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/outdoors/powered)
 "nxF" = (
 /obj/structure/railing,
@@ -15601,7 +16403,11 @@
 	},
 /obj/structure/curtain,
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
+"nyl" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "nyq" = (
 /obj/structure/bed/chair/backed_red{
 	dir = 4
@@ -15622,6 +16428,10 @@
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/vr/powered/mall)
+"nzw" = (
+/obj/structure/bed/pillowpile/green,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "nzH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
@@ -15646,6 +16456,15 @@
 /obj/effect/map_effect/perma_light/gateway,
 /turf/unsimulated/fake_space,
 /area/vr/powered/mall/backrooms)
+"nzO" = (
+/obj/structure/table/darkglass,
+/obj/structure/stripper_pole,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
+"nzP" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "nAa" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/carpet/oracarpet,
@@ -15722,6 +16541,20 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
+"nDt" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "nDZ" = (
 /obj/structure/table/hardwoodtable,
 /obj/machinery/chemical_dispenser/bar_soft/full{
@@ -15958,6 +16791,20 @@
 	outdoors = 1
 	},
 /area/vr/outdoors/powered)
+"nJM" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "nJZ" = (
 /obj/item/weapon/material/twohanded/baseballbat/gold,
 /obj/item/stack/material/gold,
@@ -15990,7 +16837,7 @@
 /area/vr/powered/space/whiteship)
 "nKG" = (
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "nKH" = (
 /turf/simulated/floor/beach/sand/desert{
 	can_atmos_pass = 0;
@@ -16007,6 +16854,18 @@
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/dungeon)
+"nKT" = (
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
+"nLa" = (
+/obj/structure/bed/pillowpile/orange,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "nLi" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -16033,9 +16892,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 0
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
 "nMh" = (
 /obj/structure/window/phoronreinforced{
@@ -16052,6 +16909,15 @@
 	},
 /turf/simulated/floor/redgrid/animated,
 /area/vr/powered/cult)
+"nMk" = (
+/obj/machinery/power/generator{
+	anchored = 1;
+	dir = 2
+	},
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "nMn" = (
 /obj/machinery/door/blast/gate/bars{
 	id = "cringeeasteregg"
@@ -16095,6 +16961,13 @@
 "nOq" = (
 /turf/simulated/floor/airless,
 /area/vr/space)
+"nOE" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "nOW" = (
 /obj/structure/salvageable/server_os,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -16312,6 +17185,12 @@
 /obj/item/weapon/reagent_containers/glass/beaker/measuring_cup,
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"nWI" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 10
+	},
+/turf/simulated/floor/wood,
+/area/vr/powered/mall)
 "nWN" = (
 /obj/effect/landmark/virtual_reality{
 	name = "White Ship"
@@ -16343,7 +17222,7 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "nYH" = (
 /obj/structure/salvageable/console_os,
 /turf/simulated/shuttle/floor/voidcraft,
@@ -16397,6 +17276,18 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
+"oae" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL5";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "oaU" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/simple_portal/linked{
@@ -16430,7 +17321,7 @@
 	},
 /obj/structure/curtain,
 /turf/simulated/floor/tiled/yellow,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "ocy" = (
 /obj/machinery/light/bigfloorlamp{
 	light_range = 10
@@ -16507,16 +17398,20 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/cult)
 "ogY" = (
-/obj/structure/disposaloutlet{
-	dir = 4
+/obj/item/clothing/shoes/bhop,
+/obj/item/clothing/shoes/bhop,
+/obj/item/clothing/shoes/bhop,
+/obj/item/clothing/shoes/bhop,
+/obj/item/clothing/shoes/bhop,
+/obj/item/clothing/shoes/bhop,
+/obj/item/clothing/shoes/bhop,
+/obj/item/clothing/shoes/bhop,
+/obj/item/clothing/shoes/bhop,
+/obj/item/clothing/shoes/bhop,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
+/area/vr/powered/mall/backrooms)
 "ohm" = (
 /obj/structure/prop/statue/pillar,
 /turf/simulated/floor/tiled/white,
@@ -16671,6 +17566,12 @@
 	},
 /turf/simulated/floor/concrete,
 /area/vr/powered/mall)
+"ojR" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/vr/powered/mall)
 "ojU" = (
 /obj/effect/floor_decal/techfloor/corner,
 /turf/simulated/shuttle/floor/purple,
@@ -16760,7 +17661,7 @@
 "onX" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "ooe" = (
 /obj/machinery/door/airlock/hatch{
 	icon_state = "door_locked";
@@ -16865,7 +17766,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/tiled/old_cargo,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "oqY" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/item/clothing/under/permit,
@@ -16982,7 +17883,9 @@
 	portal_id = 75;
 	name = "Fast Travel to Mall"
 	},
-/obj/effect/floor_decal/corner/purple/diagonal,
+/obj/effect/floor_decal/corner/purple/diagonal{
+	color = "#f700ff"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/vr/outdoors/powered)
 "ovM" = (
@@ -17034,7 +17937,7 @@
 /obj/structure/table/rack/shelf/wood,
 /obj/random/plushie,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "oyk" = (
 /obj/structure/table/steel,
 /obj/item/device/tvcamera,
@@ -17142,7 +18045,7 @@
 	id_tag = "VRmall1"
 	},
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "oBi" = (
 /obj/structure/table/darkglass,
 /obj/item/device/flashlight/lamp,
@@ -17207,10 +18110,21 @@
 	icon = 'icons/turf/wall_masks.dmi'
 	},
 /area/vr/powered/mall/backrooms)
+"oCA" = (
+/obj/structure/bed/pillowpile/yellow,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "oCQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
+"oDb" = (
+/turf/simulated/wall/concrete,
+/area/vr/powered/mall/dorms/secondlife4)
 "oDd" = (
 /obj/machinery/light{
 	dir = 4
@@ -17262,7 +18176,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/old_cargo,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "oFV" = (
 /obj/structure/railing{
 	dir = 8
@@ -17305,7 +18219,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "oHz" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/storage/toolbox/electrical,
@@ -17352,6 +18266,14 @@
 /obj/item/weapon/material/twohanded/fireaxe,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
+"oIG" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 2;
+	pixel_y = 0
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "oJb" = (
 /obj/machinery/light{
 	dir = 1
@@ -17389,6 +18311,10 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/vr/powered/mall)
+"oJW" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "oKw" = (
 /obj/machinery/vending/radren,
 /turf/simulated/floor/carpet/geo,
@@ -17411,7 +18337,13 @@
 	pixel_y = 10
 	},
 /obj/item/clothing/suit/storage/teshari/cloak/standard/blue_grey,
-/obj/machinery/light/floortube,
+/obj/machinery/light/floortube{
+	overlay_color = "#e060e0";
+	brightness_color_ns = "#9C439C";
+	light_color = "#e060e0";
+	brightness_color = "#e060e0";
+	name = "tinted light fixture"
+	},
 /turf/simulated/floor/wood/alt/parquet/turfpack,
 /area/vr/powered/mall)
 "oLn" = (
@@ -17426,14 +18358,6 @@
 /mob/living/simple_mob/animal/giant_spider/lurker,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/dungeon)
-"oLI" = (
-/obj/effect/floor_decal/corner/green/border{
-	dir = 10
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "oLP" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -17475,6 +18399,17 @@
 	},
 /turf/space,
 /area/vr/space)
+"oOj" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "oOr" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -17546,6 +18481,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
+"oRL" = (
+/obj/item/toy/plushie/black_fox{
+	pixel_y = -10
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "oRY" = (
 /obj/structure/sink{
 	dir = 4;
@@ -17576,6 +18517,21 @@
 /obj/item/weapon/towel/random,
 /turf/simulated/floor/carpet/bcarpet,
 /area/vr/powered)
+"oVy" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 9
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
+"oVM" = (
+/obj/structure/railing/grey,
+/turf/simulated/floor/water/pool{
+	temperature = 293.15;
+	outdoors = 1
+	},
+/area/vr/outdoors/powered)
 "oVV" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -17590,7 +18546,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/carpet/retro,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "oWi" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -17616,7 +18572,7 @@
 /obj/structure/table/rack/shelf/wood,
 /obj/random/plushie,
 /turf/simulated/floor/carpet/retro,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "oZk" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/carpet/blue,
@@ -17662,9 +18618,7 @@
 /obj/effect/map_effect/portal/line/side_a{
 	dir = 8
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 0
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
 "pbq" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -17979,7 +18933,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "pmG" = (
 /turf/simulated/floor/carpet,
 /area/vr/powered/mall)
@@ -18022,6 +18976,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/vet)
+"poO" = (
+/obj/structure/table/bench/marble,
+/obj/item/weapon/reagent_containers/glass/beaker/mayo{
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/fruit_smudge,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "poZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/extinguisher_cabinet{
@@ -18074,6 +19036,11 @@
 /obj/machinery/portable_atmospherics/powered/pump/huge,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/cult)
+"pqd" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/mask/muzzle/ballgag,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "pqD" = (
 /turf/simulated/wall/r_wall,
 /area/vr/powered/art)
@@ -18135,6 +19102,17 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/vr/powered)
+"pul" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL3";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "pvd" = (
 /obj/structure/table/fancyblack,
 /obj/effect/floor_decal/spline/fancy{
@@ -18188,7 +19166,7 @@
 /obj/item/weapon/book/bundle/custom_library/nonfiction/riseandfallofpersianempire,
 /obj/item/weapon/book/bundle/custom_library/nonfiction/skrelliancastesystem,
 /turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "pyc" = (
 /turf/simulated/floor/water/beach{
 	dir = 10;
@@ -18243,6 +19221,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
+"pzL" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL4";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "pzO" = (
 /obj/structure/railing,
 /turf/simulated/floor/wood{
@@ -18278,7 +19267,7 @@
 "pBo" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "pBr" = (
 /obj/structure/table/marble,
 /obj/item/weapon/material/knife/butch,
@@ -18335,7 +19324,7 @@
 "pDH" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "pDL" = (
 /obj/machinery/conveyor{
 	id = "vrsushitrain";
@@ -18345,6 +19334,20 @@
 /obj/item/weapon/reagent_containers/food/snacks/slice/sushi/filled/filled,
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"pDR" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "pEd" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	locked = 0
@@ -18419,6 +19422,9 @@
 	outdoors = 0
 	},
 /area/vr/powered/rocks)
+"pGH" = (
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms2)
 "pGO" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -18456,6 +19462,11 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"pIO" = (
+/obj/structure/bed/double/padded,
+/obj/effect/decal/cleanable/fruit_smudge,
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "pJm" = (
 /obj/machinery/autolathe{
 	hacked = 1
@@ -18602,6 +19613,12 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/vr/powered/cult)
+"pNv" = (
+/obj/machinery/door/airlock/gold{
+	id_tag = "VRmallSL4"
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "pNF" = (
 /obj/item/weapon/cell/device/weapon/recharge/alien/hybrid{
 	pixel_y = -7
@@ -18613,6 +19630,12 @@
 /obj/structure/table/alien/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
+"pNM" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms1)
 "pNU" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -18630,7 +19653,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "pOg" = (
 /obj/structure/flora/rocks1,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -18681,7 +19704,7 @@
 "pRJ" = (
 /obj/effect/floor_decal/milspec/color/silver,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "pRN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -18711,6 +19734,12 @@
 /obj/effect/floor_decal/carpet,
 /turf/simulated/floor/carpet,
 /area/vr/powered/art)
+"pTD" = (
+/obj/machinery/door/window/eastright{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "pTH" = (
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/dungeon)
@@ -18782,6 +19811,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/vet)
+"pXn" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/mankini,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "pXD" = (
 /obj/machinery/vending/wardrobe/virodrobe{
 	req_access = null
@@ -18814,7 +19848,7 @@
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "pYG" = (
 /obj/effect/floor_decal/industrial/arrows{
 	dir = 1
@@ -18846,16 +19880,14 @@
 "qab" = (
 /obj/effect/zone_divider,
 /obj/structure/fans/tiny,
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/outdoors/powered)
 "qan" = (
 /obj/structure/bed/chair/sofa/left/beige{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "qaJ" = (
 /obj/machinery/chemical_dispenser/ert/specialops{
 	pixel_y = 7
@@ -18896,12 +19928,19 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"qba" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "qbf" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/cult{
 	icon_state = "cult-narsie"
 	},
 /area/vr/powered/cult)
+"qbH" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "qbM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/random/junk,
@@ -18983,6 +20022,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
+"qdD" = (
+/obj/structure/bed/pillowpile/yellow,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "qdR" = (
 /obj/structure/flora/pottedplant/overgrown,
 /turf/simulated/floor/wood,
@@ -19021,6 +20064,13 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/whiteship)
+"qfi" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "qft" = (
 /obj/item/tape/police,
 /turf/simulated/floor/tiled,
@@ -19038,7 +20088,7 @@
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/red,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "qgk" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -19145,7 +20195,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "qiO" = (
 /obj/structure/cliff/automatic,
 /turf/simulated/floor/lava,
@@ -19165,11 +20215,24 @@
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/yellow,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
+"qjX" = (
+/turf/simulated/wall/stonebricks{
+	color = "pink"
+	},
+/area/vr/powered/mall/dorms/secondlife3)
 "qkg" = (
 /mob/living/simple_mob/vore/alienanimals/catslug/custom/spaceslug/syndislug,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/dungeon)
+"qki" = (
+/obj/machinery/atmospherics/binary/circulator{
+	dir = 2
+	},
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "qkt" = (
 /obj/machinery/light{
 	dir = 1
@@ -19303,6 +20366,11 @@
 /obj/item/device/radio/phone,
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
+"qpq" = (
+/obj/structure/bed/pillowpile/teal,
+/obj/item/toy/plushie/red_fox,
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "qpQ" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
@@ -19345,13 +20413,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/vet)
-"qrQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/green/bordercorner,
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "qsk" = (
 /obj/item/weapon/flame/candle/everburn,
 /obj/structure/table/bench/wooden,
@@ -19414,6 +20475,9 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
+"qvq" = (
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "qvE" = (
 /obj/vehicle/boat/dragon/sifwood{
 	dir = 8
@@ -19479,7 +20543,7 @@
 /obj/structure/table/rack/shelf/wood,
 /obj/random/plushie,
 /turf/simulated/floor/carpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "qxC" = (
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/space/mechfactory)
@@ -19497,6 +20561,12 @@
 /obj/item/weapon/reagent_containers/food/snacks/sharkmeatcooked,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"qyn" = (
+/obj/effect/decal/remains/mummy2,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "qyu" = (
 /obj/structure/simple_door/wood,
 /obj/item/tape/police,
@@ -19660,7 +20730,7 @@
 	},
 /obj/structure/curtain,
 /turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "qBd" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/outdoors/mud{
@@ -19758,7 +20828,7 @@
 "qEy" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "qFa" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -19843,7 +20913,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "qIM" = (
 /obj/machinery/optable,
 /turf/simulated/shuttle/floor/voidcraft/dark,
@@ -19898,7 +20968,7 @@
 /obj/structure/table/bench/wooden,
 /obj/item/weapon/pen/blade/blue,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "qMa" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -20004,7 +21074,7 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/old_cargo,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "qRp" = (
 /obj/structure/table/hardwoodtable,
 /obj/machinery/chemical_dispenser/bar_coffee/full,
@@ -20021,7 +21091,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "qSK" = (
 /turf/simulated/floor/outdoors/dirt{
 	temperature = 311
@@ -20050,6 +21120,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
+"qTR" = (
+/obj/random/trash,
+/turf/simulated/floor/outdoors/road,
+/area/vr/outdoors/powered)
 "qUP" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
@@ -20176,7 +21250,7 @@
 	pixel_x = -4
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "rbH" = (
 /obj/structure/table/standard,
 /obj/item/weapon/reagent_containers/food/snacks/semki,
@@ -20206,7 +21280,18 @@
 "rcW" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
+"rdj" = (
+/obj/structure/table/darkglass,
+/obj/item/toy/tennis/purple{
+	pixel_x = -6
+	},
+/obj/item/toy/tennis/blue{
+	pixel_y = 0;
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "rdo" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -20248,6 +21333,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/dungeon)
+"rgX" = (
+/obj/machinery/crystal/lava,
+/turf/simulated/floor/lava,
+/area/vr/powered/mall/backrooms)
 "rgY" = (
 /obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -20428,6 +21517,13 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/vr/powered/mall)
+"rmm" = (
+/obj/structure/table/gamblingtable,
+/obj/item/weapon/fluff/fidgetspinner,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "rmr" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/gorefloor,
@@ -20479,7 +21575,7 @@
 	id_tag = "VRmall6"
 	},
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "roq" = (
 /obj/item/weapon/material/minihoe,
 /obj/item/weapon/tool/wirecutters/clippers/trimmers,
@@ -20566,6 +21662,22 @@
 	},
 /turf/simulated/floor/wmarble,
 /area/vr/powered/motel)
+"rse" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/obj/machinery/light/floortube{
+	overlay_color = "#e060e0";
+	brightness_color_ns = "#9C439C";
+	light_color = "#e060e0";
+	brightness_color = "#e060e0";
+	name = "tinted light fixture";
+	dir = 8
+	},
+/obj/structure/bed/pillowpile/red,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "rsE" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/drinks/shaker,
@@ -20723,7 +21835,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "rCZ" = (
 /obj/machinery/light/small,
 /obj/structure/table/woodentable,
@@ -20741,7 +21853,7 @@
 /obj/item/weapon/book/manual,
 /obj/item/weapon/book/manual,
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "rEt" = (
 /obj/item/weapon/storage/belt/soulstone/full,
 /turf/simulated/floor/cult,
@@ -20767,6 +21879,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/whiteship)
+"rFt" = (
+/obj/structure/window/plastitanium{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "rFW" = (
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
@@ -20784,13 +21902,16 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "rHq" = (
 /obj/machinery/vending/wardrobe/chefdrobe{
 	req_access = null
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
+"rHw" = (
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms1)
 "rHO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -20816,14 +21937,6 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered)
-"rJM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "rKk" = (
 /obj/structure/table/rack/shelf,
 /obj/item/ammo_magazine/m45,
@@ -20917,6 +22030,10 @@
 /obj/effect/zone_divider,
 /turf/unsimulated/wall,
 /area/vr/powered/cult)
+"rNo" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "rOk" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod{
@@ -20977,7 +22094,7 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "rQD" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/mecha_parts/component/hull/lightweight,
@@ -21036,6 +22153,12 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
+"rTF" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/vr/powered/mall)
 "rTK" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave{
@@ -21091,12 +22214,16 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"rVY" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "rWI" = (
 /turf/simulated/shuttle/floor/purple,
 /area/vr/outdoors/powered)
 "rWO" = (
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "rXb" = (
 /turf/simulated/floor/water/pool/turfpack/station,
 /area/vr/powered/mall/vw)
@@ -21224,13 +22351,21 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"saj" = (
+/obj/structure/bed/pillowpile/orange,
+/obj/item/toy/plushie/orange_fox{
+	pixel_y = -5;
+	pixel_x = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "saD" = (
 /obj/structure/table/bench/wooden,
 /obj/structure/flora/pottedplant/minitree{
 	pixel_y = 10
 	},
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "saH" = (
 /obj/structure/showcase/sign,
 /turf/simulated/floor/outdoors/rocks{
@@ -21239,11 +22374,8 @@
 	},
 /area/vr/powered/dungeon)
 "sbp" = (
-/obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/outdoors/newdirt_nograss{
-	temperature = 293.15
-	},
-/area/vr/outdoors/powered)
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "sbA" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 24
@@ -21294,6 +22426,20 @@
 	},
 /turf/unsimulated/floor/tiled/techfloor,
 /area/vr/powered/mall)
+"sed" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "seo" = (
 /obj/effect/rune,
 /obj/effect/step_trigger/message{
@@ -21415,6 +22561,11 @@
 "siU" = (
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/sciship)
+"sjg" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/stripper_green,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "sjQ" = (
 /obj/machinery/vending/wardrobe/detdrobe{
 	req_access = null
@@ -21453,9 +22604,14 @@
 	},
 /turf/simulated/floor/carpet/geo,
 /area/vr/powered/mall/vw)
+"snb" = (
+/obj/effect/floor_decal/industrial/stand_clear,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "snq" = (
 /obj/machinery/light{
-	layer = 3
+	layer = 3;
+	dir = 1
 	},
 /obj/structure/table/marble,
 /obj/item/weapon/storage/box/glasses/coffeecup{
@@ -21497,10 +22653,30 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"soT" = (
+/obj/machinery/feeder,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "soW" = (
 /obj/structure/sign/warning/vacuum,
 /turf/simulated/wall/skipjack,
 /area/vr/powered/space/sciship)
+"spe" = (
+/obj/structure/table/darkglass,
+/obj/item/device/mindbinder{
+	pixel_y = 4;
+	pixel_x = -2
+	},
+/obj/item/device/mindbinder{
+	pixel_y = -4;
+	pixel_x = -3
+	},
+/obj/item/device/mindbinder{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "spC" = (
 /obj/item/weapon/storage/box/wormcan,
 /turf/simulated/floor/beach/sand/desert{
@@ -21565,14 +22741,14 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/carpet/green,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "stq" = (
 /obj/machinery/button/windowtint{
 	id = "vrmalltint2";
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/brown,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "stB" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/snacks/chickenkatsu{
@@ -21650,9 +22826,7 @@
 /area/vr/powered/mall)
 "sut" = (
 /obj/random/trash,
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
 "suw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -21660,17 +22834,6 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/space/mechfactory)
-"sva" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/deliveryChute{
-	dir = 1
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "svz" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -21736,7 +22899,7 @@
 	id = "vrmalltint6"
 	},
 /turf/simulated/floor/plating,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "sww" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -21800,10 +22963,18 @@
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/cult)
+"syD" = (
+/obj/structure/bed/pillowpile/black,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "syF" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/wood/alt/parquet,
 /area/vr/powered/mall)
+"syO" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "syQ" = (
 /obj/machinery/vending/loadout/clothing{
 	prices = list(/obj/item/clothing/under/bathrobe=0,/obj/item/clothing/under/dress/black_corset=0,/obj/item/clothing/under/blazer=0,/obj/item/clothing/under/blazer/skirt=0,/obj/item/clothing/under/cheongsam=0,/obj/item/clothing/under/cheongsam/red=0,/obj/item/clothing/under/cheongsam/blue=0,/obj/item/clothing/under/cheongsam/black=0,/obj/item/clothing/under/cheongsam/darkred=0,/obj/item/clothing/under/cheongsam/green=0,/obj/item/clothing/under/cheongsam/purple=0,/obj/item/clothing/under/cheongsam/darkblue=0,/obj/item/clothing/under/croptop=0,/obj/item/clothing/under/croptop/red=0,/obj/item/clothing/under/croptop/grey=0,/obj/item/clothing/under/cuttop=0,/obj/item/clothing/under/cuttop/red=0,/obj/item/clothing/under/suit_jacket/female/skirt=0,/obj/item/clothing/under/dress/dress_fire=0,/obj/item/clothing/under/dress/flamenco=0,/obj/item/clothing/under/dress/flower_dress=0,/obj/item/clothing/under/fluff/gnshorts=0,/obj/item/clothing/under/color=0,/obj/item/clothing/under/color/aqua=0,/obj/item/clothing/under/color/black=0,/obj/item/clothing/under/color/blackf=0,/obj/item/clothing/under/color/blackjumpskirt=0,/obj/item/clothing/under/color/blue=0,/obj/item/clothing/under/color/brown=0,/obj/item/clothing/under/color/darkblue=0,/obj/item/clothing/under/color/darkred=0,/obj/item/clothing/under/color/green=0,/obj/item/clothing/under/color/grey=0,/obj/item/clothing/under/color/lightblue=0,/obj/item/clothing/under/color/lightbrown=0,/obj/item/clothing/under/color/lightgreen=0,/obj/item/clothing/under/color/lightpurple=0,/obj/item/clothing/under/color/lightred=0,/obj/item/clothing/under/color/orange=0,/obj/item/clothing/under/color/pink=0,/obj/item/clothing/under/color/prison=0,/obj/item/clothing/under/color/ranger=0,/obj/item/clothing/under/color/red=0,/obj/item/clothing/under/color/white=0,/obj/item/clothing/under/color/yellow=0,/obj/item/clothing/under/color/yellowgreen=0,/obj/item/clothing/under/corp/aether=0,/obj/item/clothing/under/corp/focal=0,/obj/item/clothing/under/corp/hephaestus=0,/obj/item/clothing/under/corp/wardt=0,/obj/item/clothing/under/kilt=0,/obj/item/clothing/under/fluff/latexmaid=0,/obj/item/clothing/under/dress/lilacdress=0,/obj/item/clothing/under/dress/white2=0,/obj/item/clothing/under/dress/white4=0,/obj/item/clothing/under/dress/maid=0,/obj/item/clothing/under/dress/maid/sexy=0,/obj/item/clothing/under/dress/maid/janitor=0,/obj/item/clothing/under/moderncoat=0,/obj/item/clothing/under/permit=0,/obj/item/clothing/under/oldwoman=0,/obj/item/clothing/under/frontier=0,/obj/item/clothing/under/mbill=0,/obj/item/clothing/under/pants/baggy=0,/obj/item/clothing/under/pants/baggy/classicjeans=0,/obj/item/clothing/under/pants/baggy/mustangjeans=0,/obj/item/clothing/under/pants/baggy/blackjeans=0,/obj/item/clothing/under/pants/baggy/greyjeans=0,/obj/item/clothing/under/pants/baggy/youngfolksjeans=0,/obj/item/clothing/under/pants/baggy/white=0,/obj/item/clothing/under/pants/baggy/red=0,/obj/item/clothing/under/pants/baggy/black=0,/obj/item/clothing/under/pants/baggy/tan=0,/obj/item/clothing/under/pants/baggy/track=0,/obj/item/clothing/under/pants/baggy/khaki=0,/obj/item/clothing/under/pants/baggy/camo=0,/obj/item/clothing/under/pants/utility=0,/obj/item/clothing/under/pants/utility/orange=0,/obj/item/clothing/under/pants/utility/blue=0,/obj/item/clothing/under/pants/utility/white=0,/obj/item/clothing/under/pants/utility/red=0,/obj/item/clothing/under/pants/chaps=0,/obj/item/clothing/under/pants/chaps/black=0,/obj/item/clothing/under/pants/track=0,/obj/item/clothing/under/pants/track/red=0,/obj/item/clothing/under/pants/track/white=0,/obj/item/clothing/under/pants/track/green=0,/obj/item/clothing/under/pants/track/blue=0,/obj/item/clothing/under/pants/yogapants=0,/obj/item/clothing/under/ascetic=0,/obj/item/clothing/under/dress/white3=0,/obj/item/clothing/under/skirt/pleated=0,/obj/item/clothing/under/dress/darkred=0,/obj/item/clothing/under/dress/redeveninggown=0,/obj/item/clothing/under/dress/red_swept_dress=0,/obj/item/clothing/under/dress/sailordress=0,/obj/item/clothing/under/dress/sari=0,/obj/item/clothing/under/dress/sari/green=0,/obj/item/clothing/under/qipao=0,/obj/item/clothing/under/qipao/red=0,/obj/item/clothing/under/qipao/white=0,/obj/item/clothing/under/shorts/red=0,/obj/item/clothing/under/shorts/green=0,/obj/item/clothing/under/shorts/blue=0,/obj/item/clothing/under/shorts/black=0,/obj/item/clothing/under/shorts/grey=0,/obj/item/clothing/under/shorts/white=0,/obj/item/clothing/under/shorts/jeans=0,/obj/item/clothing/under/shorts/jeans=0,/obj/item/clothing/under/shorts/jeans/classic=0,/obj/item/clothing/under/shorts/jeans/mustang=0,/obj/item/clothing/under/shorts/jeans/youngfolks=0,/obj/item/clothing/under/shorts/jeans/black=0,/obj/item/clothing/under/shorts/jeans/grey=0,/obj/item/clothing/under/shorts/khaki=0,/obj/item/clothing/under/skirt/loincloth=0,/obj/item/clothing/under/skirt/khaki=0,/obj/item/clothing/under/skirt/blue=0,/obj/item/clothing/under/skirt/red=0,/obj/item/clothing/under/skirt/denim=0,/obj/item/clothing/under/skirt/pleated=0,/obj/item/clothing/under/skirt/outfit/plaid_blue=0,/obj/item/clothing/under/skirt/outfit/plaid_red=0,/obj/item/clothing/under/skirt/outfit/plaid_purple=0,/obj/item/clothing/under/overalls/sleek=0,/obj/item/clothing/under/sl_suit=0,/obj/item/clothing/under/gentlesuit=0,/obj/item/clothing/under/gentlesuit/skirt=0,/obj/item/clothing/under/suit_jacket=0,/obj/item/clothing/under/suit_jacket/really_black/skirt=0,/obj/item/clothing/under/suit_jacket/really_black=0,/obj/item/clothing/under/suit_jacket/female/skirt=0,/obj/item/clothing/under/suit_jacket/female=0,/obj/item/clothing/under/suit_jacket/red=0,/obj/item/clothing/under/suit_jacket/red/skirt=0,/obj/item/clothing/under/suit_jacket/charcoal=0,/obj/item/clothing/under/suit_jacket/charcoal/skirt=0,/obj/item/clothing/under/suit_jacket/navy=0,/obj/item/clothing/under/suit_jacket/navy/skirt=0,/obj/item/clothing/under/suit_jacket/burgundy=0,/obj/item/clothing/under/suit_jacket/burgundy/skirt=0,/obj/item/clothing/under/suit_jacket/checkered=0,/obj/item/clothing/under/suit_jacket/checkered/skirt=0,/obj/item/clothing/under/suit_jacket/tan=0,/obj/item/clothing/under/suit_jacket/tan/skirt=0,/obj/item/clothing/under/scratch=0,/obj/item/clothing/under/scratch/skirt=0,/obj/item/clothing/under/sundress=0,/obj/item/clothing/under/sundress_white=0,/obj/item/clothing/under/rank/psych/turtleneck/sweater=0,/obj/item/weapon/storage/box/fluff/swimsuit=0,/obj/item/weapon/storage/box/fluff/swimsuit/blue=0,/obj/item/weapon/storage/box/fluff/swimsuit/purple=0,/obj/item/weapon/storage/box/fluff/swimsuit/green=0,/obj/item/weapon/storage/box/fluff/swimsuit/red=0,/obj/item/weapon/storage/box/fluff/swimsuit/white=0,/obj/item/weapon/storage/box/fluff/swimsuit/earth=0,/obj/item/weapon/storage/box/fluff/swimsuit/engineering=0,/obj/item/weapon/storage/box/fluff/swimsuit/science=0,/obj/item/weapon/storage/box/fluff/swimsuit/security=0,/obj/item/weapon/storage/box/fluff/swimsuit/medical=0,/obj/item/weapon/storage/box/fluff/swimsuit/cowbikini=0,/obj/item/clothing/under/utility=0,/obj/item/clothing/under/utility/grey=0,/obj/item/clothing/under/utility/blue=0,/obj/item/clothing/under/fluff/v_nanovest=0,/obj/item/clothing/under/dress/westernbustle=0,/obj/item/clothing/under/wedding/bride_white=0,/obj/item/weapon/storage/backpack=0,/obj/item/weapon/storage/backpack/messenger=0,/obj/item/weapon/storage/backpack/satchel=0,/obj/item/clothing/under/tropical=0,/obj/item/clothing/under/tropical/green=0,/obj/item/clothing/under/tropical/pink=0,/obj/item/clothing/under/tropical/blue=0)
@@ -21817,6 +22988,13 @@
 /obj/effect/blocker,
 /turf/space,
 /area/vr/space)
+"szB" = (
+/obj/structure/sign/warning/lava,
+/turf/unsimulated/wall/concrete/turfpack/station{
+	color = "#ebcd7c";
+	icon = 'icons/turf/wall_masks.dmi'
+	},
+/area/vr/powered/mall/backrooms)
 "szE" = (
 /obj/machinery/sleeper{
 	dir = 4;
@@ -21825,6 +23003,13 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
+"sAO" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "sAQ" = (
 /obj/structure/window/basic,
 /obj/structure/table/rack/wood,
@@ -21876,7 +23061,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/red,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "sCe" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -22033,7 +23218,9 @@
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
 "sIg" = (
-/obj/effect/floor_decal/corner/purple/diagonal,
+/obj/effect/floor_decal/corner/purple/diagonal{
+	color = "#f700ff"
+	},
 /obj/item/weapon/stool/baystool/padded{
 	dir = 1
 	},
@@ -22050,7 +23237,7 @@
 "sJh" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/carpet/turcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "sJk" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/fruitspawner/icechili,
@@ -22079,6 +23266,14 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"sJv" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "sJy" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/dip/guac,
@@ -22096,6 +23291,16 @@
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/plating,
 /area/vr/powered/space/mechfactory)
+"sKj" = (
+/obj/structure/railing/grey{
+	pixel_y = 0;
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "sKU" = (
 /obj/machinery/door/airlock/glass_medical{
 	req_one_access = null
@@ -22159,7 +23364,14 @@
 /obj/structure/bed/double,
 /obj/item/weapon/bedsheet/hosdouble,
 /turf/simulated/floor/carpet/turcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
+"sOV" = (
+/obj/structure/table/darkglass,
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "sPT" = (
 /obj/machinery/vending/food,
 /obj/structure/window/reinforced{
@@ -22219,6 +23431,12 @@
 /obj/item/weapon/weldingtool,
 /turf/simulated/floor/tiled,
 /area/vr/powered/nuke)
+"sRu" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/vr/powered/mall)
 "sRQ" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -22307,11 +23525,8 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/vr/powered/mall)
 "sWf" = (
-/obj/structure/flora/ausbushes/pointybush,
-/turf/simulated/floor/outdoors/newdirt_nograss{
-	temperature = 293.15
-	},
-/area/vr/outdoors/powered)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms4)
 "sWx" = (
 /turf/simulated/shuttle/floor/darkred,
 /area/vr/powered/space/sciship)
@@ -22367,6 +23582,11 @@
 	icon_state = "cult-narsie"
 	},
 /area/vr/powered/cult)
+"tbN" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "tcB" = (
 /obj/structure/table/woodentable,
 /obj/item/stack/cable_coil{
@@ -22416,13 +23636,13 @@
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/whiteship)
 "teH" = (
+/obj/machinery/light/lamppost,
 /obj/structure/railing/grey{
 	pixel_y = 0;
 	dir = 8
 	},
-/obj/machinery/light/lamppost,
-/turf/simulated/floor/concrete{
-	outdoors = 1
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
 "tfh" = (
@@ -22480,6 +23700,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/mall)
+"thx" = (
+/obj/item/weapon/bedsheet/pillow/red,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
+"thL" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 10
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "thY" = (
 /obj/machinery/vending/dinnerware{
 	dir = 4;
@@ -22497,14 +23728,13 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/mall)
-"tjn" = (
-/obj/effect/floor_decal/corner/green/border{
-	dir = 6
+"tjg" = (
+/obj/item/weapon/gun/magnetic/railgun,
+/obj/structure/table/reinforced,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
+/area/vr/powered/mall/backrooms)
 "tjv" = (
 /obj/structure/bed/chair/sofa/left/brown{
 	dir = 4
@@ -22558,6 +23788,11 @@
 /obj/machinery/vending/magivend,
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
+"tme" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "tmj" = (
 /obj/effect/floor_decal/industrial/loading,
 /turf/simulated/shuttle/floor/voidcraft/light,
@@ -22708,18 +23943,6 @@
 /obj/structure/shuttle/engine/router,
 /turf/simulated/shuttle/wall,
 /area/vr/powered/space/whiteship)
-"ttW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/corner/green/border{
-	dir = 1
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "tui" = (
 /obj/structure/salvageable/console_broken_os,
 /obj/effect/floor_decal/techfloor{
@@ -22837,6 +24060,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/space/sciship)
+"tyk" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 10
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "tyJ" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
@@ -22849,6 +24079,14 @@
 "tyN" = (
 /turf/simulated/wall,
 /area/vr/powered/material)
+"tyX" = (
+/obj/structure/salvageable/console_os{
+	name = "Turret control console"
+	},
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "tzq" = (
 /mob/living/simple_mob/animal/giant_spider,
 /turf/simulated/floor/plating,
@@ -22966,7 +24204,7 @@
 /obj/item/weapon/book/manual,
 /obj/item/weapon/book/manual,
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "tEI" = (
 /obj/structure/toilet,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -23023,7 +24261,7 @@
 	},
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/tiled/red,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "tFV" = (
 /obj/machinery/power/smes/buildable/hybrid,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -23033,6 +24271,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
+"tGg" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "tGi" = (
 /obj/machinery/light{
 	layer = 3
@@ -23043,6 +24286,14 @@
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
+"tGE" = (
+/obj/structure/railing/grey,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/simulated/floor/water/pool{
+	temperature = 293.15;
+	outdoors = 1
+	},
+/area/vr/outdoors/powered)
 "tGL" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
@@ -23190,6 +24441,11 @@
 	temperature = 311
 	},
 /area/vr/powered)
+"tOh" = (
+/obj/structure/bed/double,
+/obj/effect/decal/cleanable/fruit_smudge,
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "tOD" = (
 /obj/item/weapon/storage/box/wormcan/sickly,
 /turf/simulated/floor/beach/sand/desert{
@@ -23278,18 +24534,6 @@
 /obj/structure/window/reinforced/full,
 /turf/simulated/floor/plating,
 /area/vr/powered/vet)
-"tQw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/corner/green/border{
-	dir = 1
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "tQJ" = (
 /obj/structure/table/wooden_reinforced,
 /obj/structure/window/reinforced{
@@ -23330,7 +24574,10 @@
 "tSw" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
+"tSB" = (
+/turf/simulated/floor/lava,
+/area/vr/powered/mall/backrooms)
 "tSO" = (
 /obj/structure/window/phoronreinforced{
 	dir = 8
@@ -23495,6 +24742,12 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"tYP" = (
+/obj/structure/prop/dominator/blue,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "tYS" = (
 /obj/structure/table/marble,
 /obj/item/weapon/fossil/skull{
@@ -23534,8 +24787,45 @@
 /obj/random/trash,
 /turf/simulated/wall/r_concrete,
 /area/vr/powered/dungeon)
+"tZz" = (
+/obj/item/clothing/accessory/shiny/gloves,
+/obj/item/clothing/accessory/shiny/socks,
+/obj/item/clothing/head/shiny_hood,
+/obj/item/clothing/head/shiny_hood/closed,
+/obj/item/clothing/under/shiny/catsuit,
+/obj/item/weapon/handcuffs/fuzzy,
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/obj/item/weapon/material/twohanded/riding_crop,
+/obj/item/weapon/tape_roll,
+/obj/item/stack/cable_coil/random,
+/obj/item/clothing/under/fluff/latexmaid,
+/obj/item/weapon/melee/fluff/holochain/mass,
+/obj/item/clothing/accessory/collar/shock,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle/ballgag,
+/obj/item/clothing/mask/muzzle/ballgag/ringgag,
+/obj/item/clothing/under/skinsuit,
+/obj/item/clothing/under/skinsuit/fem,
+/obj/item/clothing/under/skinsuit/fem/gray,
+/obj/item/clothing/under/skinsuit/fem/leotard,
+/obj/item/clothing/under/skinsuit/fem/leotard/gray,
+/obj/item/clothing/under/skinsuit/gray,
+/obj/item/clothing/under/skinsuit/leotard,
+/obj/item/clothing/under/skinsuit/leotard/gray,
+/obj/item/clothing/under/rank/nullsuit/civ,
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/obj/item/clothing/accessory/shiny/socks/poly,
+/obj/item/clothing/head/shiny_hood/poly,
+/obj/item/clothing/head/shiny_hood/closed/poly,
+/obj/item/clothing/under/shiny/catsuit/poly,
+/obj/structure/table/darkglass,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "tZR" = (
-/obj/effect/floor_decal/corner/purple/diagonal,
+/obj/effect/floor_decal/corner/purple/diagonal{
+	color = "#f700ff"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/vr/powered/mall/vw)
 "uaq" = (
@@ -23711,6 +25001,14 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"ugg" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "ugj" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod{
@@ -23739,11 +25037,17 @@
 	},
 /turf/space,
 /area/vr/space)
+"ugR" = (
+/obj/item/toy/plushie/teshari/w_yw{
+	pixel_y = 5
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "uhu" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/clown,
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "uhw" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/material/sharpeningkit,
@@ -23787,6 +25091,10 @@
 	},
 /turf/simulated/shuttle/floor/purple,
 /area/vr/powered/dungeon)
+"ujo" = (
+/obj/machinery/vending/loadout/gadget,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "ujT" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/acid{
@@ -23829,7 +25137,7 @@
 "ulc" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "uli" = (
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
@@ -23938,11 +25246,36 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"uqt" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 6
+	},
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "uqx" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
+"uqz" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/handcuffs/fuzzy,
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "uqB" = (
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/structure/railing/grey{
@@ -23958,7 +25291,7 @@
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "urQ" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/carpet/blue,
@@ -23999,7 +25332,7 @@
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "uuc" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 8
@@ -24056,7 +25389,7 @@
 "uyc" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "uyo" = (
 /obj/effect/map_effect/portal/master/side_b{
 	dir = 4;
@@ -24101,6 +25434,13 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/whiteship)
+"uzw" = (
+/obj/structure/table/darkglass,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "uzB" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/wmarble,
@@ -24113,6 +25453,10 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
+"uzT" = (
+/obj/structure/closet/crate/trashcart,
+/turf/simulated/floor/outdoors/road,
+/area/vr/outdoors/powered)
 "uzU" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/wood,
@@ -24144,12 +25488,6 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion/rigged,
 /turf/simulated/floor/airless,
 /area/vr/space)
-"uAS" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "uBn" = (
 /obj/structure/bed/double/padded,
 /obj/structure/curtain/bed,
@@ -24199,7 +25537,7 @@
 	id = "vrmalltint3"
 	},
 /turf/simulated/floor/plating,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "uDd" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -24229,7 +25567,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/old_cargo,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "uFe" = (
 /obj/machinery/light{
 	layer = 3
@@ -24258,10 +25596,10 @@
 "uFH" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "uFT" = (
 /turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "uGs" = (
 /obj/machinery/sleeper{
 	dir = 4;
@@ -24391,6 +25729,17 @@
 	},
 /turf/simulated/floor/concrete,
 /area/vr/powered/mall)
+"uJo" = (
+/obj/item/toy/plushie/green_fox{
+	pixel_y = -11;
+	pixel_x = 9
+	},
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/shiny/catsuit/poly,
+/obj/item/clothing/head/shiny_hood/closed/poly,
+/obj/item/clothing/head/shiny_hood/poly,
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "uJt" = (
 /obj/structure/salvageable/bliss,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -24403,7 +25752,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/carpet/brown,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "uJR" = (
 /obj/structure/grille/cult,
 /obj/structure/window/phoronreinforced/full,
@@ -24471,7 +25820,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "uMu" = (
 /obj/structure/sign/scenery/map/left{
 	dir = 2;
@@ -24512,9 +25861,7 @@
 /area/vr/powered)
 "uNG" = (
 /obj/item/tape/police,
-/turf/simulated/floor/concrete{
-	outdoors = 0
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
 "uOu" = (
 /obj/structure/salvageable/implant_container_os,
@@ -24538,7 +25885,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "uPJ" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -24623,7 +25970,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "uRC" = (
 /obj/structure/sign/deck1,
 /turf/simulated/wall/skipjack,
@@ -24639,7 +25986,11 @@
 /obj/item/weapon/storage/fancy/egg_box,
 /obj/item/weapon/storage/fancy/egg_box,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
+"uSA" = (
+/obj/structure/bed/double/padded,
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "uSU" = (
 /obj/machinery/light/floortube{
 	dir = 8
@@ -24661,6 +26012,22 @@
 	movement_cost = 12
 	},
 /area/vr/powered/mall/backrooms)
+"uUA" = (
+/obj/structure/bed/pillowpile/red,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/obj/machinery/light/floortube{
+	overlay_color = "#e060e0";
+	brightness_color_ns = "#9C439C";
+	light_color = "#e060e0";
+	brightness_color = "#e060e0";
+	name = "tinted light fixture";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "uUX" = (
 /turf/simulated/floor/outdoors/sidewalk/slab{
 	movement_cost = 0;
@@ -24681,6 +26048,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/mall)
+"uVx" = (
+/obj/effect/floor_decal/corner/purple/bordercorner{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
+"uVX" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "uWc" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/sign/department/cargo_dock{
@@ -24707,7 +26089,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "uXF" = (
 /obj/structure/prop/rock/watersharp,
 /turf/simulated/floor/water{
@@ -24724,6 +26106,12 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"uYk" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms6)
 "uYl" = (
 /obj/machinery/appliance/cooker/grill,
 /turf/simulated/floor/wood,
@@ -24733,7 +26121,7 @@
 	pixel_x = 31
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "uYA" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -24749,7 +26137,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/turcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "vaJ" = (
 /obj/item/weapon/stool/padded{
 	dir = 4
@@ -24777,9 +26165,20 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled,
 /area/vr/powered/nuke)
+"vcE" = (
+/obj/random/humanoidremains,
+/turf/unsimulated/floor/lino/turfpack/station{
+	color = "#ffe9ab"
+	},
+/area/vr/powered/mall/backrooms)
 "vcM" = (
 /turf/simulated/floor/plating,
 /area/vr/outdoors/powered)
+"vdb" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "vdd" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/outdoors/grass{
@@ -24818,6 +26217,17 @@
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
+"veM" = (
+/obj/structure/bed/pillowpile/orange,
+/obj/item/toy/plushie/orange_cat{
+	pixel_y = 7;
+	pixel_x = 8
+	},
+/obj/item/toy/plushie/teshari/b_yw{
+	pixel_y = -12
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "vfd" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -24904,6 +26314,10 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/whiteship)
+"vin" = (
+/obj/item/weapon/digestion_remains/variant2,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "vip" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor,
@@ -24919,6 +26333,17 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"vjd" = (
+/obj/structure/bed/pillowpile/red,
+/obj/item/toy/plushie/blue_fox{
+	pixel_y = -15;
+	pixel_x = 11
+	},
+/obj/item/toy/plushie/foxbear{
+	pixel_y = 4
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "vjp" = (
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
@@ -24982,9 +26407,7 @@
 	dir = 8;
 	portal_id = "vrdungeon"
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 0
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
 "vlV" = (
 /obj/structure/bed/double/padded,
@@ -25001,13 +26424,10 @@
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/dungeon)
 "vmn" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
+/turf/unsimulated/wall/fakeglass{
+	dir = 1
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
+/area/vr/powered/mall/backrooms)
 "vmH" = (
 /obj/structure/curtain/black{
 	icon_state = "open";
@@ -25102,6 +26522,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
+"vpG" = (
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "vpH" = (
 /obj/mecha/working/hoverpod/combatpod{
 	dir = 8
@@ -25267,7 +26690,18 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
+"vwn" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "vwT" = (
 /obj/structure/bed/chair/sofa/left/black,
 /turf/simulated/floor/wood,
@@ -25286,6 +26720,15 @@
 /obj/item/weapon/reagent_containers/glass/rag,
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
+"vyR" = (
+/obj/structure/railing/grey{
+	pixel_y = 0;
+	dir = 8
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "vzc" = (
 /obj/machinery/recharger/wallcharger{
 	pixel_x = 4;
@@ -25407,6 +26850,14 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"vFE" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/obj/structure/bed/pillowpile/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "vGh" = (
 /obj/machinery/vending/wardrobe/hydrobe{
 	req_access = null
@@ -25505,6 +26956,10 @@
 /obj/machinery/light/poi,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/sciship)
+"vJD" = (
+/obj/structure/curtain/black,
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "vJF" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/action_figure{
@@ -25683,7 +27138,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/red,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "vSD" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -25726,6 +27181,17 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/sciship)
+"vTk" = (
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "vTq" = (
 /turf/simulated/floor/wood,
 /area/vr/powered/cult)
@@ -26057,6 +27523,13 @@
 	outdoors = 0
 	},
 /area/vr/powered/dungeon)
+"wgL" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 9
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "wgX" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/wood,
@@ -26071,6 +27544,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"wii" = (
+/obj/machinery/door/airlock/gold{
+	id_tag = "VRmallSL2"
+	},
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "wik" = (
 /mob/living/simple_mob/animal/passive/cat/bones{
 	desc = "A very odd behaved cat, their scratched name tag reads 'Felix'. They look very malnourished.";
@@ -26151,6 +27630,14 @@
 /obj/machinery/gear_dispenser/suit/aether,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/cult)
+"wji" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/outdoors/grass{
+	temperature = 293.15
+	},
+/area/vr/outdoors/powered)
 "wjI" = (
 /obj/structure/table/darkglass,
 /obj/item/weapon/storage/toolbox/syndicate/powertools,
@@ -26174,7 +27661,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "wkE" = (
 /obj/structure/table/marble,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -26192,7 +27679,7 @@
 	id = "vrmalltint1"
 	},
 /turf/simulated/floor/plating,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "wlP" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 1
@@ -26260,7 +27747,7 @@
 /obj/structure/table/bench/wooden,
 /obj/item/weapon/pen/blade/blue,
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "woV" = (
 /obj/structure/sign/explosive,
 /turf/unsimulated/wall/concrete/turfpack/station{
@@ -26309,7 +27796,7 @@
 	id_tag = "VRmall2"
 	},
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "wsc" = (
 /obj/machinery/floor_light{
 	anchored = 1
@@ -26440,7 +27927,7 @@
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/brown,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "wAz" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/storage/briefcase/inflatable{
@@ -26463,7 +27950,7 @@
 /obj/item/weapon/storage/fancy/egg_box,
 /obj/item/weapon/storage/fancy/egg_box,
 /turf/simulated/floor/tiled/old_cargo,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "wBm" = (
 /mob/living/simple_mob/construct/juggernaut/behemoth{
 	dir = 1;
@@ -26544,7 +28031,7 @@
 /obj/structure/table/rack/shelf/wood,
 /obj/random/plushie,
 /turf/simulated/floor/carpet/brown,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "wDN" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 8
@@ -26559,7 +28046,7 @@
 /area/vr/powered/rocks)
 "wEq" = (
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms3)
 "wEB" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 4
@@ -26693,7 +28180,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "wLH" = (
 /obj/item/weapon/rcd/advanced/loaded{
 	pixel_x = -5;
@@ -26762,7 +28249,7 @@
 "wNb" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/red,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
 "wNd" = (
 /obj/machinery/vending/wardrobe/medidrobe{
 	req_access = null
@@ -26813,7 +28300,7 @@
 	pixel_y = 10
 	},
 /turf/simulated/floor/carpet/blue,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms4)
 "wNW" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
@@ -26836,6 +28323,17 @@
 "wPa" = (
 /turf/simulated/wall/wood,
 /area/vr/powered/rocks)
+"wPk" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL1";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "wPm" = (
 /obj/structure/toilet{
 	dir = 4
@@ -26912,7 +28410,7 @@
 "wSj" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/old_cargo,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "wSm" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/machinery/button/remote/airlock{
@@ -26924,7 +28422,7 @@
 	pixel_y = 30
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms1)
 "wSw" = (
 /obj/item/clothing/suit/space/void/autolok,
 /obj/item/clothing/suit/space/void/autolok,
@@ -26968,12 +28466,24 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/whiteship)
+"wTU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/fruit_smudge,
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "wUr" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/unsimulated/floor/tiled/techfloor,
 /area/vr/powered/mall)
+"wUw" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/stripper_pink,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "wUx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -27091,7 +28601,12 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/tiled/red,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms5)
+"wWt" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "wWC" = (
 /obj/machinery/light{
 	dir = 8
@@ -27212,7 +28727,7 @@
 	},
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/tiled/old_cargo,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms6)
 "xeT" = (
 /turf/simulated/shuttle/floor/black,
 /area/vr/outdoors/powered)
@@ -27227,6 +28742,22 @@
 /obj/item/weapon/reagent_containers/food/snacks/slice/sushi/filled/filled,
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"xfq" = (
+/obj/structure/bed/pillowpile/teal,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/machinery/light/floortube{
+	overlay_color = "#e060e0";
+	brightness_color_ns = "#9C439C";
+	light_color = "#e060e0";
+	brightness_color = "#e060e0";
+	name = "tinted light fixture";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "xfu" = (
 /obj/structure/bed/alien,
 /obj/structure/curtain/open/privacy,
@@ -27364,6 +28895,12 @@
 /obj/machinery/chem_master,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/vr/powered/cult)
+"xkx" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 31
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "xkB" = (
 /obj/machinery/vending/wardrobe/genedrobe{
 	req_access = null
@@ -27392,6 +28929,10 @@
 	},
 /turf/simulated/floor/redgrid/animated,
 /area/vr/powered/cult)
+"xma" = (
+/obj/machinery/door/window/eastleft,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "xnt" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -27400,20 +28941,6 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
-"xnL" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/green/border{
-	dir = 5
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
-	},
-/area/vr/outdoors/powered/mall)
 "xoa" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -27598,6 +29125,9 @@
 /obj/random/maintenance/research,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/whiteship)
+"xuX" = (
+/turf/simulated/wall/concrete,
+/area/vr/powered/mall/secondlife)
 "xvh" = (
 /obj/machinery/vending/loadout{
 	prices = list(/obj/item/clothing/gloves/evening=0,/obj/item/clothing/gloves/fingerless=0,/obj/item/clothing/gloves/black=0,/obj/item/clothing/gloves/blue=0,/obj/item/clothing/gloves/brown=0,/obj/item/clothing/gloves/color=0,/obj/item/clothing/gloves/green=0,/obj/item/clothing/gloves/grey=0,/obj/item/clothing/gloves/sterile/latex=0,/obj/item/clothing/gloves/light_brown=0,/obj/item/clothing/gloves/sterile/nitrile=0,/obj/item/clothing/gloves/orange=0,/obj/item/clothing/gloves/purple=0,/obj/item/clothing/gloves/red=0,/obj/item/clothing/gloves/fluff/siren=0,/obj/item/clothing/gloves/white=0,/obj/item/clothing/gloves/duty=0,/obj/item/clothing/shoes/athletic=0,/obj/item/clothing/shoes/boots/fluff/siren=0,/obj/item/clothing/shoes/slippers=0,/obj/item/clothing/shoes/boots/cowboy/classic=0,/obj/item/clothing/shoes/boots/cowboy=0,/obj/item/clothing/shoes/boots/duty=0,/obj/item/clothing/shoes/flats/white/color=0,/obj/item/clothing/shoes/flipflop=0,/obj/item/clothing/shoes/heels=0,/obj/item/clothing/shoes/hitops/black=0,/obj/item/clothing/shoes/hitops/blue=0,/obj/item/clothing/shoes/hitops/green=0,/obj/item/clothing/shoes/hitops/orange=0,/obj/item/clothing/shoes/hitops/purple=0,/obj/item/clothing/shoes/hitops/red=0,/obj/item/clothing/shoes/flats/white/color=0,/obj/item/clothing/shoes/hitops/yellow=0,/obj/item/clothing/shoes/boots/jackboots=0,/obj/item/clothing/shoes/boots/jungle=0,/obj/item/clothing/shoes/black/cuffs=0,/obj/item/clothing/shoes/black/cuffs/blue=0,/obj/item/clothing/shoes/black/cuffs/red=0,/obj/item/clothing/shoes/sandal=0,/obj/item/clothing/shoes/black=0,/obj/item/clothing/shoes/blue=0,/obj/item/clothing/shoes/brown=0,/obj/item/clothing/shoes/laceup=0,/obj/item/clothing/shoes/green=0,/obj/item/clothing/shoes/laceup/brown=0,/obj/item/clothing/shoes/orange=0,/obj/item/clothing/shoes/purple=0,/obj/item/clothing/shoes/red=0,/obj/item/clothing/shoes/white=0,/obj/item/clothing/shoes/yellow=0,/obj/item/clothing/shoes/skater=0,/obj/item/clothing/shoes/boots/cowboy/snakeskin=0,/obj/item/clothing/shoes/boots/jackboots/toeless=0,/obj/item/clothing/shoes/boots/workboots/toeless=0,/obj/item/clothing/shoes/boots/winter=0,/obj/item/clothing/shoes/boots/workboots=0,/obj/item/clothing/shoes/footwraps=0,/obj/item/clothing/shoes/sneakerspurple=0,/obj/item/clothing/shoes/sneakersblue=0,/obj/item/clothing/shoes/sneakersred=0)
@@ -27763,7 +29293,7 @@
 "xEl" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "xEQ" = (
 /obj/structure/salvageable/console_os{
 	dir = 8
@@ -27915,6 +29445,10 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
+"xJs" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "xJF" = (
 /obj/machinery/light,
 /turf/simulated/floor/concrete,
@@ -27959,6 +29493,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
+"xKL" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "xLm" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/item/weapon/stool{
@@ -28017,9 +29563,7 @@
 /area/vr/powered/gunshop)
 "xOy" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/concrete{
-	outdoors = 0
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
 "xOT" = (
 /obj/structure/table/rack/shelf/steel,
@@ -28055,9 +29599,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/concrete{
-	outdoors = 0
-	},
+/turf/simulated/floor/outdoors/road,
 /area/vr/outdoors/powered)
 "xQE" = (
 /obj/fiftyspawner/wood,
@@ -28083,11 +29625,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/tealcarpet,
-/area/vr/powered/mall/dorms)
+/area/vr/powered/mall/dorms/dorms2)
 "xRg" = (
 /obj/machinery/chem_master/condimaster,
 /turf/simulated/floor/plating,
 /area/vr/powered/cafe)
+"xSC" = (
+/obj/structure/window/plastitanium,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "xTe" = (
 /obj/machinery/vending/wardrobe/clowndrobe{
 	req_access = null
@@ -28127,11 +29673,27 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered/lava)
+"xTU" = (
+/obj/structure/table/darkglass,
+/obj/machinery/chemical_dispenser/bar_alc/full,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "xUj" = (
 /obj/structure/table/gamblingtable,
 /obj/random/cigarettes,
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
+"xUp" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "xUP" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/grenade/explosive,
@@ -28222,12 +29784,9 @@
 /area/vr/outdoors/powered)
 "xZf" = (
 /obj/structure/railing/grey,
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/concrete{
-	outdoors = 1
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/outdoors/newdirt_nograss{
+	temperature = 293.15
 	},
 /area/vr/outdoors/powered/mall)
 "xZn" = (
@@ -28281,6 +29840,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"ycu" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/vr/powered/mall)
 "ydM" = (
 /obj/structure/salvageable/data_os,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -28355,9 +29920,18 @@
 	temperature = 293.15
 	},
 /area/vr/powered/dungeon)
+"yfs" = (
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "yft" = (
 /obj/structure/table/hardwoodtable,
-/obj/machinery/light/floortube,
+/obj/machinery/light/floortube{
+	overlay_color = "#e060e0";
+	brightness_color_ns = "#9C439C";
+	light_color = "#e060e0";
+	brightness_color = "#e060e0";
+	name = "tinted light fixture"
+	},
 /turf/simulated/floor/outdoors/sidewalk/slab{
 	movement_cost = 0;
 	temperature = 293.15;
@@ -28420,6 +29994,13 @@
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/building1)
+"yhp" = (
+/obj/effect/floor_decal/corner/purple/bordercorner{
+	color = "#f700ff";
+	dir = 2
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "yhv" = (
 /obj/machinery/light{
 	dir = 2;
@@ -28450,9 +30031,19 @@
 	pixel_y = 7;
 	pixel_x = 5
 	},
-/obj/machinery/light/floortube,
+/obj/machinery/light/floortube{
+	overlay_color = "#e060e0";
+	brightness_color_ns = "#9C439C";
+	light_color = "#e060e0";
+	brightness_color = "#e060e0";
+	name = "tinted light fixture"
+	},
 /turf/simulated/floor/wood/alt/parquet/turfpack,
 /area/vr/powered/mall)
+"yiL" = (
+/obj/item/toy/plushie/orange_fox,
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "yiX" = (
 /obj/structure/closet/cabinet{
 	pixel_y = 20
@@ -29419,11 +31010,11 @@ kcZ
 kcZ
 kcZ
 pwc
-fGS
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -29677,11 +31268,11 @@ kcZ
 kcZ
 kcZ
 pwc
-fGS
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -29935,11 +31526,11 @@ kcZ
 kcZ
 kcZ
 pwc
-fGS
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -30160,18 +31751,18 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 lIn
 lIn
 lIn
@@ -30194,10 +31785,10 @@ eXx
 kcZ
 pwc
 gXu
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -30418,18 +32009,18 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-ixu
-ixu
-lTR
-lTR
-nJI
-lTR
+aTx
+aTx
+fan
+fan
+aTx
+aTx
+qTR
+aTx
 iEH
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 lIn
 lIn
 lIn
@@ -30451,11 +32042,11 @@ wsc
 eXx
 kcZ
 pwc
-fGS
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -30676,18 +32267,18 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-ixu
-ixu
-ixu
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+fan
+fan
+fan
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 lIn
 lIn
 lIn
@@ -30709,11 +32300,11 @@ wsc
 eXx
 kcZ
 pwc
-fGS
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -30934,17 +32525,17 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-ixu
-ixu
-ixu
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+fan
+fan
+fan
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 kbv
 lIn
 lIn
@@ -30967,11 +32558,11 @@ wsc
 eXx
 kcZ
 pwc
-fGS
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -31192,18 +32783,18 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-ixu
-ixu
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+fan
+fan
+fan
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 lIn
 lIn
 lIn
@@ -31225,11 +32816,11 @@ fZo
 eXx
 kcZ
 pwc
-fGS
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -31450,18 +33041,18 @@ uOW
 uOW
 kcZ
 kcZ
-nJI
-ixu
-ixu
+qTR
+fan
+fan
 uiA
 uiA
 uiA
 uiA
-lTR
-lTR
-lTR
-lTR
-nJI
+aTx
+aTx
+aTx
+aTx
+qTR
 lIn
 lIn
 lIn
@@ -31483,11 +33074,11 @@ pfm
 eXx
 kcZ
 pwc
-fGS
+iIT
 sut
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -31708,9 +33299,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-ixu
+aTx
+fan
+fan
 uiA
 qKH
 qKH
@@ -31742,10 +33333,10 @@ eXx
 kcZ
 pwc
 gXu
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -31966,9 +33557,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-lTR
+aTx
+fan
+aTx
 uiA
 qKH
 uli
@@ -31999,11 +33590,11 @@ pfm
 eXx
 kcZ
 pwc
-fGS
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -32224,9 +33815,9 @@ uOW
 uOW
 kcZ
 kcZ
-ixu
-ixu
-lTR
+fan
+fan
+aTx
 uiA
 qKH
 uli
@@ -32257,11 +33848,11 @@ pfm
 eXx
 kcZ
 pwc
-fGS
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -32482,9 +34073,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 qKH
 svz
@@ -32515,11 +34106,11 @@ qTB
 eXx
 pwc
 pwc
-fGS
-fGS
-fGS
-fGS
-fGS
+iIT
+iIT
+iIT
+iIT
+iIT
 pwc
 pwc
 kcZ
@@ -32740,9 +34331,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 qKH
 vwT
@@ -32773,11 +34364,11 @@ pfm
 slK
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -32998,9 +34589,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 qKH
 xpH
@@ -33031,11 +34622,11 @@ pfm
 sIA
 tPv
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -33256,9 +34847,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 qKH
 qKH
@@ -33289,11 +34880,11 @@ pfm
 sIA
 tPv
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -33514,9 +35105,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-lTR
+aTx
+fan
+aTx
 uiA
 qKH
 jcH
@@ -33547,11 +35138,11 @@ eXx
 eXx
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -33772,9 +35363,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 qKH
 jcH
@@ -33805,11 +35396,11 @@ lTR
 lTR
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -34030,9 +35621,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 qKH
 qKH
@@ -34063,11 +35654,11 @@ nCF
 nCF
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -34288,9 +35879,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 qKH
 fVG
@@ -34321,11 +35912,11 @@ fgP
 nCF
 udN
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -34546,9 +36137,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-lTR
+aTx
+fan
+aTx
 uiA
 qKH
 fVG
@@ -34579,11 +36170,11 @@ jhd
 nCF
 udN
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -34804,9 +36395,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-lTR
+aTx
+fan
+aTx
 uiA
 qKH
 nJC
@@ -34837,11 +36428,11 @@ xOq
 nCF
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
-nJI
+aTx
+aTx
+aTx
+aTx
+qTR
 mGX
 hHa
 kcZ
@@ -35062,9 +36653,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 qKH
 bGB
@@ -35095,11 +36686,11 @@ xOq
 cho
 tPv
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -35320,9 +36911,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-nJI
+aTx
+aTx
+qTR
 uiA
 qKH
 uli
@@ -35353,11 +36944,11 @@ azG
 nCF
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -35578,9 +37169,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 qKH
 uli
@@ -35611,11 +37202,11 @@ odZ
 nCF
 mkY
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -35836,9 +37427,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 qKH
 uli
@@ -35869,11 +37460,11 @@ vQg
 nCF
 mkY
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -36094,9 +37685,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 qKH
 qKH
@@ -36127,11 +37718,11 @@ uxt
 nCF
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -36352,9 +37943,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 uiA
 uiA
@@ -36385,11 +37976,11 @@ nCF
 nCF
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -36610,9 +38201,9 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
 uiA
 uiA
 uiA
@@ -36643,11 +38234,11 @@ lTR
 lTR
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -36868,10 +38459,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 vKr
 vKr
 nmF
@@ -36901,11 +38492,11 @@ uyL
 uyL
 cVh
 mGX
-lTR
-nJI
-lTR
-lTR
-lTR
+aTx
+qTR
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -37126,10 +38717,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-lTR
-lTR
+aTx
+fan
+aTx
+aTx
 vKr
 vKr
 ihP
@@ -37159,11 +38750,11 @@ vKr
 vKr
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -37384,10 +38975,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-ixu
-lTR
+aTx
+aTx
+fan
+aTx
 vKr
 vKr
 ihP
@@ -37417,11 +39008,11 @@ vKr
 vKr
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -37642,10 +39233,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-ixu
-lTR
+aTx
+fan
+fan
+aTx
 vKr
 vKr
 ihP
@@ -37675,11 +39266,11 @@ vKr
 mSx
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -37900,10 +39491,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-ixu
-lTR
+aTx
+fan
+fan
+aTx
 vKr
 vKr
 ihP
@@ -37933,11 +39524,11 @@ vKr
 vKr
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -38158,10 +39749,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-ixu
-lTR
+aTx
+fan
+fan
+aTx
 vKr
 vKr
 ihP
@@ -38191,11 +39782,11 @@ vKr
 vKr
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -38416,10 +40007,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-ixu
-lTR
+aTx
+fan
+fan
+aTx
 vKr
 vKr
 ihP
@@ -38449,11 +40040,11 @@ vKr
 vKr
 tXJ
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -38674,10 +40265,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-lTR
-lTR
+aTx
+fan
+aTx
+aTx
 vKr
 vKr
 ihP
@@ -38707,11 +40298,11 @@ vKr
 vKr
 vKr
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -38932,10 +40523,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-lTR
-lTR
+aTx
+fan
+aTx
+aTx
 vKr
 vKr
 ihP
@@ -38965,11 +40556,11 @@ jPG
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -39190,10 +40781,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-ixu
-ixu
+aTx
+fan
+fan
+fan
 vKr
 vKr
 ihP
@@ -39223,11 +40814,11 @@ jPG
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -39349,7 +40940,7 @@ rDu
 rDu
 xoh
 lpj
-hss
+jFD
 hss
 lpj
 vRo
@@ -39448,10 +41039,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-ixu
-lTR
+aTx
+fan
+fan
+aTx
 mnD
 vKr
 ihP
@@ -39481,11 +41072,11 @@ vKr
 vKr
 vKr
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -39706,10 +41297,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-ixu
-ixu
-lTR
+aTx
+fan
+fan
+aTx
 vKr
 vKr
 ihP
@@ -39739,11 +41330,11 @@ vKr
 vKr
 bVV
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -39964,10 +41555,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 vKr
 vKr
 ihP
@@ -39997,11 +41588,11 @@ kpw
 vKr
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -40222,10 +41813,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 vKr
 mkY
 ihP
@@ -40255,11 +41846,11 @@ kpw
 vKr
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -40480,10 +42071,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-nJI
-lTR
-lTR
+aTx
+qTR
+aTx
+aTx
 vKr
 vKr
 ihP
@@ -40513,11 +42104,11 @@ kpw
 vKr
 ihP
 mGX
-lTR
-lTR
-nJI
-lTR
-lTR
+aTx
+aTx
+qTR
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -40738,10 +42329,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 vKr
 vKr
 ihP
@@ -40771,11 +42362,11 @@ kpw
 vKr
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -40996,10 +42587,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 vKr
 vKr
 ihP
@@ -41029,11 +42620,11 @@ kpw
 vKr
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -41254,10 +42845,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 vKr
 vKr
 ihP
@@ -41287,11 +42878,11 @@ kpw
 vKr
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -41512,10 +43103,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 vKr
 vKr
 ihP
@@ -41545,11 +43136,11 @@ kpw
 vKr
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -41770,10 +43361,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 vKr
 vKr
 ihP
@@ -41803,11 +43394,11 @@ vKr
 vKr
 ihP
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -42028,10 +43619,10 @@ uOW
 uOW
 kcZ
 kcZ
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 vKr
 vKr
 fcZ
@@ -42061,11 +43652,11 @@ uyL
 uyL
 vPB
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 hHa
 kcZ
@@ -42319,11 +43910,11 @@ tPv
 tPv
 tPv
 uiA
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 hHa
 hHa
 hHa
@@ -42571,22 +44162,22 @@ tPv
 tPv
 tPv
 uiA
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 qab
 cem
 tUn
@@ -42817,34 +44408,34 @@ hhf
 hhf
 hhf
 mGX
-lTR
-ixu
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-ixu
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+fan
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+fan
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 qab
 ksj
 tUn
@@ -43075,34 +44666,34 @@ klX
 vIR
 hhf
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-ixu
-ixu
-ixu
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+fan
+fan
+fan
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 qab
 tUn
 tUn
@@ -43333,34 +44924,34 @@ cCO
 cCO
 wgq
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-nJI
-lTR
-lTR
-lTR
-ixu
-ixu
-ixu
-ixu
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+qTR
+aTx
+aTx
+aTx
+fan
+fan
+fan
+fan
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 qab
 tUn
 elg
@@ -43591,10 +45182,10 @@ cCO
 cCO
 wgq
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 rJj
 pbe
 pbe
@@ -43609,16 +45200,16 @@ neM
 kkJ
 pbe
 rYi
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 qab
 tUn
 fqb
@@ -43849,10 +45440,10 @@ cCO
 cCO
 hhf
 oyk
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 jIm
 pjc
 nWP
@@ -43867,10 +45458,10 @@ mBD
 rPK
 pjc
 vKp
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 pwc
 pwc
 pwc
@@ -44107,10 +45698,10 @@ cCO
 cCO
 uzB
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 jIm
 nWP
 muT
@@ -44125,10 +45716,10 @@ mBD
 rPK
 nWP
 vKp
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 pwc
 cwz
 cwz
@@ -44365,10 +45956,10 @@ dHr
 cCO
 uzB
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 mGX
 oFV
 rTS
@@ -44383,10 +45974,10 @@ lTR
 oFV
 oFV
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 pwc
 cwz
 sFk
@@ -44623,10 +46214,10 @@ cCO
 cCO
 hhf
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 mGX
 ixu
 ixu
@@ -44641,10 +46232,10 @@ jNk
 lTR
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 lTR
 cwz
 cwz
@@ -44881,10 +46472,10 @@ cCO
 gMj
 hhf
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 mGX
 ixu
 ixu
@@ -44899,10 +46490,10 @@ lTR
 lTR
 lTR
 mGX
-lTR
-lTR
-nJI
-lTR
+aTx
+aTx
+qTR
+aTx
 lTR
 lTR
 lTR
@@ -45139,10 +46730,10 @@ cCO
 cCO
 hhf
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 mGX
 lTR
 lTR
@@ -45157,10 +46748,10 @@ lTR
 lTR
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 lTR
 lTR
 lTR
@@ -45397,10 +46988,10 @@ ylv
 cCO
 hhf
 mGX
-lTR
-nJI
-lTR
-lTR
+aTx
+qTR
+aTx
+aTx
 mGX
 lTR
 lTR
@@ -45415,10 +47006,10 @@ lTR
 lTR
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 lTR
 lTR
 lTR
@@ -45655,10 +47246,10 @@ hhf
 lCT
 hhf
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 mGX
 lTR
 lTR
@@ -45673,10 +47264,10 @@ lTR
 lTR
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 hHa
 xeT
 xeT
@@ -45913,10 +47504,10 @@ cjr
 mwO
 hhf
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 mGX
 lTR
 lTR
@@ -45931,10 +47522,10 @@ jNk
 lTR
 lTR
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 hHa
 xeT
 nPI
@@ -46171,10 +47762,10 @@ mwO
 mwO
 hhf
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 mGX
 klO
 klO
@@ -46189,10 +47780,10 @@ lTR
 klO
 klO
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 hHa
 xeT
 xeT
@@ -46429,10 +48020,10 @@ mwO
 mwO
 hhf
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 jIm
 nWP
 nWP
@@ -46447,10 +48038,10 @@ npD
 nWP
 nWP
 vKp
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 hHa
 bvN
 bvN
@@ -46687,10 +48278,10 @@ aAv
 xRg
 hhf
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 jIm
 pjc
 nWP
@@ -46705,10 +48296,10 @@ npD
 nWP
 pjc
 vKp
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 hHa
 bvN
 ovr
@@ -46945,10 +48536,10 @@ hhf
 hhf
 hhf
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 rYi
 nhu
 nhu
@@ -46963,10 +48554,10 @@ mGX
 nhu
 nhu
 rYi
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 hHa
 bvN
 bvN
@@ -47203,28 +48794,28 @@ fIM
 fIM
 pqD
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 hHa
 hHa
 hHa
@@ -47461,28 +49052,28 @@ tpp
 rrG
 pqD
 mGX
-lTR
-lTR
-nJI
-lTR
-lTR
-lTR
-lTR
-nJI
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+qTR
+aTx
+aTx
+aTx
+aTx
+qTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 pwc
 kcZ
 kcZ
@@ -47719,28 +49310,28 @@ bAl
 rrG
 pqD
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 pwc
 kcZ
 kcZ
@@ -47977,28 +49568,28 @@ bAl
 rrG
 fXR
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 pwc
 kcZ
 kcZ
@@ -48253,10 +49844,10 @@ mGX
 mGX
 mGX
 mGX
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
 pwc
 kcZ
 kcZ
@@ -54836,35 +56427,35 @@ cpX
 hPe
 "}
 (103,1,1) = {"
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
-mGW
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
+fuy
 mGW
 mGW
 mGW
@@ -55094,35 +56685,35 @@ cpX
 hPe
 "}
 (104,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -55205,11 +56796,11 @@ xuH
 xuH
 xuH
 iXd
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 iXd
 xuH
 xuH
@@ -55352,35 +56943,35 @@ fzl
 hPe
 "}
 (105,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+bOh
+bOh
+bOh
+bOh
+bOh
+bOh
+bOh
+bOh
+bOh
+vrG
+aWG
+tgj
+tgj
+tSB
+tSB
+tSB
+tSB
+tgj
+tgj
+tSB
+tSB
+tgj
+tgj
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -55463,11 +57054,11 @@ xuH
 xuH
 xuH
 iXd
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 iXd
 xuH
 xuH
@@ -55610,35 +57201,35 @@ fzl
 hPe
 "}
 (106,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+bOh
+rBu
+wYr
+tgj
+tgj
+tgj
+wYr
+tgj
+bOh
+vrG
+aWG
+vrG
+ogY
+tSB
+tSB
+tSB
+aUc
+tgj
+tSB
+tSB
+tSB
+tgj
+aUc
+vrG
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -55721,11 +57312,11 @@ xuH
 xuH
 xuH
 iXd
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 iXd
 xuH
 xuH
@@ -55868,35 +57459,35 @@ fzl
 hPe
 "}
 (107,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+bOh
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+bOh
+vrG
+tgj
+vrG
+tgj
+tSB
+tSB
+tSB
+tSB
+tgj
+tSB
+tSB
+tSB
+tgj
+tgj
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -55979,11 +57570,11 @@ xuH
 xuH
 xuH
 ang
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 iXd
 xuH
 xuH
@@ -56126,35 +57717,35 @@ fzl
 hPe
 "}
 (108,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+bOh
+tgj
+tgj
+afC
+qlF
+fGt
+tgj
+tgj
+bOh
+vrG
+tgj
+vrG
+tgj
+tSB
+tSB
+tSB
+tSB
+tgj
+tSB
+tSB
+tSB
+tgj
+vrG
+tSB
+vrG
+vrG
+fuy
 kIl
 kIl
 dLz
@@ -56237,11 +57828,11 @@ xuH
 xuH
 xuH
 iXd
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 iXd
 xuH
 xuH
@@ -56384,35 +57975,35 @@ fzl
 hPe
 "}
 (109,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+bOh
+tgj
+tgj
+kIY
+rrD
+qNV
+tgj
+tgj
+bOh
+vrG
+tgj
+vrG
+vrG
+vrG
+vmn
+cUz
+bne
+szB
+dQA
+vrG
+vrG
+tSB
+vrG
+tSB
+vrG
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -56495,11 +58086,11 @@ xuH
 xuH
 xuH
 iXd
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 iXd
 xuH
 xuH
@@ -56642,35 +58233,35 @@ fzl
 hPe
 "}
 (110,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+bOh
+tgj
+tgj
+eeo
+qgI
+wei
+tgj
+tgj
+bOh
+vrG
+tgj
+vrG
+tyX
+dfx
+bYA
+tgj
+rgX
+tgj
+tgj
+tSB
+tSB
+tSB
+vrG
+tSB
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -56753,11 +58344,11 @@ xuH
 xuH
 xuH
 iXd
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 iXd
 xuH
 xuH
@@ -56900,35 +58491,35 @@ fzl
 hPe
 "}
 (111,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+bOh
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+bOh
+vrG
+tgj
+vrG
+tyX
+tgj
+tgj
+tgj
+tSB
+tgj
+tgj
+tSB
+tSB
+tSB
+tSB
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -57011,11 +58602,11 @@ xuH
 xuH
 xuH
 iXd
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 iXd
 xuH
 xuH
@@ -57158,35 +58749,35 @@ fzl
 hPe
 "}
 (112,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+bOh
+tgj
+tgj
+tgj
+cDc
+tgj
+tgj
+vFt
+bOh
+vrG
+tgj
+vrG
+lUR
+tjg
+tgj
+tgj
+tSB
+tgj
+aUc
+tSB
+tSB
+tSB
+tSB
+aUc
+vrG
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -57269,11 +58860,11 @@ xuH
 xuH
 xuH
 iXd
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 iXd
 xuH
 xuH
@@ -57416,35 +59007,35 @@ eAB
 hPe
 "}
 (113,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+bOh
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vFt
+bOh
+vrG
+tgj
+vrG
+vrG
+tgj
+tgj
+tgj
+tSB
+tgj
+tgj
+tSB
+tSB
+tSB
+tSB
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -57527,11 +59118,11 @@ xuH
 xuH
 xuH
 iXd
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 iXd
 xuH
 xuH
@@ -57674,35 +59265,35 @@ fzl
 hPe
 "}
 (114,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+bOh
+tgj
+tgj
+tgj
+tgj
+cDc
+tgj
+ymi
+bOh
+vrG
+tgj
+tgj
+vrG
+tYP
+tgj
+tgj
+tSB
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 dLz
@@ -57785,11 +59376,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -57932,35 +59523,35 @@ fzl
 hPe
 "}
 (115,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+bOh
+bOh
+bOh
+tgj
+tgj
+tgj
+lUa
+bOh
+bOh
+vrG
+vrG
+tgj
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -58043,11 +59634,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -58190,35 +59781,35 @@ fzl
 hPe
 "}
 (116,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+fuy
 kIl
 kIl
 kIl
@@ -58301,11 +59892,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -58448,35 +60039,35 @@ fzl
 hPe
 "}
 (117,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+vrG
+vrG
+tgj
+tgj
+tgj
+aUc
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+aUc
+tgj
+tgj
+fuy
 kIl
 kIl
 kIl
@@ -58559,11 +60150,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -58706,35 +60297,35 @@ fzl
 hPe
 "}
 (118,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+sSL
+tgj
+tgj
+tgj
+tgj
+vrG
+vrG
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+fuy
 kIl
 kIl
 kIl
@@ -58817,11 +60408,11 @@ kIl
 jPG
 jPG
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -58964,35 +60555,35 @@ fzl
 hPe
 "}
 (119,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+tgj
+aUc
+tgj
+vrG
+vmn
+cUz
+cUz
+bne
+vrG
+tgj
+tgj
+vrG
+vrG
+vrG
+tgj
+tgj
+vrG
+vrG
+vrG
+vrG
+vrG
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+fuy
 kIl
 kIl
 kIl
@@ -59075,11 +60666,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -59222,35 +60813,35 @@ fzl
 hPe
 "}
 (120,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+fuy
 dLz
 kIl
 kIl
@@ -59333,11 +60924,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -59480,35 +61071,35 @@ fzl
 hPe
 "}
 (121,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+aUc
+tgj
+tgj
+khU
+tgj
+aUc
+tgj
+tgj
+tgj
+aUc
+tgj
+tgj
+tgj
+tgj
+fuy
 kIl
 kIl
 kIl
@@ -59591,11 +61182,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -59738,35 +61329,35 @@ fzl
 hPe
 "}
 (122,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+tgj
+tgj
+tgj
+vrG
+tgj
+aUc
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+fuy
 kIl
 kIl
 kIl
@@ -59849,11 +61440,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -59996,35 +61587,35 @@ fzl
 hPe
 "}
 (123,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -60107,11 +61698,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -60254,35 +61845,35 @@ fzl
 hPe
 "}
 (124,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+vrG
+vrG
+vrG
+tgj
+tgj
+tgj
+vrG
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+fuy
 kIl
 dLz
 kIl
@@ -60365,11 +61956,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -60512,35 +62103,35 @@ eAB
 hPe
 "}
 (125,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -60623,11 +62214,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -60770,35 +62361,35 @@ eAB
 hPe
 "}
 (126,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+aUc
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -60881,11 +62472,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -61028,35 +62619,35 @@ eAB
 hPe
 "}
 (127,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+tgj
+tgj
+vrG
+vrG
+vmn
+bne
+vrG
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -61139,11 +62730,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -61286,35 +62877,35 @@ qty
 hPe
 "}
 (128,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+amV
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -61397,11 +62988,11 @@ kIl
 jPG
 jPG
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -61544,35 +63135,35 @@ eAB
 hPe
 "}
 (129,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+tgj
+tgj
+aUc
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -61655,11 +63246,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -61802,35 +63393,35 @@ eAB
 hPe
 "}
 (130,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+nOW
+nOW
+nOW
+nOW
+nOW
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -61913,11 +63504,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -62060,35 +63651,35 @@ eAB
 hPe
 "}
 (131,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -62171,11 +63762,11 @@ tPv
 tPv
 tPv
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -62318,35 +63909,35 @@ eAB
 hPe
 "}
 (132,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+bNs
+tgj
+vrG
+tgj
+tgj
+vrG
+vrG
+vrG
+vrG
+vrG
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -62394,46 +63985,46 @@ rXW
 lTR
 lTR
 lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -62576,35 +64167,35 @@ qty
 hPe
 "}
 (133,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+aUc
+tgj
+tgj
+bNs
+tgj
+vrG
+vrG
+vrG
+vrG
+tgj
+tgj
+tgj
+aUc
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -62652,46 +64243,46 @@ rXW
 lTR
 lTR
 pYG
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -62834,35 +64425,35 @@ qty
 hPe
 "}
 (134,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-mGW
+fuy
+vrG
+tgj
+vrG
+vrG
+vrG
+vrG
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+fuy
 kIl
 kIl
 kIl
@@ -62910,46 +64501,46 @@ rXW
 lTR
 lTR
 pYG
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -63092,34 +64683,34 @@ eAB
 hPe
 "}
 (135,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
-fuy
-fuy
-fuy
-fuy
-fuy
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+nOW
+qki
+nMk
+qki
+nOW
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+vrG
+vrG
+vrG
+vrG
 fuy
 kIl
 kIl
@@ -63168,46 +64759,46 @@ rXW
 lTR
 lTR
 lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -63350,29 +64941,29 @@ qty
 hPe
 "}
 (136,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
 vrG
 vrG
 vrG
@@ -63461,11 +65052,11 @@ tPv
 tPv
 tPv
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -63608,29 +65199,29 @@ qty
 hPe
 "}
 (137,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
-fuy
-fuy
-fuy
-fuy
-fuy
-fuy
-fuy
-fuy
-fuy
-fuy
-fuy
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+aUc
+tgj
+tgj
 vrG
 qnD
 qnD
@@ -63719,11 +65310,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -63866,19 +65457,13 @@ qty
 hPe
 "}
 (138,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
 vrG
+tgj
+tgj
+aUc
+tgj
+tgj
 vrG
 vrG
 vrG
@@ -63889,6 +65474,12 @@ vrG
 vrG
 vrG
 vrG
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
 vrG
 qnD
 qnD
@@ -63977,11 +65568,11 @@ kIl
 jPG
 jPG
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -64124,29 +65715,29 @@ qty
 hPe
 "}
 (139,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
 vrG
-bOh
-bOh
-bOh
-bOh
-bOh
-bOh
-bOh
-bOh
-bOh
+tgj
+tgj
+tgj
+tgj
+tgj
 vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+vrG
+tgj
 vrG
 qnD
 wQa
@@ -64235,11 +65826,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -64382,29 +65973,29 @@ qty
 hPe
 "}
 (140,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
 vrG
-bOh
-rBu
-wYr
 tgj
 tgj
 tgj
-wYr
 tgj
-bOh
+tgj
 vrG
+tgj
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+tgj
+tgj
+vrG
+vrG
+tgj
 vrG
 qnD
 qnD
@@ -64493,11 +66084,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -64640,29 +66231,29 @@ qty
 hPe
 "}
 (141,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
 vrG
-bOh
 tgj
-tgj
-tgj
-tgj
-tgj
-tgj
-tgj
-bOh
 vrG
+vrG
+vrG
+vrG
+vrG
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
 vrG
 qnD
 nzL
@@ -64751,11 +66342,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -64898,29 +66489,29 @@ qty
 hPe
 "}
 (142,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
 vrG
-bOh
 tgj
 tgj
-afC
-qlF
-fGt
 tgj
 tgj
-bOh
+tgj
 vrG
+tgj
+vrG
+tgj
+vrG
+vrG
+vrG
+vrG
+vrG
+tgj
+vrG
+tgj
+tgj
+aUc
+tgj
+tgj
 vrG
 qnD
 qnD
@@ -64986,7 +66577,7 @@ ghU
 ghU
 wPM
 teH
-hPd
+jvT
 hPd
 hPd
 hPd
@@ -65009,11 +66600,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -65156,29 +66747,29 @@ qty
 hPe
 "}
 (143,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
 vrG
-bOh
 tgj
 tgj
-kIY
-rrD
-qNV
 tgj
-tgj
-bOh
 vrG
+tgj
+vrG
+tgj
+vrG
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
+tgj
 vrG
 qnD
 qnD
@@ -65243,14 +66834,14 @@ sYd
 sYd
 hJh
 wPM
+jNo
+jNo
+jNo
+jNo
+jNo
+jNo
+jNo
 bOr
-bOr
-bOr
-bOr
-bOr
-bOr
-bOr
-jcI
 lTR
 lTR
 lTR
@@ -65267,11 +66858,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -65414,29 +67005,29 @@ qty
 hPe
 "}
 (144,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
 vrG
-bOh
 tgj
-tgj
-eeo
-qgI
-wei
-tgj
-tgj
-bOh
 vrG
+tgj
+vrG
+vrG
+vrG
+tgj
+vrG
+vrG
+vrG
+vrG
+vrG
+tgj
+vrG
+tgj
+tgj
+tgj
+vrG
+vrG
+vrG
+tgj
 vrG
 qnD
 qnD
@@ -65501,14 +67092,14 @@ sYd
 sYd
 sYd
 wPM
+dZv
+jNo
+jNo
+jNo
+jNo
+jNo
+jNo
 bOr
-bOr
-bOr
-bOr
-bOr
-bOr
-bOr
-jcI
 lTR
 lTR
 lTR
@@ -65525,11 +67116,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -65672,29 +67263,29 @@ qty
 hPe
 "}
 (145,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
 vrG
-bOh
 tgj
-tgj
-tgj
-tgj
-tgj
-tgj
-tgj
-bOh
 vrG
+aUc
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
+aUc
+vrG
+tgj
+tgj
+vrG
+tgj
+aUc
+tgj
+tgj
+tgj
+vrG
+tgj
 vrG
 qnD
 qnD
@@ -65759,35 +67350,35 @@ xck
 wPM
 xck
 wPM
-gmY
-uAS
-uAS
-uAS
-dsS
+jNo
+jNo
+jNo
+jNo
+jNo
+jNo
+jNo
 bOr
-bOr
-bOr
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+gBR
+gBR
+gBR
+gBR
+gBR
+gBR
+gBR
+gBR
+gBR
+gBR
+gBR
 kIl
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -65930,29 +67521,29 @@ qty
 hPe
 "}
 (146,1,1) = {"
-mGW
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
 fuy
 vrG
-bOh
 tgj
-tgj
-tgj
-cDc
-tgj
-tgj
-vFt
-bOh
 vrG
+tgj
+vrG
+vrG
+vrG
+vrG
+vrG
+vrG
+tgj
+tgj
+tgj
+aUc
+vrG
+tgj
+tgj
+vrG
+vrG
+vrG
+vrG
+tgj
 vrG
 qnD
 qnD
@@ -66017,14 +67608,14 @@ lbg
 wPM
 lbg
 wPM
-rJM
-bOr
-bOr
-bOr
-jFD
-uAS
-uAS
-xZf
+jNo
+jNo
+jNo
+jNo
+jNo
+sHe
+mbF
+mbF
 lTR
 lTR
 lTR
@@ -66041,11 +67632,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -66189,28 +67780,28 @@ hPe
 "}
 (147,1,1) = {"
 fuy
-fuy
-fuy
-fuy
-fuy
-fuy
-fuy
-fuy
-fuy
-fuy
-kIl
-fuy
 vrG
-bOh
 tgj
 tgj
 tgj
 tgj
 tgj
+aUc
 tgj
-vFt
-bOh
+tgj
 vrG
+vrG
+vrG
+tgj
+tgj
+vrG
+tgj
+tgj
+vrG
+tgj
+tgj
+tgj
+tgj
 vrG
 qnD
 qnD
@@ -66275,14 +67866,14 @@ wPM
 wPM
 wPM
 wPM
-rJM
-gmY
-dsS
-bOr
-gmY
-uAS
-uAS
-hXy
+jNo
+jNo
+jNo
+jNo
+jNo
+mbF
+mbF
+mbF
 lTR
 lTR
 lTR
@@ -66299,11 +67890,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -66455,20 +68046,20 @@ vrG
 vrG
 vrG
 vrG
-fuy
-fuy
-fuy
+tgj
+tgj
+tgj
+tgj
+tgj
+tgj
 vrG
-bOh
 tgj
 tgj
 tgj
 tgj
-cDc
 tgj
-ymi
-bOh
-vrG
+tgj
+tgj
 vrG
 qnD
 qnD
@@ -66533,35 +68124,35 @@ pGp
 pGp
 pGp
 wPM
-rJM
-rJM
-rJM
-bOr
-vmn
-jvT
-bOr
-jcI
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+kFt
+jNo
+jNo
+jNo
+jNo
+mbF
+mbF
+hXy
+dsS
+dsS
+dsS
+dsS
+dsS
+dsS
+dsS
+dsS
+dsS
+dsS
+dsS
 kIl
 kIl
 jPG
 jPG
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -66717,15 +68308,15 @@ vrG
 vrG
 vrG
 vrG
-bOh
-bOh
-bOh
+vrG
+vrG
+vrG
 tgj
 tgj
-tgj
-lUa
-bOh
-bOh
+vrG
+vrG
+vrG
+vrG
 vrG
 vrG
 qnD
@@ -66791,13 +68382,13 @@ pGp
 pGp
 qGW
 wPM
-rJM
-rJM
-rJM
-bOr
-jFD
-uAS
-uAS
+kFt
+jNo
+jNo
+jNo
+jNo
+mbF
+mbF
 xZf
 lTR
 lTR
@@ -66815,11 +68406,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -67049,13 +68640,13 @@ wPM
 wPM
 wPM
 wPM
-jFD
-aLN
-jFD
-uAS
-uAS
-uAS
-cgv
+jNo
+jNo
+jNo
+jNo
+jNo
+mbF
+mbF
 hXy
 lTR
 lTR
@@ -67073,11 +68664,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -67308,12 +68899,12 @@ wPM
 pzs
 wPM
 eUL
-oLI
-bOr
-bOr
-bOr
-bOr
-rJM
+jNo
+jNo
+jNo
+jNo
+mbF
+mbF
 jcI
 hfI
 lTR
@@ -67326,16 +68917,16 @@ lTR
 lTR
 lTR
 hfI
-kIl
+wji
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -67565,35 +69156,35 @@ xck
 wPM
 xck
 wPM
-tQw
-cUz
-bne
-bne
-bne
-mAG
-rJM
-bOr
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-kIl
+jNo
+jNo
+jNo
+jNo
+jNo
+mbF
+mbF
+mbF
+enN
+enN
+enN
+enN
+enN
+enN
+enN
+enN
+enN
+enN
+enN
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -67823,35 +69414,35 @@ sYd
 sYd
 hJh
 wPM
-ttW
-qrQ
-cLV
-cLV
-cLV
-aWG
-ogY
-bOr
-epd
+dZv
+jNo
+jNo
+jNo
+jNo
+mbF
+mbF
+mbF
+enN
 gFH
 avf
 wkd
 rGJ
 rbF
 pYB
-epd
+enN
 pRJ
-iHV
-epd
-kIl
-kIl
+sed
+enN
+oVM
+hSI
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -68081,35 +69672,35 @@ xck
 wPM
 xck
 wPM
-xnL
-tjn
-bOr
-bOr
-bOr
+jNo
+jNo
+jNo
+jNo
+jNo
 mbF
 sHe
 mbF
-epd
+enN
 ixQ
 cTE
 cTE
 cTE
 cTE
 cTE
-epd
-mOR
-mUk
-epd
-kIl
+enN
+nog
+luH
+enN
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -68339,35 +69930,35 @@ bCG
 wPM
 bCG
 wPM
-bOr
-bOr
-bOr
-ivc
-bOr
+jNo
+jNo
+jNo
+jNo
+jNo
 mbF
 mbF
 sHe
-epd
+enN
 wSm
 cTE
 cTE
 cTE
 cTE
 qAG
-epd
-epd
-jVS
-epd
-kIl
+enN
+enN
+tme
+enN
+tGE
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -68597,35 +70188,35 @@ wPM
 wPM
 wPM
 wPM
-bOr
-kXB
-bOr
-sva
-bOr
+jNo
+jNo
+jNo
+jNo
+jNo
 mbF
 sHe
 mbF
 gBz
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-aJc
-dgT
-epd
-kIl
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+pNM
+rHw
+enN
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -68855,35 +70446,35 @@ mfD
 mfD
 mfD
 wPM
-bOr
-khU
-bOr
-khU
-bOr
+kFt
+jNo
+jNo
+jNo
+jNo
 mbF
 mbF
 mbF
-epd
+enN
 rQv
-qan
-vwl
-wEq
-wEq
-epd
-epd
-epd
+boF
+bZJ
+lAT
+lAT
+enN
+enN
+enN
 mYs
-epd
-kIl
-kIl
+enN
+oVM
+dsG
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -69113,35 +70704,35 @@ gLM
 gLM
 mfD
 wPM
-bOr
-khU
-bOr
-khU
-bOr
+jNo
+jNo
+jNo
+jNo
+jNo
 mKY
 mbF
 mKY
-epd
-wEq
+enN
+lAT
 pBo
 qLF
 iWc
 ifd
-epd
+enN
 qxv
 iVO
 aHs
 fmB
-kIl
+oVM
 kIl
 jPG
 jPG
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -69371,35 +70962,35 @@ bJJ
 gLM
 mfD
 wPM
-bOr
-khU
-bOr
-khU
-bOr
+jNo
+jNo
+jNo
+jNo
+jNo
 mbF
 mbF
 mbF
-epd
-kao
-wEq
-wEq
+enN
+iKR
+lAT
+lAT
 iWc
-tSw
-epd
+jCa
+enN
 aJP
 aHs
 aHs
 fmB
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -69629,35 +71220,35 @@ kfS
 gLM
 mfD
 wPM
-bOr
-khU
-bOr
-khU
-bOr
+dZv
+jNo
+jNo
+jNo
+jNo
 mbF
 mKY
 nrp
-epd
-kao
-uYn
-uYn
+enN
+iKR
+xkx
+xkx
 iWc
-qiH
-epd
+jKc
+enN
 khJ
 uqE
 cWw
-epd
-kIl
+enN
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -69887,35 +71478,35 @@ xZU
 gLM
 pol
 wPM
-bOr
-gBR
-bOr
-ezi
-bOr
+jNo
+jNo
+jNo
+jNo
+jNo
 mbF
 mbF
 nrp
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-kIl
+enN
+enN
+enN
+enN
+enN
+enN
+enN
+enN
+enN
+enN
+enN
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -70145,35 +71736,35 @@ dBj
 gLM
 mfD
 wPM
-bOr
-bOr
-bOr
-bOr
-bOr
+jNo
+jNo
+jNo
+jNo
+jNo
 mbF
 mbF
 nrp
-epd
+kdB
 iDr
 ane
 joA
 qRP
 dFF
 jSK
-epd
-pRJ
-iHV
-epd
-kIl
+kdB
+qba
+flB
+kdB
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -70403,35 +71994,35 @@ nNV
 gLM
 mfD
 wPM
-bOr
-bOr
-bOr
-bOr
-bOr
+jNo
+jNo
+jNo
+jNo
+jNo
 mbF
 sHe
 mbF
-epd
+kdB
 axg
 aGv
 aGv
 aGv
 aGv
 aGv
-epd
-mOR
+kdB
+uVX
 mUk
-epd
-kIl
+kdB
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -70661,35 +72252,35 @@ umx
 gLM
 mfD
 wPM
-bOr
+kFt
 noI
 bCC
 oWi
-bOr
+jNo
 mbF
 mbF
 mbF
-epd
+kdB
 wKS
 aGv
 aGv
 aGv
 aGv
 nxY
-epd
-epd
-jVS
-epd
-kIl
+kdB
+kdB
+tbN
+kdB
+tGE
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -70919,35 +72510,35 @@ lvy
 kKd
 mfD
 wPM
-bOr
+kFt
 lzM
 bYn
 abC
-bOr
+jNo
 mbF
 mbF
 sHe
 rom
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
 aJc
-dgT
-epd
-kIl
-kIl
+pGH
+kdB
+oVM
+dsG
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -71177,35 +72768,35 @@ gLM
 gLM
 mfD
 wPM
-bOr
+kFt
 fjD
 bYn
 abC
-bOr
+jNo
 mbF
 mbF
 mbF
-epd
+kdB
 saD
 xRd
 lHF
 jFf
 jFf
-epd
-epd
-epd
+kdB
+kdB
+kdB
 onX
-epd
-kIl
+kdB
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -71435,35 +73026,35 @@ nWE
 gLM
 mfD
 wPM
-bOr
+jNo
 tlY
 brW
 khC
-bOr
+jNo
 mbF
 mKY
 mKY
-epd
+kdB
 jFf
 xEl
 jIp
 kOw
 nrY
-epd
+kdB
 oxT
 bTn
 hsD
 swk
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -71693,35 +73284,35 @@ hfi
 gLM
 mfD
 wPM
-bOr
-bOr
-bOr
+jNo
+jNo
+jNo
 ivc
-bOr
+jNo
 mbF
 mbF
 mbF
-epd
+kdB
 tEr
 jFf
 jFf
 kOw
 uFH
-epd
+kdB
 uMe
 hsD
 hsD
 swk
-kIl
+tGE
 kIl
 jPG
 jPG
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -71951,35 +73542,35 @@ cZE
 gLM
 pol
 wPM
-bOr
-bOr
-bOr
-bOr
-bOr
+jNo
+jNo
+jNo
+jNo
+jNo
 mbF
 sHe
 mbF
-epd
+kdB
 tEr
 lnS
 lnS
 kOw
 uRx
-epd
+kdB
 pxI
 dFd
 eif
-epd
-kIl
-kIl
+kdB
+oVM
+fGS
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -72209,35 +73800,35 @@ nml
 fgo
 mfD
 wPM
-jIZ
-bOr
-bOr
-bOr
-jIZ
+eUL
+jNo
+jNo
+jNo
+eUL
 mKY
 mbF
 mbF
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-kIl
+kdB
+kdB
+kdB
+kdB
+kdB
+kdB
+kdB
+kdB
+kdB
+kdB
+kdB
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -72486,16 +74077,16 @@ wPM
 wPM
 wPM
 kIl
-kIl
+vyR
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -72744,16 +74335,16 @@ jNo
 wPM
 wPM
 kIl
-kIl
+fGS
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -73007,11 +74598,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -73265,11 +74856,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -73429,8 +75020,8 @@ tgj
 tgj
 tgj
 tgj
-tgj
-tgj
+ssN
+vcE
 tgj
 tgj
 tgj
@@ -73523,11 +75114,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -73686,10 +75277,10 @@ tgj
 tgj
 tgj
 tgj
-tgj
-tgj
-tgj
-tgj
+cGy
+aiv
+rmm
+cGy
 tgj
 tgj
 tgj
@@ -73781,11 +75372,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -73944,10 +75535,10 @@ vrG
 tgj
 tgj
 tgj
-tgj
-tgj
-tgj
-tgj
+cGy
+cGy
+cGy
+cGy
 tgj
 tgj
 tgj
@@ -74039,11 +75630,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -74203,7 +75794,7 @@ tgj
 tgj
 tgj
 tgj
-tgj
+qyn
 tgj
 tgj
 tgj
@@ -74297,11 +75888,11 @@ wPM
 jPG
 jPG
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -74555,11 +76146,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -74813,11 +76404,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -75071,11 +76662,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -75329,11 +76920,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -75587,11 +77178,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -75848,8 +77439,8 @@ mGX
 cwz
 cwz
 cwz
-lTR
-lTR
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -76106,8 +77697,8 @@ mGX
 cwz
 xje
 cwz
-lTR
-lTR
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -76364,8 +77955,8 @@ mGX
 cwz
 cwz
 cwz
-lTR
-lTR
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -76619,11 +78210,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -76877,11 +78468,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -77135,11 +78726,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -77393,11 +78984,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -77651,11 +79242,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -77909,11 +79500,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -78167,11 +79758,11 @@ wPM
 jPG
 jPG
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -78425,11 +80016,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -78683,11 +80274,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -78941,11 +80532,11 @@ wPM
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -79199,11 +80790,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -79452,16 +81043,16 @@ jNo
 wPM
 wPM
 kIl
-kIl
+vdd
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -79695,10 +81286,10 @@ wPM
 wPM
 wPM
 wPM
-wPM
-pGp
-pGp
-pGp
+fKg
+eTu
+rTF
+nWI
 lKQ
 lKQ
 lKQ
@@ -79710,16 +81301,16 @@ lKQ
 lKQ
 lKQ
 lKQ
-kIl
-kIl
+wji
+fGS
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -79954,9 +81545,9 @@ mfD
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 epd
 epd
 epd
@@ -79968,16 +81559,16 @@ epd
 epd
 epd
 epd
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -80212,9 +81803,9 @@ mfD
 mfD
 ihz
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 epd
 uSd
 moh
@@ -80223,19 +81814,19 @@ hBZ
 jQx
 mhy
 epd
-pRJ
+mPJ
 iHV
 epd
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -80431,12 +82022,12 @@ wPM
 wPM
 mfD
 wPM
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+cZD
+nkR
+uJo
+veM
+eIH
+aZi
 wPM
 mfD
 mfD
@@ -80470,9 +82061,9 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 epd
 ghV
 ePC
@@ -80482,18 +82073,18 @@ ePC
 ePC
 epd
 mOR
-mUk
+eKD
 epd
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -80689,12 +82280,12 @@ mfD
 mfD
 mfD
 wPM
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+kss
+kss
+fKI
+vjd
+qpq
+aZi
 wPM
 mfD
 mfD
@@ -80729,8 +82320,8 @@ mfD
 mfD
 wPM
 ftm
-pGp
-pGp
+nhm
+ajQ
 epd
 qIn
 ePC
@@ -80742,16 +82333,16 @@ epd
 epd
 jVS
 epd
-kIl
-kIl
+oVM
+vdd
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -80947,12 +82538,12 @@ mfD
 mfD
 mfD
 wPM
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+tOh
+bQG
+oRL
+jaw
+gVQ
+diP
 wPM
 ihz
 mfD
@@ -80986,30 +82577,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 oAC
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-aJc
-dgT
+aeS
+aeS
+aeS
+aeS
+aeS
+aeS
+aeS
+hfV
+aeS
 epd
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -81205,12 +82796,12 @@ wPM
 wPM
 wPM
 wPM
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+eRK
+eRK
+kss
+saj
+ugR
+kss
 wPM
 mfD
 mfD
@@ -81244,9 +82835,9 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 epd
 fwZ
 qan
@@ -81258,16 +82849,16 @@ epd
 epd
 sJh
 epd
-kIl
-kIl
+oVM
+crG
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -81448,27 +83039,27 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+awD
+kIc
+yfs
+yfs
+ipC
+cag
+hzU
+hzU
+dTX
+uqz
+dES
+hqN
+qjX
+vTk
+syO
+vpG
+ivl
+aZi
+oJW
+kss
+aZi
 wPM
 mfD
 mfD
@@ -81502,30 +83093,30 @@ wPM
 mfD
 xJF
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 epd
 wEq
-pBo
-qLF
-iWc
-ifd
+xJs
+mqX
+nzP
+vdb
 epd
 bos
 uZT
 cqn
 wkK
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -81706,27 +83297,27 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
+awD
+cXe
+cXe
+yfs
+ipC
+hzU
+rVY
+hzU
+dTX
+dES
+dES
+hqN
+qjX
+vpG
+gDd
+vpG
+ivl
+iWh
+aZi
+aZi
+aZi
 wPM
 mfD
 ihz
@@ -81760,30 +83351,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 epd
 kao
 wEq
 wEq
-iWc
+nzP
 tSw
 epd
 hwS
 cqn
 cqn
 wkK
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -81964,27 +83555,27 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+awD
+yfs
+yfs
+yfs
+ipC
+hzU
+hzU
+hzU
+dTX
+dES
+dES
+dES
+qjX
+vin
+kLe
+vpG
+ivl
+oJW
+aZi
+yiL
+aZi
 wPM
 mfD
 xJF
@@ -82018,30 +83609,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 epd
 kao
 uYn
 uYn
-iWc
+nzP
 qiH
 epd
 gIm
 neC
 sNQ
 epd
-kIl
+tGE
 kIl
 jPG
 jPG
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -82222,27 +83813,27 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+awD
+wPk
+xUp
+jxs
+ipC
+hOI
+aUe
+uSA
+dTX
+pul
+wTU
+pIO
+qjX
+pzL
+ayz
+jPB
+ivl
+oae
+aZi
+aZi
+diP
 wPM
 mfD
 mfD
@@ -82276,9 +83867,9 @@ cVF
 ihz
 mfD
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 epd
 epd
 epd
@@ -82290,16 +83881,16 @@ epd
 epd
 epd
 epd
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -82480,27 +84071,27 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+awD
+dzT
+ipC
+ipC
+ipC
+wii
+dTX
+dTX
+dTX
+gPR
+qjX
+qjX
+qjX
+pNv
+oDb
+ivl
+ivl
+jpy
+ivr
+eRK
+eRK
 wPM
 mfD
 mfD
@@ -82534,30 +84125,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+sWf
 hAQ
 hlj
 ffM
 ifX
 cHE
 qjp
-epd
-pRJ
-iHV
-epd
-kIl
+sWf
+rNo
+nDt
+sWf
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -82738,28 +84329,28 @@ tgj
 vrG
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+lcd
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+xuX
 ihz
 mfD
 pPo
@@ -82792,30 +84383,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+sWf
 uXy
 hGy
 hGy
 hGy
 hGy
 hGy
-epd
-mOR
-mUk
-epd
-kIl
+sWf
+fMZ
+vwn
+sWf
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -82996,28 +84587,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+qbH
+gVF
+gVF
+gVF
+gVF
+gVF
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+lcd
+qbH
+qbH
+qbH
+xuX
 mfD
 mfD
 wPM
@@ -83051,29 +84642,29 @@ mfD
 mfD
 wPM
 ftm
-pGp
-pGp
-epd
+nhm
+ajQ
+sWf
 dCS
 hGy
 hGy
 hGy
 hGy
 ocj
-epd
-epd
-jVS
-epd
-kIl
-kIl
+sWf
+sWf
+mqT
+sWf
+oVM
+crG
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -83254,28 +84845,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+qbH
+gVF
+eLf
+nvu
+thx
+gVF
+qbH
+qbH
+yhp
+aOK
+qfi
+uVx
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+xuX
 mfD
 mfD
 wPM
@@ -83308,30 +84899,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 wrr
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-aJc
-dgT
-epd
-kIl
+dzQ
+dzQ
+dzQ
+dzQ
+dzQ
+dzQ
+dzQ
+kCv
+dzQ
+sWf
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -83512,28 +85103,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+qbH
+bNT
+duU
+mky
+hGH
+gVF
+qbH
+yhp
+uqt
+lhR
+wWt
+cdC
+jdX
+kVm
+fcO
+xKL
+qfi
+xfq
+qfi
+qfi
+xuX
 mfD
 mfD
 wPM
@@ -83566,30 +85157,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+sWf
 wNS
 kGV
 fim
 dwH
 dwH
-epd
-epd
-epd
+sWf
+sWf
+sWf
 hKT
-epd
-kIl
+sWf
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -83770,28 +85361,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+qbH
+gVF
+gHF
+aAH
+gVF
+gVF
+qbH
+jWY
+lhR
+pqd
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+xuX
 mfD
 mfD
 wPM
@@ -83824,30 +85415,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+sWf
 dwH
 jxe
 woJ
 ulc
 uqx
-epd
+sWf
 wDy
 stq
 hFX
 ewx
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -84028,28 +85619,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+qbH
+gVF
+gVF
+gVF
+gVF
+gVF
+qbH
+jWY
+lhR
+jbT
+nzO
+lhR
+lhR
+lhR
+nzO
+jbT
+lhR
+lhR
+lhR
+lhR
+xuX
 mfD
 xJF
 wPM
@@ -84082,30 +85673,30 @@ wPM
 mfD
 ihz
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+sWf
 mVR
 dwH
 dwH
 ulc
 pDH
-epd
+sWf
 uJK
 hFX
 hFX
 ewx
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -84286,28 +85877,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+uzw
+uzw
+pTD
+lut
+lut
+soT
+qbH
+jWY
+lhR
+pXn
+lhR
+sjg
+lhR
+lhR
+lhR
+lhR
+pqd
+lhR
+lhR
+lhR
+xuX
 ihR
 ihR
 wPM
@@ -84340,30 +85931,30 @@ cVF
 mfD
 xJF
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+sWf
 mVR
 kHq
 kHq
 ulc
 aon
-epd
+sWf
 jGS
 wAv
 fDg
-epd
-kIl
+sWf
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -84544,28 +86135,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+oVy
+sAO
+sAO
+tyk
+lut
+syD
+qbH
+gPA
+thL
+lhR
+lhR
+wgL
+dTK
+nOE
+uUA
+nOE
+oCA
+nOE
+nOE
+nOE
+xuX
 wPM
 wPM
 wPM
@@ -84598,30 +86189,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-kIl
+ycu
+nhm
+ajQ
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -84802,28 +86393,28 @@ tgj
 vrG
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+xTU
+dhl
+ugg
+oIG
+lut
+qvq
+qbH
+ljQ
+fSy
+dax
+dax
+dZc
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+xuX
 ouN
 vgN
 ouN
@@ -84856,30 +86447,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+iXf
 esR
 tFD
 vRU
 wWm
 kWn
 qfX
-epd
-pRJ
-iHV
-epd
-kIl
+iXf
+nyl
+pDR
+iXf
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -85060,28 +86651,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+lFd
+dhl
+dhl
+oIG
+rdj
+iMc
+qbH
+yhp
+fur
+lhR
+lhR
+cdC
+qfi
+nLa
+qfi
+qfi
+qfi
+qfi
+jfo
+qfi
+xuX
 ouN
 tiz
 ouN
@@ -85114,30 +86705,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+iXf
 dEk
 wNb
 wNb
 wNb
 wNb
 wNb
-epd
-mOR
-mUk
-epd
-kIl
-kIl
+iXf
+dRn
+fDN
+iXf
+oVM
+vdd
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -85318,28 +86909,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+hIK
+dhl
+dhl
+oIG
+lut
+qvq
+qbH
+jWY
+lhR
+lhR
+lhR
+lhR
+lhR
+wUw
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+xuX
 ouN
 tiz
 ouN
@@ -85373,29 +86964,29 @@ mfD
 mfD
 wPM
 ftm
-pGp
-pGp
-epd
+nhm
+ajQ
+iXf
 sBU
 wNb
 wNb
 wNb
 wNb
 kWY
-epd
-epd
-jVS
-epd
-kIl
+iXf
+iXf
+tGg
+iXf
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -85576,28 +87167,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+jRV
+dhl
+dhl
+oIG
+bbT
+qdD
+nKT
+jWY
+lhR
+jbT
+nzO
+lhR
+lhR
+lhR
+nzO
+jbT
+lhR
+lhR
+lhR
+lhR
+xuX
 ouN
 noa
 ouN
@@ -85630,9 +87221,9 @@ wPM
 ihz
 mfD
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 cRS
 dgT
 dgT
@@ -85641,19 +87232,19 @@ dgT
 dgT
 dgT
 dgT
-aJc
+dHL
 dgT
-epd
-kIl
+iXf
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -85834,28 +87425,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+jRV
+dhl
+dhl
+oIG
+lut
+qvq
+qbH
+jWY
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+lhR
+xuX
 ouN
 jzh
 tiz
@@ -85888,30 +87479,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+iXf
 stn
 pmF
 oHb
 rWO
 rWO
-epd
-epd
-epd
+iXf
+iXf
+iXf
 iNx
-epd
-kIl
+iXf
+tGE
 kIl
 jPG
 jPG
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -86092,28 +87683,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-dLz
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+hIK
+dhl
+dhl
+oIG
+rdj
+nzw
+dqU
+gPA
+thL
+lhR
+lhR
+wgL
+nrU
+nOE
+nOE
+vFE
+nOE
+rse
+nOE
+nOE
+xuX
 ouN
 jzh
 tiz
@@ -86146,30 +87737,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+iXf
 rWO
 bwN
 lMZ
 daE
 aDw
-epd
+iXf
 oYU
 ehz
 dED
 uCK
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -86350,28 +87941,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-wPM
+xuX
+xTU
+dhl
+dhl
+oIG
+lut
+qvq
+qbH
+qbH
+qbH
+nOE
+nOE
+aLS
+qbH
+qbH
+blH
+qbH
+qbH
+qbH
+qbH
+qbH
+xuX
 ouN
 ouN
 ouN
@@ -86404,30 +87995,30 @@ cVF
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+iXf
 hTp
 rWO
 rWO
 daE
 cfX
-epd
+iXf
 oVX
 dED
 dED
 uCK
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -86608,28 +88199,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-jPG
-wPM
+xuX
+lFd
+dhl
+ugg
+oIG
+lut
+fnu
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+sbp
+sbp
+xuX
 ouN
 ouN
 ouN
@@ -86662,30 +88253,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+iXf
 hTp
 dxe
 dxe
 daE
 ckk
-epd
+iXf
 hAt
 erY
 bmm
-epd
-kIl
+iXf
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -86866,29 +88457,29 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+xuX
+ijc
+eCg
+eCg
+dbk
+lut
+qvq
+qbH
+qbH
+mfJ
+qbH
+qbH
 sbp
-wPM
-ouN
+qbH
+mfJ
+qbH
+qbH
+qbH
+qbH
+sbp
+sbp
+xuX
+kRJ
 ouN
 ohm
 rXH
@@ -86920,30 +88511,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-kIl
+ycu
+nhm
+ajQ
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -87124,30 +88715,30 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
+xuX
+sOV
+sOV
+xma
+lut
+lut
+soT
+qbH
+qbH
+qbH
+qbH
 sbp
-ebN
-ouN
-ouN
+sbp
+sbp
+sbp
+sbp
+sbp
+sbp
+sbp
+sbp
+sbp
+vJD
+kRJ
+kRJ
 ouN
 pGp
 pGp
@@ -87178,30 +88769,30 @@ wPM
 mfD
 xJF
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+eoO
 wAV
 xeP
 fMj
 oqE
 qQH
 jsx
-epd
-pRJ
-iHV
-epd
-kIl
+eoO
+lBI
+nJM
+eoO
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -87382,30 +88973,30 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-aTx
-ebN
-ouN
-ouN
+xuX
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+spe
+fgs
+qbH
+sJv
+sbp
+sbp
+sbp
+sbp
+sbp
+gla
+sbp
+sbp
+sbp
+sbp
+vJD
+kRJ
+kRJ
 ouN
 pGp
 pGp
@@ -87436,30 +89027,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+eoO
 oFn
 wSj
 wSj
 wSj
 wSj
 wSj
-epd
-mOR
-mUk
-epd
-kIl
-kIl
+eoO
+aLr
+oOj
+eoO
+tGE
+vdd
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -87640,29 +89231,29 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-sWf
-wPM
-ouN
+xuX
+ujo
+dqU
+qbH
+dqU
+dqU
+qbH
+iXX
+qbH
+qbH
+qbH
+qbH
+sbp
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+sbp
+sbp
+xuX
+kRJ
 ouN
 ohm
 oWZ
@@ -87695,29 +89286,29 @@ mfD
 mfD
 wPM
 ftm
-pGp
-pGp
-epd
+nhm
+ajQ
+eoO
 uEQ
 wSj
 wSj
 wSj
 wSj
 etN
-epd
-epd
-jVS
-epd
-kIl
+eoO
+eoO
+jxd
+eoO
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -87898,28 +89489,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-jPG
-wPM
+xuX
+soT
+sJv
+dqU
+poO
+snb
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+azq
+qbH
+qbH
+sbp
+sbp
+xuX
 ouN
 ouN
 ouN
@@ -87952,30 +89543,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 kKz
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-aJc
-dgT
-epd
-kIl
+iag
+iag
+iag
+iag
+iag
+iag
+iag
+uYk
+iag
+eoO
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -88156,28 +89747,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-jPG
-wPM
+xuX
+gVN
+qbH
+dqU
+dqU
+dqU
+xSC
+eag
+tZz
+tZz
+tZz
+tZz
+rFt
+loW
+qbH
+bpF
+qbH
+qbH
+qbH
+qbH
+qbH
+xuX
 ouN
 ouN
 ouN
@@ -88210,30 +89801,30 @@ wPM
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+eoO
 nYd
 axn
 pNW
 nKG
 nKG
-epd
-epd
-epd
+eoO
+eoO
+eoO
 rcW
-epd
-kIl
+eoO
+tGE
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -88414,28 +90005,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-jPG
-wPM
+xuX
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+kBb
+kBb
+kBb
+kBb
+kBb
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+qbH
+xuX
 ouN
 ouN
 ouN
@@ -88468,30 +90059,30 @@ cVF
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+eoO
 nKG
 qEy
 erz
 uyc
 uhu
-epd
+eoO
 aXy
 uPj
 uFT
 eis
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -88672,28 +90263,28 @@ tgj
 tgj
 vrG
 fuy
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-dLz
-kIl
-kIl
-kIl
-kIl
-kIl
-kIl
-jPG
-wPM
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
+xuX
 jiV
 ouN
 ouN
@@ -88726,30 +90317,30 @@ wPM
 mfD
 ihz
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+eoO
 rDL
 nKG
 nKG
 uyc
 bvW
-epd
+eoO
 hAV
 uFT
 uFT
 eis
-kIl
+oVM
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -88984,30 +90575,30 @@ mfD
 mfD
 xJF
 wPM
-pGp
-pGp
-pGp
-epd
+ycu
+nhm
+ajQ
+eoO
 rDL
 dHv
 dHv
 uyc
 rCB
-epd
+eoO
 anx
 utS
 cQx
-epd
-kIl
+eoO
+sKj
 kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -89242,30 +90833,30 @@ mfD
 mfD
 mfD
 wPM
-pGp
-pGp
-pGp
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
+ycu
+nhm
+ajQ
+eoO
+eoO
+eoO
+eoO
+eoO
+eoO
+eoO
+eoO
+eoO
+eoO
+eoO
 tPv
 tPv
 tPv
 tPv
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -89500,9 +91091,9 @@ wPM
 wPM
 wPM
 wPM
-pGp
-pGp
-pGp
+ycu
+nhm
+ajQ
 wPM
 wPM
 wPM
@@ -89514,16 +91105,16 @@ uMz
 uMz
 uMz
 uMz
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -89758,30 +91349,30 @@ kIl
 kIl
 kIl
 wPM
-pGp
-pGp
-pGp
+hou
+ojR
+sRu
 fyS
 mfD
 mfD
 mfD
 gmN
 wPM
-xbu
-lTR
-rXW
-lTR
-rXW
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+uzT
+aTx
+bOB
+aTx
+bOB
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -90025,21 +91616,21 @@ mfD
 mfD
 vXR
 wPM
-xbu
-lTR
-rXW
-lTR
-rXW
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+uzT
+aTx
+bOB
+aTx
+bOB
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -90283,21 +91874,21 @@ mfD
 mfD
 mfD
 fyS
-lTR
-lTR
-rXW
-lTR
-rXW
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+bOB
+aTx
+bOB
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -90541,21 +92132,21 @@ mfD
 mfD
 mfD
 wPM
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -90799,21 +92390,21 @@ mfD
 mfD
 mfD
 wPM
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -91057,21 +92648,21 @@ wPM
 wPM
 wPM
 wPM
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -91325,11 +92916,11 @@ tPv
 tPv
 tPv
 hfB
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -91583,11 +93174,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -91841,11 +93432,11 @@ kIl
 jPG
 jPG
 mGX
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 mGX
 jPG
 jPG
@@ -92099,11 +93690,11 @@ kIl
 jPG
 xuH
 iXd
-lTR
-lTR
-lTR
-lTR
-lTR
+aTx
+aTx
+aTx
+aTx
+aTx
 iXd
 jPG
 xuH
@@ -92357,11 +93948,11 @@ kIl
 xuH
 xuH
 hHa
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 hHa
 xuH
 xuH
@@ -92616,10 +94207,10 @@ xuH
 xuH
 hHa
 xQB
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
 hHa
 xuH
 xuH
@@ -92873,11 +94464,11 @@ xuH
 xuH
 xuH
 hHa
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 hHa
 xuH
 xuH
@@ -93131,11 +94722,11 @@ xuH
 xuH
 xuH
 hHa
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 hHa
 xuH
 xuH
@@ -93389,11 +94980,11 @@ xuH
 xuH
 xuH
 hHa
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 hHa
 xuH
 xuH
@@ -93648,10 +95239,10 @@ xuH
 xuH
 hHa
 xQB
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
 hHa
 xuH
 xuH
@@ -94163,11 +95754,11 @@ xuH
 xuH
 xuH
 hHa
-wST
-wST
-wST
-wST
-wST
+aTx
+aTx
+aTx
+aTx
+aTx
 hHa
 xuH
 xuH

--- a/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
+++ b/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
@@ -99,6 +99,24 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"afZ" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
+"agH" = (
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "ahA" = (
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/sciship)
@@ -170,11 +188,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/whiteship)
-"akn" = (
-/obj/structure/table/darkglass,
-/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "akC" = (
 /turf/simulated/wall/phoron,
 /area/vr/powered/cult)
@@ -386,6 +399,11 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"auQ" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "avf" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
@@ -476,9 +494,8 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
 "azq" = (
-/obj/item/weapon/digestion_remains/variant2,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms1)
 "azz" = (
 /obj/machinery/vending/dinnerware{
 	dir = 4;
@@ -744,12 +761,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
+"aIN" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "aJc" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms1)
+/area/vr/powered/mall/dorms/dorms3)
 "aJB" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/item/clothing/under/teshari/undercoat/standard/black_grey,
@@ -804,6 +835,10 @@
 	},
 /area/vr/powered)
 "aLr" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 6
+	},
 /obj/effect/map_effect/perma_light/brighter{
 	light_color = "#e060e0";
 	light_power = 1;
@@ -912,11 +947,6 @@
 "aQJ" = (
 /turf/simulated/wall/cult,
 /area/vr/outdoors/powered/cult)
-"aQR" = (
-/obj/structure/table/hardwoodtable,
-/obj/item/device/flashlight/lamp/green,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "aRb" = (
 /obj/structure/flora/smallbould,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -1136,6 +1166,12 @@
 /obj/item/weapon/reagent_containers/food/snacks/monkeysdelight,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"aZu" = (
+/obj/effect/landmark/virtual_reality{
+	name = "'Strip' Mall"
+	},
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "aZv" = (
 /turf/unsimulated/wall,
 /area/vr/powered/material)
@@ -1404,14 +1440,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
-"blQ" = (
-/obj/structure/table/darkglass,
-/obj/structure/window/basic{
-	dir = 4
-	},
-/obj/item/weapon/material/twohanded/riding_crop,
-/turf/simulated/floor/tiled/milspec/raised,
-/area/vr/powered/mall/secondlife)
 "bmi" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/under/pants/camo,
@@ -1423,6 +1451,11 @@
 /obj/item/weapon/bedsheet/hosdouble,
 /turf/simulated/floor/carpet/retro,
 /area/vr/powered/mall/dorms/dorms5)
+"bmI" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "bmZ" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/wood/alt/panel,
@@ -1583,12 +1616,6 @@
 	},
 /turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
-"buP" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms4)
 "bvk" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/foodcart,
@@ -1694,15 +1721,6 @@
 "bAl" = (
 /turf/simulated/floor/carpet,
 /area/vr/powered/art)
-"bAC" = (
-/obj/structure/table/hardwoodtable,
-/obj/machinery/light/small{
-	dir = 4;
-	nightshift_enabled = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "bAM" = (
 /obj/structure/bonfire/permanent,
 /obj/effect/decal/cleanable/dirt,
@@ -1892,6 +1910,14 @@
 	icon_state = "cult-narsie"
 	},
 /area/vr/powered/cult)
+"bIw" = (
+/obj/item/weapon/digestion_remains/skull/teshari,
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/item/clothing/mask/muzzle/ballgag{
+	pixel_y = -7
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "bII" = (
 /obj/structure/table/marble,
 /obj/item/weapon/storage/firstaid/bonemed{
@@ -1928,6 +1954,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/vet)
+"bKW" = (
+/obj/structure/sign/poster/custom{
+	pixel_y = 0;
+	dir = 2
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "bLz" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/techfloor{
@@ -2062,10 +2095,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/vr/powered/dungeon)
-"bPm" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "bPy" = (
 /obj/structure/sign/science{
 	pixel_y = 32
@@ -2219,6 +2248,12 @@
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack,
 /area/vr/powered/mall)
+"bSk" = (
+/obj/structure/bed/chair/sofa/left/beige{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "bSP" = (
 /obj/structure/sink{
 	dir = 8;
@@ -2300,20 +2335,15 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
-"bWc" = (
-/obj/structure/table/darkglass,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 5
-	},
-/obj/machinery/chemical_dispenser/bar_coffee/full,
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "bWI" = (
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel,
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
+"bWV" = (
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "bXg" = (
 /turf/simulated/wall/sandstonediamond,
 /area/vr/powered)
@@ -2574,9 +2604,6 @@
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled,
 /area/vr/powered/gunshop)
-"ciy" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms4)
 "ciT" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -2687,12 +2714,12 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
-"clK" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 6
+"clV" = (
+/obj/item/toy/plushie/mouse{
+	pixel_y = 2;
+	pixel_x = 6
 	},
-/turf/unsimulated/shuttle/floor/purple,
+/turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "cmf" = (
 /obj/structure/salvageable/data_os{
@@ -3027,16 +3054,11 @@
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
 "cBz" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL3";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/vr/powered/mall/dorms/secondlife3)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms2)
 "cCO" = (
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
@@ -3186,6 +3208,10 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"cIs" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "cIG" = (
 /obj/machinery/light{
 	dir = 4;
@@ -3243,13 +3269,6 @@
 "cLE" = (
 /turf/simulated/shuttle/floor/darkred,
 /area/vr/powered/armory)
-"cMb" = (
-/obj/item/toy/plushie/black_fox{
-	pixel_y = 0;
-	name = "latex black fox"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "cME" = (
 /obj/item/weapon/coin/gold,
 /obj/item/weapon/coin/diamond,
@@ -3292,14 +3311,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
-"cNx" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/obj/item/clothing/under/swimsuit/purple,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "cOM" = (
 /obj/machinery/button/remote/blast_door{
 	id = "vrsewers1";
@@ -3310,6 +3321,14 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
 /area/vr/powered/dungeon)
+"cPN" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "cPW" = (
 /obj/structure/table/standard,
 /obj/random/cigarettes,
@@ -3335,6 +3354,11 @@
 /obj/machinery/light/poi,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
+"cRj" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "cRo" = (
 /obj/structure/window/plastitanium/full,
 /obj/structure/window/reinforced/survival_pod,
@@ -3487,14 +3511,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
-"cZd" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/secondlife)
 "cZo" = (
 /obj/machinery/autolathe{
 	hacked = 1;
@@ -3711,7 +3727,9 @@
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
 "dhl" = (
-/turf/unsimulated/shuttle/floor/purple,
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/mankini,
+/turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "dhv" = (
 /obj/structure/table/wooden_reinforced,
@@ -3834,6 +3852,13 @@
 	},
 /turf/simulated/floor/weird_things/dark,
 /area/vr/powered/mall/backrooms)
+"dlj" = (
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "dlu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -3905,6 +3930,10 @@
 	},
 /turf/unsimulated/floor/tiled/techfloor,
 /area/vr/powered/mall)
+"dnZ" = (
+/obj/item/weapon/tape_roll,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "dop" = (
 /obj/structure/window/phoronreinforced{
 	dir = 1
@@ -4096,13 +4125,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
-"dyK" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "dyO" = (
 /obj/machinery/computer/operating{
 	dir = 4
@@ -4124,17 +4146,13 @@
 	},
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/whiteship)
-"dzE" = (
-/obj/item/weapon/tape_roll,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "dzQ" = (
 /obj/structure/sign/poster/custom{
 	pixel_y = 0;
 	dir = 2
 	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/vr/powered/mall/dorms/secondlife3)
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "dzT" = (
 /obj/machinery/door/airlock/gold{
 	id_tag = "VRmallSL1"
@@ -4236,6 +4254,10 @@
 	specialfunctions = 4;
 	dir = 4;
 	pixel_y = 30
+	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/vr/powered/mall/dorms/dorms4)
@@ -4348,11 +4370,6 @@
 "dHI" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/vr/powered/cult)
-"dJF" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "dKF" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -4390,6 +4407,15 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/vr/powered/mall)
+"dLk" = (
+/obj/machinery/vending/deluxe_boozeomat,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 1;
+	pixel_y = 0
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "dLo" = (
 /obj/structure/closet/l3closet/virology,
 /turf/simulated/floor/tiled/white,
@@ -4813,6 +4839,14 @@
 /obj/item/weapon/reagent_containers/food/snacks/reishicup,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"dVN" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "dWc" = (
 /turf/simulated/floor/wood/alt/parquet,
 /area/vr/powered/mall)
@@ -5283,10 +5317,13 @@
 	},
 /area/vr/powered/rocks)
 "enN" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/mask/muzzle/ballgag,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "eoA" = (
 /obj/machinery/light{
 	dir = 8
@@ -5306,17 +5343,16 @@
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/sciship)
 "eoO" = (
-/obj/structure/table/darkglass,
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 2;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/unsimulated/shuttle/floor/purple,
 /area/vr/powered/mall/secondlife)
 "epd" = (
 /turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms1)
+/area/vr/powered/mall/dorms/dorms6)
 "epk" = (
 /obj/structure/table/marble{
 	pixel_y = 0
@@ -5442,12 +5478,28 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"evB" = (
+/obj/structure/table/darkglass,
+/obj/structure/stripper_pole{
+	icon_scale_x = 0.5;
+	icon_scale_y = 0.5
+	},
+/obj/item/toy/plushie/mouse{
+	pixel_y = 2;
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "evY" = (
 /obj/structure/railing,
 /turf/simulated/floor/outdoors/rocks{
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered/lava)
+"ews" = (
+/obj/item/toy/balloon,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "ewx" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
@@ -5542,11 +5594,6 @@
 /turf/simulated/floor/wood,
 /area/vr/powered)
 "eCg" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 2;
-	pixel_y = 0
-	},
 /turf/unsimulated/shuttle/floor/purple,
 /area/vr/powered/mall/secondlife)
 "eCs" = (
@@ -5783,10 +5830,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
-"eHr" = (
-/obj/item/toy/balloon,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "eHR" = (
 /obj/machinery/light{
 	layer = 3
@@ -5883,13 +5926,8 @@
 /turf/simulated/floor/carpet/geo,
 /area/vr/powered/mall)
 "eKD" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms4)
 "eKF" = (
 /obj/structure/bed/chair/sofa/brown{
 	dir = 8
@@ -6046,6 +6084,17 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"eRp" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL3";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "eRK" = (
 /turf/simulated/wall/sandstone{
 	color = "purple"
@@ -6148,6 +6197,14 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
+"eWW" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "eXx" = (
 /turf/simulated/wall/r_wall,
 /area/vr/powered/bar)
@@ -6185,6 +6242,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/outdoors/road,
 /area/vr/outdoors/powered)
+"fas" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "faC" = (
 /obj/item/clothing/shoes/cult,
 /obj/item/clothing/suit/cultrobes/alt,
@@ -6532,6 +6603,13 @@
 /obj/structure/bed/pillowpile,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/vr/powered/mall/secondlife)
+"fnx" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "fnC" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -6637,6 +6715,14 @@
 	},
 /turf/space,
 /area/vr/space)
+"frI" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "frW" = (
 /obj/machinery/light{
 	dir = 4
@@ -6665,17 +6751,6 @@
 /obj/item/weapon/reagent_containers/food/condiment/soysauce,
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
-"fsK" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "fsL" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
@@ -6706,11 +6781,6 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/redgrid/animated,
 /area/vr/powered/cult)
-"ftN" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/stripper_pink,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "ftQ" = (
 /obj/structure/railing,
 /obj/effect/step_trigger/teleporter/bridge/north_to_south,
@@ -6828,6 +6898,10 @@
 "fwD" = (
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
+"fwJ" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "fwX" = (
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 4
@@ -6850,6 +6924,11 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"fxe" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/mask/muzzle/ballgag,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "fyf" = (
 /obj/structure/prop/rock/small/alt,
 /turf/simulated/floor/outdoors/dirt{
@@ -6998,6 +7077,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"fFp" = (
+/obj/item/device/camera,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "fGt" = (
 /obj/machinery/gateway/brass{
 	dir = 10
@@ -7134,22 +7217,6 @@
 	},
 /turf/simulated/floor/tiled/old_cargo,
 /area/vr/powered/mall/dorms/dorms6)
-"fMq" = (
-/obj/structure/table/darkglass,
-/obj/item/device/mindbinder{
-	pixel_y = 4;
-	pixel_x = -2
-	},
-/obj/item/device/mindbinder{
-	pixel_y = -4;
-	pixel_x = -3
-	},
-/obj/item/device/mindbinder{
-	pixel_y = 2;
-	pixel_x = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "fMF" = (
 /obj/structure/table/marble,
 /obj/structure/window/reinforced{
@@ -7212,20 +7279,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
-"fMP" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "fMQ" = (
 /obj/structure/table/marble{
 	color = "grey"
@@ -7261,6 +7314,15 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
+"fQf" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 9
+	},
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "fQh" = (
 /obj/machinery/vending/loadout/costume{
 	prices = list(/obj/item/clothing/suit/storage/hooded/costume/carp=0,/obj/item/clothing/suit/storage/hooded/costume/carp=0,/obj/item/clothing/suit/chickensuit=0,/obj/item/clothing/head/chicken=0,/obj/item/clothing/head/helmet/gladiator=0,/obj/item/clothing/under/gladiator=0,/obj/item/clothing/suit/storage/toggle/labcoat/mad=0,/obj/item/clothing/under/suit_jacket/green=0,/obj/item/clothing/glasses/gglasses=0,/obj/item/clothing/head/flatcap=0,/obj/item/clothing/shoes/boots/jackboots=0,/obj/item/clothing/under/schoolgirl=0,/obj/item/clothing/head/kitty=0,/obj/item/clothing/glasses/sunglasses/blindfold=0,/obj/item/clothing/head/beret=0,/obj/item/clothing/under/skirt=0,/obj/item/clothing/under/suit_jacket=0,/obj/item/clothing/head/that=0,/obj/item/clothing/accessory/wcoat=0,/obj/item/clothing/under/scratch=0,/obj/item/clothing/shoes/white=0,/obj/item/clothing/gloves/white=0,/obj/item/clothing/under/kilt=0,/obj/item/clothing/glasses/monocle=0,/obj/item/clothing/under/sl_suit=0,/obj/item/clothing/mask/fakemoustache=0,/obj/item/weapon/cane=0,/obj/item/clothing/head/bowler=0,/obj/item/clothing/head/plaguedoctorhat=0,/obj/item/clothing/suit/bio_suit/plaguedoctorsuit=0,/obj/item/clothing/mask/gas/plaguedoctor/fluff=0,/obj/item/clothing/under/owl=0,/obj/item/clothing/mask/gas/owl_mask=0,/obj/item/clothing/under/waiter=0,/obj/item/clothing/suit/storage/apron=0,/obj/item/clothing/under/pirate=0,/obj/item/clothing/head/pirate=0,/obj/item/clothing/suit/pirate=0,/obj/item/clothing/glasses/eyepatch=0,/obj/item/clothing/head/ushanka=0,/obj/item/clothing/under/soviet=0,/obj/item/clothing/suit/imperium_monk=0,/obj/item/clothing/suit/holidaypriest=0,/obj/item/clothing/head/witchwig=0,/obj/item/clothing/under/sundress=0,/obj/item/weapon/staff/broom=0,/obj/item/clothing/suit/wizrobe/fake=0,/obj/item/clothing/head/wizard/fake=0,/obj/item/weapon/staff=0,/obj/item/clothing/mask/gas/sexyclown=0,/obj/item/clothing/under/sexyclown=0,/obj/item/clothing/mask/gas/sexymime=0,/obj/item/clothing/under/sexymime=0,/obj/item/clothing/suit/storage/hooded/knight_costume=0,/obj/item/clothing/suit/storage/hooded/knight_costume/galahad=0,/obj/item/clothing/suit/storage/hooded/knight_costume/lancelot=0,/obj/item/clothing/suit/storage/hooded/knight_costume/robin=0,/obj/item/clothing/suit/armor/combat/crusader_costume=0,/obj/item/clothing/suit/armor/combat/crusader_costume/bedevere=0,/obj/item/clothing/head/helmet/combat/crusader_costume=0,/obj/item/clothing/head/helmet/combat/bedevere_costume=0,/obj/item/clothing/gloves/combat/knight_costume=0,/obj/item/clothing/gloves/combat/knight_costume/brown=0,/obj/item/clothing/shoes/knight_costume=0,/obj/item/clothing/shoes/knight_costume/black=0,/obj/item/clothing/suit/storage/hooded/foodcostume/hotdog=0,/obj/item/clothing/suit/storage/hooded/foodcostume/turnip=0)
@@ -7559,6 +7621,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cult)
+"gbm" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "gbU" = (
 /obj/structure/sign/atmos_air{
 	pixel_x = 32;
@@ -7809,12 +7879,6 @@
 	outdoors = 0
 	},
 /area/vr/powered/dungeon)
-"gqU" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms3)
 "grL" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1
@@ -7840,6 +7904,17 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor/wmarble,
 /area/vr/powered/cult)
+"gtl" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "gui" = (
 /turf/simulated/floor/outdoors/rocks{
 	temperature = 293.15
@@ -7856,6 +7931,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/mall)
+"guZ" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "gvF" = (
 /turf/simulated/floor/tiled,
 /area/vr/powered/nuke)
@@ -8020,6 +8099,14 @@
 	},
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
+"gEm" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "gEJ" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -8183,15 +8270,16 @@
 /obj/structure/bed/chair/comfy/purp,
 /turf/simulated/floor/bronze,
 /area/vr/powered/cult)
+"gNy" = (
+/obj/item/weapon/material/twohanded/riding_crop,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "gNI" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/orange,
 /turf/simulated/floor/carpet/blue,
 /area/vr/powered/motel)
-"gNP" = (
-/obj/item/weapon/handcuffs/legcuffs/fuzzy,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "gNU" = (
 /obj/structure/cliff/automatic/corner,
 /turf/simulated/floor/lava,
@@ -8393,6 +8481,10 @@
 /mob/living/simple_mob/clowns/big/c_shift/chlown,
 /turf/simulated/mineral/floor/ignore_mapgen/cave,
 /area/vr/powered/dungeon)
+"gXY" = (
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "gYA" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/outdoors/grass{
@@ -8420,10 +8512,6 @@
 	},
 /turf/simulated/shuttle/floor/darkred,
 /area/vr/powered/space/sciship)
-"hcr" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "hds" = (
 /obj/structure/window/basic{
 	dir = 1
@@ -8685,12 +8773,6 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/simulated/floor,
 /area/vr/powered)
-"hlR" = (
-/obj/structure/bookcase,
-/obj/item/weapon/book/manual,
-/obj/item/weapon/book/manual,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "hmv" = (
 /obj/machinery/conveyor{
 	id = "vrsushitrain";
@@ -8960,6 +9042,13 @@
 	},
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/whiteship)
+"hvR" = (
+/obj/structure/sign/poster/custom{
+	pixel_y = 0;
+	dir = 2
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "hwS" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -9026,9 +9115,6 @@
 /obj/item/weapon/book/bundle/custom_library/nonfiction/skrelliancastesystem,
 /turf/simulated/floor/carpet/retro,
 /area/vr/powered/mall/dorms/dorms5)
-"hAO" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms1)
 "hAQ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/random/meat,
@@ -9222,11 +9308,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/vr/powered/mall)
-"hKD" = (
-/obj/structure/table/darkglass,
-/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
-/turf/simulated/floor/tiled/milspec/raised,
-/area/vr/powered/mall/secondlife)
 "hKT" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/carpet/brown,
@@ -9259,16 +9340,13 @@
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/dungeon)
 "hOI" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
 	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "hPd" = (
 /obj/structure/railing/grey{
 	pixel_y = 0;
@@ -9285,6 +9363,17 @@
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/cult)
+"hPO" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL1";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "hPU" = (
 /obj/random/cash/huge,
 /obj/random/cash/huge,
@@ -9415,6 +9504,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"hVq" = (
+/obj/structure/bed/chair/sofa/right/beige{
+	dir = 4
+	},
+/obj/machinery/light/floortube{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "hVB" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave{
@@ -9595,12 +9693,16 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/constore)
 "iag" = (
-/obj/structure/sign/poster/custom{
-	pixel_y = 0;
-	dir = 2
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL2";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "iam" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -9689,18 +9791,7 @@
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
-"ifg" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL4";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
+/area/vr/powered/mall/dorms/dorms3)
 "ifF" = (
 /obj/machinery/smartfridge/survival_pod{
 	icon = 'icons/obj/vending.dmi';
@@ -10009,6 +10100,13 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
+"ioj" = (
+/obj/structure/sign/poster/custom{
+	pixel_y = 0;
+	dir = 2
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "ion" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/melee/energy/sword,
@@ -10057,6 +10155,11 @@
 "irA" = (
 /turf/simulated/floor/tiled/neutral,
 /area/vr/powered)
+"isD" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "isZ" = (
 /obj/structure/closet/walllocker_double/kitchen/north{
 	dir = 8;
@@ -10216,13 +10319,10 @@
 	},
 /area/vr/outdoors/powered/mall)
 "ivl" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
+/turf/simulated/wall/sandstone{
+	color = "purple"
 	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
+/area/vr/powered/mall/dorms/secondlife4)
 "ivr" = (
 /obj/machinery/door/airlock/gold{
 	id_tag = "VRmallSL5"
@@ -10327,6 +10427,11 @@
 /obj/item/weapon/reagent_containers/food/snacks/syndicake,
 /turf/simulated/floor/airless,
 /area/vr/space)
+"iyQ" = (
+/turf/simulated/wall/sandstone{
+	color = "purple"
+	},
+/area/vr/powered/mall/secondlife)
 "iyU" = (
 /obj/structure/cliff/automatic{
 	dir = 5
@@ -10441,11 +10546,6 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
-"iGo" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "iGx" = (
 /obj/structure/table/marble,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -10530,11 +10630,6 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/whiteship)
-"iKF" = (
-/obj/structure/curtain/black,
-/obj/machinery/door/airlock/angled_bay/double/glass,
-/turf/simulated/floor/flock,
-/area/vr/powered/mall/secondlife)
 "iLp" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -10573,18 +10668,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/space/whiteship)
-"iMW" = (
-/obj/effect/decal/cleanable/fruit_smudge,
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL5";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/vr/powered/mall/dorms/secondlife5)
 "iNt" = (
 /obj/structure/window/basic,
 /turf/simulated/floor/wood/alt/parquet/turfpack,
@@ -10627,10 +10710,6 @@
 /obj/structure/loot_pile/mecha/odysseus/murdysseus,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/mechfactory)
-"iPE" = (
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "iQe" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -10638,23 +10717,6 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
-"iQY" = (
-/obj/structure/table/darkglass,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/item/weapon/storage/box/glasses/rocks{
-	pixel_y = -2;
-	pixel_x = -10
-	},
-/obj/item/weapon/storage/box/glasses/square{
-	pixel_y = -2;
-	pixel_x = 12
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "iRw" = (
 /obj/structure/bed/chair/office/dark{
 	pixel_y = 0;
@@ -10727,14 +10789,7 @@
 "iWc" = (
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
-"iWd" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 8
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
+/area/vr/powered/mall/dorms/dorms1)
 "iWh" = (
 /obj/item/toy/plushie/possum,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10762,8 +10817,9 @@
 	},
 /area/vr/outdoors/powered)
 "iXf" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms5)
+/obj/item/clothing/mask/muzzle/ballgag,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "iXg" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/device/communicator,
@@ -10947,12 +11003,6 @@
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack,
 /area/vr/powered/mall)
-"jdy" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms5)
 "jdU" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/carpet/blue,
@@ -11154,14 +11204,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/dungeon)
-"jkX" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "jle" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/storage/fancy/cigar/havana,
@@ -11254,8 +11296,11 @@
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
 "jpy" = (
-/obj/item/device/camera,
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/turf/unsimulated/shuttle/floor/purple,
 /area/vr/powered/mall/secondlife)
 "jpL" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -11619,18 +11664,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
-"jGm" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 6
-	},
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "jGt" = (
 /obj/item/weapon/flamethrower/full,
 /turf/simulated/floor/tiled,
@@ -11788,11 +11821,6 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered)
-"jLw" = (
-/turf/simulated/wall/sandstone{
-	color = "purple"
-	},
-/area/vr/powered/mall/secondlife)
 "jMc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
@@ -12038,7 +12066,7 @@
 /obj/effect/floor_decal/milspec/color/silver,
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
+/area/vr/powered/mall/dorms/dorms1)
 "jWs" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -12138,7 +12166,7 @@
 /obj/item/weapon/book/manual,
 /obj/item/weapon/book/manual,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
+/area/vr/powered/mall/dorms/dorms3)
 "kaK" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled,
@@ -12201,13 +12229,13 @@
 /turf/simulated/wall/solidrock,
 /area/vr/powered/rocks)
 "kdB" = (
-/obj/machinery/vending/deluxe_boozeomat,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 1;
-	pixel_y = 0
+/obj/structure/table/darkglass,
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
 	},
-/turf/unsimulated/shuttle/floor/purple,
+/turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "kdJ" = (
 /mob/living/simple_mob/animal/passive/pillbug,
@@ -12265,20 +12293,6 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/vr/powered/mall)
-"kgh" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "kgu" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/snacks/kitsuneudon{
@@ -12480,6 +12494,10 @@
 /obj/item/weapon/stool/padded,
 /turf/simulated/shuttle/floor/yellow,
 /area/vr/powered/space/sciship)
+"kmE" = (
+/obj/item/clothing/under/shiny/catsuit/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "kmG" = (
 /turf/simulated/floor/water/beach/corner{
 	dir = 1;
@@ -12591,18 +12609,6 @@
 	},
 /turf/simulated/floor/redgrid/off,
 /area/vr/powered/cult)
-"kug" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "kuk" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/blue,
@@ -12638,20 +12644,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
-"kuV" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "kvd" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	locked = 0
@@ -12692,10 +12684,6 @@
 /obj/item/clothing/suit/storage/apron/white,
 /turf/simulated/floor/plating,
 /area/vr/powered/cafe)
-"kwJ" = (
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "kxk" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/vr/powered)
@@ -12795,14 +12783,18 @@
 	temperature = 293.15
 	},
 /area/vr/powered/dungeon)
-"kDl" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "kDr" = (
 /obj/machinery/vending/loadout/uniform,
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"kDD" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "kEv" = (
 /obj/item/weapon/storage/box/ambrosiadeus,
 /obj/fruitspawner/ambrosia,
@@ -13264,17 +13256,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
-"kVe" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL2";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms/secondlife2)
 "kVX" = (
 /obj/machinery/door/window/northright{
 	name = "Server Room";
@@ -13413,15 +13394,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/vr/powered/mall)
-"lbr" = (
-/obj/structure/bed/chair/sofa/right/beige{
-	dir = 4
-	},
-/obj/machinery/light/floortube{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "lbK" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/random/meat,
@@ -13546,14 +13518,6 @@
 	dir = 10
 	},
 /area/vr/powered/mall/vw)
-"lgp" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "lhj" = (
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor,
@@ -13568,6 +13532,12 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
+"lhq" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms1)
 "lhR" = (
 /obj/structure/table/darkglass,
 /turf/simulated/floor/tiled/techfloor,
@@ -13610,6 +13580,10 @@
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
+"lky" = (
+/obj/item/weapon/digestion_remains/variant3,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "lkR" = (
 /turf/simulated/floor/wood/broken,
 /area/vr/powered)
@@ -14178,6 +14152,14 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
+"lCG" = (
+/obj/item/weapon/digestion_remains/variant2,
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "lCT" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/plating,
@@ -14399,6 +14381,12 @@
 	},
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/sciship)
+"lMp" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms4)
 "lMZ" = (
 /obj/structure/table/bench/wooden,
 /obj/item/weapon/pen/blade/blue,
@@ -14897,8 +14885,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/sciship)
 "mfJ" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms4)
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "mgc" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/wood,
@@ -14907,13 +14895,6 @@
 /obj/structure/cliff/automatic/corner,
 /turf/simulated/floor/weird_things/dark,
 /area/vr/powered/mall/backrooms)
-"mgZ" = (
-/obj/structure/sign/poster/custom{
-	pixel_y = 0;
-	dir = 2
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/vr/powered/mall/dorms/secondlife5)
 "mha" = (
 /obj/structure/table/marble,
 /obj/structure/window/reinforced,
@@ -15308,21 +15289,20 @@
 "mwO" = (
 /turf/simulated/floor/plating,
 /area/vr/powered/cafe)
+"mwU" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/item/clothing/under/swimsuit/purple,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "mxh" = (
 /obj/effect/decal/remains,
 /turf/simulated/floor/outdoors/rocks{
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered/lava)
-"mxm" = (
-/obj/structure/table/darkglass,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 9
-	},
-/obj/machinery/chemical_dispenser/bar_coffee/full,
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "mxG" = (
 /obj/structure/table/alien/blue,
 /obj/item/weapon/surgical/circular_saw/alien,
@@ -15348,6 +15328,17 @@
 /obj/structure/table/rack,
 /turf/simulated/floor/bmarble,
 /area/vr/powered/mall)
+"myP" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "mzg" = (
 /obj/machinery/autolathe{
 	hacked = 1;
@@ -15611,10 +15602,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered)
-"mJl" = (
-/obj/item/clothing/mask/muzzle/ballgag,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
+"mJa" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "mJE" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/deck/cards,
@@ -15652,6 +15647,11 @@
 	},
 /turf/simulated/floor/redgrid/animated,
 /area/vr/powered/cult)
+"mLz" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/stripper_green,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "mLB" = (
 /obj/structure/bed/chair/sofa/right/brown{
 	dir = 8
@@ -15740,7 +15740,7 @@
 	pixel_x = -5
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
+/area/vr/powered/mall/dorms/dorms3)
 "mOS" = (
 /obj/structure/bed/chair/backed_red{
 	dir = 4
@@ -15847,7 +15847,7 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
+/area/vr/powered/mall/dorms/dorms6)
 "mUR" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -16365,14 +16365,6 @@
 "npj" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/cult)
-"npm" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/flock,
-/area/vr/powered/mall/secondlife)
 "npD" = (
 /obj/structure/railing,
 /turf/simulated/floor/concrete{
@@ -16504,6 +16496,13 @@
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
 /area/vr/powered/dungeon)
+"nuQ" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 6
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "nuY" = (
 /obj/item/weapon/weldingtool/largetank,
 /turf/simulated/floor/tiled,
@@ -16924,9 +16923,8 @@
 	},
 /area/vr/outdoors/powered)
 "nJM" = (
-/obj/structure/curtain/black,
-/turf/simulated/floor/flock,
-/area/vr/powered/mall/secondlife)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms1)
 "nJZ" = (
 /obj/item/weapon/material/twohanded/baseballbat/gold,
 /obj/item/stack/material/gold,
@@ -16977,10 +16975,8 @@
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/dungeon)
 "nKT" = (
-/obj/item/weapon/material/twohanded/riding_crop,
-/obj/effect/decal/cleanable/blood/oil/streak,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms6)
 "nLa" = (
 /obj/structure/bed/pillowpile/orange,
 /obj/effect/floor_decal/corner/purple/border{
@@ -17081,14 +17077,6 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/vr/powered/mall)
-"nOm" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "nOq" = (
 /turf/simulated/floor/airless,
 /area/vr/space)
@@ -17099,6 +17087,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
+"nOQ" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "nOW" = (
 /obj/structure/salvageable/server_os,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -17354,10 +17346,6 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/vr/powered/mall/dorms/dorms6)
-"nYu" = (
-/obj/item/weapon/digestion_remains/variant3,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "nYH" = (
 /obj/structure/salvageable/console_os,
 /turf/simulated/shuttle/floor/voidcraft,
@@ -17914,6 +17902,20 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
+"orV" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "orW" = (
 /turf/simulated/floor/carpet/geo,
 /area/vr/powered/mall)
@@ -18033,6 +18035,14 @@
 	},
 /turf/simulated/floor/bmarble,
 /area/vr/powered/mall)
+"ovU" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
+"ovW" = (
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms2)
 "owa" = (
 /obj/structure/grille/rustic{
 	health = 25;
@@ -18169,6 +18179,18 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/vr/powered/mall/dorms/dorms3)
+"oBf" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "oBi" = (
 /obj/structure/table/darkglass,
 /obj/item/device/flashlight/lamp,
@@ -18246,10 +18268,8 @@
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
 "oDb" = (
-/turf/simulated/wall/sandstone{
-	color = "purple"
-	},
-/area/vr/powered/mall/dorms/secondlife4)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms3)
 "oDd" = (
 /obj/machinery/light{
 	dir = 4
@@ -18392,8 +18412,8 @@
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
 "oIG" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms2)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms4)
 "oJb" = (
 /obj/machinery/light{
 	dir = 1
@@ -18502,12 +18522,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/space/whiteship)
-"oMt" = (
-/obj/structure/bed/chair/sofa/left/beige{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "oMQ" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -18545,6 +18559,20 @@
 /obj/item/stack/material/diamond,
 /turf/simulated/floor/flock,
 /area/vr/powered/rocks)
+"oOY" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "oPe" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -18632,13 +18660,6 @@
 /obj/item/weapon/towel/random,
 /turf/simulated/floor/carpet/bcarpet,
 /area/vr/powered)
-"oVv" = (
-/obj/structure/sign/poster/custom{
-	pixel_y = 0;
-	dir = 2
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms/secondlife)
 "oVM" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/water/pool{
@@ -18682,6 +18703,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/mall)
+"oYF" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "oYU" = (
 /obj/structure/table/rack/shelf/wood,
 /obj/random/plushie,
@@ -18960,13 +18995,6 @@
 	movement_cost = 0
 	},
 /area/vr/outdoors/powered)
-"pjI" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 10
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "pkd" = (
 /obj/machinery/conveyor{
 	id = "vrsushitrain";
@@ -19022,17 +19050,6 @@
 /obj/item/weapon/scepter,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/vr/powered/cult)
-"plZ" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "pma" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -19163,6 +19180,12 @@
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack,
 /area/vr/powered/mall)
+"ppu" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms5)
 "ppH" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/powered/pump/huge,
@@ -19372,7 +19395,7 @@
 "pBo" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms1)
 "pBr" = (
 /obj/structure/table/marble,
 /obj/item/weapon/material/knife/butch,
@@ -19514,11 +19537,8 @@
 	},
 /area/vr/powered/rocks)
 "pGH" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 31
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms2)
 "pGO" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -19632,6 +19652,13 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
+"pKS" = (
+/obj/item/toy/plushie/black_fox{
+	pixel_y = 0;
+	name = "latex black fox"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "pKU" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/toy/figure/assistant,
@@ -19742,14 +19769,6 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/vr/powered/mall/dorms/dorms6)
-"pOd" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "pOg" = (
 /obj/structure/flora/rocks1,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -19787,10 +19806,6 @@
 /obj/item/clothing/accessory/bracelet/material/gold,
 /turf/simulated/floor/flock,
 /area/vr/powered/rocks)
-"pQx" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "pRx" = (
 /obj/structure/toilet{
 	dir = 8;
@@ -19804,7 +19819,7 @@
 "pRJ" = (
 /obj/effect/floor_decal/milspec/color/silver,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
+/area/vr/powered/mall/dorms/dorms1)
 "pRN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -19952,6 +19967,15 @@
 	outdoors = 1
 	},
 /area/vr/outdoors/powered)
+"pZh" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 5
+	},
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "pZp" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -19982,7 +20006,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms1)
 "qaJ" = (
 /obj/machinery/chemical_dispenser/ert/specialops{
 	pixel_y = 7
@@ -20024,8 +20048,11 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
 "qba" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms6)
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual,
+/obj/item/weapon/book/manual,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "qbf" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/cult{
@@ -20173,11 +20200,6 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/wood/alt/parquet/turfpack,
 /area/vr/powered/mall)
-"qfO" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "qfX" = (
 /obj/structure/table/marble,
 /obj/structure/sink/countertop{
@@ -20188,6 +20210,11 @@
 /obj/effect/floor_decal/corner/black/diagonal,
 /turf/simulated/floor/tiled/red,
 /area/vr/powered/mall/dorms/dorms5)
+"qfZ" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "qgk" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -20294,7 +20321,7 @@
 	pixel_y = 0
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms1)
 "qiO" = (
 /obj/structure/cliff/automatic,
 /turf/simulated/floor/lava,
@@ -20456,10 +20483,6 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
-"qot" = (
-/obj/item/clothing/under/shiny/catsuit/poly,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "qou" = (
 /obj/structure/bed/chair/sofa/right/black,
 /turf/simulated/floor/tiled/white,
@@ -20536,11 +20559,6 @@
 "qty" = (
 /turf/simulated/floor/gorefloor,
 /area/vr/outdoors/powered/cult)
-"qtH" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "qtU" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -21020,6 +21038,10 @@
 	dir = 4;
 	pixel_y = 30
 	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/mall/dorms/dorms3)
 "qIM" = (
@@ -21144,6 +21166,10 @@
 /obj/vehicle/train/engine/quadbike/random,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"qPP" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "qPR" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/material/kitchen/utensil/fork,
@@ -21441,6 +21467,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/dungeon)
+"rgm" = (
+/obj/structure/table/darkglass,
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/item/weapon/material/twohanded/riding_crop,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "rgX" = (
 /obj/machinery/crystal/lava,
 /turf/simulated/floor/lava,
@@ -21805,17 +21839,6 @@
 /obj/structure/fans/tiny,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/dungeon)
-"rvV" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL1";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms/secondlife)
 "rvW" = (
 /obj/machinery/telecomms/relay/preset{
 	name = "VR Telelink"
@@ -21883,6 +21906,13 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/dungeon)
+"rzN" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 10
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "rzY" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/wood/alt/parquet/turfpack,
@@ -21933,12 +21963,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
-"rCs" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms6)
 "rCt" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/mimedouble,
@@ -22035,16 +22059,8 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
 "rHw" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms3)
 "rHO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -22272,6 +22288,18 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/vr/powered/redbase)
+"rSM" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL5";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "rTm" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/wood/alt/tile,
@@ -22567,6 +22595,11 @@
 /obj/item/weapon/storage/pouch/holding,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"seC" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/stripper_pink,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "seJ" = (
 /obj/structure/railing/grey{
 	pixel_y = 0;
@@ -22682,6 +22715,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
+"skm" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "skq" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/closet/jcloset,
@@ -22692,11 +22729,6 @@
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/whiteship)
-"slv" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "slC" = (
 /obj/machinery/robotic_fabricator,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -22933,6 +22965,17 @@
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/space/mechfactory)
+"suB" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL4";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "svz" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
@@ -23003,18 +23046,6 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/building2)
-"swx" = (
-/obj/structure/table/darkglass,
-/obj/structure/stripper_pole{
-	icon_scale_x = 0.5;
-	icon_scale_y = 0.5
-	},
-/obj/item/toy/plushie/mouse{
-	pixel_y = 2;
-	pixel_x = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "swz" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -23164,6 +23195,10 @@
 	dir = 4;
 	pixel_y = 30
 	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/red,
 /area/vr/powered/mall/dorms/dorms5)
 "sCe" = (
@@ -23243,6 +23278,15 @@
 /obj/structure/fans/hardlight,
 /turf/simulated/floor/airless,
 /area/vr/powered/space/mechfactory)
+"sEP" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/light/small{
+	dir = 4;
+	nightshift_enabled = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "sFk" = (
 /obj/effect/simple_portal/linked{
 	portal_id = 70;
@@ -23370,6 +23414,22 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"sJv" = (
+/obj/structure/table/darkglass,
+/obj/item/device/mindbinder{
+	pixel_y = 4;
+	pixel_x = -2
+	},
+/obj/item/device/mindbinder{
+	pixel_y = -4;
+	pixel_x = -3
+	},
+/obj/item/device/mindbinder{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "sJy" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/dip/guac,
@@ -23432,6 +23492,12 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"sNs" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms6)
 "sNE" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/stock_parts/scanning_module/adv{
@@ -23622,8 +23688,8 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/vr/powered/mall)
 "sWf" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms2)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms5)
 "sWx" = (
 /turf/simulated/shuttle/floor/darkred,
 /area/vr/powered/space/sciship)
@@ -23920,6 +23986,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
+"tnK" = (
+/obj/structure/sign/poster/custom{
+	pixel_y = 0;
+	dir = 2
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "tol" = (
 /obj/machinery/light{
 	dir = 1
@@ -24167,6 +24240,10 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
+"tzg" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "tzq" = (
 /mob/living/simple_mob/animal/giant_spider,
 /turf/simulated/floor/plating,
@@ -24279,20 +24356,6 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
-"tDU" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "tEr" = (
 /obj/structure/bookcase,
 /obj/item/weapon/book/manual,
@@ -24366,20 +24429,8 @@
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
 "tGg" = (
-/obj/structure/table/darkglass,
-/obj/item/device/bodysnatcher{
-	pixel_y = 4;
-	pixel_x = 3
-	},
-/obj/item/device/bodysnatcher{
-	pixel_y = -2;
-	pixel_x = -2
-	},
-/obj/item/device/bodysnatcher{
-	pixel_y = -4;
-	pixel_x = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/curtain/black,
+/turf/simulated/floor/flock,
 /area/vr/powered/mall/secondlife)
 "tGi" = (
 /obj/machinery/light{
@@ -24521,6 +24572,11 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/cult)
+"tMF" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "tMG" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -24847,6 +24903,11 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"tYL" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "tYP" = (
 /obj/structure/prop/dominator/blue,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -25391,9 +25452,6 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
-"usA" = (
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "usM" = (
 /obj/structure/simple_door/flock,
 /turf/simulated/floor/flock,
@@ -25655,6 +25713,10 @@
 	dir = 4;
 	pixel_y = 30
 	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/old_cargo,
 /area/vr/powered/mall/dorms/dorms6)
 "uFe" = (
@@ -25856,11 +25918,6 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
-"uKc" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/stripper_green,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "uKg" = (
 /turf/simulated/shuttle/wall/hard_corner,
 /area/vr/powered/space/whiteship)
@@ -26150,12 +26207,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "uVX" = (
-/obj/structure/sign/poster/custom{
-	pixel_y = 0;
-	dir = 2
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms/secondlife2)
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "uWc" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/sign/department/cargo_dock{
@@ -26218,9 +26279,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
-"uYM" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms6)
 "uZT" = (
 /obj/machinery/button/windowtint{
 	id = "vrmalltint1";
@@ -26265,8 +26323,16 @@
 /turf/simulated/floor/plating,
 /area/vr/outdoors/powered)
 "vdb" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms3)
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "vdd" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/outdoors/grass{
@@ -26435,11 +26501,6 @@
 "vjp" = (
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
-"vjy" = (
-/obj/structure/table/bench/wooden,
-/obj/item/weapon/pen/blade/blue,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "vjB" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/pancakes{
@@ -26940,20 +27001,6 @@
 /obj/structure/bed/pillowpile/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
-"vGe" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "vGh" = (
 /obj/machinery/vending/wardrobe/hydrobe{
 	req_access = null
@@ -27240,14 +27287,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
-"vSE" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/obj/item/clothing/accessory/shiny/gloves/poly,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "vSJ" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave{
@@ -27340,11 +27379,6 @@
 /obj/item/weapon/reagent_containers/food/condiment/small/saltshaker,
 /turf/simulated/floor/wood,
 /area/vr/powered)
-"vVj" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/mankini,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "vVx" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/maintenance/clean,
@@ -27507,12 +27541,6 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/whiteship)
-"wbh" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms2)
 "wbm" = (
 /obj/structure/table/marble{
 	color = "grey"
@@ -27978,10 +28006,6 @@
 /obj/mecha/combat/phazon/old,
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/sciship)
-"wxd" = (
-/obj/item/clothing/accessory/shiny/gloves/poly,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "wxu" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/effect/floor_decal/techfloor{
@@ -28181,6 +28205,10 @@
 	},
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
+"wEW" = (
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "wFa" = (
 /mob/living/simple_mob/animal/giant_spider,
 /turf/simulated/floor/tiled,
@@ -28218,17 +28246,6 @@
 	},
 /turf/simulated/floor/weird_things/dark,
 /area/vr/powered/mall/backrooms)
-"wGx" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "wGy" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/item/weapon/stool{
@@ -28307,6 +28324,10 @@
 	specialfunctions = 4;
 	dir = 4;
 	pixel_y = 30
+	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/old_cargo/purple,
 /area/vr/powered/mall/dorms/dorms2)
@@ -28449,10 +28470,6 @@
 	outdoors = 0
 	},
 /area/vr/powered/rocks)
-"wOq" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "wPa" = (
 /turf/simulated/wall/wood,
 /area/vr/powered/rocks)
@@ -28521,6 +28538,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/space/mechfactory)
+"wRz" = (
+/obj/structure/curtain/black,
+/obj/machinery/door/airlock/angled_bay/double/glass,
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "wRG" = (
 /obj/structure/railing,
 /turf/simulated/floor/beach/sand/desert{
@@ -28542,6 +28564,10 @@
 	specialfunctions = 4;
 	dir = 4;
 	pixel_y = 30
+	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/dorms/dorms1)
@@ -28588,6 +28614,11 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/whiteship)
+"wTJ" = (
+/obj/structure/table/bench/wooden,
+/obj/item/weapon/pen/blade/blue,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "wTU" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -28595,6 +28626,14 @@
 /obj/effect/decal/cleanable/fruit_smudge,
 /turf/simulated/floor/carpet/purcarpet,
 /area/vr/powered/mall/dorms/secondlife3)
+"wTY" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
 "wUr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -28602,7 +28641,10 @@
 /turf/unsimulated/floor/tiled/techfloor,
 /area/vr/powered/mall)
 "wUw" = (
-/turf/simulated/wall/wood,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 31
+	},
+/turf/simulated/floor/carpet/oracarpet,
 /area/vr/powered/mall/dorms/dorms3)
 "wUx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -28723,7 +28765,7 @@
 /turf/simulated/floor/tiled/red,
 /area/vr/powered/mall/dorms/dorms5)
 "wWt" = (
-/obj/structure/table/hardwoodtable,
+/obj/item/weapon/stool/padded,
 /turf/simulated/floor/carpet/oracarpet,
 /area/vr/powered/mall/dorms/dorms3)
 "wWC" = (
@@ -28799,14 +28841,6 @@
 	outdoors = 1
 	},
 /area/vr/outdoors/powered)
-"xbG" = (
-/obj/item/weapon/digestion_remains/skull/teshari,
-/obj/effect/decal/cleanable/fruit_smudge,
-/obj/item/clothing/mask/muzzle/ballgag{
-	pixel_y = -7
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "xbS" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -29300,10 +29334,6 @@
 /obj/item/weapon/gun/projectile/automatic/serdy/awp,
 /turf/simulated/floor/reinforced,
 /area/vr/powered/redbase)
-"xxG" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "xys" = (
 /turf/simulated/mineral/alt{
 	temperature = 293.15
@@ -29519,6 +29549,14 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
+"xGX" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "xHm" = (
 /obj/machinery/conveyor{
 	id = "vrsushitrain";
@@ -29614,6 +29652,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
+"xKI" = (
+/obj/structure/table/darkglass,
+/obj/item/device/bodysnatcher{
+	pixel_y = 4;
+	pixel_x = 3
+	},
+/obj/item/device/bodysnatcher{
+	pixel_y = -2;
+	pixel_x = -2
+	},
+/obj/item/device/bodysnatcher{
+	pixel_y = -4;
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "xLm" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/item/weapon/stool{
@@ -29955,6 +30009,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
+"ydc" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/box/glasses/rocks{
+	pixel_y = -2;
+	pixel_x = -10
+	},
+/obj/item/weapon/storage/box/glasses/square{
+	pixel_y = -2;
+	pixel_x = 12
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "ydM" = (
 /obj/structure/salvageable/data_os,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -69273,17 +69344,17 @@ jNo
 mbF
 mbF
 mbF
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
 oVM
 kIl
 jPG
@@ -69531,17 +69602,17 @@ jNo
 mbF
 mbF
 mbF
-epd
+nJM
 gFH
 avf
 wkd
 rGJ
 rbF
 pYB
-epd
-pQx
-kgh
-epd
+nJM
+pRJ
+oOY
+nJM
 oVM
 hSI
 jPG
@@ -69789,17 +69860,17 @@ jNo
 mbF
 sHe
 mbF
-epd
+nJM
 ixQ
 cTE
 cTE
 cTE
 cTE
 cTE
-epd
-pOd
-wGx
-epd
+nJM
+xGX
+uVX
+nJM
 oVM
 kIl
 jPG
@@ -70047,17 +70118,17 @@ jNo
 mbF
 mbF
 sHe
-epd
+nJM
 wSm
 cTE
 cTE
 cTE
 cTE
 qAG
-epd
-epd
-dJF
-epd
+nJM
+nJM
+jVS
+nJM
 tGE
 kIl
 jPG
@@ -70306,16 +70377,16 @@ mbF
 sHe
 mbF
 gBz
-hAO
-hAO
-hAO
-hAO
-hAO
-hAO
-hAO
-aJc
-hAO
-epd
+azq
+azq
+azq
+azq
+azq
+azq
+azq
+lhq
+azq
+nJM
 oVM
 kIl
 jPG
@@ -70563,17 +70634,17 @@ jNo
 mbF
 mbF
 mbF
-epd
+nJM
 rQv
-oMt
-lbr
+qan
+hVq
 wEq
 wEq
-epd
-epd
-epd
+nJM
+nJM
+nJM
 mYs
-epd
+nJM
 oVM
 dsG
 jPG
@@ -70821,13 +70892,13 @@ jNo
 mKY
 mbF
 mKY
-epd
+nJM
 wEq
-kwJ
+pBo
 qLF
-iPE
-ifd
-epd
+iWc
+ovU
+nJM
 qxv
 iVO
 aHs
@@ -71079,13 +71150,13 @@ jNo
 mbF
 mbF
 mbF
-epd
-kao
+nJM
+qba
 wEq
 wEq
-iPE
+iWc
 tSw
-epd
+nJM
 aJP
 aHs
 aHs
@@ -71337,17 +71408,17 @@ jNo
 mbF
 mKY
 nrp
-epd
-kao
+nJM
+qba
 uYn
 uYn
-iPE
-bAC
-epd
+iWc
+qiH
+nJM
 khJ
 uqE
 cWw
-epd
+nJM
 oVM
 kIl
 jPG
@@ -71595,17 +71666,17 @@ jNo
 mbF
 mbF
 nrp
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
+nJM
 oVM
 kIl
 jPG
@@ -71853,17 +71924,17 @@ jNo
 mbF
 mbF
 nrp
-oIG
+pGH
 iDr
 ane
 joA
 qRP
 dFF
 jSK
-oIG
-pRJ
-vGe
-oIG
+pGH
+skm
+fas
+pGH
 oVM
 kIl
 jPG
@@ -72111,17 +72182,17 @@ jNo
 mbF
 sHe
 mbF
-oIG
+pGH
 axg
 aGv
 aGv
 aGv
 aGv
 aGv
-oIG
-lgp
-hOI
-oIG
+pGH
+enN
+myP
+pGH
 oVM
 kIl
 jPG
@@ -72369,17 +72440,17 @@ jNo
 mbF
 mbF
 mbF
-oIG
+pGH
 wKS
 aGv
 aGv
 aGv
 aGv
 nxY
-oIG
-oIG
-qfO
-oIG
+pGH
+pGH
+tYL
+pGH
 tGE
 kIl
 jPG
@@ -72628,16 +72699,16 @@ mbF
 mbF
 sHe
 rom
-sWf
-sWf
-sWf
-sWf
-sWf
-sWf
-sWf
-wbh
-sWf
-oIG
+ovW
+ovW
+ovW
+ovW
+ovW
+ovW
+ovW
+cBz
+ovW
+pGH
 oVM
 dsG
 jPG
@@ -72885,17 +72956,17 @@ jNo
 mbF
 mbF
 mbF
-oIG
+pGH
 saD
 xRd
 lHF
 jFf
 jFf
-oIG
-oIG
-oIG
+pGH
+pGH
+pGH
 onX
-oIG
+pGH
 oVM
 kIl
 jPG
@@ -73143,13 +73214,13 @@ jNo
 mbF
 mKY
 mKY
-oIG
+pGH
 jFf
 xEl
 jIp
 kOw
 nrY
-oIG
+pGH
 oxT
 bTn
 hsD
@@ -73401,13 +73472,13 @@ jNo
 mbF
 mbF
 mbF
-oIG
+pGH
 tEr
 jFf
 jFf
 kOw
 uFH
-oIG
+pGH
 uMe
 hsD
 hsD
@@ -73659,17 +73730,17 @@ jNo
 mbF
 sHe
 mbF
-oIG
+pGH
 tEr
 lnS
 lnS
 kOw
 uRx
-oIG
+pGH
 pxI
 dFd
 eif
-oIG
+pGH
 oVM
 fGS
 jPG
@@ -73917,17 +73988,17 @@ eUL
 mKY
 mbF
 mbF
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
-oIG
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
+pGH
 oVM
 kIl
 jPG
@@ -81657,17 +81728,17 @@ wPM
 ycu
 nhm
 ajQ
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
 oVM
 kIl
 jPG
@@ -81915,17 +81986,17 @@ wPM
 ycu
 nhm
 ajQ
-wUw
+oDb
 uSd
 moh
 lRA
 hBZ
 jQx
 mhy
-wUw
-bPm
+oDb
+cIs
 iHV
-wUw
+oDb
 oVM
 kIl
 jPG
@@ -82173,17 +82244,17 @@ wPM
 ycu
 nhm
 ajQ
-wUw
+oDb
 ghV
 ePC
 ePC
 ePC
 ePC
 ePC
-wUw
-jkX
-fsK
-wUw
+oDb
+mOR
+afZ
+oDb
 oVM
 kIl
 jPG
@@ -82431,17 +82502,17 @@ wPM
 ftm
 nhm
 ajQ
-wUw
+oDb
 qIn
 ePC
 ePC
 ePC
 ePC
 mkU
-wUw
-wUw
-iGo
-wUw
+oDb
+oDb
+tMF
+oDb
 oVM
 vdd
 jPG
@@ -82690,16 +82761,16 @@ ycu
 nhm
 ajQ
 oAC
-vdb
-vdb
-vdb
-vdb
-vdb
-vdb
-vdb
-gqU
-vdb
-wUw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+aJc
+rHw
+oDb
 oVM
 kIl
 jPG
@@ -82947,17 +83018,17 @@ wPM
 ycu
 nhm
 ajQ
-wUw
+oDb
 fwZ
-qan
+bSk
 vwl
-usA
-usA
-wUw
-wUw
-wUw
+mfJ
+mfJ
+oDb
+oDb
+oDb
 sJh
-wUw
+oDb
 oVM
 crG
 jPG
@@ -83164,7 +83235,7 @@ qjX
 vTk
 syO
 vpG
-oDb
+ivl
 aZi
 oJW
 kss
@@ -83205,13 +83276,13 @@ wPM
 ycu
 nhm
 ajQ
-wUw
-usA
-pBo
-vjy
-iWc
-aQR
-wUw
+oDb
+mfJ
+tzg
+wTJ
+wWt
+ifd
+oDb
 bos
 uZT
 cqn
@@ -83413,16 +83484,16 @@ yfs
 ipC
 hzU
 rVY
-uVX
+dzQ
 dTX
 dES
 dES
-dzQ
+ioj
 qjX
 vpG
-nYu
-iag
-oDb
+lky
+tnK
+ivl
 iWh
 aZi
 aZi
@@ -83463,13 +83534,13 @@ wPM
 ycu
 nhm
 ajQ
-wUw
-hlR
-usA
-usA
-iWc
+oDb
+kao
+mfJ
+mfJ
 wWt
-wUw
+wEW
+oDb
 hwS
 cqn
 cqn
@@ -83665,26 +83736,26 @@ tgj
 vrG
 fuy
 awD
+agH
 yfs
-yfs
-oVv
+bKW
 ipC
-hzU
+dlj
 hzU
 hzU
 dTX
-dES
+hOI
 dES
 dES
 qjX
-azq
-xbG
+lCG
+bIw
 vpG
-oDb
-oJW
+ivl
+eWW
 aZi
 yiL
-mgZ
+hvR
 wPM
 mfD
 xJF
@@ -83721,17 +83792,17 @@ wPM
 ycu
 nhm
 ajQ
+oDb
+kao
 wUw
-hlR
-pGH
-pGH
-iWc
-qiH
 wUw
+wWt
+sEP
+oDb
 gIm
 neC
 sNQ
-wUw
+oDb
 tGE
 kIl
 jPG
@@ -83923,23 +83994,23 @@ tgj
 vrG
 fuy
 awD
-rvV
+hPO
 xUp
 jxs
 ipC
-kVe
+iag
 aUe
 uSA
 dTX
-cBz
+eRp
 wTU
 pIO
 qjX
-ifg
+suB
 ayz
 jPB
-oDb
-iMW
+ivl
+rSM
 aZi
 aZi
 diP
@@ -83979,17 +84050,17 @@ wPM
 ycu
 nhm
 ajQ
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
+oDb
 oVM
 kIl
 jPG
@@ -84194,9 +84265,9 @@ qjX
 qjX
 qjX
 pNv
-oDb
-oDb
-oDb
+ivl
+ivl
+ivl
 eRK
 ivr
 eRK
@@ -84237,17 +84308,17 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
+eKD
 hAQ
 hlj
 ffM
 ifX
 cHE
 qjp
-mfJ
-xxG
-tDU
-mfJ
+eKD
+qPP
+orV
+eKD
 oVM
 kIl
 jPG
@@ -84446,7 +84517,7 @@ qbH
 qbH
 qbH
 qbH
-dzE
+dnZ
 qbH
 qbH
 qbH
@@ -84495,17 +84566,17 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
+eKD
 uXy
 hGy
 hGy
 hGy
 hGy
 hGy
-mfJ
-mOR
-mUk
-mfJ
+eKD
+dVN
+gtl
+eKD
 oVM
 kIl
 jPG
@@ -84713,7 +84784,7 @@ qbH
 qbH
 qbH
 qbH
-dzE
+dnZ
 qbH
 qbH
 qbH
@@ -84753,17 +84824,17 @@ wPM
 ftm
 nhm
 ajQ
-mfJ
+eKD
 dCS
 hGy
 hGy
 hGy
 hGy
 ocj
-mfJ
-mfJ
-jVS
-mfJ
+eKD
+eKD
+qfZ
+eKD
 oVM
 crG
 jPG
@@ -84964,10 +85035,10 @@ gVF
 qbH
 qbH
 yhp
-cNx
+mwU
 qfi
 uVx
-eHr
+ews
 qbH
 qbH
 qbH
@@ -85012,16 +85083,16 @@ ycu
 nhm
 ajQ
 wrr
-ciy
-ciy
-ciy
-ciy
-ciy
-ciy
-ciy
-buP
-ciy
-mfJ
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+lMp
+oIG
+eKD
 oVM
 kIl
 jPG
@@ -85214,21 +85285,21 @@ vrG
 fuy
 xuX
 qbH
-cZd
+wTY
 duU
 mky
 hGH
 gVF
 qbH
 yhp
-jGm
+aLr
 lhR
-akn
+isD
 cdC
 jdX
-vSE
+kDD
 fcO
-kug
+oBf
 qfi
 xfq
 qfi
@@ -85269,17 +85340,17 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
+eKD
 wNS
 kGV
 fim
 dwH
 dwH
-mfJ
-mfJ
-mfJ
+eKD
+eKD
+eKD
 hKT
-mfJ
+eKD
 oVM
 kIl
 jPG
@@ -85477,10 +85548,10 @@ gHF
 aAH
 gVF
 gVF
-jpy
+fFp
 jWY
 lhR
-enN
+fxe
 lhR
 lhR
 lhR
@@ -85527,13 +85598,13 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
+eKD
 dwH
 jxe
 woJ
 ulc
 uqx
-mfJ
+eKD
 wDy
 stq
 hFX
@@ -85738,13 +85809,13 @@ gVF
 qbH
 jWY
 lhR
-eoO
+kdB
 nzO
 lhR
 lhR
 lhR
 nzO
-eoO
+kdB
 lhR
 lhR
 lhR
@@ -85785,13 +85856,13 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
+eKD
 mVR
 dwH
 dwH
 ulc
 pDH
-mfJ
+eKD
 uJK
 hFX
 hFX
@@ -85996,14 +86067,14 @@ soT
 qbH
 jWY
 lhR
-vVj
+dhl
 lhR
-uKc
-lhR
-lhR
+mLz
 lhR
 lhR
-enN
+lhR
+lhR
+fxe
 lhR
 lhR
 lhR
@@ -86043,17 +86114,17 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
+eKD
 mVR
 kHq
 kHq
 ulc
 aon
-mfJ
+eKD
 jGS
 wAv
 fDg
-mfJ
+eKD
 oVM
 kIl
 jPG
@@ -86245,10 +86316,10 @@ tgj
 vrG
 fuy
 xuX
-mxm
-iWd
-iWd
-pjI
+fQf
+jpy
+jpy
+rzN
 lut
 syD
 qbH
@@ -86301,17 +86372,17 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
+eKD
+eKD
+eKD
+eKD
+eKD
+eKD
+eKD
+eKD
+eKD
+eKD
+eKD
 oVM
 kIl
 jPG
@@ -86504,26 +86575,26 @@ vrG
 fuy
 xuX
 xTU
-dhl
-nOm
 eCg
+cPN
+eoO
 lut
 qvq
 qbH
-swx
+evB
 fSy
 dax
 dax
 dZc
 qbH
-eHr
+ews
 qbH
 qbH
 qbH
 qbH
 qbH
 qbH
-jLw
+iyQ
 ouN
 vgN
 ouN
@@ -86559,17 +86630,17 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+sWf
 esR
 tFD
 vRU
 wWm
 kWn
 qfX
-iXf
-wOq
-fMP
-iXf
+sWf
+nOQ
+oYF
+sWf
 oVM
 kIl
 jPG
@@ -86762,9 +86833,9 @@ vrG
 fuy
 xuX
 lFd
-dhl
-dhl
 eCg
+eCg
+eoO
 rdj
 iMc
 qbH
@@ -86781,7 +86852,7 @@ qfi
 qfi
 jfo
 qfi
-jLw
+iyQ
 ouN
 tiz
 ouN
@@ -86817,17 +86888,17 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+sWf
 dEk
 wNb
 wNb
 wNb
 wNb
 wNb
-iXf
-eKD
-rHw
-iXf
+sWf
+mJa
+vdb
+sWf
 oVM
 vdd
 jPG
@@ -87020,9 +87091,9 @@ vrG
 fuy
 xuX
 hIK
-dhl
-dhl
 eCg
+eCg
+eoO
 lut
 qvq
 qbH
@@ -87032,14 +87103,14 @@ lhR
 lhR
 lhR
 lhR
-ftN
+seC
 lhR
 lhR
 lhR
 lhR
 lhR
 lhR
-jLw
+iyQ
 ouN
 tiz
 ouN
@@ -87075,17 +87146,17 @@ wPM
 ftm
 nhm
 ajQ
-iXf
+sWf
 sBU
 wNb
 wNb
 wNb
 wNb
 kWY
-iXf
-iXf
-qtH
-iXf
+sWf
+sWf
+auQ
+sWf
 oVM
 kIl
 jPG
@@ -87277,27 +87348,27 @@ tgj
 vrG
 fuy
 xuX
-kdB
-dhl
-dhl
+dLk
 eCg
-hKD
+eCg
+eoO
+cRj
 qdD
-wxd
+gXY
 jWY
 lhR
-eoO
+kdB
 nzO
 lhR
 lhR
 lhR
 nzO
-eoO
+kdB
 lhR
 lhR
 lhR
 lhR
-jLw
+iyQ
 ouN
 noa
 ouN
@@ -87341,9 +87412,9 @@ dgT
 dgT
 dgT
 dgT
-jdy
+ppu
 dgT
-iXf
+sWf
 oVM
 kIl
 jPG
@@ -87536,9 +87607,9 @@ vrG
 fuy
 xuX
 jRV
-dhl
-dhl
 eCg
+eCg
+eoO
 lut
 qvq
 qbH
@@ -87555,7 +87626,7 @@ lhR
 lhR
 lhR
 lhR
-jLw
+iyQ
 ouN
 jzh
 tiz
@@ -87591,17 +87662,17 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+sWf
 stn
 pmF
 oHb
 rWO
 rWO
-iXf
-iXf
-iXf
+sWf
+sWf
+sWf
 iNx
-iXf
+sWf
 tGE
 kIl
 jPG
@@ -87793,10 +87864,10 @@ tgj
 vrG
 fuy
 xuX
-iQY
-dhl
-dhl
+ydc
 eCg
+eCg
+eoO
 rdj
 nzw
 dqU
@@ -87813,7 +87884,7 @@ nOE
 rse
 nOE
 nOE
-jLw
+iyQ
 ouN
 jzh
 tiz
@@ -87849,13 +87920,13 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+sWf
 rWO
 bwN
 lMZ
 daE
 aDw
-iXf
+sWf
 oYU
 ehz
 dED
@@ -88052,9 +88123,9 @@ vrG
 fuy
 xuX
 xTU
-dhl
-dhl
 eCg
+eCg
+eoO
 lut
 qvq
 qbH
@@ -88063,15 +88134,15 @@ qbH
 nOE
 nOE
 aLS
-eHr
+ews
 qbH
-qot
-qbH
-qbH
+kmE
 qbH
 qbH
 qbH
-jLw
+qbH
+qbH
+iyQ
 ouN
 ouN
 ouN
@@ -88107,13 +88178,13 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+sWf
 hTp
 rWO
 rWO
 daE
 cfX
-iXf
+sWf
 oVX
 dED
 dED
@@ -88310,9 +88381,9 @@ vrG
 fuy
 xuX
 lFd
-dhl
-nOm
 eCg
+cPN
+eoO
 lut
 fnu
 qbH
@@ -88329,7 +88400,7 @@ qbH
 qbH
 sbp
 sbp
-jLw
+iyQ
 ouN
 ouN
 ouN
@@ -88365,17 +88436,17 @@ wPM
 ycu
 nhm
 ajQ
-iXf
+sWf
 hTp
 dxe
 dxe
 daE
 ckk
-iXf
+sWf
 hAt
 erY
 bmm
-iXf
+sWf
 oVM
 kIl
 jPG
@@ -88567,27 +88638,27 @@ tgj
 vrG
 fuy
 xuX
-bWc
-dyK
-dyK
-clK
+pZh
+fnx
+fnx
+nuQ
 lut
 qvq
 qbH
 qbH
-mJl
+iXf
 qbH
 qbH
 sbp
 qbH
-mJl
+iXf
 qbH
 qbH
 qbH
 qbH
 sbp
 sbp
-jLw
+iyQ
 kRJ
 ouN
 ohm
@@ -88623,17 +88694,17 @@ wPM
 ycu
 nhm
 ajQ
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
-iXf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
 oVM
 kIl
 jPG
@@ -88825,7 +88896,7 @@ tgj
 vrG
 fuy
 xuX
-blQ
+rgm
 sOV
 xma
 lut
@@ -88845,7 +88916,7 @@ sbp
 sbp
 sbp
 sbp
-iKF
+wRz
 kRJ
 kRJ
 ouN
@@ -88881,17 +88952,17 @@ wPM
 ycu
 nhm
 ajQ
-qba
+epd
 wAV
 xeP
 fMj
 oqE
 qQH
 jsx
-qba
-kDl
-kuV
-qba
+epd
+guZ
+aIN
+epd
 oVM
 kIl
 jPG
@@ -89089,21 +89160,21 @@ qbH
 qbH
 qbH
 qbH
-fMq
-cMb
+sJv
+pKS
 qbH
-aLr
+frI
 sbp
 sbp
 sbp
 sbp
 sbp
-npm
+gEm
 sbp
 sbp
+aZu
 sbp
-sbp
-nJM
+tGg
 kRJ
 kRJ
 ouN
@@ -89139,17 +89210,17 @@ wPM
 ycu
 nhm
 ajQ
-qba
+epd
 oFn
 wSj
 wSj
 wSj
 wSj
 wSj
-qba
-ivl
-plZ
-qba
+epd
+gbm
+mUk
+epd
 tGE
 vdd
 jPG
@@ -89347,7 +89418,7 @@ qbH
 dqU
 dqU
 qbH
-tGg
+xKI
 qbH
 qbH
 qbH
@@ -89361,7 +89432,7 @@ qbH
 qbH
 sbp
 sbp
-jLw
+iyQ
 kRJ
 ouN
 ohm
@@ -89397,17 +89468,17 @@ wPM
 ftm
 nhm
 ajQ
-qba
+epd
 uEQ
 wSj
 wSj
 wSj
 wSj
 etN
-qba
-qba
-slv
-qba
+epd
+epd
+bmI
+epd
 oVM
 kIl
 jPG
@@ -89600,7 +89671,7 @@ vrG
 fuy
 xuX
 soT
-aLr
+frI
 dqU
 poO
 snb
@@ -89614,12 +89685,12 @@ qbH
 qbH
 qbH
 qbH
-nKT
+gNy
 qbH
 qbH
 sbp
 sbp
-jLw
+iyQ
 ouN
 ouN
 ouN
@@ -89656,16 +89727,16 @@ ycu
 nhm
 ajQ
 kKz
-uYM
-uYM
-uYM
-uYM
-uYM
-uYM
-uYM
-rCs
-uYM
-qba
+nKT
+nKT
+nKT
+nKT
+nKT
+nKT
+nKT
+sNs
+nKT
+epd
 oVM
 kIl
 jPG
@@ -89869,15 +89940,15 @@ tZz
 tZz
 tZz
 rFt
-gNP
+bWV
 qbH
-hcr
+fwJ
 qbH
 qbH
 qbH
-aLr
+frI
 qbH
-jLw
+iyQ
 ouN
 ouN
 ouN
@@ -89913,17 +89984,17 @@ wPM
 ycu
 nhm
 ajQ
-qba
+epd
 nYd
 axn
 pNW
 nKG
 nKG
-qba
-qba
-qba
+epd
+epd
+epd
 rcW
-qba
+epd
 tGE
 kIl
 jPG
@@ -90115,7 +90186,7 @@ tgj
 vrG
 fuy
 xuX
-qbH
+clV
 qbH
 qbH
 qbH
@@ -90135,7 +90206,7 @@ qbH
 qbH
 qbH
 qbH
-jLw
+iyQ
 ouN
 ouN
 ouN
@@ -90171,13 +90242,13 @@ wPM
 ycu
 nhm
 ajQ
-qba
+epd
 nKG
 qEy
 erz
 uyc
 uhu
-qba
+epd
 aXy
 uPj
 uFT
@@ -90429,13 +90500,13 @@ wPM
 ycu
 nhm
 ajQ
-qba
+epd
 rDL
 nKG
 nKG
 uyc
 bvW
-qba
+epd
 hAV
 uFT
 uFT
@@ -90687,17 +90758,17 @@ wPM
 ycu
 nhm
 ajQ
-qba
+epd
 rDL
 dHv
 dHv
 uyc
 rCB
-qba
+epd
 anx
 utS
 cQx
-qba
+epd
 sKj
 kIl
 jPG
@@ -90945,17 +91016,17 @@ wPM
 ycu
 nhm
 ajQ
-qba
-qba
-qba
-qba
-qba
-qba
-qba
-qba
-qba
-qba
-qba
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
 tPv
 tPv
 tPv

--- a/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
+++ b/maps/southern_cross/submaps/virtual_reality/constructVR.dmm
@@ -170,6 +170,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/whiteship)
+"akn" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "akC" = (
 /turf/simulated/wall/phoron,
 /area/vr/powered/cult)
@@ -374,12 +379,6 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
-"asY" = (
-/obj/structure/bed/chair/sofa/left/beige{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "ate" = (
 /obj/item/weapon/reagent_containers/food/snacks/badrecipe,
 /obj/effect/map_effect/perma_light/brighter,
@@ -387,15 +386,6 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
-"ato" = (
-/obj/structure/table/bench/wooden,
-/obj/item/weapon/pen/blade/blue,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
-"aty" = (
-/obj/structure/curtain/black,
-/turf/simulated/floor/flock,
-/area/vr/powered/mall/secondlife)
 "avf" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
@@ -486,9 +476,9 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
 "azq" = (
-/obj/item/weapon/tape_roll,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
+/obj/item/weapon/digestion_remains/variant2,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "azz" = (
 /obj/machinery/vending/dinnerware{
 	dir = 4;
@@ -759,7 +749,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms4)
+/area/vr/powered/mall/dorms/dorms1)
 "aJB" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/item/clothing/under/teshari/undercoat/standard/black_grey,
@@ -814,8 +804,13 @@
 	},
 /area/vr/powered)
 "aLr" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms2)
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "aLx" = (
 /obj/item/weapon/pickaxe,
 /obj/structure/table/rack/shelf/steel,
@@ -917,6 +912,11 @@
 "aQJ" = (
 /turf/simulated/wall/cult,
 /area/vr/outdoors/powered/cult)
+"aQR" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "aRb" = (
 /obj/structure/flora/smallbould,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -1039,22 +1039,6 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/bmarble,
 /area/vr/powered/cult)
-"aVP" = (
-/obj/structure/table/darkglass,
-/obj/item/device/mindbinder{
-	pixel_y = 4;
-	pixel_x = -2
-	},
-/obj/item/device/mindbinder{
-	pixel_y = -4;
-	pixel_x = -3
-	},
-/obj/item/device/mindbinder{
-	pixel_y = 2;
-	pixel_x = 5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "aWu" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/condiment/small/saltshaker,
@@ -1411,12 +1395,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
-"bkg" = (
-/obj/structure/bookcase,
-/obj/item/weapon/book/manual,
-/obj/item/weapon/book/manual,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "bkS" = (
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 5
@@ -1426,6 +1404,14 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
+"blQ" = (
+/obj/structure/table/darkglass,
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/item/weapon/material/twohanded/riding_crop,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "bmi" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/clothing/under/pants/camo,
@@ -1590,15 +1576,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
-"btR" = (
-/obj/structure/bed/chair/sofa/right/beige{
-	dir = 4
-	},
-/obj/machinery/light/floortube{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "bue" = (
 /obj/effect/map_effect/portal/master/side_a{
 	dir = 4;
@@ -1606,6 +1583,12 @@
 	},
 /turf/simulated/floor/outdoors/road,
 /area/vr/powered/rocks)
+"buP" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms4)
 "bvk" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/foodcart,
@@ -1711,6 +1694,15 @@
 "bAl" = (
 /turf/simulated/floor/carpet,
 /area/vr/powered/art)
+"bAC" = (
+/obj/structure/table/hardwoodtable,
+/obj/machinery/light/small{
+	dir = 4;
+	nightshift_enabled = 1;
+	pixel_y = 0
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "bAM" = (
 /obj/structure/bonfire/permanent,
 /obj/effect/decal/cleanable/dirt,
@@ -1864,14 +1856,6 @@
 	},
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/dungeon)
-"bHn" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/obj/item/clothing/accessory/shiny/gloves/poly,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "bHz" = (
 /obj/structure/sign/periodic,
 /turf/simulated/wall/wood,
@@ -2041,11 +2025,6 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
-"bNz" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/stripper_pink,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "bOh" = (
 /turf/simulated/wall/durasteel,
 /area/vr/powered/mall/backrooms)
@@ -2083,6 +2062,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/vr/powered/dungeon)
+"bPm" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "bPy" = (
 /obj/structure/sign/science{
 	pixel_y = 32
@@ -2268,15 +2251,6 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
-"bTr" = (
-/obj/machinery/vending/deluxe_boozeomat,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 1;
-	pixel_y = 0
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "bTy" = (
 /obj/structure/flora/tree/jungle,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -2301,14 +2275,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/space/sciship)
-"bUE" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/obj/item/clothing/under/swimsuit/purple,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "bVz" = (
 /obj/machinery/door/airlock/multi_tile/metal/mait{
 	icon_state = "door_locked";
@@ -2334,6 +2300,15 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"bWc" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 5
+	},
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "bWI" = (
 /obj/item/weapon/gun/projectile/shotgun/doublebarrel,
 /obj/structure/table/woodentable,
@@ -2401,6 +2376,7 @@
 	},
 /obj/structure/table/woodentable,
 /obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/obj/item/device/camera,
 /turf/simulated/floor/carpet/purple,
 /area/vr/powered/mall/dorms/secondlife2)
 "caK" = (
@@ -2598,6 +2574,9 @@
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled,
 /area/vr/powered/gunshop)
+"ciy" = (
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms4)
 "ciT" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -2708,6 +2687,13 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
+"clK" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 6
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "cmf" = (
 /obj/structure/salvageable/data_os{
 	name = "broken money printer"
@@ -2929,10 +2915,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/dungeon)
-"cvP" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "cvQ" = (
 /turf/simulated/floor/plating,
 /area/vr/powered/vendor)
@@ -3044,6 +3026,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
+"cBz" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL3";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "cCO" = (
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
@@ -3072,10 +3065,6 @@
 	color = "#ffe9ab"
 	},
 /area/vr/powered/mall/backrooms)
-"cDf" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "cDl" = (
 /obj/random/maintenance,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -3254,6 +3243,13 @@
 "cLE" = (
 /turf/simulated/shuttle/floor/darkred,
 /area/vr/powered/armory)
+"cMb" = (
+/obj/item/toy/plushie/black_fox{
+	pixel_y = 0;
+	name = "latex black fox"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "cME" = (
 /obj/item/weapon/coin/gold,
 /obj/item/weapon/coin/diamond,
@@ -3296,6 +3292,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
+"cNx" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/item/clothing/under/swimsuit/purple,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "cOM" = (
 /obj/machinery/button/remote/blast_door{
 	id = "vrsewers1";
@@ -3483,6 +3487,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/bar)
+"cZd" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/secondlife)
 "cZo" = (
 /obj/machinery/autolathe{
 	hacked = 1;
@@ -3693,14 +3705,14 @@
 /area/vr/powered/mall)
 "dgT" = (
 /turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms2)
+/area/vr/powered/mall/dorms/dorms5)
 "dha" = (
 /obj/item/toy/plushie/susred,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
 "dhl" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms3)
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "dhv" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/weapon/reagent_containers/food/drinks/soymilk,
@@ -4084,6 +4096,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
+"dyK" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "dyO" = (
 /obj/machinery/computer/operating{
 	dir = 4
@@ -4105,15 +4124,17 @@
 	},
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/space/whiteship)
-"dzQ" = (
-/obj/structure/table/darkglass,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 9
-	},
-/obj/machinery/chemical_dispenser/bar_coffee/full,
-/turf/unsimulated/shuttle/floor/purple,
+"dzE" = (
+/obj/item/weapon/tape_roll,
+/turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
+"dzQ" = (
+/obj/structure/sign/poster/custom{
+	pixel_y = 0;
+	dir = 2
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/vr/powered/mall/dorms/secondlife3)
 "dzT" = (
 /obj/machinery/door/airlock/gold{
 	id_tag = "VRmallSL1"
@@ -4327,6 +4348,11 @@
 "dHI" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/vr/powered/cult)
+"dJF" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "dKF" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -4768,8 +4794,8 @@
 	},
 /area/vr/powered/cult)
 "dTX" = (
-/turf/simulated/wall/stonebricks{
-	color = "pink"
+/turf/simulated/wall/sandstone{
+	color = "purple"
 	},
 /area/vr/powered/mall/dorms/secondlife2)
 "dUZ" = (
@@ -5257,7 +5283,8 @@
 	},
 /area/vr/powered/rocks)
 "enN" = (
-/obj/item/toy/balloon,
+/obj/structure/table/darkglass,
+/obj/item/clothing/mask/muzzle/ballgag,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "eoA" = (
@@ -5279,12 +5306,17 @@
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/sciship)
 "eoO" = (
-/obj/structure/table/hardwoodtable,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/obj/structure/table/darkglass,
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "epd" = (
 /turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms6)
+/area/vr/powered/mall/dorms/dorms1)
 "epk" = (
 /obj/structure/table/marble{
 	pixel_y = 0
@@ -5653,20 +5685,6 @@
 /obj/item/clothing/accessory/fluff/zeta_blackwell_1,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
-"eFa" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "eFl" = (
 /obj/effect/decal/cleanable/blood/gibs{
 	color = "red";
@@ -5765,6 +5783,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
+"eHr" = (
+/obj/item/toy/balloon,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "eHR" = (
 /obj/machinery/light{
 	layer = 3
@@ -5861,13 +5883,10 @@
 /turf/simulated/floor/carpet/geo,
 /area/vr/powered/mall)
 "eKD" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
 	},
 /turf/simulated/floor/tiled/white,
 /area/vr/powered/mall/dorms/dorms5)
@@ -6028,8 +6047,8 @@
 	},
 /area/vr/powered/rocks)
 "eRK" = (
-/turf/simulated/wall/stonebricks{
-	color = "pink"
+/turf/simulated/wall/sandstone{
+	color = "purple"
 	},
 /area/vr/powered/mall/dorms/secondlife5)
 "eRP" = (
@@ -6095,12 +6114,6 @@
 /obj/item/weapon/storage/firstaid/surgery,
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/cult)
-"eVj" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms3)
 "eVV" = (
 /obj/structure/table/marble{
 	color = "grey"
@@ -6311,11 +6324,6 @@
 /obj/structure/salvageable/console_broken_os,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/sciship)
-"ffx" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "ffA" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/hosdouble,
@@ -6629,17 +6637,6 @@
 	},
 /turf/space,
 /area/vr/space)
-"frB" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "frW" = (
 /obj/machinery/light{
 	dir = 4
@@ -6668,6 +6665,17 @@
 /obj/item/weapon/reagent_containers/food/condiment/soysauce,
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
+"fsK" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "fsL" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/condiment/enzyme,
@@ -6698,10 +6706,11 @@
 /obj/structure/window/phoronreinforced,
 /turf/simulated/floor/redgrid/animated,
 /area/vr/powered/cult)
-"ftE" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
+"ftN" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/stripper_pink,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "ftQ" = (
 /obj/structure/railing,
 /obj/effect/step_trigger/teleporter/bridge/north_to_south,
@@ -6901,14 +6910,6 @@
 /obj/item/weapon/reagent_containers/glass/beaker,
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
-"fAX" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "fAY" = (
 /obj/machinery/access_button{
 	master_tag = null;
@@ -6939,10 +6940,6 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/medigun,
 /turf/simulated/floor/airless,
 /area/vr/space)
-"fBV" = (
-/obj/item/weapon/digestion_remains/variant2,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "fBZ" = (
 /obj/item/clothing/accessory/fluff/zeta_blackwell_1,
 /turf/simulated/floor/cult,
@@ -7137,6 +7134,22 @@
 	},
 /turf/simulated/floor/tiled/old_cargo,
 /area/vr/powered/mall/dorms/dorms6)
+"fMq" = (
+/obj/structure/table/darkglass,
+/obj/item/device/mindbinder{
+	pixel_y = 4;
+	pixel_x = -2
+	},
+/obj/item/device/mindbinder{
+	pixel_y = -4;
+	pixel_x = -3
+	},
+/obj/item/device/mindbinder{
+	pixel_y = 2;
+	pixel_x = 5
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "fMF" = (
 /obj/structure/table/marble,
 /obj/structure/window/reinforced{
@@ -7199,6 +7212,20 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
+"fMP" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "fMQ" = (
 /obj/structure/table/marble{
 	color = "grey"
@@ -7782,6 +7809,12 @@
 	outdoors = 0
 	},
 /area/vr/powered/dungeon)
+"gqU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms3)
 "grL" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1
@@ -8155,6 +8188,10 @@
 /obj/item/weapon/bedsheet/orange,
 /turf/simulated/floor/carpet/blue,
 /area/vr/powered/motel)
+"gNP" = (
+/obj/item/weapon/handcuffs/legcuffs/fuzzy,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "gNU" = (
 /obj/structure/cliff/automatic/corner,
 /turf/simulated/floor/lava,
@@ -8362,9 +8399,6 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered)
-"gZX" = (
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "hcc" = (
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_x = -25;
@@ -8386,6 +8420,10 @@
 	},
 /turf/simulated/shuttle/floor/darkred,
 /area/vr/powered/space/sciship)
+"hcr" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "hds" = (
 /obj/structure/window/basic{
 	dir = 1
@@ -8648,12 +8686,11 @@
 /turf/simulated/floor,
 /area/vr/powered)
 "hlR" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 10
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
+/obj/structure/bookcase,
+/obj/item/weapon/book/manual,
+/obj/item/weapon/book/manual,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "hmv" = (
 /obj/machinery/conveyor{
 	id = "vrsushitrain";
@@ -8989,6 +9026,9 @@
 /obj/item/weapon/book/bundle/custom_library/nonfiction/skrelliancastesystem,
 /turf/simulated/floor/carpet/retro,
 /area/vr/powered/mall/dorms/dorms5)
+"hAO" = (
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms1)
 "hAQ" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/random/meat,
@@ -9154,13 +9194,17 @@
 	dir = 1;
 	pixel_y = 0
 	},
-/obj/item/weapon/storage/box/glasses/rocks{
-	pixel_y = -2;
-	pixel_x = -10
+/obj/item/weapon/storage/box/glasses/meta/metapint{
+	pixel_y = 4;
+	pixel_x = 5
 	},
-/obj/item/weapon/storage/box/glasses/square{
-	pixel_y = -2;
-	pixel_x = 12
+/obj/item/weapon/storage/box/glasses/meta/metapint{
+	pixel_y = 9;
+	pixel_x = 9
+	},
+/obj/item/weapon/storage/box/glasses/meta/metapint{
+	pixel_y = 6;
+	pixel_x = 7
 	},
 /turf/unsimulated/shuttle/floor/purple,
 /area/vr/powered/mall/secondlife)
@@ -9178,6 +9222,11 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/vr/powered/mall)
+"hKD" = (
+/obj/structure/table/darkglass,
+/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/vr/powered/mall/secondlife)
 "hKT" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/carpet/brown,
@@ -9210,8 +9259,16 @@
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/dungeon)
 "hOI" = (
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "hPd" = (
 /obj/structure/railing/grey{
 	pixel_y = 0;
@@ -9322,11 +9379,6 @@
 /obj/mecha/combat/marauder/seraph,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/mechfactory)
-"hTA" = (
-/obj/structure/table/darkglass,
-/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "hTV" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/pancakes{
@@ -9375,17 +9427,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/cafe)
-"hVL" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL3";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/vr/powered/mall/dorms/secondlife3)
 "hVP" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/weapon/storage/briefcase/inflatable{
@@ -9394,18 +9435,6 @@
 /obj/item/weapon/storage/toolbox/syndicate/powertools,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
-"hVQ" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "hWB" = (
 /obj/structure/table/marble{
 	pixel_y = 0
@@ -9566,8 +9595,12 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/constore)
 "iag" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms4)
+/obj/structure/sign/poster/custom{
+	pixel_y = 0;
+	dir = 2
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "iam" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
@@ -9656,7 +9689,18 @@
 /obj/structure/table/hardwoodtable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms1)
+"ifg" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL4";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "ifF" = (
 /obj/machinery/smartfridge/survival_pod{
 	icon = 'icons/obj/vending.dmi';
@@ -9903,14 +9947,6 @@
 	},
 /turf/simulated/shuttle/floor/white,
 /area/vr/powered/cult)
-"imT" = (
-/obj/structure/table/darkglass,
-/obj/structure/stripper_pole{
-	icon_scale_x = 0.5;
-	icon_scale_y = 0.5
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "imW" = (
 /obj/item/weapon/photo,
 /obj/item/weapon/photo{
@@ -10002,8 +10038,8 @@
 /turf/simulated/floor/wood,
 /area/vr/powered)
 "ipC" = (
-/turf/simulated/wall/stonebricks{
-	color = "pink"
+/turf/simulated/wall/sandstone{
+	color = "purple"
 	},
 /area/vr/powered/mall/dorms/secondlife)
 "ipY" = (
@@ -10018,14 +10054,6 @@
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
-"iqP" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "irA" = (
 /turf/simulated/floor/tiled/neutral,
 /area/vr/powered)
@@ -10188,10 +10216,13 @@
 	},
 /area/vr/outdoors/powered/mall)
 "ivl" = (
-/turf/simulated/wall/stonebricks{
-	color = "pink"
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
 	},
-/area/vr/powered/mall/dorms/secondlife4)
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "ivr" = (
 /obj/machinery/door/airlock/gold{
 	id_tag = "VRmallSL5"
@@ -10410,6 +10441,11 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/vr/powered/mall)
+"iGo" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "iGx" = (
 /obj/structure/table/marble,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -10453,7 +10489,7 @@
 	nightshift_enabled = 1
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
+/area/vr/powered/mall/dorms/dorms3)
 "iIl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -10494,11 +10530,11 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/whiteship)
-"iKM" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
+"iKF" = (
+/obj/structure/curtain/black,
+/obj/machinery/door/airlock/angled_bay/double/glass,
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "iLp" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -10531,18 +10567,24 @@
 /obj/structure/table/marble,
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
-"iMO" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms2)
 "iMU" = (
 /obj/machinery/door/window/survival_pod{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/space/whiteship)
+"iMW" = (
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL5";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "iNt" = (
 /obj/structure/window/basic,
 /turf/simulated/floor/wood/alt/parquet/turfpack,
@@ -10585,6 +10627,10 @@
 /obj/structure/loot_pile/mecha/odysseus/murdysseus,
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/space/mechfactory)
+"iPE" = (
+/obj/item/weapon/stool/padded,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "iQe" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -10592,6 +10638,23 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
+"iQY" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 1;
+	pixel_y = 0
+	},
+/obj/item/weapon/storage/box/glasses/rocks{
+	pixel_y = -2;
+	pixel_x = -10
+	},
+/obj/item/weapon/storage/box/glasses/square{
+	pixel_y = -2;
+	pixel_x = 12
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "iRw" = (
 /obj/structure/bed/chair/office/dark{
 	pixel_y = 0;
@@ -10599,14 +10662,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/dungeon)
-"iRC" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "iSq" = (
 /obj/random/trash,
 /obj/random/trash,
@@ -10673,6 +10728,13 @@
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/carpet/oracarpet,
 /area/vr/powered/mall/dorms/dorms3)
+"iWd" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 8
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "iWh" = (
 /obj/item/toy/plushie/possum,
 /turf/simulated/floor/carpet/bcarpet,
@@ -10700,13 +10762,8 @@
 	},
 /area/vr/outdoors/powered)
 "iXf" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/flock,
-/area/vr/powered/mall/secondlife)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms5)
 "iXg" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/device/communicator,
@@ -10890,6 +10947,12 @@
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack,
 /area/vr/powered/mall)
+"jdy" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms5)
 "jdU" = (
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/carpet/blue,
@@ -11091,6 +11154,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/dungeon)
+"jkX" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms3)
 "jle" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/item/weapon/storage/fancy/cigar/havana,
@@ -11183,8 +11254,9 @@
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
 "jpy" = (
-/turf/simulated/wall/concrete,
-/area/vr/powered/mall/dorms/secondlife5)
+/obj/item/device/camera,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "jpL" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -11547,6 +11619,18 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
+"jGm" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 6
+	},
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "jGt" = (
 /obj/item/weapon/flamethrower/full,
 /turf/simulated/floor/tiled,
@@ -11704,6 +11788,11 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered)
+"jLw" = (
+/turf/simulated/wall/sandstone{
+	color = "purple"
+	},
+/area/vr/powered/mall/secondlife)
 "jMc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
@@ -12016,25 +12105,6 @@
 	movement_cost = 0
 	},
 /area/vr/outdoors/powered)
-"jYq" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
-"jYy" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/mask/muzzle/ballgag,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "jYM" = (
 /turf/simulated/floor/wood/broken,
 /area/vr/powered/space/whiteship)
@@ -12068,7 +12138,7 @@
 /obj/item/weapon/book/manual,
 /obj/item/weapon/book/manual,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms1)
 "kaK" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled,
@@ -12131,13 +12201,13 @@
 /turf/simulated/wall/solidrock,
 /area/vr/powered/rocks)
 "kdB" = (
-/obj/structure/table/darkglass,
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
+/obj/machinery/vending/deluxe_boozeomat,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 1;
+	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/unsimulated/shuttle/floor/purple,
 /area/vr/powered/mall/secondlife)
 "kdJ" = (
 /mob/living/simple_mob/animal/passive/pillbug,
@@ -12195,6 +12265,20 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/vr/powered/mall)
+"kgh" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "kgu" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/snacks/kitsuneudon{
@@ -12507,6 +12591,18 @@
 	},
 /turf/simulated/floor/redgrid/off,
 /area/vr/powered/cult)
+"kug" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "kuk" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/blue,
@@ -12542,6 +12638,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/conspawn)
+"kuV" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "kvd" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	locked = 0
@@ -12582,6 +12692,10 @@
 /obj/item/clothing/suit/storage/apron/white,
 /turf/simulated/floor/plating,
 /area/vr/powered/cafe)
+"kwJ" = (
+/obj/structure/table/bench/wooden,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "kxk" = (
 /turf/simulated/floor/carpet/sblucarpet,
 /area/vr/powered)
@@ -12681,6 +12795,10 @@
 	temperature = 293.15
 	},
 /area/vr/powered/dungeon)
+"kDl" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "kDr" = (
 /obj/machinery/vending/loadout/uniform,
 /turf/simulated/floor/wood,
@@ -13146,6 +13264,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
+"kVe" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL2";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "kVX" = (
 /obj/machinery/door/window/northright{
 	name = "Server Room";
@@ -13284,6 +13413,15 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/vr/powered/mall)
+"lbr" = (
+/obj/structure/bed/chair/sofa/right/beige{
+	dir = 4
+	},
+/obj/machinery/light/floortube{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "lbK" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/random/meat,
@@ -13351,17 +13489,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/space/whiteship)
-"ley" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "leB" = (
 /obj/machinery/light{
 	layer = 3
@@ -13419,6 +13546,14 @@
 	dir = 10
 	},
 /area/vr/powered/mall/vw)
+"lgp" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "lhj" = (
 /obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/techfloor,
@@ -13786,11 +13921,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/vr/powered/vet)
-"lur" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/stripper_green,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "lut" = (
 /obj/structure/table/darkglass,
 /turf/simulated/floor/tiled/milspec/raised,
@@ -14437,14 +14567,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/vr/powered/mall)
-"lRy" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
 "lRA" = (
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/table/marble,
@@ -14585,17 +14707,6 @@
 /obj/random/unidentified_medicine,
 /turf/simulated/floor/tiled,
 /area/vr/powered)
-"lXe" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "lXA" = (
 /obj/structure/bed/alien,
 /obj/structure/curtain/open/privacy,
@@ -14787,7 +14898,7 @@
 /area/vr/powered/space/sciship)
 "mfJ" = (
 /turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms4)
 "mgc" = (
 /obj/structure/table/hardwoodtable,
 /turf/simulated/floor/wood,
@@ -14796,6 +14907,13 @@
 /obj/structure/cliff/automatic/corner,
 /turf/simulated/floor/weird_things/dark,
 /area/vr/powered/mall/backrooms)
+"mgZ" = (
+/obj/structure/sign/poster/custom{
+	pixel_y = 0;
+	dir = 2
+	},
+/turf/simulated/floor/carpet/bcarpet,
+/area/vr/powered/mall/dorms/secondlife5)
 "mha" = (
 /obj/structure/table/marble,
 /obj/structure/window/reinforced,
@@ -14975,12 +15093,6 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
-"mmf" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms5)
 "mmV" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/department/robo{
@@ -15193,20 +15305,6 @@
 /obj/item/weapon/storage/box/matches,
 /turf/simulated/floor/wood,
 /area/vr/powered)
-"mwD" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "mwO" = (
 /turf/simulated/floor/plating,
 /area/vr/powered/cafe)
@@ -15216,6 +15314,15 @@
 	temperature = 293.15
 	},
 /area/vr/outdoors/powered/lava)
+"mxm" = (
+/obj/structure/table/darkglass,
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 9
+	},
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "mxG" = (
 /obj/structure/table/alien/blue,
 /obj/item/weapon/surgical/circular_saw/alien,
@@ -15260,17 +15367,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
-"mAJ" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL4";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "mBa" = (
 /obj/fiftyspawner/glass,
 /obj/fiftyspawner/glass,
@@ -15515,6 +15611,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"mJl" = (
+/obj/item/clothing/mask/muzzle/ballgag,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "mJE" = (
 /obj/structure/table/gamblingtable,
 /obj/item/weapon/deck/cards,
@@ -15640,7 +15740,7 @@
 	pixel_x = -5
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
+/area/vr/powered/mall/dorms/dorms4)
 "mOS" = (
 /obj/structure/bed/chair/backed_red{
 	dir = 4
@@ -15747,18 +15847,13 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms4)
 "mUR" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack,
 /area/vr/powered/mall)
-"mVk" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "mVy" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/action_figure{
@@ -16214,10 +16309,6 @@
 /obj/fruitspawner/rice,
 /turf/simulated/floor/wmarble,
 /area/vr/powered/mall)
-"nmX" = (
-/obj/structure/table/bench/wooden,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
 "nng" = (
 /obj/effect/floor_decal/chapel{
 	dir = 1
@@ -16274,10 +16365,14 @@
 "npj" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/vr/powered/cult)
-"npn" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
+"npm" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/simulated/floor/flock,
+/area/vr/powered/mall/secondlife)
 "npD" = (
 /obj/structure/railing,
 /turf/simulated/floor/concrete{
@@ -16829,9 +16924,8 @@
 	},
 /area/vr/outdoors/powered)
 "nJM" = (
-/obj/item/weapon/material/twohanded/riding_crop,
-/obj/effect/decal/cleanable/blood/oil/streak,
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/curtain/black,
+/turf/simulated/floor/flock,
 /area/vr/powered/mall/secondlife)
 "nJZ" = (
 /obj/item/weapon/material/twohanded/baseballbat/gold,
@@ -16883,8 +16977,10 @@
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/dungeon)
 "nKT" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms4)
+/obj/item/weapon/material/twohanded/riding_crop,
+/obj/effect/decal/cleanable/blood/oil/streak,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "nLa" = (
 /obj/structure/bed/pillowpile/orange,
 /obj/effect/floor_decal/corner/purple/border{
@@ -16985,6 +17081,14 @@
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/vr/powered/mall)
+"nOm" = (
+/obj/effect/map_effect/perma_light/brighter{
+	light_color = "#e060e0";
+	light_power = 1;
+	light_range = 6
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "nOq" = (
 /turf/simulated/floor/airless,
 /area/vr/space)
@@ -17250,6 +17354,10 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/vr/powered/mall/dorms/dorms6)
+"nYu" = (
+/obj/item/weapon/digestion_remains/variant3,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "nYH" = (
 /obj/structure/salvageable/console_os,
 /turf/simulated/shuttle/floor/voidcraft,
@@ -17734,10 +17842,6 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/cult)
-"opB" = (
-/obj/item/clothing/mask/muzzle/ballgag,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "opG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18142,7 +18246,9 @@
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/space/mechfactory)
 "oDb" = (
-/turf/simulated/wall/concrete,
+/turf/simulated/wall/sandstone{
+	color = "purple"
+	},
 /area/vr/powered/mall/dorms/secondlife4)
 "oDd" = (
 /obj/machinery/light{
@@ -18253,10 +18359,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vr/powered/space/whiteship)
-"oHI" = (
-/obj/item/weapon/handcuffs/legcuffs/fuzzy,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "oHJ" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/item/clothing/under/teshari/undercoat/standard/black_grey,
@@ -18290,26 +18392,8 @@
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
 "oIG" = (
-/obj/structure/table/darkglass,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/item/weapon/storage/box/glasses/meta/metapint{
-	pixel_y = 4;
-	pixel_x = 5
-	},
-/obj/item/weapon/storage/box/glasses/meta/metapint{
-	pixel_y = 9;
-	pixel_x = 9
-	},
-/obj/item/weapon/storage/box/glasses/meta/metapint{
-	pixel_y = 6;
-	pixel_x = 7
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms2)
 "oJb" = (
 /obj/machinery/light{
 	dir = 1
@@ -18418,6 +18502,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/space/whiteship)
+"oMt" = (
+/obj/structure/bed/chair/sofa/left/beige{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms1)
 "oMQ" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -18542,6 +18632,13 @@
 /obj/item/weapon/towel/random,
 /turf/simulated/floor/carpet/bcarpet,
 /area/vr/powered)
+"oVv" = (
+/obj/structure/sign/poster/custom{
+	pixel_y = 0;
+	dir = 2
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "oVM" = (
 /obj/structure/railing/grey,
 /turf/simulated/floor/water/pool{
@@ -18720,10 +18817,6 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
-"pcJ" = (
-/obj/item/weapon/digestion_remains/variant3,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "pdu" = (
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled,
@@ -18747,18 +18840,6 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
-"pee" = (
-/obj/effect/decal/cleanable/fruit_smudge,
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL5";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/bcarpet,
-/area/vr/powered/mall/dorms/secondlife5)
 "pen" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 8
@@ -18823,14 +18904,6 @@
 /obj/item/weapon/cell/slime,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
-"pgz" = (
-/obj/structure/table/darkglass,
-/obj/structure/window/basic{
-	dir = 4
-	},
-/obj/item/weapon/material/whip,
-/turf/simulated/floor/tiled/milspec/raised,
-/area/vr/powered/mall/secondlife)
 "pgH" = (
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/carpet,
@@ -18887,6 +18960,13 @@
 	movement_cost = 0
 	},
 /area/vr/outdoors/powered)
+"pjI" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 10
+	},
+/turf/unsimulated/shuttle/floor/purple,
+/area/vr/powered/mall/secondlife)
 "pkd" = (
 /obj/machinery/conveyor{
 	id = "vrsushitrain";
@@ -18942,6 +19022,17 @@
 /obj/item/weapon/scepter,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/vr/powered/cult)
+"plZ" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "pma" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -19270,10 +19361,6 @@
 /obj/item/clothing/shoes/boots/marine,
 /turf/simulated/floor/tiled,
 /area/vr/powered/gunshop)
-"pAQ" = (
-/obj/item/weapon/stool/padded,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "pBf" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
@@ -19285,7 +19372,7 @@
 "pBo" = (
 /obj/structure/table/bench/wooden,
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
+/area/vr/powered/mall/dorms/dorms3)
 "pBr" = (
 /obj/structure/table/marble,
 /obj/item/weapon/material/knife/butch,
@@ -19427,21 +19514,11 @@
 	},
 /area/vr/powered/rocks)
 "pGH" = (
-/obj/structure/table/darkglass,
-/obj/item/device/bodysnatcher{
-	pixel_y = 4;
-	pixel_x = 3
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 31
 	},
-/obj/item/device/bodysnatcher{
-	pixel_y = -2;
-	pixel_x = -2
-	},
-/obj/item/device/bodysnatcher{
-	pixel_y = -4;
-	pixel_x = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "pGO" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -19607,10 +19684,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_grid,
 /area/vr/powered/space/whiteship)
-"pMg" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "pMW" = (
 /obj/structure/table/woodentable,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -19669,6 +19742,14 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/vr/powered/mall/dorms/dorms6)
+"pOd" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "pOg" = (
 /obj/structure/flora/rocks1,
 /turf/simulated/floor/outdoors/grass/heavy{
@@ -19706,6 +19787,10 @@
 /obj/item/clothing/accessory/bracelet/material/gold,
 /turf/simulated/floor/flock,
 /area/vr/powered/rocks)
+"pQx" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "pRx" = (
 /obj/structure/toilet{
 	dir = 8;
@@ -19719,7 +19804,7 @@
 "pRJ" = (
 /obj/effect/floor_decal/milspec/color/silver,
 /turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms2)
 "pRN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -19897,7 +19982,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
+/area/vr/powered/mall/dorms/dorms3)
 "qaJ" = (
 /obj/machinery/chemical_dispenser/ert/specialops{
 	pixel_y = 7
@@ -19939,8 +20024,8 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
 "qba" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms5)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms6)
 "qbf" = (
 /obj/structure/cult/pylon,
 /turf/simulated/floor/cult{
@@ -20088,6 +20173,11 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/wood/alt/parquet/turfpack,
 /area/vr/powered/mall)
+"qfO" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "qfX" = (
 /obj/structure/table/marble,
 /obj/structure/sink/countertop{
@@ -20226,8 +20316,8 @@
 /turf/simulated/floor/tiled/yellow,
 /area/vr/powered/mall/dorms/dorms4)
 "qjX" = (
-/turf/simulated/wall/stonebricks{
-	color = "pink"
+/turf/simulated/wall/sandstone{
+	color = "purple"
 	},
 /area/vr/powered/mall/dorms/secondlife3)
 "qkg" = (
@@ -20309,14 +20399,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
-"qlq" = (
-/obj/item/weapon/digestion_remains/skull/teshari,
-/obj/effect/decal/cleanable/fruit_smudge,
-/obj/item/clothing/mask/muzzle/ballgag{
-	pixel_y = -7
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/dorms/secondlife4)
 "qlF" = (
 /obj/machinery/gateway/brass{
 	dir = 8
@@ -20374,6 +20456,10 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
+"qot" = (
+/obj/item/clothing/under/shiny/catsuit/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "qou" = (
 /obj/structure/bed/chair/sofa/right/black,
 /turf/simulated/floor/tiled/white,
@@ -20450,6 +20536,11 @@
 "qty" = (
 /turf/simulated/floor/gorefloor,
 /area/vr/outdoors/powered/cult)
+"qtH" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "qtU" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -20942,18 +21033,6 @@
 	},
 /turf/simulated/floor/airless,
 /area/vr/space)
-"qKj" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 6
-	},
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "qKo" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
@@ -21726,6 +21805,17 @@
 /obj/structure/fans/tiny,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/dungeon)
+"rvV" = (
+/obj/machinery/button/remote/airlock{
+	id = "VRmallSL1";
+	name = "Bolt Control";
+	pixel_x = 6;
+	specialfunctions = 4;
+	dir = 4;
+	pixel_y = 30
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/vr/powered/mall/dorms/secondlife)
 "rvW" = (
 /obj/machinery/telecomms/relay/preset{
 	name = "VR Telelink"
@@ -21843,6 +21933,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
+"rCs" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms6)
 "rCt" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/mimedouble,
@@ -21865,20 +21961,6 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/vr/powered/mall/dorms/dorms6)
-"rCI" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "rCZ" = (
 /obj/machinery/light/small,
 /obj/structure/table/woodentable,
@@ -21953,10 +22035,16 @@
 /turf/simulated/floor/tiled,
 /area/vr/powered/vendor)
 "rHw" = (
-/obj/structure/table/darkglass,
-/obj/item/weapon/storage/box/fluff/swimsuit/strippergreen,
-/turf/simulated/floor/tiled/milspec/raised,
-/area/vr/powered/mall/secondlife)
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "rHO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -22442,15 +22530,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/vr/powered/mall)
-"sdb" = (
-/obj/structure/table/hardwoodtable,
-/obj/machinery/light/small{
-	dir = 4;
-	nightshift_enabled = 1;
-	pixel_y = 0
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "sdc" = (
 /obj/structure/salvageable/console_os,
 /obj/effect/floor_decal/techfloor{
@@ -22613,6 +22692,11 @@
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/shuttle/plating,
 /area/vr/powered/space/whiteship)
+"slv" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/simple_door/wood,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms6)
 "slC" = (
 /obj/machinery/robotic_fabricator,
 /turf/simulated/floor/tiled/asteroid_steel,
@@ -22919,6 +23003,18 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/asteroid_steel,
 /area/vr/powered/building2)
+"swx" = (
+/obj/structure/table/darkglass,
+/obj/structure/stripper_pole{
+	icon_scale_x = 0.5;
+	icon_scale_y = 0.5
+	},
+/obj/item/toy/plushie/mouse{
+	pixel_y = 2;
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "swz" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -23163,17 +23259,6 @@
 /obj/item/weapon/pen,
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
-"sFW" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL2";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/purple,
-/area/vr/powered/mall/dorms/secondlife2)
 "sGC" = (
 /obj/machinery/vending/wallmed1/public{
 	pixel_y = 32
@@ -23381,7 +23466,7 @@
 /obj/structure/window/basic{
 	dir = 4
 	},
-/obj/item/weapon/material/twohanded/riding_crop,
+/obj/item/weapon/material/whip,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/vr/powered/mall/secondlife)
 "sPT" = (
@@ -23537,13 +23622,8 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/vr/powered/mall)
 "sWf" = (
-/obj/effect/map_effect/perma_light/brighter{
-	light_color = "#e060e0";
-	light_power = 1;
-	light_range = 6
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/vr/powered/mall/secondlife)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms2)
 "sWx" = (
 /turf/simulated/shuttle/floor/darkred,
 /area/vr/powered/space/sciship)
@@ -23599,10 +23679,6 @@
 	icon_state = "cult-narsie"
 	},
 /area/vr/powered/cult)
-"tbM" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "tcB" = (
 /obj/structure/table/woodentable,
 /obj/item/stack/cable_coil{
@@ -23692,10 +23768,6 @@
 "tgD" = (
 /turf/simulated/wall/r_wall,
 /area/vr/powered/building2)
-"tgH" = (
-/obj/item/clothing/under/shiny/catsuit/poly,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "tgJ" = (
 /obj/machinery/gear_dispenser/suit/autolok,
 /turf/simulated/shuttle/floor/voidcraft/dark,
@@ -24207,6 +24279,20 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
+"tDU" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "tEr" = (
 /obj/structure/bookcase,
 /obj/item/weapon/book/manual,
@@ -24280,19 +24366,21 @@
 /turf/simulated/floor/plating,
 /area/vr/powered/space/sciship)
 "tGg" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/toilet{
-	dir = 4
+/obj/structure/table/darkglass,
+/obj/item/device/bodysnatcher{
+	pixel_y = 4;
+	pixel_x = 3
 	},
-/obj/machinery/light/small{
-	brightness_color = "#DA0205";
-	brightness_power = 1;
-	brightness_range = 5;
-	dir = 8;
-	nightshift_enabled = 1
+/obj/item/device/bodysnatcher{
+	pixel_y = -2;
+	pixel_x = -2
 	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms3)
+/obj/item/device/bodysnatcher{
+	pixel_y = -4;
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "tGi" = (
 /obj/machinery/light{
 	layer = 3
@@ -24398,11 +24486,6 @@
 /obj/item/weapon/fossil/skull/horned,
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
-"tKI" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms2)
 "tLr" = (
 /obj/effect/landmark/virtual_reality{
 	name = "City"
@@ -24415,17 +24498,6 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/cult)
-"tLD" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/simple_door/wood,
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
-"tLL" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms1)
 "tLM" = (
 /obj/machinery/light/floortube/flicker{
 	pixel_y = -2
@@ -24647,12 +24719,6 @@
 /obj/random/maintenance/morestuff,
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
-"tTK" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 31
-	},
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "tTT" = (
 /obj/item/trash/rkibble{
 	pixel_x = 8;
@@ -24685,13 +24751,6 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/space/sciship)
-"tUk" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 8
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "tUm" = (
 /obj/machinery/optable,
 /turf/simulated/shuttle/floor/white,
@@ -24788,10 +24847,6 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
-"tYA" = (
-/obj/item/clothing/accessory/shiny/gloves/poly,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "tYP" = (
 /obj/structure/prop/dominator/blue,
 /turf/unsimulated/floor/lino/turfpack/station{
@@ -25336,6 +25391,9 @@
 	temperature = 311
 	},
 /area/vr/powered/rocks)
+"usA" = (
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "usM" = (
 /obj/structure/simple_door/flock,
 /turf/simulated/floor/flock,
@@ -25798,6 +25856,11 @@
 	color = "grey"
 	},
 /area/vr/powered/cult)
+"uKc" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/stripper_green,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "uKg" = (
 /turf/simulated/shuttle/wall/hard_corner,
 /area/vr/powered/space/whiteship)
@@ -26059,13 +26122,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
-"uUN" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 6
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "uUX" = (
 /turf/simulated/floor/outdoors/sidewalk/slab{
 	movement_cost = 0;
@@ -26094,8 +26150,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
 "uVX" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms1)
+/obj/structure/sign/poster/custom{
+	pixel_y = 0;
+	dir = 2
+	},
+/turf/simulated/floor/carpet/purple,
+/area/vr/powered/mall/dorms/secondlife2)
 "uWc" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/sign/department/cargo_dock{
@@ -26148,7 +26208,7 @@
 	pixel_x = 31
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms3)
+/area/vr/powered/mall/dorms/dorms1)
 "uYA" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -26158,6 +26218,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
+"uYM" = (
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms6)
 "uZT" = (
 /obj/machinery/button/windowtint{
 	id = "vrmalltint1";
@@ -26202,8 +26265,8 @@
 /turf/simulated/floor/plating,
 /area/vr/outdoors/powered)
 "vdb" = (
-/turf/simulated/wall/wood,
-/area/vr/powered/mall/dorms/dorms5)
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms3)
 "vdd" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/outdoors/grass{
@@ -26250,6 +26313,10 @@
 	},
 /obj/item/toy/plushie/teshari/b_yw{
 	pixel_y = -12
+	},
+/obj/structure/sign/poster/custom{
+	pixel_y = 0;
+	dir = 8
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/vr/powered/mall/dorms/secondlife5)
@@ -26368,6 +26435,11 @@
 "vjp" = (
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
+"vjy" = (
+/obj/structure/table/bench/wooden,
+/obj/item/weapon/pen/blade/blue,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "vjB" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/pancakes{
@@ -26575,14 +26647,6 @@
 	temperature = 293.15
 	},
 /area/vr/powered/dungeon)
-"vqJ" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms5)
 "vrb" = (
 /turf/simulated/floor/tiled/steel_dirty,
 /area/vr/powered/cult)
@@ -26627,14 +26691,6 @@
 	},
 /turf/simulated/shuttle/floor/yellow,
 /area/vr/powered/space/sciship)
-"vsS" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms1)
 "vtf" = (
 /obj/item/weapon/material/twohanded/baseballbat/gold,
 /obj/item/clothing/gloves/ring/material/gold,
@@ -26727,7 +26783,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
+/area/vr/powered/mall/dorms/dorms3)
 "vwT" = (
 /obj/structure/bed/chair/sofa/left/black,
 /turf/simulated/floor/wood,
@@ -26884,6 +26940,20 @@
 /obj/structure/bed/pillowpile/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/mall/secondlife)
+"vGe" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	brightness_color = "#DA0205";
+	brightness_power = 1;
+	brightness_range = 5;
+	dir = 8;
+	nightshift_enabled = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms2)
 "vGh" = (
 /obj/machinery/vending/wardrobe/hydrobe{
 	req_access = null
@@ -27044,13 +27114,6 @@
 /obj/effect/decal/remains,
 /turf/simulated/shuttle/floor/voidcraft,
 /area/vr/powered/dungeon)
-"vLa" = (
-/obj/item/toy/plushie/black_fox{
-	pixel_y = 0;
-	name = "latex black fox"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "vLG" = (
 /obj/machinery/button/remote/blast_door{
 	id = "vrgunshop";
@@ -27177,6 +27240,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/vr/powered/dungeon)
+"vSE" = (
+/obj/effect/floor_decal/corner/purple/border{
+	color = "#f700ff";
+	dir = 4
+	},
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "vSJ" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave{
@@ -27269,23 +27340,17 @@
 /obj/item/weapon/reagent_containers/food/condiment/small/saltshaker,
 /turf/simulated/floor/wood,
 /area/vr/powered)
+"vVj" = (
+/obj/structure/table/darkglass,
+/obj/item/clothing/under/swimsuit/stripper/mankini,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "vVx" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/morestuff,
 /turf/simulated/floor/wood,
 /area/vr/powered/shop)
-"vVL" = (
-/obj/machinery/button/remote/airlock{
-	id = "VRmallSL1";
-	name = "Bolt Control";
-	pixel_x = 6;
-	specialfunctions = 4;
-	dir = 4;
-	pixel_y = 30
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/vr/powered/mall/dorms/secondlife)
 "vWm" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
@@ -27311,15 +27376,6 @@
 	temperature = 311
 	},
 /area/vr/outdoors/powered)
-"vXa" = (
-/obj/structure/table/darkglass,
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 5
-	},
-/obj/machinery/chemical_dispenser/bar_coffee/full,
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "vXA" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/grenade/box,
@@ -27451,6 +27507,12 @@
 	},
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/whiteship)
+"wbh" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/parquet,
+/area/vr/powered/mall/dorms/dorms2)
 "wbm" = (
 /obj/structure/table/marble{
 	color = "grey"
@@ -27562,13 +27624,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/alt/panel,
 /area/vr/powered/mall)
-"wfY" = (
-/obj/effect/floor_decal/corner/purple/border{
-	color = "#f700ff";
-	dir = 4
-	},
-/turf/unsimulated/shuttle/floor/purple,
-/area/vr/powered/mall/secondlife)
 "wgq" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/wood,
@@ -27923,6 +27978,10 @@
 /obj/mecha/combat/phazon/old,
 /turf/simulated/shuttle/floor/voidcraft/light,
 /area/vr/powered/space/sciship)
+"wxd" = (
+/obj/item/clothing/accessory/shiny/gloves/poly,
+/turf/simulated/floor/tiled/techfloor,
+/area/vr/powered/mall/secondlife)
 "wxu" = (
 /obj/structure/bed/chair/comfy/black,
 /obj/effect/floor_decal/techfloor{
@@ -28159,6 +28218,17 @@
 	},
 /turf/simulated/floor/weird_things/dark,
 /area/vr/powered/mall/backrooms)
+"wGx" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms1)
 "wGy" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/item/weapon/stool{
@@ -28379,6 +28449,10 @@
 	outdoors = 0
 	},
 /area/vr/powered/rocks)
+"wOq" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms5)
 "wPa" = (
 /turf/simulated/wall/wood,
 /area/vr/powered/rocks)
@@ -28528,8 +28602,8 @@
 /turf/unsimulated/floor/tiled/techfloor,
 /area/vr/powered/mall)
 "wUw" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms1)
+/turf/simulated/wall/wood,
+/area/vr/powered/mall/dorms/dorms3)
 "wUx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -28649,8 +28723,9 @@
 /turf/simulated/floor/tiled/red,
 /area/vr/powered/mall/dorms/dorms5)
 "wWt" = (
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms6)
+/obj/structure/table/hardwoodtable,
+/turf/simulated/floor/carpet/oracarpet,
+/area/vr/powered/mall/dorms/dorms3)
 "wWC" = (
 /obj/machinery/light{
 	dir = 8
@@ -28724,6 +28799,14 @@
 	outdoors = 1
 	},
 /area/vr/outdoors/powered)
+"xbG" = (
+/obj/item/weapon/digestion_remains/skull/teshari,
+/obj/effect/decal/cleanable/fruit_smudge,
+/obj/item/clothing/mask/muzzle/ballgag{
+	pixel_y = -7
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/vr/powered/mall/dorms/secondlife4)
 "xbS" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -28971,12 +29054,6 @@
 /obj/machinery/door/window/eastleft,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/vr/powered/mall/secondlife)
-"xmj" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/parquet,
-/area/vr/powered/mall/dorms/dorms6)
 "xnt" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -29120,14 +29197,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/vr/powered/vet)
-"xsz" = (
-/obj/structure/curtain/open/shower,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms4)
 "xtQ" = (
 /obj/machinery/light{
 	layer = 3
@@ -29231,6 +29300,10 @@
 /obj/item/weapon/gun/projectile/automatic/serdy/awp,
 /turf/simulated/floor/reinforced,
 /area/vr/powered/redbase)
+"xxG" = (
+/obj/effect/floor_decal/milspec/color/silver,
+/turf/simulated/floor/tiled/white,
+/area/vr/powered/mall/dorms/dorms4)
 "xys" = (
 /turf/simulated/mineral/alt{
 	temperature = 293.15
@@ -29257,11 +29330,6 @@
 	},
 /turf/simulated/floor/cult,
 /area/vr/powered/cult)
-"xAk" = (
-/obj/structure/table/hardwoodtable,
-/obj/item/device/flashlight/lamp/green,
-/turf/simulated/floor/carpet/oracarpet,
-/area/vr/powered/mall/dorms/dorms1)
 "xAp" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 10
@@ -29554,17 +29622,6 @@
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/vr/powered/mall)
-"xLP" = (
-/obj/effect/floor_decal/milspec/color/silver,
-/obj/structure/sink{
-	dir = 1
-	},
-/obj/structure/mirror{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/simulated/floor/tiled/white,
-/area/vr/powered/mall/dorms/dorms6)
 "xLW" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -29761,11 +29818,6 @@
 /obj/item/weapon/grenade/explosive,
 /turf/simulated/shuttle/floor/black,
 /area/vr/powered/armory)
-"xVL" = (
-/obj/structure/table/darkglass,
-/obj/item/clothing/under/swimsuit/stripper/mankini,
-/turf/simulated/floor/tiled/techfloor,
-/area/vr/powered/mall/secondlife)
 "xVV" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/machinery/light{
@@ -69221,17 +69273,17 @@ jNo
 mbF
 mbF
 mbF
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
 oVM
 kIl
 jPG
@@ -69479,17 +69531,17 @@ jNo
 mbF
 mbF
 mbF
-uVX
+epd
 gFH
 avf
 wkd
 rGJ
 rbF
 pYB
-uVX
-tbM
-jYq
-uVX
+epd
+pQx
+kgh
+epd
 oVM
 hSI
 jPG
@@ -69737,17 +69789,17 @@ jNo
 mbF
 sHe
 mbF
-uVX
+epd
 ixQ
 cTE
 cTE
 cTE
 cTE
 cTE
-uVX
-vsS
-frB
-uVX
+epd
+pOd
+wGx
+epd
 oVM
 kIl
 jPG
@@ -69995,17 +70047,17 @@ jNo
 mbF
 mbF
 sHe
-uVX
+epd
 wSm
 cTE
 cTE
 cTE
 cTE
 qAG
-uVX
-uVX
-iKM
-uVX
+epd
+epd
+dJF
+epd
 tGE
 kIl
 jPG
@@ -70254,16 +70306,16 @@ mbF
 sHe
 mbF
 gBz
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-wUw
-tLL
-wUw
-uVX
+hAO
+hAO
+hAO
+hAO
+hAO
+hAO
+hAO
+aJc
+hAO
+epd
 oVM
 kIl
 jPG
@@ -70511,17 +70563,17 @@ jNo
 mbF
 mbF
 mbF
-uVX
+epd
 rQv
-qan
-vwl
+oMt
+lbr
 wEq
 wEq
-uVX
-uVX
-uVX
+epd
+epd
+epd
 mYs
-uVX
+epd
 oVM
 dsG
 jPG
@@ -70769,13 +70821,13 @@ jNo
 mKY
 mbF
 mKY
-uVX
+epd
 wEq
-pBo
+kwJ
 qLF
-pAQ
-xAk
-uVX
+iPE
+ifd
+epd
 qxv
 iVO
 aHs
@@ -71027,13 +71079,13 @@ jNo
 mbF
 mbF
 mbF
-uVX
-bkg
+epd
+kao
 wEq
 wEq
-pAQ
+iPE
 tSw
-uVX
+epd
 aJP
 aHs
 aHs
@@ -71285,17 +71337,17 @@ jNo
 mbF
 mKY
 nrp
-uVX
-bkg
-tTK
-tTK
-pAQ
-sdb
-uVX
+epd
+kao
+uYn
+uYn
+iPE
+bAC
+epd
 khJ
 uqE
 cWw
-uVX
+epd
 oVM
 kIl
 jPG
@@ -71543,17 +71595,17 @@ jNo
 mbF
 mbF
 nrp
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
-uVX
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
+epd
 oVM
 kIl
 jPG
@@ -71801,17 +71853,17 @@ jNo
 mbF
 mbF
 nrp
-aLr
+oIG
 iDr
 ane
 joA
 qRP
 dFF
 jSK
-aLr
-cvP
-rCI
-aLr
+oIG
+pRJ
+vGe
+oIG
 oVM
 kIl
 jPG
@@ -72059,17 +72111,17 @@ jNo
 mbF
 sHe
 mbF
-aLr
+oIG
 axg
 aGv
 aGv
 aGv
 aGv
 aGv
-aLr
-mOR
-ley
-aLr
+oIG
+lgp
+hOI
+oIG
 oVM
 kIl
 jPG
@@ -72317,17 +72369,17 @@ jNo
 mbF
 mbF
 mbF
-aLr
+oIG
 wKS
 aGv
 aGv
 aGv
 aGv
 nxY
-aLr
-aLr
-tKI
-aLr
+oIG
+oIG
+qfO
+oIG
 tGE
 kIl
 jPG
@@ -72576,16 +72628,16 @@ mbF
 mbF
 sHe
 rom
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-dgT
-iMO
-dgT
-aLr
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+sWf
+wbh
+sWf
+oIG
 oVM
 dsG
 jPG
@@ -72833,17 +72885,17 @@ jNo
 mbF
 mbF
 mbF
-aLr
+oIG
 saD
 xRd
 lHF
 jFf
 jFf
-aLr
-aLr
-aLr
+oIG
+oIG
+oIG
 onX
-aLr
+oIG
 oVM
 kIl
 jPG
@@ -73091,13 +73143,13 @@ jNo
 mbF
 mKY
 mKY
-aLr
+oIG
 jFf
 xEl
 jIp
 kOw
 nrY
-aLr
+oIG
 oxT
 bTn
 hsD
@@ -73349,13 +73401,13 @@ jNo
 mbF
 mbF
 mbF
-aLr
+oIG
 tEr
 jFf
 jFf
 kOw
 uFH
-aLr
+oIG
 uMe
 hsD
 hsD
@@ -73607,17 +73659,17 @@ jNo
 mbF
 sHe
 mbF
-aLr
+oIG
 tEr
 lnS
 lnS
 kOw
 uRx
-aLr
+oIG
 pxI
 dFd
 eif
-aLr
+oIG
 oVM
 fGS
 jPG
@@ -73865,17 +73917,17 @@ eUL
 mKY
 mbF
 mbF
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
-aLr
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
+oIG
 oVM
 kIl
 jPG
@@ -81605,17 +81657,17 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
 oVM
 kIl
 jPG
@@ -81863,17 +81915,17 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
+wUw
 uSd
 moh
 lRA
 hBZ
 jQx
 mhy
-mfJ
-pRJ
-tGg
-mfJ
+wUw
+bPm
+iHV
+wUw
 oVM
 kIl
 jPG
@@ -82121,17 +82173,17 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
+wUw
 ghV
 ePC
 ePC
 ePC
 ePC
 ePC
-mfJ
-lRy
-mUk
-mfJ
+wUw
+jkX
+fsK
+wUw
 oVM
 kIl
 jPG
@@ -82379,17 +82431,17 @@ wPM
 ftm
 nhm
 ajQ
-mfJ
+wUw
 qIn
 ePC
 ePC
 ePC
 ePC
 mkU
-mfJ
-mfJ
-ffx
-mfJ
+wUw
+wUw
+iGo
+wUw
 oVM
 vdd
 jPG
@@ -82638,16 +82690,16 @@ ycu
 nhm
 ajQ
 oAC
-dhl
-dhl
-dhl
-dhl
-dhl
-dhl
-dhl
-eVj
-dhl
-mfJ
+vdb
+vdb
+vdb
+vdb
+vdb
+vdb
+vdb
+gqU
+vdb
+wUw
 oVM
 kIl
 jPG
@@ -82895,17 +82947,17 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
+wUw
 fwZ
-asY
-btR
-gZX
-gZX
-mfJ
-mfJ
-mfJ
+qan
+vwl
+usA
+usA
+wUw
+wUw
+wUw
 sJh
-mfJ
+wUw
 oVM
 crG
 jPG
@@ -83112,7 +83164,7 @@ qjX
 vTk
 syO
 vpG
-ivl
+oDb
 aZi
 oJW
 kss
@@ -83153,13 +83205,13 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
-gZX
-nmX
-ato
+wUw
+usA
+pBo
+vjy
 iWc
-ifd
-mfJ
+aQR
+wUw
 bos
 uZT
 cqn
@@ -83361,16 +83413,16 @@ yfs
 ipC
 hzU
 rVY
-hzU
+uVX
 dTX
 dES
 dES
-hqN
+dzQ
 qjX
 vpG
-pcJ
-vpG
-ivl
+nYu
+iag
+oDb
 iWh
 aZi
 aZi
@@ -83411,13 +83463,13 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
-kao
-gZX
-gZX
+wUw
+hlR
+usA
+usA
 iWc
-eoO
-mfJ
+wWt
+wUw
 hwS
 cqn
 cqn
@@ -83615,7 +83667,7 @@ fuy
 awD
 yfs
 yfs
-yfs
+oVv
 ipC
 hzU
 hzU
@@ -83625,14 +83677,14 @@ dES
 dES
 dES
 qjX
-fBV
-qlq
+azq
+xbG
 vpG
-ivl
+oDb
 oJW
 aZi
 yiL
-aZi
+mgZ
 wPM
 mfD
 xJF
@@ -83669,17 +83721,17 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
-kao
-uYn
-uYn
+wUw
+hlR
+pGH
+pGH
 iWc
 qiH
-mfJ
+wUw
 gIm
 neC
 sNQ
-mfJ
+wUw
 tGE
 kIl
 jPG
@@ -83871,23 +83923,23 @@ tgj
 vrG
 fuy
 awD
-vVL
+rvV
 xUp
 jxs
 ipC
-sFW
+kVe
 aUe
 uSA
 dTX
-hVL
+cBz
 wTU
 pIO
 qjX
-mAJ
+ifg
 ayz
 jPB
-ivl
-pee
+oDb
+iMW
 aZi
 aZi
 diP
@@ -83927,17 +83979,17 @@ wPM
 ycu
 nhm
 ajQ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
-mfJ
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
+wUw
 oVM
 kIl
 jPG
@@ -84143,9 +84195,9 @@ qjX
 qjX
 pNv
 oDb
-ivl
-ivl
-jpy
+oDb
+oDb
+eRK
 ivr
 eRK
 eRK
@@ -84185,17 +84237,17 @@ wPM
 ycu
 nhm
 ajQ
-iag
+mfJ
 hAQ
 hlj
 ffM
 ifX
 cHE
 qjp
-iag
-pMg
-eFa
-iag
+mfJ
+xxG
+tDU
+mfJ
 oVM
 kIl
 jPG
@@ -84394,7 +84446,7 @@ qbH
 qbH
 qbH
 qbH
-azq
+dzE
 qbH
 qbH
 qbH
@@ -84443,17 +84495,17 @@ wPM
 ycu
 nhm
 ajQ
-iag
+mfJ
 uXy
 hGy
 hGy
 hGy
 hGy
 hGy
-iag
-xsz
-lXe
-iag
+mfJ
+mOR
+mUk
+mfJ
 oVM
 kIl
 jPG
@@ -84661,7 +84713,7 @@ qbH
 qbH
 qbH
 qbH
-azq
+dzE
 qbH
 qbH
 qbH
@@ -84701,17 +84753,17 @@ wPM
 ftm
 nhm
 ajQ
-iag
+mfJ
 dCS
 hGy
 hGy
 hGy
 hGy
 ocj
-iag
-iag
+mfJ
+mfJ
 jVS
-iag
+mfJ
 oVM
 crG
 jPG
@@ -84912,10 +84964,10 @@ gVF
 qbH
 qbH
 yhp
-bUE
+cNx
 qfi
 uVx
-enN
+eHr
 qbH
 qbH
 qbH
@@ -84960,16 +85012,16 @@ ycu
 nhm
 ajQ
 wrr
-nKT
-nKT
-nKT
-nKT
-nKT
-nKT
-nKT
-aJc
-nKT
-iag
+ciy
+ciy
+ciy
+ciy
+ciy
+ciy
+ciy
+buP
+ciy
+mfJ
 oVM
 kIl
 jPG
@@ -85162,21 +85214,21 @@ vrG
 fuy
 xuX
 qbH
-sWf
+cZd
 duU
 mky
 hGH
 gVF
 qbH
 yhp
-qKj
+jGm
 lhR
-hTA
+akn
 cdC
 jdX
-bHn
+vSE
 fcO
-hVQ
+kug
 qfi
 xfq
 qfi
@@ -85217,17 +85269,17 @@ wPM
 ycu
 nhm
 ajQ
-iag
+mfJ
 wNS
 kGV
 fim
 dwH
 dwH
-iag
-iag
-iag
+mfJ
+mfJ
+mfJ
 hKT
-iag
+mfJ
 oVM
 kIl
 jPG
@@ -85425,10 +85477,10 @@ gHF
 aAH
 gVF
 gVF
-qbH
+jpy
 jWY
 lhR
-jYy
+enN
 lhR
 lhR
 lhR
@@ -85475,13 +85527,13 @@ wPM
 ycu
 nhm
 ajQ
-iag
+mfJ
 dwH
 jxe
 woJ
 ulc
 uqx
-iag
+mfJ
 wDy
 stq
 hFX
@@ -85686,13 +85738,13 @@ gVF
 qbH
 jWY
 lhR
-kdB
+eoO
 nzO
 lhR
 lhR
 lhR
 nzO
-kdB
+eoO
 lhR
 lhR
 lhR
@@ -85733,13 +85785,13 @@ wPM
 ycu
 nhm
 ajQ
-iag
+mfJ
 mVR
 dwH
 dwH
 ulc
 pDH
-iag
+mfJ
 uJK
 hFX
 hFX
@@ -85944,14 +85996,14 @@ soT
 qbH
 jWY
 lhR
-xVL
+vVj
 lhR
-lur
-lhR
-lhR
+uKc
 lhR
 lhR
-jYy
+lhR
+lhR
+enN
 lhR
 lhR
 lhR
@@ -85991,17 +86043,17 @@ wPM
 ycu
 nhm
 ajQ
-iag
+mfJ
 mVR
 kHq
 kHq
 ulc
 aon
-iag
+mfJ
 jGS
 wAv
 fDg
-iag
+mfJ
 oVM
 kIl
 jPG
@@ -86193,10 +86245,10 @@ tgj
 vrG
 fuy
 xuX
-dzQ
-tUk
-tUk
-hlR
+mxm
+iWd
+iWd
+pjI
 lut
 syD
 qbH
@@ -86249,17 +86301,17 @@ wPM
 ycu
 nhm
 ajQ
-iag
-iag
-iag
-iag
-iag
-iag
-iag
-iag
-iag
-iag
-iag
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
+mfJ
 oVM
 kIl
 jPG
@@ -86452,26 +86504,26 @@ vrG
 fuy
 xuX
 xTU
-hOI
-fAX
+dhl
+nOm
 eCg
 lut
 qvq
 qbH
-imT
+swx
 fSy
 dax
 dax
 dZc
 qbH
-enN
+eHr
 qbH
 qbH
 qbH
 qbH
 qbH
 qbH
-xuX
+jLw
 ouN
 vgN
 ouN
@@ -86507,17 +86559,17 @@ wPM
 ycu
 nhm
 ajQ
-vdb
+iXf
 esR
 tFD
 vRU
 wWm
 kWn
 qfX
-vdb
-npn
-iHV
-vdb
+iXf
+wOq
+fMP
+iXf
 oVM
 kIl
 jPG
@@ -86710,8 +86762,8 @@ vrG
 fuy
 xuX
 lFd
-hOI
-hOI
+dhl
+dhl
 eCg
 rdj
 iMc
@@ -86729,7 +86781,7 @@ qfi
 qfi
 jfo
 qfi
-xuX
+jLw
 ouN
 tiz
 ouN
@@ -86765,17 +86817,17 @@ wPM
 ycu
 nhm
 ajQ
-vdb
+iXf
 dEk
 wNb
 wNb
 wNb
 wNb
 wNb
-vdb
-vqJ
+iXf
 eKD
-vdb
+rHw
+iXf
 oVM
 vdd
 jPG
@@ -86967,9 +87019,9 @@ tgj
 vrG
 fuy
 xuX
-oIG
-hOI
-hOI
+hIK
+dhl
+dhl
 eCg
 lut
 qvq
@@ -86980,14 +87032,14 @@ lhR
 lhR
 lhR
 lhR
-bNz
+ftN
 lhR
 lhR
 lhR
 lhR
 lhR
 lhR
-xuX
+jLw
 ouN
 tiz
 ouN
@@ -87023,17 +87075,17 @@ wPM
 ftm
 nhm
 ajQ
-vdb
+iXf
 sBU
 wNb
 wNb
 wNb
 wNb
 kWY
-vdb
-vdb
-tLD
-vdb
+iXf
+iXf
+qtH
+iXf
 oVM
 kIl
 jPG
@@ -87225,27 +87277,27 @@ tgj
 vrG
 fuy
 xuX
-bTr
-hOI
-hOI
+kdB
+dhl
+dhl
 eCg
-rHw
+hKD
 qdD
-tYA
+wxd
 jWY
 lhR
-kdB
+eoO
 nzO
 lhR
 lhR
 lhR
 nzO
-kdB
+eoO
 lhR
 lhR
 lhR
 lhR
-xuX
+jLw
 ouN
 noa
 ouN
@@ -87282,16 +87334,16 @@ ycu
 nhm
 ajQ
 cRS
-qba
-qba
-qba
-qba
-qba
-qba
-qba
-mmf
-qba
-vdb
+dgT
+dgT
+dgT
+dgT
+dgT
+dgT
+dgT
+jdy
+dgT
+iXf
 oVM
 kIl
 jPG
@@ -87484,8 +87536,8 @@ vrG
 fuy
 xuX
 jRV
-hOI
-hOI
+dhl
+dhl
 eCg
 lut
 qvq
@@ -87503,7 +87555,7 @@ lhR
 lhR
 lhR
 lhR
-xuX
+jLw
 ouN
 jzh
 tiz
@@ -87539,17 +87591,17 @@ wPM
 ycu
 nhm
 ajQ
-vdb
+iXf
 stn
 pmF
 oHb
 rWO
 rWO
-vdb
-vdb
-vdb
+iXf
+iXf
+iXf
 iNx
-vdb
+iXf
 tGE
 kIl
 jPG
@@ -87741,9 +87793,9 @@ tgj
 vrG
 fuy
 xuX
-hIK
-hOI
-hOI
+iQY
+dhl
+dhl
 eCg
 rdj
 nzw
@@ -87761,7 +87813,7 @@ nOE
 rse
 nOE
 nOE
-xuX
+jLw
 ouN
 jzh
 tiz
@@ -87797,13 +87849,13 @@ wPM
 ycu
 nhm
 ajQ
-vdb
+iXf
 rWO
 bwN
 lMZ
 daE
 aDw
-vdb
+iXf
 oYU
 ehz
 dED
@@ -88000,8 +88052,8 @@ vrG
 fuy
 xuX
 xTU
-hOI
-hOI
+dhl
+dhl
 eCg
 lut
 qvq
@@ -88011,15 +88063,15 @@ qbH
 nOE
 nOE
 aLS
-enN
+eHr
 qbH
-tgH
-qbH
-qbH
+qot
 qbH
 qbH
 qbH
-xuX
+qbH
+qbH
+jLw
 ouN
 ouN
 ouN
@@ -88055,13 +88107,13 @@ wPM
 ycu
 nhm
 ajQ
-vdb
+iXf
 hTp
 rWO
 rWO
 daE
 cfX
-vdb
+iXf
 oVX
 dED
 dED
@@ -88258,8 +88310,8 @@ vrG
 fuy
 xuX
 lFd
-hOI
-fAX
+dhl
+nOm
 eCg
 lut
 fnu
@@ -88277,7 +88329,7 @@ qbH
 qbH
 sbp
 sbp
-xuX
+jLw
 ouN
 ouN
 ouN
@@ -88313,17 +88365,17 @@ wPM
 ycu
 nhm
 ajQ
-vdb
+iXf
 hTp
 dxe
 dxe
 daE
 ckk
-vdb
+iXf
 hAt
 erY
 bmm
-vdb
+iXf
 oVM
 kIl
 jPG
@@ -88515,27 +88567,27 @@ tgj
 vrG
 fuy
 xuX
-vXa
-wfY
-wfY
-uUN
+bWc
+dyK
+dyK
+clK
 lut
 qvq
 qbH
 qbH
-opB
+mJl
 qbH
 qbH
 sbp
 qbH
-opB
+mJl
 qbH
 qbH
 qbH
 qbH
 sbp
 sbp
-xuX
+jLw
 kRJ
 ouN
 ohm
@@ -88571,17 +88623,17 @@ wPM
 ycu
 nhm
 ajQ
-vdb
-vdb
-vdb
-vdb
-vdb
-vdb
-vdb
-vdb
-vdb
-vdb
-vdb
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
+iXf
 oVM
 kIl
 jPG
@@ -88773,8 +88825,8 @@ tgj
 vrG
 fuy
 xuX
+blQ
 sOV
-pgz
 xma
 lut
 lut
@@ -88793,7 +88845,7 @@ sbp
 sbp
 sbp
 sbp
-aty
+iKF
 kRJ
 kRJ
 ouN
@@ -88829,17 +88881,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+qba
 wAV
 xeP
 fMj
 oqE
 qQH
 jsx
-epd
-ftE
-mwD
-epd
+qba
+kDl
+kuV
+qba
 oVM
 kIl
 jPG
@@ -89037,21 +89089,21 @@ qbH
 qbH
 qbH
 qbH
-aVP
-vLa
+fMq
+cMb
 qbH
-iRC
+aLr
 sbp
 sbp
 sbp
 sbp
 sbp
-iXf
+npm
 sbp
 sbp
 sbp
 sbp
-aty
+nJM
 kRJ
 kRJ
 ouN
@@ -89087,17 +89139,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+qba
 oFn
 wSj
 wSj
 wSj
 wSj
 wSj
-epd
-iqP
-xLP
-epd
+qba
+ivl
+plZ
+qba
 tGE
 vdd
 jPG
@@ -89295,7 +89347,7 @@ qbH
 dqU
 dqU
 qbH
-pGH
+tGg
 qbH
 qbH
 qbH
@@ -89309,7 +89361,7 @@ qbH
 qbH
 sbp
 sbp
-xuX
+jLw
 kRJ
 ouN
 ohm
@@ -89345,17 +89397,17 @@ wPM
 ftm
 nhm
 ajQ
-epd
+qba
 uEQ
 wSj
 wSj
 wSj
 wSj
 etN
-epd
-epd
-mVk
-epd
+qba
+qba
+slv
+qba
 oVM
 kIl
 jPG
@@ -89548,7 +89600,7 @@ vrG
 fuy
 xuX
 soT
-iRC
+aLr
 dqU
 poO
 snb
@@ -89562,12 +89614,12 @@ qbH
 qbH
 qbH
 qbH
-nJM
+nKT
 qbH
 qbH
 sbp
 sbp
-xuX
+jLw
 ouN
 ouN
 ouN
@@ -89604,16 +89656,16 @@ ycu
 nhm
 ajQ
 kKz
-wWt
-wWt
-wWt
-wWt
-wWt
-wWt
-wWt
-xmj
-wWt
-epd
+uYM
+uYM
+uYM
+uYM
+uYM
+uYM
+uYM
+rCs
+uYM
+qba
 oVM
 kIl
 jPG
@@ -89817,15 +89869,15 @@ tZz
 tZz
 tZz
 rFt
-oHI
+gNP
 qbH
-cDf
-qbH
-qbH
+hcr
 qbH
 qbH
 qbH
-xuX
+aLr
+qbH
+jLw
 ouN
 ouN
 ouN
@@ -89861,17 +89913,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+qba
 nYd
 axn
 pNW
 nKG
 nKG
-epd
-epd
-epd
+qba
+qba
+qba
 rcW
-epd
+qba
 tGE
 kIl
 jPG
@@ -90083,7 +90135,7 @@ qbH
 qbH
 qbH
 qbH
-xuX
+jLw
 ouN
 ouN
 ouN
@@ -90119,13 +90171,13 @@ wPM
 ycu
 nhm
 ajQ
-epd
+qba
 nKG
 qEy
 erz
 uyc
 uhu
-epd
+qba
 aXy
 uPj
 uFT
@@ -90377,13 +90429,13 @@ wPM
 ycu
 nhm
 ajQ
-epd
+qba
 rDL
 nKG
 nKG
 uyc
 bvW
-epd
+qba
 hAV
 uFT
 uFT
@@ -90635,17 +90687,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
+qba
 rDL
 dHv
 dHv
 uyc
 rCB
-epd
+qba
 anx
 utS
 cQx
-epd
+qba
 sKj
 kIl
 jPG
@@ -90893,17 +90945,17 @@ wPM
 ycu
 nhm
 ajQ
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
-epd
+qba
+qba
+qba
+qba
+qba
+qba
+qba
+qba
+qba
+qba
+qba
 tPv
 tPv
 tPv

--- a/modular_chomp/code/datums/outfits/jobs/noncrew.dm
+++ b/modular_chomp/code/datums/outfits/jobs/noncrew.dm
@@ -39,3 +39,9 @@
 	if(istype(wallet))
 		wallet.owner_name = H.real_name
 		wallet.worth = 1000
+
+/decl/hierarchy/outfit/noncrew/vr_avatar
+	pda_slot = null
+	id_slot = null
+	r_pocket = null
+	l_pocket = null

--- a/modular_chomp/code/game/jobs/job/noncrew.dm
+++ b/modular_chomp/code/game/jobs/job/noncrew.dm
@@ -63,3 +63,20 @@
 		return TRUE
 	else
 		return FALSE
+
+/datum/job/vr_avatar //So VR avatars dont spawn with PDAs and flood the servers
+	title = JOB_VR
+	disallow_jobhop = TRUE
+	total_positions = 99
+	spawn_positions = 5
+	latejoin_only = 1
+	supervisors = "The VR world"
+
+	flag = NONCREW
+	departments = list(DEPARTMENT_NONCREW)
+	department_flag = OTHER
+	faction = "Station"
+	assignable = FALSE
+	account_allowed = 0
+	offmap_spawn = TRUE
+	outfit_type = /decl/hierarchy/outfit/noncrew/vr_avatar

--- a/modular_chomp/code/modules/mob/dead/observer/observer.dm
+++ b/modular_chomp/code/modules/mob/dead/observer/observer.dm
@@ -15,6 +15,7 @@
 	set category = "Ghost"
 	set desc = "Log into NanoTrasen's local virtual reality server."
 
+/* Temp removal while I figure out how to reduce the respawn time to 1 minute
 	var/time_till_respawn = time_till_respawn()
 	if(time_till_respawn == -1) // Special case, never allowed to respawn
 		to_chat(usr, "<span class='warning'>Respawning is not allowed!</span>")
@@ -22,7 +23,7 @@
 	if(time_till_respawn) // Nonzero time to respawn
 		to_chat(usr, "<span class='warning'>You can't do that yet! You died too recently. You need to wait another [round(time_till_respawn/10/60, 0.1)] minutes.</span>")
 		return
-
+*/
 	var/datum/data/record/record_found
 	record_found = find_general_record("name", client.prefs.real_name)
 	// Found their record, they were spawned previously. Remind them corpses cannot play games.
@@ -61,7 +62,7 @@
 
 	avatar.regenerate_icons()
 	avatar.update_transform()
-	job_master.EquipRank(avatar,"Visitor", 1, FALSE)
+	job_master.EquipRank(avatar,"VR Avatar", 1, FALSE)
 	add_verb(avatar,/mob/living/carbon/human/proc/fake_exit_vr)  //CHOMPEdit
 	add_verb(avatar,/mob/living/carbon/human/proc/vr_transform_into_mob)  //CHOMPEdit
 	add_verb(avatar,/mob/living/proc/set_size) //CHOMPEdit TGPanel // Introducing NeosVR


### PR DESCRIPTION

## About The Pull Request
This PR should address the bug where joining in VR via autosleever and the ghost menu will spawn you without a PDA now to prevent flooding the PDA servers with fake people.
I have also axed the respawn time by joining VR (You could spam it anyway if you simply left without dieing) and to make it consistent with the auto sleevers. I will add a short respawn timer if this becomes a problem.

Added a new bar past the VR food court for uh... extreme recreational activities.
![image](https://github.com/CHOMPStation2/CHOMPStation2/assets/10555869/865091fe-0f9a-4027-a54e-d4912701ee6c)


## Changelog
:cl:
del: Removed VR respawn time
fix: VR no longer will spawn duplicate PDAs flooding the PDA servers with fake people.
maptweak: VR new bar room added.
/:cl:
