### PR TITLE
VR fixy

### DIFF
--- a/code/_helpers/global_lists_vr.dm
+++ b/code/_helpers/global_lists_vr.dm
@@ -1067,7 +1067,8 @@ var/global/list/SPECIALS = list(
 	/turf/unsimulated/wall/planetary,
 	/area/submap/virgo2,
 	/area/submap/event,
-	/area/submap/casino_event
+	/area/submap/casino_event,
+	/area/vr //CHOMPedit
 	// /area/derelict //commented out, all hail derelict-rebuilders!
 )
 
@@ -1089,5 +1090,6 @@ var/global/list/area_or_turf_fail_types = typecacheof(list(
 	/turf/unsimulated/wall/planetary,
 	/area/submap/virgo2,
 	/area/submap/event,
-	/area/submap/casino_event
+	/area/submap/casino_event,
+	/area/vr //CHOMPedit
 	))


### PR DESCRIPTION

## About The Pull Request
Can't make areas in VR anymore as you get auto-erased if you're in a place that isn't a /vr/ subtype.
## Changelog
:cl:
fix: Fixed a bug involving making custom areas in VR which can delete you if made.
/:cl:
