### PR TITLE
Fixes certain firework stars from not working and nighttime changes

### DIFF
--- a/code/modules/planet/sif.dm
+++ b/code/modules/planet/sif.dm
@@ -36,8 +36,8 @@ var/datum/planet/sif/planet_sif = null
 
 	switch(sun_position)
 		if(0 to 0.40) // Night
-			low_brightness = 0.1
-			low_color = "#000066"
+			low_brightness = 0.15 //CHOMPedit
+			low_color = "#19195c" //CHOMPedit
 
 			high_brightness = 0.3
 			high_color = "#66004D"
@@ -122,7 +122,9 @@ var/datum/planet/sif/planet_sif = null
 		WEATHER_BLOOD_MOON	= new /datum/weather/sif/blood_moon(),
 		WEATHER_EMBERFALL	= new /datum/weather/sif/emberfall(),
 		WEATHER_ASH_STORM	= new /datum/weather/sif/ash_storm(),
-		WEATHER_FALLOUT		= new /datum/weather/sif/fallout()
+		WEATHER_FALLOUT		= new /datum/weather/sif/fallout(),
+		WEATHER_FALLOUT_TEMP	= new /datum/weather/sif/fallout/temp(), //CHOMPedit
+		WEATHER_CONFETTI		= new /datum/weather/sif/confetti() //CHOMPedit
 		)
 	roundstart_weather_chances = list(
 		WEATHER_CLEAR		= 30,
@@ -553,6 +555,7 @@ var/datum/planet/sif/planet_sif = null
 	transition_messages = list(
 		"Radioactive soot and ash start to float down around you, contaminating whatever they touch."
 	)
+	imminent_transition_message = "Sky and clouds are growing sickly green... Radiation storm is approaching, get to cover!"
 	outdoor_sounds_type = /datum/looping_sound/weather/wind
 	indoor_sounds_type = /datum/looping_sound/weather/wind/indoors
 

--- a/modular_chomp/code/modules/planet/sif.dm
+++ b/modular_chomp/code/modules/planet/sif.dm
@@ -16,7 +16,7 @@
 		WEATHER_RAIN = 5
 		)
 
-/datum/weather/sif/fallout/temp
+/datum/weather/sif/fallout/temp //fixys firework stars
 	name = "short-term fallout"
 	timer_low_bound = 1
 	timer_high_bound = 3
@@ -28,7 +28,7 @@
 		WEATHER_OVERCAST = 5
 		)
 
-/datum/weather/sif/confetti
+/datum/weather/sif/confetti //fixys firework stars
 	name = "confetti"
 	icon_state = "confetti"
 

--- a/modular_chomp/code/modules/planet/sif.dm
+++ b/modular_chomp/code/modules/planet/sif.dm
@@ -15,3 +15,30 @@
 		WEATHER_LIGHT_SNOW = 10,
 		WEATHER_RAIN = 5
 		)
+
+/datum/weather/sif/fallout/temp
+	name = "short-term fallout"
+	timer_low_bound = 1
+	timer_high_bound = 3
+	transition_chances = list(
+		WEATHER_FALLOUT = 10,
+		WEATHER_RAIN = 50,
+		WEATHER_FOG = 35,
+		WEATHER_STORM = 20,
+		WEATHER_OVERCAST = 5
+		)
+
+/datum/weather/sif/confetti
+	name = "confetti"
+	icon_state = "confetti"
+
+	transition_chances = list(
+		WEATHER_CLEAR = 50,
+		WEATHER_OVERCAST = 20,
+		WEATHER_CONFETTI = 5
+		)
+	observed_message = "Confetti is raining from the sky."
+	transition_messages = list(
+		"Suddenly, colorful confetti starts raining from the sky."
+	)
+	imminent_transition_message = "A rain is starting... A rain of confetti...?"


### PR DESCRIPTION

## About The Pull Request
Fixes certain firework stars like the nuclear one from working at all, this is a bugfix, balance about these are outside the scope of this PR.

Also makes night time just _barely_ more brighter, still impossible to see because the lighting refactor made night pitch black. 
![dreamseeker_4sbBct3UIF](https://github.com/CHOMPStation2/CHOMPStation2/assets/10555869/6c1cfc85-1c9d-41bf-a61d-f0024630161f)
How night looks now
## Changelog
:cl:
fix: Fixed certain firework stars from being able to change Sif's weather
/:cl:
