### PR TITLE
Fixing all the issues I created on the map (Changes Deck 0/1/2/3 as well as Sif Plains and CentCom maps)

### DIFF
--- a/maps/southern_cross/southern_cross-0.dmm
+++ b/maps/southern_cross/southern_cross-0.dmm
@@ -7,7 +7,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "ad" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19,7 +19,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "ag" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -34,7 +34,7 @@
 "ah" = (
 /obj/structure/foamedmetal,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "ak" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -54,19 +54,20 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "am" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "ao" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
+/obj/machinery/atmospherics/binary/pump/on{
+	dir = 8;
+	target_pressure = 200
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "ap" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81,7 +82,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "aq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -104,11 +105,11 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "as" = (
 /obj/machinery/light/floortube,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "at" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloor{
@@ -153,7 +154,7 @@
 /obj/machinery/door/airlock/maintenance/common,
 /obj/item/tape/atmos,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "aC" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/table/rack,
@@ -174,7 +175,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "aF" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 5
@@ -240,7 +241,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "aS" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -248,7 +249,7 @@
 	},
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "aT" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow{
@@ -305,12 +306,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "aX" = (
 /obj/structure/table/marble,
 /obj/random/drinksoft,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "aY" = (
 /obj/structure/table/rack/shelf,
 /obj/random/fishing_junk,
@@ -352,7 +353,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "bc" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -384,7 +385,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "bi" = (
 /obj/structure/table/rack/shelf,
 /obj/random/soap,
@@ -428,13 +429,13 @@
 "bp" = (
 /obj/structure/prop/dark_node,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "bq" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "br" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -506,17 +507,22 @@
 	},
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "bD" = (
 /obj/effect/floor_decal/rust,
 /obj/random/flashlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
+"bG" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/plating,
+/area/maintenance/engineering/gravgen)
 "bH" = (
 /obj/structure/catwalk,
 /obj/structure/flora/pottedplant/fern,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "bM" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -568,7 +574,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "bU" = (
 /obj/machinery/light/spot{
 	dir = 4
@@ -594,7 +600,7 @@
 	name = "maint_pred"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "cg" = (
 /obj/structure/smoletrack/roadT{
 	dir = 8
@@ -670,7 +676,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "cs" = (
 /obj/random/trash,
 /obj/machinery/light/small{
@@ -683,21 +689,29 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "cv" = (
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
+/obj/effect/floor_decal/rust,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zeroaft)
 "cw" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "cy" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -731,7 +745,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "cF" = (
 /obj/structure/table/marble,
 /obj/random/maintenance,
@@ -741,11 +755,11 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "cJ" = (
 /obj/random/flashlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "cK" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
@@ -754,7 +768,7 @@
 /obj/item/tape/engineering,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "cL" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -792,7 +806,7 @@
 	dir = 8;
 	pixel_y = -10
 	},
-/turf/simulated/wall/r_wall/turfpack/station,
+/turf/simulated/wall,
 /area/engineering/lowlobby)
 "cR" = (
 /obj/structure/railing/grey{
@@ -822,7 +836,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "cZ" = (
 /obj/structure/flora/pottedplant/dead,
 /obj/effect/floor_decal/borderfloor{
@@ -859,8 +873,8 @@
 	dir = 4;
 	pixel_y = -10
 	},
-/turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/aft)
+/turf/simulated/wall,
+/area/maintenance/zerofore)
 "dd" = (
 /turf/simulated/wall/r_wall/turfpack/station,
 /area/engineering/gravgen)
@@ -878,17 +892,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "dl" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "dm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/abcargo)
 "dn" = (
 /obj/machinery/door/firedoor/border_only,
@@ -911,7 +925,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "do" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -922,7 +936,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "dr" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow{
@@ -944,7 +958,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "dw" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -964,7 +978,7 @@
 /obj/effect/floor_decal/rust,
 /obj/random/mainttoyloot,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "dB" = (
 /turf/simulated/floor/wood/broken/turfpack/station,
 /area/maintenance/bar/dorms/dorm_2)
@@ -1035,7 +1049,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "dS" = (
 /obj/random/junk,
 /obj/effect/floor_decal/rust,
@@ -1043,7 +1057,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "dT" = (
 /obj/random/trash,
 /obj/structure/cable{
@@ -1058,30 +1072,29 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "dW" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/tiled/hydro,
 /area/maintenance/abhydroponicssupp)
 "dX" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
 	icon_state = "door_locked";
-	id_tag = "d0_outer";
 	locked = 1;
 	name = "External Airlock Access";
-	req_access = list(13)
+	req_access = list(13);
+	frequency = 1379;
+	id_tag = "d0_outer"
 	},
-/obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "dY" = (
 /obj/structure/curtain/bed,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "dZ" = (
 /turf/simulated/floor/grass,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "ea" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/turfpack/station,
@@ -1089,7 +1102,7 @@
 "eb" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "ec" = (
 /obj/item/weapon/storage/bag/cash,
 /obj/machinery/button/remote/airlock{
@@ -1115,7 +1128,7 @@
 "eh" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "ei" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1157,13 +1170,13 @@
 "em" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "eo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "ep" = (
 /obj/machinery/light{
 	dir = 4
@@ -1174,7 +1187,7 @@
 /obj/random/cash,
 /obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "er" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -1191,23 +1204,31 @@
 /area/maintenance/bar/dorms/dorm_1)
 "ex" = (
 /obj/machinery/door/airlock/external{
-	frequency = 1379;
 	icon_state = "door_locked";
-	id_tag = "d0_outer";
 	locked = 1;
 	name = "External Airlock Access";
-	req_access = list(13)
+	req_access = list(13);
+	frequency = 1379;
+	id_tag = "d0_outer"
 	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/effect/map_helper/airlock/button/ext_button,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "d0_airlock";
+	name = "exterior access button";
+	pixel_y = -28;
+	req_access = null;
+	dir = 8;
+	pixel_x = -8
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "ez" = (
 /obj/structure/sign/warning/secure_area{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "eA" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
@@ -1223,44 +1244,25 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "eC" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows/yellow{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/arrows/yellow{
-	dir = 8
-	},
-/obj/machinery/door/airlock/maintenance/common,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/maintenance/central)
+/turf/simulated/wall,
+/area/maintenance/abfirstaid)
 "eE" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "eI" = (
 /obj/random/maintenance,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "eJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "eM" = (
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
@@ -1314,7 +1316,7 @@
 	},
 /obj/random/obstruction,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "eY" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -1326,7 +1328,7 @@
 "fb" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "fc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1345,7 +1347,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "fe" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1364,7 +1366,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "fg" = (
 /obj/machinery/light/floortube,
 /turf/simulated/floor/plating/turfpack/station,
@@ -1391,7 +1393,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fieldhallway)
+/area/maintenance/zeroaft)
 "fl" = (
 /obj/structure/table/rack/shelf,
 /obj/random/mainttoyloot,
@@ -1412,7 +1414,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "fr" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable{
@@ -1432,7 +1434,7 @@
 "ft" = (
 /obj/structure/flora/pottedplant/aquatic,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "fu" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
@@ -1480,7 +1482,7 @@
 "fz" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/grass,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "fC" = (
 /turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/abtheatre)
@@ -1488,6 +1490,12 @@
 /obj/structure/closet/crate/wooden,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abcargo)
+"fF" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating/turfpack/station,
+/area/maintenance/zerostarboard)
 "fG" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -1506,11 +1514,11 @@
 /obj/structure/barricade,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "fL" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "fM" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -1521,38 +1529,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "fR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/turf/simulated/wall,
+/area/maintenance/bar/dorms/dorm_2)
 "fS" = (
 /obj/structure/table/marble,
 /obj/random/drinksoft,
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "fT" = (
 /obj/structure/catwalk,
 /obj/random/toolbox,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "fW" = (
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "fX" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "fY" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1566,7 +1563,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "ga" = (
 /obj/structure/table/rack,
 /obj/item/stack/cable_coil,
@@ -1585,7 +1582,7 @@
 /obj/structure/bed/double/padded,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "gc" = (
 /obj/structure/hyperball_goal/blue,
 /turf/simulated/floor/tiled/monotile,
@@ -1622,7 +1619,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "gh" = (
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 4
@@ -1652,7 +1649,7 @@
 /area/maintenance/engineering/gravgen)
 "gk" = (
 /turf/unsimulated/floor/carpet/gaycarpet,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "gl" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -1669,7 +1666,7 @@
 	on = 0
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "go" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -1688,15 +1685,15 @@
 /area/maintenance/substation/gravgen)
 "gq" = (
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "gr" = (
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "gs" = (
 /obj/item/clothing/mask/muzzle/ballgag,
 /obj/structure/table/standard,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "gv" = (
 /turf/simulated/wall,
 /area/maintenance/abcargo)
@@ -1723,7 +1720,7 @@
 "gB" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "gE" = (
 /obj/structure/table/marble,
 /obj/item/seeds/ambrosiagaiaseed,
@@ -1747,19 +1744,19 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "gH" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "gI" = (
 /obj/structure/firedoor_assembly,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "gJ" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -1770,14 +1767,14 @@
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abcargo)
 "gL" = (
-/turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/starboard)
+/turf/simulated/wall,
+/area/maintenance/zeroaft)
 "gM" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/barricade,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "gN" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable{
@@ -1829,7 +1826,7 @@
 	name = "Maintenance Access"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "gX" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -1857,7 +1854,7 @@
 "gZ" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "hb" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -1879,11 +1876,11 @@
 "hg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "hh" = (
 /obj/random/junk,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "hj" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/lowlobby)
@@ -1892,7 +1889,7 @@
 	dir = 8
 	},
 /turf/unsimulated/floor/carpet/gaycarpet,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "hl" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow{
@@ -1903,7 +1900,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "hn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1937,7 +1934,7 @@
 "hx" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "hy" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable{
@@ -1978,7 +1975,7 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "hH" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -2057,7 +2054,7 @@
 "hU" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "hV" = (
 /obj/structure/catwalk,
 /obj/machinery/firealarm{
@@ -2065,7 +2062,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "hX" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -2087,7 +2084,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/engi,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "hZ" = (
 /obj/structure/table/rack/shelf,
 /obj/random/material,
@@ -2103,7 +2100,7 @@
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "ic" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/pottedplant/large{
@@ -2113,20 +2110,19 @@
 /area/engineering/lowlobby)
 "ie" = (
 /obj/machinery/door/airlock/glass_external{
-	frequency = 1379;
 	icon_state = "door_locked";
-	id_tag = "d0_inner";
 	locked = 1;
 	name = "Internal Airlock Access";
-	req_access = list(13)
+	req_access = list(13);
+	frequency = 1379;
+	id_tag = "d0_inner"
 	},
-/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "if" = (
 /obj/structure/flora/pottedplant/overgrown,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "ig" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2137,7 +2133,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "ij" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
@@ -2175,8 +2171,8 @@
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abtheatre)
 "iv" = (
-/turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/turf/simulated/wall,
+/area/engineering/lowlobby)
 "iw" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -2197,7 +2193,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "iA" = (
 /obj/structure/table/rack/shelf,
 /obj/random/soap,
@@ -2243,7 +2239,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "iM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2293,6 +2289,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fieldhallway)
+"iZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/turfpack/station,
+/area/maintenance/zeroaft)
 "jb" = (
 /obj/random/trash,
 /obj/random/junk,
@@ -2301,12 +2308,12 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "jc" = (
 /obj/structure/catwalk,
 /obj/random/tool,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "jd" = (
 /turf/simulated/wall/r_lead,
 /area/engineering/gravgen)
@@ -2324,11 +2331,11 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "jf" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "jg" = (
 /obj/machinery/smartfridge/drying_rack,
 /obj/effect/floor_decal/borderfloor{
@@ -2342,11 +2349,11 @@
 "ji" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "jk" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "jm" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
@@ -2355,22 +2362,22 @@
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "jo" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "d0_airlock";
 	pixel_y = -26;
 	req_access = null;
-	tag_airpump = "d3_port_dorms_pump";
-	tag_chamber_sensor = "d3_port_dorms_sensor";
-	tag_exterior_door = "d3_port_dorms_outer";
-	tag_interior_door = "d3_port_dorms_inner"
+	tag_airpump = "d0_pump";
+	tag_chamber_sensor = "d0_sensor";
+	tag_exterior_door = "d0_outer";
+	tag_interior_door = "d0_inner"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "jp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -2379,7 +2386,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "jq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2389,7 +2396,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "jr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -2421,7 +2428,7 @@
 "jv" = (
 /obj/structure/flora/pottedplant/shoot,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "jw" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/rust,
@@ -2447,7 +2454,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "jz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2455,14 +2462,14 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "jB" = (
 /obj/structure/table,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "jC" = (
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "jE" = (
 /obj/random/action_figure{
 	pixel_x = -5;
@@ -2487,13 +2494,13 @@
 "jF" = (
 /obj/structure/flora/pottedplant/bamboo,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "jI" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/barricade,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "jJ" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -2503,7 +2510,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "jK" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -2520,7 +2527,7 @@
 	on = 0
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "jM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2534,7 +2541,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "jP" = (
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/mercury,
 /obj/item/weapon/reagent_containers/chem_disp_cartridge/sugar{
@@ -2575,7 +2582,7 @@
 	dir = 4
 	},
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "jW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2628,7 +2635,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "kf" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -2689,12 +2696,12 @@
 	},
 /obj/random/flashlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "kn" = (
 /obj/structure/catwalk,
 /obj/random/flashlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "ko" = (
 /obj/structure/bed/pillowpilefront/orange,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -2711,7 +2718,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "kt" = (
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/field)
@@ -2722,15 +2729,15 @@
 "ky" = (
 /obj/structure/grille/broken,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "kB" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "kC" = (
 /obj/random/tool,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "kE" = (
 /turf/simulated/wall/turfpack/station,
 /area/maintenance/abtheatre)
@@ -2745,7 +2752,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "kH" = (
 /obj/structure/railing,
 /obj/structure/railing{
@@ -2779,18 +2786,18 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "kN" = (
 /obj/structure/table,
 /obj/structure/table,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "kP" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
 /obj/structure/catwalk,
 /turf/simulated/floor/dungeon,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "kQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2807,7 +2814,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "kR" = (
 /obj/structure/smolebuilding/museum,
 /turf/simulated/floor/smole,
@@ -2848,7 +2855,7 @@
 "kY" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "lb" = (
 /obj/random/plushie{
 	pixel_y = -3
@@ -2880,7 +2887,7 @@
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "lg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2896,7 +2903,7 @@
 /obj/structure/catwalk,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "li" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -2909,7 +2916,7 @@
 "lj" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "lr" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
@@ -2938,7 +2945,7 @@
 "lv" = (
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "lx" = (
 /obj/structure/table/marble,
 /obj/effect/floor_decal/borderfloor{
@@ -2958,7 +2965,7 @@
 /area/maintenance/abhydroponics)
 "ly" = (
 /turf/simulated/wall/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "lz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2973,10 +2980,10 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "lA" = (
-/turf/simulated/wall/turfpack/station,
-/area/maintenance/engineering)
+/turf/simulated/wall,
+/area/maintenance/bar/dorms/dorm_1)
 "lC" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
@@ -2988,7 +2995,7 @@
 /obj/structure/catwalk,
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "lH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -3007,7 +3014,7 @@
 "lM" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/grass,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "lN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3047,11 +3054,11 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "lW" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "lY" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -3073,15 +3080,15 @@
 "me" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "mh" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/fieldhallway)
 "mj" = (
-/obj/random/junk,
+/obj/effect/landmark/event_spawn/morphspawn,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerostarboard)
 "mm" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3096,14 +3103,14 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "mp" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "mq" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -3135,7 +3142,7 @@
 	},
 /obj/random/cash,
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "mx" = (
 /obj/item/weapon/storage/briefcase/inflatable,
 /obj/structure/cable{
@@ -3150,7 +3157,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "my" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
@@ -3158,12 +3165,12 @@
 "mz" = (
 /obj/structure/door_assembly/door_assembly_highsecurity,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "mA" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "mB" = (
 /obj/structure/table/rack/shelf,
 /obj/random/tool,
@@ -3183,7 +3190,7 @@
 	},
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "mD" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
@@ -3262,7 +3269,7 @@
 "mQ" = (
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "mT" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -3279,7 +3286,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "mU" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -3305,7 +3312,7 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/firedoor_assembly,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "mX" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow{
@@ -3327,7 +3334,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "mZ" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
@@ -3335,7 +3342,7 @@
 	},
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "na" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -3355,7 +3362,7 @@
 	on = 0
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "nb" = (
 /obj/structure/bed/chair/bay{
 	dir = 4
@@ -3377,20 +3384,20 @@
 "nf" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "ng" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "nh" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /obj/random/obstruction,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "nj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -3399,7 +3406,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "nl" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -3445,7 +3452,7 @@
 /obj/item/tape/engineering,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "np" = (
 /obj/structure/bed/chair/bay/chair/padded/red/smallnest,
 /obj/machinery/firealarm{
@@ -3482,17 +3489,18 @@
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abmedical)
 "ny" = (
-/obj/structure/catwalk,
-/obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "nz" = (
 /obj/structure/table/woodentable,
 /obj/item/clothing/gloves/vox,
 /obj/item/clothing/under/suit_jacket/burgundy/skirt,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "nA" = (
 /obj/item/weapon/storage/backpack/clown/loaded,
 /turf/simulated/floor/plating,
@@ -3512,7 +3520,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "nF" = (
 /obj/structure/sign/directions/security{
 	dir = 8
@@ -3525,7 +3533,7 @@
 	dir = 8;
 	pixel_y = -10
 	},
-/turf/simulated/wall/r_wall/turfpack/station,
+/turf/simulated/wall,
 /area/engineering/lowlobby)
 "nG" = (
 /obj/structure/bed/chair/bay{
@@ -3546,7 +3554,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "nJ" = (
 /obj/structure/railing,
 /turf/simulated/floor/wood/alt/panel,
@@ -3564,7 +3572,7 @@
 "nL" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "nQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -3573,7 +3581,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "nR" = (
 /obj/random/obstruction,
 /obj/effect/floor_decal/rust,
@@ -3586,7 +3594,7 @@
 	},
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating/turfpack/airless,
-/area/space)
+/area/maintenance/zeroport)
 "nT" = (
 /obj/machinery/light/spot{
 	dir = 8
@@ -3620,11 +3628,11 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "ob" = (
 /obj/structure/flora/pottedplant/tropical,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "oc" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -3647,10 +3655,10 @@
 	on = 0
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "of" = (
 /turf/simulated/floor/tiled/white,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "og" = (
 /obj/structure/table/rack/shelf,
 /obj/structure/curtain/black,
@@ -3665,14 +3673,14 @@
 /obj/structure/table/marble,
 /obj/random/maintenance/foodstuff,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "oj" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
 	pixel_y = 26
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "ok" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -3691,18 +3699,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "on" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/turf/simulated/wall/turfpack/station,
+/area/maintenance/zerofore)
 "oo" = (
 /obj/structure/table/steel,
 /obj/item/seeds/poppyseed,
@@ -3777,11 +3777,11 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "ox" = (
-/obj/random/flashlight,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "oz" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/rust,
@@ -3804,11 +3804,11 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "oH" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "oJ" = (
 /obj/structure/sign/directions/recreation{
 	dir = 5
@@ -3847,7 +3847,7 @@
 "oU" = (
 /obj/random/toolbox,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "oV" = (
 /turf/simulated/floor/plating,
 /area/maintenance/janitoral)
@@ -3864,13 +3864,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "oY" = (
 /obj/item/stack/material/marble{
 	amount = 25
 	},
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "pa" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techmaint,
@@ -3893,11 +3893,11 @@
 	},
 /obj/random/maintenance/foodstuff,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "pe" = (
 /obj/random/trash,
 /turf/unsimulated/floor/carpet/gaycarpet,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "pf" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/bed/chair/bay{
@@ -3908,11 +3908,11 @@
 "pg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "pj" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "pk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3926,14 +3926,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "pn" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "pp" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
@@ -3974,7 +3974,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "pv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3995,7 +3995,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "pw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4022,7 +4022,7 @@
 /obj/structure/table/marble,
 /obj/random/coin/sometimes,
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "pD" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -4042,7 +4042,7 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "pJ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow{
@@ -4065,7 +4065,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "pP" = (
 /turf/simulated/floor/bmarble,
 /area/maintenance/thrift)
@@ -4073,7 +4073,7 @@
 /obj/effect/floor_decal/rust,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "pR" = (
 /obj/machinery/light/floortube,
 /turf/simulated/floor/lino,
@@ -4088,7 +4088,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/item/tape/engineering,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "pV" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -4118,18 +4118,18 @@
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "pX" = (
 /obj/machinery/firealarm{
 	layer = 3.3;
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "qb" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "qd" = (
 /obj/structure/table/marble,
 /obj/random/cash,
@@ -4142,7 +4142,7 @@
 "qf" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "qg" = (
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/backuppower)
@@ -4164,7 +4164,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "qm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
@@ -4191,7 +4191,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "qs" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/cable{
@@ -4231,7 +4231,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "qv" = (
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 4
@@ -4270,7 +4270,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "qB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4290,11 +4290,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1379;
-	id_tag = "d3_port_dorms_pump"
+	id_tag = "d0_pump"
 	},
 /obj/machinery/airlock_sensor{
-	id_tag = "d0_sensor";
-	pixel_y = 25
+	pixel_y = 25;
+	id_tag = "d0_sensor"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
@@ -4302,14 +4302,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "qJ" = (
 /obj/random/tool,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "qK" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/turfpack/station,
@@ -4328,7 +4326,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "qN" = (
 /obj/item/weapon/storage/briefcase/inflatable,
 /turf/simulated/floor/bmarble,
@@ -4350,7 +4348,7 @@
 "qR" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "qS" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -4383,12 +4381,13 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/fieldhallway)
+/area/maintenance/zeroaft)
 "qW" = (
-/obj/structure/catwalk,
-/obj/structure/catwalk,
+/obj/effect/wingrille_spawn/reinforced,
+/obj/item/tape/engineering,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
-/area/maintenance/fieldhallway)
+/area/maintenance/engineering/gravgen)
 "rc" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -4429,7 +4428,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "rh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood/turfpack/station,
@@ -4450,7 +4449,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "rl" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -4471,7 +4470,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/landmark/event_spawn/morphspawn,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "rq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4481,11 +4480,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "rs" = (
 /obj/effect/decal/cleanable/spiderling_remains,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abtheatre)
+"rt" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/turf/simulated/floor/plating,
+/area/maintenance/zeroaft)
 "rv" = (
 /turf/simulated/floor/plating,
 /area/maintenance/abtheatre)
@@ -4513,23 +4517,23 @@
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "rC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "rD" = (
 /obj/structure/table/marble,
 /obj/item/weapon/storage/box/glasses/meta/metapint,
 /obj/random/drinkbottle,
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "rF" = (
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "rJ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -4561,7 +4565,7 @@
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "rP" = (
 /obj/effect/floor_decal/rust,
 /obj/random/maintenance,
@@ -4605,7 +4609,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "rX" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -4620,7 +4624,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "rY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4641,9 +4645,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fieldhallway)
 "sa" = (
-/obj/structure/mob_spawner/mouse_nest/mousehole,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "sc" = (
 /obj/random/trash,
 /turf/simulated/floor/grass2/turfpack/station,
@@ -4651,11 +4665,11 @@
 "se" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "sf" = (
 /obj/effect/decal/cleanable/fruit_smudge,
 /turf/unsimulated/floor/carpet/gaycarpet,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "sh" = (
 /obj/item/weapon/storage/firstaid/regular{
 	empty = 1;
@@ -4685,7 +4699,7 @@
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "sl" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow{
@@ -4714,7 +4728,7 @@
 	},
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "sq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4728,7 +4742,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "sr" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
@@ -4741,7 +4755,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "sw" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -4758,7 +4772,7 @@
 	},
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "sz" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -4768,7 +4782,7 @@
 /obj/structure/catwalk,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "sC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4787,7 +4801,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "sD" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
@@ -4809,18 +4823,18 @@
 "sG" = (
 /obj/structure/flora/pottedplant/smelly,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "sH" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "sI" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/bed/chair/bay{
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "sK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -4859,12 +4873,12 @@
 /obj/structure/catwalk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "sV" = (
 /turf/unsimulated/mask,
 /area/engineering/lowlobby)
 "sW" = (
-/turf/simulated/wall/r_wall/turfpack/station,
+/turf/simulated/wall,
 /area/maintenance/field)
 "sY" = (
 /obj/structure/table/woodentable,
@@ -4922,7 +4936,7 @@
 /obj/structure/barricade,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "tj" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -4940,14 +4954,14 @@
 /obj/structure/table/marble,
 /obj/random/junk,
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "tl" = (
 /obj/random/junk,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "tm" = (
 /obj/item/clothing/under/swimsuit/stripper/stripper_pink,
 /obj/item/clothing/under/swimsuit/stripper/stripper_green,
@@ -4955,7 +4969,7 @@
 /obj/structure/table/standard,
 /obj/item/clothing/head/kitty,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "tp" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -4971,7 +4985,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "ts" = (
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating/turfpack/station,
@@ -5021,7 +5035,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "tG" = (
 /obj/random/drinkbottle,
 /turf/simulated/floor/plating/turfpack/station,
@@ -5049,11 +5063,11 @@
 "tN" = (
 /obj/item/weapon/storage/briefcase/inflatable,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "tO" = (
 /obj/random/maintenance,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "tP" = (
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abhydroponicssupp)
@@ -5063,7 +5077,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "tR" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/accessory/bowtie,
@@ -5084,7 +5098,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "tW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -5093,7 +5107,7 @@
 /area/maintenance/lookout)
 "ua" = (
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "ub" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/loot_pile/surface/medicine_cabinet/fresh{
@@ -5149,7 +5163,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "uh" = (
 /obj/structure/table/rack/shelf,
 /obj/random/powercell/device,
@@ -5167,7 +5181,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "uj" = (
 /obj/structure/sign/directions/ladder_up{
 	dir = 4
@@ -5177,7 +5191,7 @@
 "uk" = (
 /obj/structure/door_assembly/door_assembly_ext,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "ul" = (
 /obj/structure/salvageable/computer_os,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -5198,7 +5212,7 @@
 "up" = (
 /obj/structure/bed/chair/bay,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "ur" = (
 /obj/structure/smolebuilding/warehouses,
 /turf/simulated/floor/smole,
@@ -5212,7 +5226,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "uz" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -5252,7 +5266,7 @@
 	req_one_access = null
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "uI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -5286,7 +5300,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "uQ" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/device/radio/subspace,
@@ -5296,7 +5310,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1379;
-	id_tag = "d3_port_dorms_pump"
+	id_tag = "d0_pump"
 	},
 /obj/structure/sign/warning/airlock{
 	pixel_y = 32
@@ -5304,9 +5318,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "uS" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/borderfloor{
@@ -5324,19 +5337,19 @@
 /obj/item/seeds/reishimycelium,
 /obj/random/trash,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "uU" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "uV" = (
 /obj/effect/floor_decal/rust,
 /obj/random/mainttoyloot,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "uY" = (
 /obj/random/trash,
 /obj/effect/floor_decal/borderfloor{
@@ -5358,11 +5371,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/gravgen)
 "vc" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/power/breakerbox{
+	name = "Rusty Breaker Box"
 	},
+/obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/ragecage)
 "vd" = (
@@ -5377,11 +5389,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "vn" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "vo" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -5404,7 +5416,7 @@
 "vt" = (
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "vu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -5454,7 +5466,7 @@
 	pixel_y = 5
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "vE" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/cable{
@@ -5470,7 +5482,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "vG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5478,13 +5490,13 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "vH" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "vJ" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating,
@@ -5512,12 +5524,8 @@
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/field)
 "vM" = (
-/obj/structure/catwalk,
-/obj/machinery/door/firedoor/multi_tile/glass{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fieldhallway)
+/turf/simulated/wall,
+/area/maintenance/zerofore)
 "vN" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/wood/alt/parquet/turfpack/station,
@@ -5563,7 +5571,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "vY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5573,11 +5581,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "vZ" = (
 /obj/random/tool/powermaint,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "wd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5585,10 +5593,10 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "we" = (
 /turf/simulated/wall,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "wf" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -5602,7 +5610,7 @@
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "wh" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable{
@@ -5618,7 +5626,7 @@
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "wl" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -5642,7 +5650,7 @@
 /area/engineering/backuppowerlobby)
 "wn" = (
 /turf/simulated/wall/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "wo" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/effect/floor_decal/borderfloor{
@@ -5656,14 +5664,14 @@
 "wp" = (
 /obj/structure/flora/pottedplant/sticky,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "wq" = (
 /turf/simulated/wall,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "wr" = (
 /obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "wu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -5696,7 +5704,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "wB" = (
 /obj/random/trash,
 /turf/simulated/floor/tiled,
@@ -5711,7 +5719,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "wD" = (
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 8
@@ -5726,23 +5734,23 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "wF" = (
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "wG" = (
 /obj/machinery/floor_light{
 	anchored = 1
 	},
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "wH" = (
 /obj/item/weapon/stool/baystool/padded{
 	dir = 8
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "wI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5756,17 +5764,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "wK" = (
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "wN" = (
 /obj/structure/catwalk,
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "wP" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5774,15 +5782,6 @@
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/smoleroom)
 "wQ" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light_switch{
@@ -5791,11 +5790,11 @@
 	on = 0
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "wR" = (
 /obj/structure/bed/chair/oldsofa/left,
 /turf/simulated/floor/grass,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "wS" = (
 /turf/simulated/floor/tiled,
 /area/maintenance/thrift)
@@ -5807,24 +5806,31 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "wV" = (
 /obj/machinery/door/airlock/glass_external{
-	frequency = 1379;
 	icon_state = "door_locked";
-	id_tag = "d0_inner";
 	locked = 1;
 	name = "Internal Airlock Access";
-	req_access = list(13)
+	req_access = list(13);
+	frequency = 1379;
+	id_tag = "d0_inner"
 	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/effect/map_helper/airlock/button/int_button,
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "d0_airlock";
+	name = "interior access button";
+	pixel_x = 26;
+	pixel_y = 23;
+	req_access = null
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "wW" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "wX" = (
 /obj/structure/table/rack/shelf,
 /obj/random/tool,
@@ -5872,7 +5878,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "xf" = (
 /turf/simulated/floor/reinforced,
 /area/maintenance/abchemistry)
@@ -5886,20 +5892,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/engineering/gravgen)
 "xh" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/barricade,
+/obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerocent)
 "xl" = (
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 3
@@ -5922,11 +5919,11 @@
 /area/maintenance/absgenetics)
 "xn" = (
 /turf/simulated/floor/weird_things/dark,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "xo" = (
 /obj/structure/flora/pottedplant/crystal,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "xq" = (
 /obj/random/trash,
 /obj/effect/decal/cleanable/cobweb2,
@@ -5953,12 +5950,12 @@
 "xt" = (
 /obj/structure/door_assembly,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "xv" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "xw" = (
 /obj/structure/table/rack/shelf,
 /obj/random/contraband,
@@ -5971,7 +5968,7 @@
 "xy" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "xz" = (
 /obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/plating/turfpack/station,
@@ -5988,16 +5985,14 @@
 /area/maintenance/field)
 "xG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "xH" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -6011,7 +6006,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/random/flashlight,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "xI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -6028,7 +6023,7 @@
 "xL" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "xM" = (
 /obj/random/plushie{
 	pixel_x = 5
@@ -6053,7 +6048,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "xP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -6085,7 +6080,7 @@
 /area/maintenance/ragecage)
 "xS" = (
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "xU" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/bmarble,
@@ -6093,7 +6088,7 @@
 "xV" = (
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "xX" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
@@ -6108,11 +6103,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/abmedical)
+"xY" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating/turfpack/station,
+/area/maintenance/zerofore)
 "yc" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "yf" = (
 /obj/structure/railing/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6141,16 +6142,16 @@
 	dir = 5
 	},
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "yl" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/unsimulated/floor/carpet/gaycarpet,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "yo" = (
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "yr" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -6197,7 +6198,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "yF" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6249,7 +6250,7 @@
 /obj/structure/table/standard,
 /obj/item/weapon/gun/projectile/revolver/capgun,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "yU" = (
 /turf/simulated/floor/wood/alt/panel,
 /area/maintenance/abtheatre)
@@ -6259,7 +6260,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "yX" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6269,7 +6270,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "yY" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/accessory/collar/shock/bluespace/malfunctioning,
@@ -6323,13 +6324,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "zf" = (
 /obj/item/weapon/reagent_containers/hypospray/autoinjector/biginjector/expired,
 /obj/machinery/light/small,
@@ -6362,7 +6358,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "zn" = (
 /turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/janitoral)
@@ -6382,7 +6378,7 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "zB" = (
 /obj/item/weapon/material/shard,
 /obj/item/weapon/material/shard{
@@ -6405,12 +6401,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "zI" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "zJ" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/accessory/collar/collarplanet_earth,
@@ -6432,14 +6428,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "zL" = (
 /turf/simulated/wall/turfpack/station,
 /area/maintenance/ragecage)
 "zM" = (
 /obj/random/flashlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "zN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6453,7 +6449,7 @@
 "zP" = (
 /obj/structure/firedoor_assembly,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "zS" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -6468,7 +6464,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "zX" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/lime/border,
@@ -6491,7 +6487,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Ab" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/tiled/hydro,
@@ -6521,7 +6517,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Ai" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6545,7 +6541,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Ak" = (
 /obj/structure/table/rack/shelf,
 /obj/random/thermalponcho,
@@ -6612,7 +6608,7 @@
 	on = 0
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Az" = (
 /obj/structure/smoletrack/roadS,
 /turf/simulated/floor/smole,
@@ -6633,14 +6629,13 @@
 "AC" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1379;
-	id_tag = "d3_port_dorms_pump"
+	id_tag = "d0_pump"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "AE" = (
 /turf/simulated/wall/turfpack/station,
 /area/maintenance/abmedical)
@@ -6667,7 +6662,7 @@
 "AI" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "AL" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating/turfpack/station,
@@ -6710,12 +6705,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "AW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/abcargo)
 "AX" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
@@ -6735,7 +6730,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "AZ" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -6758,7 +6753,7 @@
 /obj/random/junk,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "Be" = (
 /obj/effect/decal/cleanable/fruit_smudge,
 /turf/simulated/floor/tiled,
@@ -6770,10 +6765,10 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Bh" = (
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Bm" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
@@ -6829,26 +6824,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Bs" = (
 /obj/structure/catwalk,
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Bu" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/turf/simulated/wall,
+/area/maintenance/thrift)
 "Bx" = (
 /obj/structure/ladder/up,
 /turf/unsimulated/floor/carpet/retro/turfpack/station,
@@ -6866,13 +6852,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "BA" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/barricade,
 /turf/simulated/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "BB" = (
 /obj/structure/bed/chair,
 /obj/machinery/firealarm{
@@ -6912,13 +6898,13 @@
 /obj/structure/table/marble,
 /obj/random/donkpocketbox,
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "BH" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "BI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6928,7 +6914,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "BJ" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -6948,11 +6934,11 @@
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "BN" = (
 /obj/structure/flora/pottedplant/drooping,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "BP" = (
 /obj/effect/decal/cleanable/filth,
 /obj/structure/mopbucket,
@@ -6967,7 +6953,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "BS" = (
 /obj/structure/bed/chair/wood{
 	dir = 4
@@ -6986,7 +6972,7 @@
 /obj/item/tape/engineering,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "BX" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -7006,7 +6992,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "BZ" = (
 /turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/fieldhallway)
@@ -7042,7 +7028,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Ci" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/tiled,
@@ -7062,7 +7048,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Cl" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/turfpack/station,
@@ -7101,7 +7087,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Cs" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -7164,7 +7150,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Cx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7210,7 +7196,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "CF" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -7220,7 +7206,7 @@
 "CG" = (
 /obj/structure/bed/chair/oldsofa,
 /turf/simulated/floor/grass,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "CH" = (
 /obj/random/mouseremains,
 /obj/machinery/firealarm{
@@ -7234,17 +7220,17 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "CK" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "CN" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/item/tape/engineering,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "CP" = (
 /obj/structure/table/rack/shelf,
 /obj/item/device/radio/subspace,
@@ -7253,7 +7239,7 @@
 "CR" = (
 /obj/structure/flora/pottedplant/decorative,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "CT" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -7262,23 +7248,21 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "CU" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "CW" = (
 /obj/structure/catwalk,
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Da" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "Df" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -7351,13 +7335,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/backuppower)
 "Do" = (
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/turf/simulated/wall,
+/area/maintenance/lookout)
 "Dr" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Ds" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
@@ -7369,16 +7352,14 @@
 /turf/space,
 /area/space)
 "Dw" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Dy" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "DA" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -7392,7 +7373,7 @@
 "DD" = (
 /obj/structure/flora/pottedplant/unusual,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "DI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7401,7 +7382,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "DJ" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -7429,23 +7410,10 @@
 "DM" = (
 /obj/structure/flora/pottedplant/smalltree,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "DN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/turf/simulated/wall,
+/area/maintenance/engineering/gravgen)
 "DO" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -7463,7 +7431,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "DP" = (
 /obj/random/maintenance,
 /turf/simulated/floor/plating,
@@ -7478,6 +7446,12 @@
 /obj/structure/table,
 /turf/simulated/floor/bmarble,
 /area/maintenance/thrift)
+"DT" = (
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/plating/turfpack/station,
+/area/maintenance/zeroport)
 "DU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -7486,7 +7460,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "DW" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -7513,7 +7487,7 @@
 "Ec" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Ed" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -7529,11 +7503,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Ef" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Eg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7543,11 +7517,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Eh" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -7561,7 +7533,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Ep" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled/hydro,
@@ -7593,7 +7565,7 @@
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "Eu" = (
 /obj/random/trash,
 /obj/structure/cable{
@@ -7616,7 +7588,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Ez" = (
 /obj/structure/smolebuilding/houses,
 /turf/simulated/floor/plating/turfpack/station,
@@ -7631,11 +7603,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "EE" = (
 /obj/effect/landmark/event_spawn/morphspawn,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "EI" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -7654,7 +7626,7 @@
 "EJ" = (
 /obj/structure/stripper_pole,
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "EK" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -7673,7 +7645,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "EM" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
@@ -7681,7 +7653,7 @@
 "EN" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "EO" = (
 /obj/structure/table/rack/shelf,
 /obj/machinery/light/small,
@@ -7691,13 +7663,13 @@
 "EP" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "ES" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "ET" = (
 /obj/effect/floor_decal/rust,
 /obj/item/weapon/storage/briefcase/inflatable,
@@ -7705,7 +7677,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "EU" = (
 /obj/structure/sign/directions/engineering/gravgen{
 	dir = 6
@@ -7714,8 +7686,8 @@
 	dir = 8;
 	pixel_y = 10
 	},
-/turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/central)
+/turf/simulated/wall,
+/area/maintenance/zerocent)
 "EW" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7725,7 +7697,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "EY" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -7772,7 +7744,7 @@
 "Fd" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Fe" = (
 /obj/item/weapon/storage/backpack/genetics,
 /obj/effect/floor_decal/rust,
@@ -7789,7 +7761,7 @@
 /obj/item/tape/engineering,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Fm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7801,7 +7773,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Fn" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow{
@@ -7823,18 +7795,15 @@
 	},
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Fo" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Fp" = (
 /obj/random/junk,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Fq" = (
 /obj/random/maintenance/foodstuff,
 /obj/random/maintenance/foodstuff,
@@ -7866,7 +7835,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Ft" = (
 /obj/random/trash,
 /obj/machinery/alarm{
@@ -7883,7 +7852,7 @@
 "Fz" = (
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "FC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7891,13 +7860,13 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "FD" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "FG" = (
 /obj/effect/floor_decal/industrial/arrows/yellow,
 /obj/effect/floor_decal/industrial/arrows/yellow{
@@ -8001,18 +7970,18 @@
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "FS" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "FV" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "FW" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -8021,7 +7990,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "FY" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -8036,22 +8005,20 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/abcargo)
 "FZ" = (
-/obj/effect/floor_decal/rust,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
+/obj/structure/ladder/up,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zerostarboard)
 "Ga" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Gb" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Gc" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -8074,7 +8041,7 @@
 "Gg" = (
 /obj/random/toolbox,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Gh" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/brown/bordercorner,
@@ -8109,7 +8076,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Gr" = (
 /obj/item/weapon/gun/energy/sizegun,
 /turf/simulated/floor/smole,
@@ -8117,17 +8084,17 @@
 "Gt" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Gu" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Gw" = (
 /obj/structure/door_assembly,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Gz" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -8149,7 +8116,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "GC" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -8161,7 +8128,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "GF" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
@@ -8170,7 +8137,7 @@
 "GH" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "GJ" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/accessory/collar/bell,
@@ -8193,17 +8160,17 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "GL" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "GM" = (
 /obj/random/tool,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "GN" = (
 /obj/random/plushie{
 	pixel_x = 5
@@ -8274,7 +8241,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "GV" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
@@ -8286,7 +8253,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "GW" = (
 /obj/structure/sign/directions/ladder_up{
 	dir = 4
@@ -8306,7 +8273,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Hd" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -8323,7 +8290,7 @@
 	on = 0
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "Hg" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor/tiled,
@@ -8355,7 +8322,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Hm" = (
 /obj/structure/catwalk,
 /obj/structure/catwalk,
@@ -8371,7 +8338,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Ho" = (
 /turf/simulated/floor/tiled/white,
 /area/maintenance/absgenetics)
@@ -8385,7 +8352,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Hr" = (
 /obj/structure/grille/broken,
 /obj/item/weapon/material/shard,
@@ -8407,11 +8374,11 @@
 	name = "Maintenance Access"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Hv" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Hw" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -8442,7 +8409,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "HC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -8462,7 +8429,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "HH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8496,11 +8463,11 @@
 "HL" = (
 /obj/random/flashlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "HN" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "HO" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8517,13 +8484,13 @@
 /area/maintenance/engineering/gravgen)
 "HS" = (
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "HT" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "HU" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -8566,7 +8533,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "Ic" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8595,7 +8562,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Ig" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
@@ -8623,7 +8590,7 @@
 /area/maintenance/abmedical)
 "In" = (
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Io" = (
 /obj/random/meat,
 /obj/random/meat,
@@ -8653,7 +8620,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Ir" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8670,7 +8637,7 @@
 "It" = (
 /obj/structure/flora/pottedplant/largebush,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Iw" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
@@ -8715,14 +8682,14 @@
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "IE" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "IG" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating/turfpack/station,
@@ -8748,12 +8715,12 @@
 /obj/random/trash,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "IO" = (
 /obj/machinery/light/small,
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "IP" = (
 /obj/item/weapon/material/shard,
 /obj/item/weapon/reagent_containers/glass/beaker,
@@ -8773,7 +8740,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "IU" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -8803,7 +8770,7 @@
 /obj/random/obstruction,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "Jb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8813,7 +8780,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "Jf" = (
 /obj/structure/salvageable/computer_os,
 /turf/simulated/floor/plating/turfpack/station,
@@ -8841,6 +8808,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/abmedical)
+"Jj" = (
+/obj/random/tool,
+/turf/simulated/floor/plating/turfpack/station,
+/area/maintenance/zeroaft)
 "Jk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8850,23 +8821,23 @@
 "Jm" = (
 /obj/structure/dark_portal/minion,
 /turf/simulated/floor/weird_things/dark,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Jp" = (
-/obj/effect/floor_decal/rust,
+/obj/random/mouseremains,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "Jq" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Jr" = (
 /obj/item/stack/rods,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/thrift)
 "Jt" = (
-/obj/structure/door_assembly/door_assembly_ext,
+/obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerostarboard)
 "Jv" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
@@ -8875,7 +8846,7 @@
 /obj/effect/decal/cleanable/cobweb2,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Jw" = (
 /obj/structure/table/rack/shelf,
 /obj/random/maintenance/engineering,
@@ -8888,7 +8859,7 @@
 "JA" = (
 /obj/structure/reagent_dispensers/fueltank/high,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "JB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8917,7 +8888,7 @@
 "JH" = (
 /obj/structure/prop/dark_node/dust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "JJ" = (
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 4
@@ -9017,7 +8988,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "JZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -9030,10 +9001,10 @@
 "Kb" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Kc" = (
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "Ke" = (
 /obj/random/organ,
 /obj/random/organ,
@@ -9070,11 +9041,11 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "Ki" = (
 /obj/item/weapon/storage/briefcase/inflatable,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Kj" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9088,7 +9059,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "Kk" = (
 /obj/random/trash,
 /obj/machinery/power/apc{
@@ -9111,7 +9082,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Km" = (
 /turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/substation/gravgen)
@@ -9121,7 +9092,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Ko" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -9134,7 +9105,7 @@
 "Kr" = (
 /obj/item/weapon/stool/baystool/padded,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Ks" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -9175,8 +9146,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/abscience)
 "Ky" = (
-/turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/turf/simulated/wall/r_wall/turfpack/station,
+/area/maintenance/zerostarboard)
 "KB" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -9193,7 +9164,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "KH" = (
 /obj/machinery/computer/power_monitor{
 	dir = 8
@@ -9251,7 +9222,7 @@
 "KQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "KR" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/piratedouble,
@@ -9289,7 +9260,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Lb" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -9298,9 +9269,8 @@
 /turf/space,
 /area/space)
 "Lc" = (
-/obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "Lf" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
@@ -9314,7 +9284,7 @@
 "Lk" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Ll" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -9341,7 +9311,7 @@
 "Lq" = (
 /obj/structure/bed/chair/oldsofa/right,
 /turf/simulated/floor/grass,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Ls" = (
 /obj/structure/table/rack/shelf,
 /obj/structure/curtain/black,
@@ -9353,7 +9323,7 @@
 "Lt" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Lv" = (
 /obj/structure/bed/chair,
 /obj/machinery/power/apc{
@@ -9375,11 +9345,11 @@
 "Ly" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Lz" = (
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "LE" = (
 /turf/simulated/wall/turfpack/station,
 /area/maintenance/absgenetics)
@@ -9387,10 +9357,10 @@
 /obj/structure/catwalk,
 /obj/random/flashlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "LH" = (
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "LI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9410,7 +9380,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "LL" = (
 /obj/structure/railing,
 /obj/random/instrument,
@@ -9422,7 +9392,7 @@
 	name = "maint_pred"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "LQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9432,20 +9402,20 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "LU" = (
 /turf/simulated/wall,
 /area/maintenance/abscience)
 "LV" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "LW" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/item/tape/engineering,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "LY" = (
 /turf/simulated/floor/wood/turfpack/station,
 /area/maintenance/bar/dorms/dorm_1)
@@ -9463,7 +9433,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Mi" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/cable{
@@ -9479,7 +9449,7 @@
 "Mj" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Ml" = (
 /obj/random/junk,
 /obj/structure/cable{
@@ -9492,10 +9462,10 @@
 "Mn" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Mq" = (
 /turf/simulated/wall/r_wall/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Mr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9504,20 +9474,20 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Ms" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/white,
 /obj/item/clothing/head/pizzaguy,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Mt" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/bar_alc/full{
 	dir = 4
 	},
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Mu" = (
 /obj/structure/table/marble,
 /obj/machinery/chemical_dispenser/bar_soft/full{
@@ -9527,7 +9497,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Mw" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -9541,7 +9511,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "MA" = (
 /obj/effect/floor_decal/techfloor,
 /obj/structure/cable{
@@ -9595,7 +9565,7 @@
 /obj/structure/table/woodentable,
 /obj/random/action_figure,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "MK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9606,7 +9576,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "MN" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
@@ -9629,13 +9599,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "MR" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/turf/simulated/wall,
+/area/maintenance/fieldthrift)
 "MS" = (
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/item/weapon/reagent_containers/glass/bucket,
@@ -9663,7 +9630,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "Na" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -9674,21 +9641,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Nc" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Ne" = (
 /obj/machinery/floor_light{
 	anchored = 1
 	},
 /obj/random/junk,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Nf" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -9703,7 +9670,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Ng" = (
 /obj/random/tool,
 /obj/machinery/firealarm{
@@ -9711,7 +9678,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "Nj" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9732,15 +9699,15 @@
 /obj/structure/catwalk,
 /obj/random/maintenance,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Nm" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "No" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Np" = (
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled,
@@ -9770,7 +9737,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Ny" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
@@ -9784,7 +9751,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "ND" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9798,7 +9765,7 @@
 /area/maintenance/substation/gravgen)
 "NE" = (
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "NF" = (
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
@@ -9829,11 +9796,11 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "NK" = (
 /obj/structure/door_assembly/door_assembly_fre,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "NL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -9853,7 +9820,7 @@
 "NQ" = (
 /obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "NR" = (
 /obj/item/weapon/storage/firstaid/regular{
 	empty = 1;
@@ -9889,7 +9856,7 @@
 "NT" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "NW" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
@@ -9905,7 +9872,7 @@
 /obj/random/trash,
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "NZ" = (
 /obj/machinery/power/smes/batteryrack,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -9937,24 +9904,15 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Of" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = 24;
 	on = 0
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "Og" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -9997,7 +9955,7 @@
 	},
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Om" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow{
@@ -10033,7 +9991,7 @@
 	name = "Maintenance Access"
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Op" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
@@ -10046,7 +10004,7 @@
 /obj/random/obstruction,
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Ow" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -10060,7 +10018,7 @@
 /obj/structure/catwalk,
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Oy" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -10089,7 +10047,7 @@
 "OE" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "OF" = (
 /obj/structure/table/marble,
 /obj/random/cigarettes,
@@ -10098,7 +10056,7 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "OG" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/carpet/blue2/turfpack/station,
@@ -10136,7 +10094,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "OM" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -10148,12 +10106,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "OO" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/ladder/up,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "OP" = (
 /obj/structure/janitorialcart,
 /turf/simulated/floor/plating,
@@ -10171,19 +10129,19 @@
 /obj/structure/table/woodentable,
 /obj/random/maintenance,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "OX" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "OY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "OZ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -10199,10 +10157,8 @@
 /turf/unsimulated/floor/carpet/retro/turfpack/station,
 /area/maintenance/abtheatre)
 "Pb" = (
-/obj/structure/catwalk,
-/obj/effect/floor_decal/rust,
-/turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/turf/simulated/wall,
+/area/maintenance/zeroport)
 "Pc" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating/turfpack/station,
@@ -10232,7 +10188,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Pk" = (
 /obj/structure/table/rack/shelf,
 /obj/random/soap,
@@ -10241,23 +10197,11 @@
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/thrift)
 "Pm" = (
-/obj/structure/catwalk,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/turf/simulated/wall/r_wall/turfpack/airless,
+/area/maintenance/zeroport)
 "Pp" = (
 /turf/simulated/floor/plating,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Pr" = (
 /obj/random/junk,
 /turf/simulated/floor/tiled,
@@ -10272,7 +10216,7 @@
 "Pu" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "Pv" = (
 /turf/simulated/floor/wood/alt/parquet/broken/turfpack/station,
 /area/maintenance/lookout)
@@ -10291,7 +10235,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Pz" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -10304,7 +10248,7 @@
 "PB" = (
 /obj/structure/flora/ausbushes/genericbush,
 /turf/simulated/floor/grass,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "PD" = (
 /obj/structure/closet/cabinet,
 /obj/random/drinkbottle,
@@ -10313,7 +10257,7 @@
 /obj/random/drinkbottle,
 /obj/random/drinkbottle,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "PG" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -10328,7 +10272,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "PH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10340,27 +10284,18 @@
 "PJ" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "PK" = (
 /obj/effect/floor_decal/rust,
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "d3_port_dorms_airlock";
-	name = "interior access button";
-	pixel_x = -25;
-	pixel_y = 26;
-	req_access = null
-	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "PM" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "PN" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/barricade,
@@ -10375,7 +10310,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "PP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -10434,11 +10369,11 @@
 "PV" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "PX" = (
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "PY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating/turfpack/station,
@@ -10470,7 +10405,7 @@
 	name = "maint_pred"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Qf" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -10504,7 +10439,7 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Qp" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -10536,15 +10471,14 @@
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/thrift)
 "Qy" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/turf/simulated/wall/r_wall/turfpack/station,
+/area/maintenance/zerofore)
 "QA" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "QC" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -10557,7 +10491,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "QH" = (
 /obj/effect/floor_decal/rust,
 /obj/item/weapon/storage/pill_bottle{
@@ -10597,7 +10531,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "QP" = (
 /obj/machinery/floodlight,
 /obj/machinery/power/apc{
@@ -10620,13 +10554,13 @@
 /obj/structure/catwalk,
 /obj/machinery/door/firedoor/multi_tile/glass,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "QT" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "QU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10645,15 +10579,15 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "QY" = (
 /obj/structure/bed/double/padded,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "QZ" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Rb" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -10669,7 +10603,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Rd" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
@@ -10686,7 +10620,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "Rg" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -10716,7 +10650,7 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "Rm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10804,7 +10738,7 @@
 "RL" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "RM" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
@@ -10812,7 +10746,7 @@
 "RO" = (
 /obj/structure/table,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "RP" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10831,7 +10765,7 @@
 /obj/structure/table/marble,
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "RU" = (
 /turf/simulated/floor/tiled/hydro,
 /area/maintenance/abhydroponicssupp)
@@ -10846,18 +10780,18 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "RX" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
 /obj/random/trash,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Sb" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Sd" = (
 /obj/machinery/door/airlock/maintenance/medical{
 	name = "Medical Storage";
@@ -10874,7 +10808,7 @@
 "Sh" = (
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Sj" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -10886,7 +10820,7 @@
 "Sk" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Sl" = (
 /obj/random/mouseremains,
 /obj/structure/cable{
@@ -10895,7 +10829,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Sm" = (
 /obj/random/crate,
 /turf/simulated/floor/tiled,
@@ -10927,7 +10861,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "Sr" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -10943,7 +10877,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "SA" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -10967,7 +10901,7 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "SF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10984,7 +10918,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "SH" = (
 /obj/structure/railing/grey,
 /obj/effect/floor_decal/rust,
@@ -11054,7 +10988,7 @@
 /obj/effect/floor_decal/rust,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "SW" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 10
@@ -11076,15 +11010,15 @@
 "SY" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Ta" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Tb" = (
 /obj/random/mouseremains,
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Tc" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 9
@@ -11101,11 +11035,11 @@
 	anchored = 1
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Tg" = (
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Th" = (
 /obj/structure/bed/chair/bay{
 	dir = 4
@@ -11115,7 +11049,7 @@
 "Ti" = (
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Tk" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -11148,7 +11082,7 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/space,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "To" = (
 /obj/item/modular_computer/console/preset/engineering{
 	dir = 8
@@ -11190,6 +11124,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/ragecage)
@@ -11306,7 +11245,7 @@
 "TT" = (
 /obj/structure/bed/chair/oldsofa/left,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "TU" = (
 /obj/random/trash,
 /turf/simulated/floor/tiled,
@@ -11334,15 +11273,15 @@
 	dir = 6
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "TX" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "TY" = (
 /obj/random/trash,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerofore)
 "Ud" = (
 /obj/effect/floor_decal/rust,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -11365,7 +11304,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "Uh" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
@@ -11394,7 +11333,7 @@
 "Uq" = (
 /obj/structure/table,
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Ur" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11409,13 +11348,13 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Ut" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Uv" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -11423,7 +11362,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Ux" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/turfpack/station,
@@ -11445,7 +11384,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "UG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11486,7 +11425,7 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/drinks/shaker,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "UQ" = (
 /obj/structure/closet/radiation,
 /obj/structure/sign/warning/radioactive{
@@ -11498,7 +11437,7 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "UU" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/borderfloor{
@@ -11550,7 +11489,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Va" = (
 /obj/item/weapon/reagent_containers/syringe/drugs{
 	pixel_y = 5;
@@ -11561,7 +11500,7 @@
 /area/maintenance/abchemistry)
 "Vb" = (
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Vc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11576,7 +11515,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Ve" = (
 /obj/structure/mopbucket,
 /obj/effect/decal/cleanable/cobweb2,
@@ -11608,7 +11547,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Vh" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 5
@@ -11620,7 +11559,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Vm" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11637,7 +11576,7 @@
 /area/maintenance/janitoral)
 "Vn" = (
 /turf/simulated/wall/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "Vo" = (
 /obj/effect/floor_decal/rust,
 /obj/structure/cable{
@@ -11708,7 +11647,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "VB" = (
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 8
@@ -11717,7 +11656,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/engineering)
+/area/maintenance/gravlobby)
 "VC" = (
 /obj/structure/sign/directions/medical,
 /obj/structure/sign/directions/bar{
@@ -11763,7 +11702,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "VI" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -11777,13 +11716,13 @@
 /obj/effect/floor_decal/rust,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "VK" = (
 /obj/structure/bed/chair/bay{
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerostarboard)
 "VL" = (
 /obj/random/empty_or_lootable_crate,
 /turf/simulated/floor/tiled,
@@ -11794,36 +11733,35 @@
 /obj/item/clothing/under/fluff/latexmaid,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "VR" = (
 /obj/structure/table/marble,
 /obj/random/maintenance/foodstuff,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "VT" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/item/tape/engineering,
 /obj/machinery/door/firedoor/border_only,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "VU" = (
 /obj/random/trash,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "VX" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	frequency = 1379;
-	id_tag = "d3_port_dorms_pump"
+	id_tag = "d0_pump"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "VY" = (
 /obj/structure/lattice,
 /obj/item/stack/rods,
@@ -11845,7 +11783,7 @@
 	on = 0
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Wb" = (
 /obj/item/device/radio/subspace,
 /turf/simulated/floor/plating,
@@ -11854,18 +11792,18 @@
 /obj/structure/catwalk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "We" = (
 /turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/abcargo)
 "Wh" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Wj" = (
 /obj/item/weapon/storage/briefcase/inflatable,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Wl" = (
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 1
@@ -11899,7 +11837,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Wr" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/rust,
@@ -11915,17 +11853,17 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Ws" = (
 /obj/structure/bed/chair/oldsofa/left{
 	dir = 8
 	},
 /turf/unsimulated/floor/carpet/gaycarpet,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Wt" = (
 /obj/structure/flora/pottedplant/subterranean,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/engineering)
+/area/maintenance/zerocent)
 "Wu" = (
 /obj/machinery/clonepod,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -11971,12 +11909,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "Wy" = (
 /obj/effect/floor_decal/rust,
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "WC" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11986,7 +11924,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "WF" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 4
@@ -11999,7 +11937,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "WG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12009,10 +11947,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "WI" = (
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "WM" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12060,7 +11998,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "WU" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -12086,7 +12024,7 @@
 	},
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "WX" = (
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
@@ -12094,7 +12032,7 @@
 "WY" = (
 /obj/random/obstruction,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "Xc" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating/turfpack/station,
@@ -12151,7 +12089,7 @@
 "Xq" = (
 /obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/lino,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "Xt" = (
 /obj/item/weapon/reagent_containers/syringe/drugs{
 	pixel_y = 5;
@@ -12182,14 +12120,14 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Xx" = (
 /obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Xy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12303,7 +12241,7 @@
 /obj/random/junk,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "XP" = (
 /turf/simulated/wall/turfpack/station,
 /area/maintenance/abchemistry)
@@ -12360,7 +12298,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "XZ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -12389,7 +12327,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "Yb" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -12410,7 +12348,13 @@
 "Yc" = (
 /obj/random/trash,
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
+"Yd" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating/turfpack/station,
+/area/maintenance/zerostarboard)
 "Ye" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -12434,11 +12378,17 @@
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Yk" = (
 /obj/structure/lattice,
 /turf/space,
 /area/space)
+"Yo" = (
+/turf/simulated/wall{
+	can_open = 1;
+	desc = "A huge chunk of metal used to seperate rooms. There are scratch marks along the floor."
+	},
+/area/maintenance/zeroaft)
 "Yp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12465,12 +12415,12 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "Yx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/abcargo)
 "Yy" = (
 /obj/effect/decal/cleanable/filth,
@@ -12485,18 +12435,8 @@
 /turf/simulated/floor/lino,
 /area/maintenance/abtheatre)
 "YA" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "d3_port_dorms_airlock";
-	name = "exterior access button";
-	pixel_y = 0;
-	req_access = null;
-	dir = 8;
-	pixel_x = 25
-	},
 /turf/simulated/floor/plating/turfpack/airless,
-/area/space)
+/area/maintenance/zeroport)
 "YB" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
@@ -12581,7 +12521,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "YJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/plating/turfpack/station,
@@ -12591,15 +12531,15 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/central)
+/area/maintenance/zerocent)
 "YN" = (
 /obj/machinery/smartfridge/drying_rack,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "YO" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/aft)
+/area/maintenance/zerofore)
 "YP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12610,7 +12550,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "YQ" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 4
@@ -12647,7 +12587,7 @@
 "YU" = (
 /obj/random/trash,
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "YX" = (
 /turf/simulated/wall/turfpack/station,
 /area/maintenance/janitoral)
@@ -12658,7 +12598,7 @@
 /area/maintenance/fieldthrift)
 "Zd" = (
 /turf/simulated/wall/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Zf" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -12686,7 +12626,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/carpet/purcarpet,
-/area/maintenance/aft)
+/area/maintenance/zeroaft)
 "Zk" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/syringe/drugs{
@@ -12723,7 +12663,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "Zs" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -12902,7 +12842,7 @@
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/port)
+/area/maintenance/zeroport)
 "ZI" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -12930,11 +12870,11 @@
 "ZJ" = (
 /obj/structure/bed/chair/oldsofa/right,
 /turf/unsimulated/floor/carpet/gaycarpet,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "ZK" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zeroaft)
 "ZL" = (
 /obj/item/stack/rods,
 /obj/random/maintenance/medical,
@@ -12943,12 +12883,12 @@
 "ZM" = (
 /obj/structure/mob_spawner/mouse_nest/mousehole,
 /turf/simulated/floor/plating/turfpack/station,
-/area/maintenance/starboard)
+/area/maintenance/zerostarboard)
 "ZO" = (
 /obj/structure/table/woodentable,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/wood/broken/turfpack/station,
-/area/maintenance/bar)
+/area/maintenance/zerobar)
 "ZP" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -32215,12 +32155,12 @@ wZ
 ua
 ua
 Or
-iv
+Fo
 QZ
 Kb
-Do
+PK
 Kb
-iv
+Fo
 ua
 ua
 wZ
@@ -32472,8 +32412,8 @@ Yk
 ua
 ua
 vC
-iv
-iv
+Fo
+Fo
 Or
 QZ
 OO
@@ -32737,7 +32677,7 @@ ua
 ua
 ua
 ua
-iv
+Fo
 me
 ua
 wZ
@@ -32996,7 +32936,7 @@ sV
 iN
 ua
 Kb
-iv
+Fo
 ua
 wZ
 wZ
@@ -33254,7 +33194,7 @@ sV
 sV
 ua
 Nc
-Do
+PK
 ua
 TJ
 TJ
@@ -33512,7 +33452,7 @@ sV
 sV
 ua
 Ox
-Do
+PK
 ua
 iP
 iP
@@ -33770,7 +33710,7 @@ sV
 sV
 ua
 sA
-iv
+Fo
 ua
 iP
 wZ
@@ -34028,7 +33968,7 @@ sV
 sV
 ua
 fT
-Do
+PK
 US
 iP
 wZ
@@ -34542,7 +34482,7 @@ qB
 qB
 QV
 XJ
-ee
+iv
 Kb
 PJ
 US
@@ -34800,7 +34740,7 @@ hj
 hj
 ei
 ov
-ee
+iv
 PJ
 PJ
 ua
@@ -35058,7 +34998,7 @@ pa
 Nj
 Ro
 Qh
-ee
+iv
 PJ
 LG
 pT
@@ -35316,7 +35256,7 @@ yO
 NI
 hj
 Cx
-ee
+iv
 PJ
 PJ
 pT
@@ -35833,7 +35773,7 @@ ic
 hj
 hn
 nF
-ny
+DT
 lE
 ua
 iP
@@ -36076,8 +36016,8 @@ gr
 gr
 gr
 gr
-gr
-gr
+wq
+wq
 uH
 gr
 gr
@@ -36090,7 +36030,7 @@ pr
 pr
 xg
 gh
-ua
+Pb
 le
 le
 ua
@@ -36110,7 +36050,7 @@ iP
 nS
 nS
 YA
-TJ
+Pm
 wZ
 wZ
 wZ
@@ -36341,14 +36281,14 @@ of
 of
 WI
 WI
-pr
+DN
 Ds
 xI
 ta
-pr
+DN
 DA
 kc
-ua
+Pb
 Hv
 IE
 We
@@ -36599,14 +36539,14 @@ of
 of
 of
 of
-pr
+DN
 QP
 JB
 HQ
-pr
+DN
 dx
 Rz
-ua
+Pb
 gl
 KG
 gv
@@ -36616,7 +36556,7 @@ gP
 Tl
 Oy
 OZ
-We
+gv
 kl
 qn
 Nt
@@ -36857,11 +36797,11 @@ gs
 om
 WI
 of
-pr
+DN
 Ds
 aq
 TS
-pr
+DN
 dx
 OJ
 Af
@@ -36874,7 +36814,7 @@ zu
 GR
 TU
 OT
-We
+gv
 FY
 qn
 qh
@@ -37115,14 +37055,14 @@ ly
 ly
 dY
 ly
-pr
+DN
 nC
 aq
 MI
-pr
+DN
 dx
 Rz
-ua
+Pb
 GU
 Nf
 gv
@@ -37373,14 +37313,14 @@ gk
 yl
 gk
 WI
-gr
-gr
+wq
+wq
 Ig
-pr
-pr
+DN
+DN
 dx
 Rz
-ua
+Pb
 me
 Nf
 gv
@@ -37632,14 +37572,14 @@ HS
 HS
 pe
 gk
-gr
+wq
 jR
 IU
 pD
 Tc
 Cu
-ua
-iv
+Pb
+Fo
 Nf
 gv
 ME
@@ -37648,7 +37588,7 @@ qh
 zu
 qh
 Zv
-We
+gv
 ZA
 Eu
 SI
@@ -37890,14 +37830,14 @@ EJ
 HS
 gk
 gk
-gr
+wq
 Ye
 lr
 UW
 UW
 vy
-ua
-iv
+Pb
+Fo
 Nf
 gv
 Hw
@@ -37913,7 +37853,7 @@ YE
 Gh
 Ks
 gv
-Do
+PK
 UC
 Uv
 ua
@@ -38148,14 +38088,14 @@ HS
 eq
 gk
 pe
-gr
+wq
 FQ
 vE
-ua
-ua
-ua
-ua
-iv
+Pb
+Pb
+Pb
+Pb
+Fo
 kQ
 gv
 gv
@@ -38171,7 +38111,7 @@ aT
 gv
 gv
 gv
-FZ
+PK
 ao
 PJ
 ua
@@ -38406,12 +38346,12 @@ hk
 Ws
 WI
 gk
-gr
+wq
 FQ
 vE
-ua
+Pb
 uV
-iv
+Fo
 nL
 Bq
 Nf
@@ -38426,7 +38366,7 @@ jc
 PJ
 PM
 Ev
-Do
+PK
 PJ
 rF
 Fo
@@ -38664,11 +38604,11 @@ ly
 ly
 ly
 ly
-gr
+wq
 FQ
 vE
-ua
-Do
+Pb
+PK
 PJ
 PJ
 BQ
@@ -38925,17 +38865,17 @@ CJ
 CJ
 sQ
 vE
-ua
+Pb
 eI
 Hv
-iv
+Fo
 eo
 Kb
 rF
 Hv
-Do
+PK
 bD
-Do
+PK
 eI
 No
 No
@@ -38945,7 +38885,7 @@ Nf
 PJ
 me
 rF
-iv
+Fo
 Ev
 eo
 No
@@ -39183,9 +39123,9 @@ WF
 WF
 aF
 qs
-ua
-Do
-iv
+Pb
+PK
+Fo
 VC
 XP
 XP
@@ -39203,7 +39143,7 @@ KI
 AE
 AE
 JK
-iv
+Fo
 Nf
 PJ
 No
@@ -39438,10 +39378,10 @@ ly
 ly
 ly
 ly
-gr
+wq
 FQ
 Mi
-ua
+Pb
 PJ
 PJ
 XP
@@ -39696,10 +39636,10 @@ Vb
 Vb
 Vb
 Vb
-gr
+wq
 FQ
 Nk
-ua
+Pb
 hV
 PJ
 XP
@@ -39954,10 +39894,10 @@ WG
 uy
 yk
 Vb
-gr
+wq
 FQ
 vE
-ua
+Pb
 Bs
 PJ
 XP
@@ -39977,7 +39917,7 @@ ZF
 nx
 sz
 AE
-iv
+Fo
 Nf
 le
 ua
@@ -40202,20 +40142,20 @@ Vb
 In
 Yc
 WI
-he
-he
-he
+lA
+lA
+lA
 kU
-he
-he
-lL
-lL
+lA
+lA
+fR
+fR
 HH
-lL
-lL
+fR
+fR
 FQ
 vE
-ua
+Pb
 le
 PJ
 XP
@@ -40235,7 +40175,7 @@ HO
 Bp
 sz
 AE
-iv
+Fo
 Nf
 PJ
 ua
@@ -40460,20 +40400,20 @@ ng
 Vb
 In
 WI
-he
+lA
 Am
 LY
 TQ
 QC
-he
+lA
 dI
 dB
 gy
 oB
-lL
+fR
 FQ
 vE
-ua
+Pb
 PJ
 PJ
 XP
@@ -40696,9 +40636,9 @@ wZ
 wZ
 wZ
 wZ
-wZ
-wZ
-wZ
+il
+il
+il
 wZ
 wZ
 wZ
@@ -40718,20 +40658,20 @@ ng
 Vb
 Vb
 Vb
-he
+lA
 aU
 aN
 PU
 ev
-he
+lA
 op
 ZE
 Gm
 ht
-lL
+fR
 FQ
 vE
-ua
+Pb
 PJ
 PJ
 XP
@@ -40751,7 +40691,7 @@ AE
 AE
 AE
 AE
-iv
+Fo
 Nf
 PJ
 ua
@@ -40954,7 +40894,7 @@ wZ
 wZ
 wZ
 wZ
-wZ
+il
 lR
 Yk
 VY
@@ -40976,23 +40916,23 @@ Vb
 In
 In
 Vb
-he
+lA
 np
 Cq
 Cn
 dw
-he
+lA
 MF
 rh
 HC
 ko
-lL
+fR
 FQ
 vE
-ua
+Pb
 PJ
-iv
-Do
+Fo
+PK
 AI
 PJ
 kY
@@ -41004,8 +40944,8 @@ PJ
 kY
 Pp
 Pp
-iv
-iv
+Fo
+Fo
 PJ
 PJ
 QS
@@ -41212,7 +41152,7 @@ wZ
 wZ
 wZ
 wZ
-Se
+Vr
 eY
 Yk
 wZ
@@ -41234,20 +41174,20 @@ Vb
 Vb
 Vb
 Yc
-he
+lA
 NF
 xK
 dP
 rn
-he
+lA
 QJ
 dB
 bs
 bs
-lL
+fR
 BJ
 vE
-ua
+Pb
 sT
 PJ
 PJ
@@ -41481,19 +41421,19 @@ wZ
 wZ
 wZ
 wZ
-Mq
-Mq
-Mq
-Mq
-Mq
-Mq
+Qy
+Qy
+vM
+vM
+vM
+vM
 db
 hl
-Mq
-Mq
-Mq
-he
-he
+vM
+vM
+vM
+lA
+lA
 he
 he
 he
@@ -41502,12 +41442,12 @@ lL
 qK
 KR
 qK
-lL
+fR
 FQ
 vE
-ua
+Pb
 PJ
-iv
+Fo
 nL
 Jq
 wW
@@ -41517,7 +41457,7 @@ US
 US
 US
 ua
-iv
+Fo
 wW
 lj
 hC
@@ -41738,21 +41678,21 @@ Yk
 wZ
 wZ
 wZ
-Mq
-Mq
+Qy
+Qy
 WY
 WY
 xL
-gB
-gB
-tF
-jC
-ox
-Mq
-Mq
-Mq
-Mq
-Mq
+TY
+TY
+xY
+Lc
+zM
+Qy
+Qy
+Qy
+Qy
+Qy
 wZ
 wZ
 wZ
@@ -41763,9 +41703,9 @@ lL
 lL
 FQ
 vE
-ua
+Pb
 PJ
-iv
+Fo
 ua
 ua
 ua
@@ -41993,20 +41933,20 @@ wZ
 wZ
 wZ
 wZ
-Mq
-Mq
-Mq
-Mq
+Qy
+Qy
+Qy
+Qy
 YO
-jC
-jC
+Lc
+Lc
 IZ
 pj
 pj
-jC
-jC
+Lc
+Lc
 WY
-Mq
+Qy
 wZ
 wZ
 wZ
@@ -42018,12 +41958,12 @@ wZ
 wZ
 wZ
 wZ
-BV
+qW
 FQ
 vE
-ua
+Pb
 le
-Do
+PK
 US
 wZ
 wZ
@@ -42251,20 +42191,20 @@ Yk
 wZ
 wZ
 wZ
-Mq
+Qy
 WY
 kC
 mQ
-gB
+TY
 pj
 pj
 pj
-jC
-qf
+Lc
+Jp
 Et
 CK
-Mq
-Mq
+Qy
+Qy
 wZ
 wZ
 wZ
@@ -42276,10 +42216,10 @@ wZ
 wZ
 wZ
 wZ
-dl
+bG
 FQ
 vE
-ua
+Pb
 jc
 le
 US
@@ -42311,9 +42251,9 @@ Mq
 Mq
 Mq
 Mq
-Rl
-Rl
-Rl
+FV
+FV
+FV
 Mq
 Mq
 Mq
@@ -42510,18 +42450,18 @@ wZ
 wZ
 wZ
 CN
-jC
-ox
-jC
+Lc
+zM
+Lc
 pj
 pj
-jC
+Lc
 OE
 tN
-gB
-Mq
-Mq
-Mq
+TY
+Qy
+Qy
+Qy
 wZ
 wZ
 wZ
@@ -42537,12 +42477,12 @@ LH
 LH
 FQ
 vE
-ua
+Pb
 me
 Kb
-LH
-LH
-jI
+we
+we
+xh
 LW
 zx
 LH
@@ -42562,21 +42502,21 @@ NE
 vn
 vn
 Xx
-pj
+Sk
 vn
 vn
-mQ
-LV
-LV
-jC
-jC
-jC
-jC
-jC
-LV
-jC
-jC
-Rl
+Fz
+qb
+qb
+Bh
+Bh
+Bh
+Bh
+Bh
+qb
+Bh
+Bh
+FV
 wZ
 wZ
 wZ
@@ -42768,9 +42708,9 @@ wZ
 wZ
 wZ
 SE
-gB
+TY
 pj
-jC
+Lc
 pj
 xV
 LU
@@ -42795,13 +42735,13 @@ Ef
 EU
 FQ
 Mi
-ua
-ua
-ua
-LH
+Pb
+Pb
+Pb
+we
 xS
-Jp
-Jp
+Dr
+Dr
 xS
 Wh
 LH
@@ -42816,25 +42756,25 @@ wZ
 zn
 YX
 YX
-Vn
+Zd
 ac
 Ht
-Vn
-Vn
+Zd
+Zd
 NE
-gB
-jC
-jC
-jC
-jC
-jC
-jC
-jC
-jC
-jC
-jC
-jC
-Rl
+Lt
+Bh
+Bh
+Bh
+Bh
+Bh
+Bh
+Bh
+Bh
+Bh
+Bh
+Bh
+FV
 wZ
 wZ
 wZ
@@ -43025,10 +42965,10 @@ wZ
 wZ
 wZ
 wZ
-Mq
+Qy
 nh
 pj
-jC
+Lc
 hU
 LU
 LU
@@ -43048,21 +42988,21 @@ dT
 Bz
 AY
 xO
-rq
-rq
+vY
+vY
 Mf
 eN
 YF
 bM
 pD
 SW
-LH
-Lc
-Lc
+we
+Sb
+Sb
 xS
 xS
 xS
-Jp
+Dr
 Wh
 zx
 zx
@@ -43072,15 +43012,15 @@ wZ
 wZ
 wZ
 Mq
-jC
-gB
+Bh
+Lt
 tF
 vn
-pj
+Sk
 PV
-Vn
-gB
-jC
+Zd
+Lt
+Bh
 RQ
 RQ
 RQ
@@ -43090,8 +43030,8 @@ RQ
 RQ
 RQ
 RQ
-jC
-jC
+Bh
+Bh
 Mq
 wZ
 wZ
@@ -43283,10 +43223,10 @@ wZ
 wZ
 wZ
 wZ
-Mq
+Qy
 jK
 Rf
-gB
+TY
 LU
 LU
 Jf
@@ -43302,26 +43242,26 @@ dl
 BV
 tO
 xS
-Kj
+sa
 yE
 fb
-Kj
+sa
 bq
-TY
-LH
+Mn
+we
 hT
 Qf
 Qf
 nq
 MA
-LH
-Lc
-Lc
-Lc
-Lc
-Lc
-Jp
-Lc
+we
+Sb
+Sb
+Sb
+Sb
+Sb
+Dr
+Sb
 xS
 LW
 zx
@@ -43333,12 +43273,12 @@ Mq
 kn
 wg
 mA
-pj
-jC
-gB
-Vn
+Sk
+Bh
+Lt
+Zd
 pX
-pj
+Sk
 RQ
 RE
 tP
@@ -43348,9 +43288,9 @@ vS
 wl
 oo
 RQ
-xL
-jC
-Rl
+Dw
+Bh
+FV
 wZ
 wZ
 wZ
@@ -43541,7 +43481,7 @@ wZ
 wZ
 wZ
 wZ
-Mq
+Qy
 sx
 PO
 WY
@@ -43560,43 +43500,43 @@ zx
 Gb
 xS
 xS
-Kj
+sa
 xS
 wn
 hX
 wn
 wn
-LH
-LH
-LH
-LH
+we
+we
+we
+we
 dx
 Rz
-LH
+we
 wn
 wn
 wn
 wn
-Lc
-Lc
-Lc
-Lc
+Sb
+Sb
+Sb
+Sb
 xS
 LW
-jI
+xh
 wZ
 wZ
 wZ
 Mq
-pj
-Vn
-Vn
-Vn
-Vn
-Vn
-Vn
+Sk
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
 XY
-pj
+Sk
 RQ
 jg
 dW
@@ -43606,7 +43546,7 @@ RU
 zE
 AB
 RQ
-jC
+Bh
 qf
 VT
 wZ
@@ -43800,7 +43740,7 @@ wZ
 wZ
 wZ
 Rl
-hg
+Da
 lz
 NC
 LU
@@ -43815,9 +43755,9 @@ wZ
 wZ
 gM
 ar
-rq
-rq
-rq
+vY
+vY
+vY
 mx
 wn
 wn
@@ -43827,18 +43767,18 @@ BH
 pO
 YK
 xS
-LH
+we
 dx
 Rz
-LH
+we
 fo
 fb
 xS
 wn
 wn
-Lc
-Lc
-Lc
+Sb
+Sb
+Sb
 hx
 xS
 zx
@@ -43846,15 +43786,15 @@ wZ
 wZ
 wZ
 Mq
-LV
-Vn
+qb
+Zd
 nz
 lW
 Gt
 jB
-Vn
+Zd
 qf
-pj
+Sk
 RQ
 ty
 RU
@@ -43864,9 +43804,9 @@ tP
 RU
 AB
 RQ
-jC
-LV
-Rl
+Bh
+qb
+FV
 wZ
 wZ
 Yk
@@ -44058,7 +43998,7 @@ wZ
 wZ
 wZ
 Rl
-jC
+Lc
 Ib
 Jb
 Kx
@@ -44085,34 +44025,34 @@ FS
 lV
 eE
 xS
-LH
+we
 dx
 Rz
 xS
 xS
 Qe
 ro
-Jp
+Dr
 wn
 wn
-Lc
-Lc
-Lc
+Sb
+Sb
+Sb
 xS
 LH
 LH
 wZ
 wZ
 Mq
-jC
-Vn
+Bh
+Zd
 lW
-LV
+qb
 YU
 kN
-Vn
-xL
-pj
+Zd
+Dw
+Sk
 RQ
 cZ
 ag
@@ -44122,7 +44062,7 @@ kb
 tP
 Wm
 RQ
-jC
+Bh
 GD
 Mq
 no
@@ -44315,8 +44255,8 @@ wZ
 wZ
 wZ
 wZ
-Mq
-gB
+Qy
+TY
 je
 WY
 LU
@@ -44329,7 +44269,7 @@ pK
 wZ
 wZ
 LH
-Jt
+uk
 oX
 xS
 xS
@@ -44343,34 +44283,34 @@ xS
 xS
 xS
 Wj
-LH
+we
 dx
 Rz
-LH
+we
 xS
 hx
 xS
-Jp
+Dr
 rA
 wn
 wn
-Lc
-Lc
+Sb
+Sb
 xS
 xS
 LH
 wZ
 wZ
 Mq
-Vn
-Vn
+Yo
+Zd
 lW
-LV
-jC
+qb
+Bh
 uT
-Vn
-pj
-pj
+Zd
+Sk
+Sk
 RQ
 XG
 nr
@@ -44380,11 +44320,11 @@ uI
 Ko
 MS
 RQ
-LV
-jC
-LV
-LV
-jC
+qb
+Bh
+qb
+qb
+Bh
 Mq
 wZ
 wZ
@@ -44573,10 +44513,10 @@ wZ
 wZ
 wZ
 wZ
-Mq
-gB
+Qy
+TY
 je
-jC
+Lc
 IH
 IH
 IH
@@ -44587,9 +44527,9 @@ Fh
 wZ
 wZ
 dl
-Jp
-Kj
-TY
+Dr
+sa
+Mn
 wn
 wn
 wn
@@ -44601,18 +44541,18 @@ wn
 wn
 wn
 wn
-LH
+we
 dx
 Rz
-LH
-LH
+we
+we
 gZ
 gZ
 gZ
-LH
-LH
-LH
-LH
+we
+we
+we
+we
 Oe
 xS
 xS
@@ -44621,12 +44561,12 @@ wZ
 wZ
 Mq
 OX
-LV
+qb
 gq
 vt
-jC
+Bh
 TX
-Vn
+Zd
 hg
 Nw
 RQ
@@ -44638,11 +44578,11 @@ RQ
 RQ
 RQ
 RQ
-jC
-jC
-jC
-jC
-LV
+Bh
+Bh
+Bh
+Bh
+qb
 Mq
 wZ
 wZ
@@ -44846,20 +44786,20 @@ wZ
 wZ
 gM
 xS
-Kj
-xS
-lA
-uk
-Ky
 sa
-Ky
-Ky
-Ky
+xS
+wn
+uk
+xS
+fb
+xS
+xS
+xS
 Mn
 Dr
-Ky
+xS
 Mn
-yo
+we
 dx
 MN
 pD
@@ -44870,7 +44810,7 @@ pD
 pD
 pD
 SW
-LH
+we
 Yt
 KQ
 Hl
@@ -44884,8 +44824,8 @@ gq
 YN
 gq
 gq
-Vn
-pj
+Zd
+Sk
 wT
 RQ
 ww
@@ -44895,11 +44835,11 @@ DU
 dS
 IL
 zP
-OE
-jC
-jC
+ZK
+Bh
+Bh
 Mq
-Rl
+FV
 fH
 Mq
 wZ
@@ -45089,7 +45029,7 @@ RB
 Nr
 ri
 vK
-RB
+eC
 OE
 xd
 Jb
@@ -45103,21 +45043,21 @@ Fh
 wZ
 wZ
 BV
-TY
-Kj
+Mn
+sa
 qJ
-lA
-Ky
-Ky
-Ky
-Ky
+wn
+xS
+xS
+xS
+xS
 Sb
 Sh
 Dr
 Dr
 rM
 uk
-yo
+we
 DY
 Hj
 Qf
@@ -45130,7 +45070,7 @@ nq
 tg
 Ck
 zm
-rq
+vY
 yX
 LW
 wZ
@@ -45140,23 +45080,23 @@ OU
 lW
 vt
 MJ
-LV
+qb
 jk
-Vn
-pj
+Zd
+Sk
 wT
 RQ
 DC
 Ai
 RQ
-LV
+qb
 JY
 Gw
-jC
-jC
+Bh
+Bh
 dZ
 lM
-Rl
+FV
 wZ
 wZ
 wZ
@@ -45347,10 +45287,10 @@ RB
 ZI
 QH
 Vv
-RB
-jC
+eC
+Lc
 je
-jC
+Lc
 IH
 ul
 Ho
@@ -45362,15 +45302,15 @@ wZ
 wZ
 LH
 Gb
-Kj
+sa
 bq
-lA
-Ky
+wn
+xS
 Sb
 Sb
-Ky
+xS
 Sb
-Ky
+xS
 dd
 dd
 dd
@@ -45386,22 +45326,22 @@ Km
 HI
 Vh
 Zs
-LH
+we
 xt
 xS
-Kj
+sa
 LH
 wZ
 wZ
 Mq
 SV
 Zg
-jC
+Bh
 gq
-LV
+qb
 em
-Vn
-pj
+Zd
+Sk
 Yi
 RQ
 bw
@@ -45409,12 +45349,12 @@ PQ
 RQ
 SG
 tQ
-jC
-jC
+Bh
+Bh
 lM
 dZ
 dZ
-Rl
+FV
 wZ
 wZ
 wZ
@@ -45605,9 +45545,9 @@ RB
 aw
 GS
 Lp
-RB
+eC
 vF
-aV
+Kj
 pj
 LE
 Wu
@@ -45616,19 +45556,19 @@ dg
 rT
 Zz
 Fh
-BV
-BV
+CN
+CN
 LH
 we
-eC
+uf
 we
-lA
+wn
 Mn
 Mn
 Dr
 Dr
 Sb
-Ky
+xS
 dd
 jd
 jd
@@ -45652,28 +45592,28 @@ LH
 zx
 LW
 Mq
-Vn
-Vn
+Zd
+Zd
 gb
 QY
 gq
 em
-Vn
-pj
+Zd
+Sk
 Fm
 RQ
 ZQ
 JJ
 mO
 qf
-jC
-jC
+Bh
+Bh
 dZ
 eb
 dZ
 fz
-Rl
-Rl
+FV
+FV
 wZ
 wZ
 wZ
@@ -45863,10 +45803,10 @@ jQ
 qS
 rY
 Vv
-RB
-Vn
+eC
+on
 mX
-Vn
+on
 LE
 LE
 LE
@@ -45876,13 +45816,13 @@ LE
 Fh
 TY
 TY
-Gb
-xS
+WY
+Lc
 Kj
-Ef
-lA
-Ky
-Ky
+YO
+wn
+xS
+xS
 Dr
 Dr
 Sb
@@ -45905,34 +45845,34 @@ sC
 Kc
 dv
 yo
-Kj
+sa
 xS
 xS
 xS
 Mq
-Vn
-Vn
-Vn
-Vn
-Vn
-Vn
-Vn
-pj
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Zd
+Sk
 wT
-jC
-jC
+Bh
+Bh
 aV
-xL
-jC
-jC
+Dw
+Bh
+Bh
 dZ
 dZ
 dZ
 RL
 PB
 dZ
-Rl
-Rl
+FV
+FV
 wZ
 wZ
 wZ
@@ -46121,30 +46061,30 @@ Ij
 aC
 Uz
 AA
-RB
+eC
 VU
-aV
+Kj
 XO
 pj
 mQ
-jC
+Lc
 Ng
 cX
-jC
+Lc
 CK
-fb
-xS
-xS
-hx
+xL
+Lc
+Lc
+Jp
 Kj
-xS
-lA
+Lc
+wn
 vH
 vZ
-Ky
+xS
 Dr
 Sb
-Ky
+xS
 dd
 jd
 va
@@ -46164,23 +46104,23 @@ wE
 Kc
 yo
 kK
-Lc
+Sb
 dj
-Lc
+Sb
 Mq
 Gq
 Ph
-xL
-pj
-pj
+Dw
+Sk
+Sk
 CW
-pj
+Sk
 kP
 Aj
-pj
+Sk
 kn
 rX
-pj
+Sk
 ql
 dZ
 dZ
@@ -46190,7 +46130,7 @@ dZ
 RL
 Lq
 eb
-Rl
+FV
 wZ
 wZ
 wZ
@@ -46382,14 +46322,14 @@ nK
 WU
 Wx
 Kf
-EC
-EC
-EC
-EC
-EC
-EC
-EC
-EC
+MK
+MK
+MK
+MK
+MK
+MK
+MK
+MK
 MK
 MK
 rq
@@ -46397,7 +46337,7 @@ MK
 pv
 MK
 Rb
-DN
+CE
 CE
 CE
 gG
@@ -46424,16 +46364,16 @@ yo
 cq
 zm
 Bz
-rq
+vY
 Ed
 GA
-EC
+iZ
 do
 fM
 fM
 fM
 fM
-EC
+iZ
 VH
 fM
 fM
@@ -46637,30 +46577,30 @@ RB
 Oh
 rl
 GO
-RB
-jC
+eC
+Lc
 je
-qf
-jC
-jC
-jC
-gB
+Jp
+Lc
+Lc
+Lc
+TY
 OE
-jC
-jC
-Gb
 Lc
 Lc
+WY
+pj
+pj
+pj
 Lc
-xS
 nf
-lA
-Bu
-Ky
-Ky
+wn
+xS
+xS
+xS
 Ur
-Ky
-Ky
+xS
+xS
 dd
 jd
 Yb
@@ -46680,24 +46620,24 @@ OY
 Kc
 yo
 qy
-Lc
+Sb
 yE
 xS
 Mq
 Ay
-pj
-pj
+Sk
+Sk
 wN
-pj
-pj
-pj
-jC
+Sk
+Sk
+Sk
+Bh
 YI
-jC
-pj
+Bh
+Sk
 rX
-pj
-Dw
+Sk
+ES
 dZ
 dZ
 lM
@@ -46706,7 +46646,7 @@ dZ
 eb
 wR
 dZ
-Rl
+FV
 wZ
 wZ
 wZ
@@ -46892,10 +46832,10 @@ wZ
 wZ
 wZ
 HE
-HE
-HE
-HE
-HE
+iB
+iB
+iB
+iB
 zL
 ue
 Ca
@@ -46908,16 +46848,16 @@ zL
 HE
 Bc
 zM
+Lc
+Lc
+Lc
+WY
+wn
 xS
-xS
-xS
-Gb
-lA
-Ky
 HL
 Sb
-Pm
-Ky
+kd
+xS
 ID
 dd
 jd
@@ -46938,8 +46878,8 @@ Kc
 Kc
 yo
 su
-Lc
-Lc
+Sb
+Sb
 xS
 fC
 kE
@@ -46949,22 +46889,22 @@ kE
 kE
 kE
 jn
-jC
+Bh
 jM
-jC
-jC
+Bh
+Bh
 aV
-jC
-jC
-jC
+Bh
+Bh
+Bh
 PB
 dZ
 dZ
 dZ
 RL
 PB
-Rl
-Rl
+FV
+FV
 wZ
 wZ
 wZ
@@ -47170,13 +47110,13 @@ LH
 we
 WS
 we
-lA
-cv
+wn
+rk
 ft
-Pb
-Pm
+FR
+kd
 Wt
-Ky
+xS
 dd
 jd
 jd
@@ -47197,7 +47137,7 @@ yo
 yo
 zG
 LH
-jI
+xh
 zx
 fC
 Ui
@@ -47207,21 +47147,21 @@ Yz
 Yz
 kE
 kE
-jC
+Bh
 QN
 eZ
 wD
 qv
 eZ
-jC
-jC
-jC
+Bh
+Bh
+Bh
 dZ
 dZ
 fz
 dZ
-Rl
-Rl
+FV
+FV
 wZ
 wZ
 wZ
@@ -47428,11 +47368,11 @@ LH
 Sw
 xS
 xS
-lA
-Ky
+wn
+xS
 Tg
 Sb
-Pm
+kd
 DM
 wp
 dd
@@ -47448,7 +47388,7 @@ Km
 Bo
 Km
 Km
-Jp
+Dr
 xS
 wn
 Nm
@@ -47465,20 +47405,20 @@ FL
 vU
 eu
 kE
-jC
+Bh
 jM
 eZ
 wP
 iD
 eZ
 Dy
-jC
-jC
-jC
+Bh
+Bh
+Bh
 RL
 PB
 lM
-Rl
+FV
 wZ
 wZ
 wZ
@@ -47682,25 +47622,25 @@ sD
 HE
 wZ
 wZ
-jI
+xh
 xS
 xS
 fb
-lA
+wn
 Mn
 ob
 DD
-Pm
+kd
 Sb
 sG
 NQ
-Ky
+xS
 mC
-Ky
-Ky
+xS
+xS
 HL
 vX
-Ky
+xS
 Km
 gp
 Yp
@@ -47712,7 +47652,7 @@ xS
 xS
 KQ
 DI
-jI
+xh
 wZ
 wZ
 fC
@@ -47731,12 +47671,12 @@ iD
 eZ
 LP
 EE
-LV
-jC
-jC
+qb
+Bh
+Bh
 dZ
 dZ
-Rl
+FV
 wZ
 wZ
 wZ
@@ -47941,36 +47881,36 @@ HE
 wZ
 wZ
 zx
-Jp
+Dr
 xS
 xS
-lA
-Ky
+wn
+xS
 Mn
 BN
 fY
-on
-on
-on
+zm
+zm
+zm
 Cw
 vY
 vY
 GK
 xv
-Ky
-Ky
+xS
+xS
 mF
 YD
 Yp
 YD
 Km
 xS
-Jp
+Dr
 wn
 xS
-Lc
+Sb
 rU
-jI
+xh
 wZ
 wZ
 fC
@@ -47991,11 +47931,11 @@ Gw
 zP
 gI
 Fp
-xL
-jC
-jC
+Dw
+Bh
+Bh
 Mq
-Rl
+FV
 VT
 Mq
 wZ
@@ -48199,23 +48139,23 @@ HE
 wZ
 wZ
 zx
-Jp
-Jp
+Dr
+Dr
 xS
-lA
-lA
+wn
+wn
 jF
 It
 bH
 vZ
 Dr
-Pb
+FR
 Px
 Sb
 Sb
-Pm
+kd
 Sb
-Pb
+FR
 Dr
 Km
 YD
@@ -48225,8 +48165,8 @@ Km
 Kl
 wn
 wn
-Lc
-Lc
+Sb
+Sb
 xS
 zx
 wZ
@@ -48251,10 +48191,10 @@ eZ
 eZ
 eZ
 uN
-jC
-jC
-jC
-jC
+Bh
+Bh
+Bh
+Bh
 Mq
 wZ
 wZ
@@ -48461,20 +48401,20 @@ rk
 xS
 xS
 xS
-lA
-lA
+wn
+wn
 lv
 It
 jv
-Ky
-Qy
+xS
+KQ
 pt
 uU
 Tg
-Pm
+kd
 Sb
 Sb
-Pb
+FR
 Km
 YD
 bA
@@ -48482,9 +48422,9 @@ Ic
 Km
 wn
 wn
-Da
-Lc
-Lc
+vH
+Sb
+Sb
 tO
 LH
 wZ
@@ -48508,11 +48448,11 @@ kk
 Ez
 kk
 eZ
-jC
-LV
-jC
-jC
-jC
+Bh
+qb
+Bh
+Bh
+Bh
 Mq
 wZ
 wZ
@@ -48719,20 +48659,20 @@ LH
 Kn
 xS
 xS
-TY
-lA
-lA
+Mn
+wn
+wn
 CR
 Tg
-Ky
+xS
 Tg
 xo
-Pb
+FR
 Sb
-Pm
+kd
 Sb
-Ky
-Ky
+xS
+xS
 Km
 YD
 IG
@@ -48740,8 +48680,8 @@ TI
 Km
 wn
 jb
-Lc
-Lc
+Sb
+Sb
 xS
 LH
 LH
@@ -48755,8 +48695,8 @@ Yz
 qk
 nG
 kE
-jC
-pj
+Bh
+Sk
 eZ
 Ge
 kq
@@ -48978,28 +48918,28 @@ hG
 xS
 xS
 xS
-TY
-lA
-lA
-Ky
+Mn
+wn
+wn
+xS
 if
-Ky
-Ky
-Ky
+xS
+xS
+xS
 QE
 UZ
 uk
-Ky
-sa
+xS
+fb
 Km
 YD
 YD
 Km
 Km
-mj
-Lc
-Lc
-Lc
+Tg
+Sb
+Sb
+Sb
 xS
 zx
 wZ
@@ -49013,8 +48953,8 @@ Yz
 Yz
 eu
 kE
-pj
-pj
+Sk
+Sk
 eZ
 kq
 Zt
@@ -49025,8 +48965,8 @@ gx
 kk
 eZ
 wN
-jC
-Rl
+Bh
+FV
 wZ
 wZ
 Yk
@@ -49233,30 +49173,30 @@ wZ
 wZ
 zx
 LW
-mj
+Tg
 xS
-Jp
+Dr
 xS
 xS
-lA
-lA
-lA
-lA
-lA
-lA
-lA
+wn
+wn
+wn
+wn
+wn
+wn
+wn
 uf
-lA
-lA
-lA
+wn
+wn
+wn
 Km
 Km
 Km
 Km
-TY
-Lc
+Mn
+Sb
 FR
-Jp
+Dr
 xS
 LW
 zx
@@ -49271,8 +49211,8 @@ Yz
 nG
 kh
 kE
-pj
-pj
+Sk
+Sk
 eZ
 kq
 WX
@@ -49282,8 +49222,8 @@ cg
 Az
 ur
 eZ
-pj
-jC
+Sk
+Bh
 VT
 wZ
 wZ
@@ -49493,26 +49433,26 @@ wZ
 LW
 LW
 xS
-Jp
+Dr
 xS
 rC
 xS
 xS
 xS
-Jp
+Dr
 we
-Lc
-Lc
+Sb
+Sb
 kd
-Lc
-Lc
+Sb
+Sb
 we
 xS
-TY
-Lc
-Lc
-Lc
-Lc
+Mn
+Sb
+Sb
+Sb
+Sb
 xS
 xS
 LW
@@ -49529,8 +49469,8 @@ pR
 eu
 nG
 kE
-pj
-jC
+Sk
+Bh
 eZ
 Ln
 kq
@@ -49540,8 +49480,8 @@ Gr
 kk
 kq
 eZ
-jC
-jC
+Bh
+Bh
 VT
 wZ
 wZ
@@ -49751,7 +49691,7 @@ wZ
 wZ
 zx
 zx
-TY
+Mn
 xS
 Iq
 eJ
@@ -49763,14 +49703,14 @@ am
 cw
 zW
 Wc
-Lc
+Sb
 wK
-Lc
-Lc
-Lc
-Lc
-Lc
-TY
+Sb
+Sb
+Sb
+Sb
+Sb
+Mn
 xS
 zx
 zx
@@ -49787,8 +49727,8 @@ dO
 wz
 nG
 kE
-pj
-kC
+Sk
+Jj
 eZ
 eZ
 eZ
@@ -49798,8 +49738,8 @@ eZ
 eZ
 eZ
 eZ
-LV
-jC
+qb
+Bh
 Mq
 wZ
 wZ
@@ -50015,18 +49955,18 @@ tl
 hx
 Ec
 xS
-TY
+Mn
 we
-Da
-Lc
-Kj
-Lc
+vH
+Sb
+sa
+Sb
 hx
 we
 xS
 Wy
-Jp
-Jp
+Dr
+Dr
 dy
 LH
 zx
@@ -50047,18 +49987,18 @@ kE
 oJ
 zI
 vn
-pj
+Sk
 qf
-jC
-xL
-CK
-OE
-pj
-pj
-LV
-LV
-jC
-Rl
+Bh
+Dw
+oH
+ZK
+Sk
+Sk
+qb
+qb
+Bh
+FV
 wZ
 wZ
 wZ
@@ -50260,8 +50200,8 @@ dr
 iB
 iB
 HE
-Mq
-Mq
+Ky
+Ky
 wZ
 wZ
 wZ
@@ -50271,7 +50211,7 @@ wZ
 LH
 LH
 zx
-jI
+xh
 zx
 LH
 LH
@@ -50279,11 +50219,11 @@ mZ
 FR
 jy
 FR
-Jp
+Dr
 LH
 LH
-jI
-jI
+xh
+xh
 zx
 LH
 LH
@@ -50305,17 +50245,17 @@ kB
 NE
 vn
 NE
-pj
-pj
-pj
-pj
-pj
-pj
+Sk
+Sk
+Sk
+Sk
+Sk
+Sk
 CW
-jC
-LV
-jC
-jC
+Bh
+qb
+Bh
+Bh
 VT
 wZ
 wZ
@@ -50513,14 +50453,14 @@ ec
 Rh
 iB
 yc
-tF
+fF
 jC
-mQ
-EE
+Jt
+mj
 ce
 gB
-Mq
-Mq
+Ky
+Ky
 wZ
 wZ
 wZ
@@ -50567,9 +50507,9 @@ Mq
 Mq
 Mq
 Mq
-Rl
-Rl
-Rl
+FV
+FV
+FV
 Mq
 Mq
 Mq
@@ -50778,7 +50718,7 @@ VK
 jC
 LV
 LV
-Mq
+Ky
 wZ
 wZ
 wZ
@@ -50790,10 +50730,10 @@ wZ
 wZ
 wZ
 wZ
-jI
+xh
 Lz
 xS
-Kj
+sa
 xS
 fb
 zx
@@ -51026,17 +50966,17 @@ wZ
 wZ
 wZ
 wZ
-Mq
-Mq
-hg
+Ky
+Ky
+ox
 nQ
-NC
+Yd
 up
 yT
 ks
 jC
-Et
-Mq
+FZ
+Ky
 BZ
 BZ
 BZ
@@ -51285,8 +51225,8 @@ wZ
 wZ
 wZ
 wZ
-Mq
-Mq
+Ky
+Ky
 oc
 wd
 LV
@@ -51330,8 +51270,8 @@ kE
 kE
 kE
 kE
-bj
-vM
+kB
+Xw
 Mq
 Mq
 wZ
@@ -51544,7 +51484,7 @@ wZ
 wZ
 wZ
 wZ
-Mq
+Ky
 ow
 Sq
 BI
@@ -51589,8 +51529,8 @@ mU
 Rm
 Rm
 qV
-iX
-BZ
+vn
+Mq
 wZ
 wZ
 wZ
@@ -51802,7 +51742,7 @@ wZ
 wZ
 wZ
 wZ
-Mq
+Ky
 bg
 QA
 jC
@@ -51847,8 +51787,8 @@ ZW
 EM
 SX
 fj
-qW
-BZ
+zI
+Mq
 wZ
 wZ
 wZ
@@ -52060,7 +52000,7 @@ wZ
 wZ
 wZ
 wZ
-gL
+Ky
 dn
 sW
 sW
@@ -52106,7 +52046,7 @@ yR
 yR
 Fn
 Zd
-gL
+Mq
 wZ
 wZ
 wZ
@@ -52317,8 +52257,8 @@ wZ
 Yk
 Yk
 Yk
-gL
-gL
+Ky
+Ky
 rf
 sW
 cz
@@ -52362,9 +52302,9 @@ bl
 KJ
 Vy
 yR
-MZ
+aV
 Lt
-gL
+Mq
 Yk
 Yk
 Yk
@@ -52575,7 +52515,7 @@ Se
 wZ
 wZ
 wZ
-gL
+Ky
 ib
 MZ
 sW
@@ -52620,9 +52560,9 @@ Xu
 SP
 RV
 yR
-xh
+rX
 cJ
-pH
+rt
 wZ
 wZ
 wZ
@@ -52833,7 +52773,7 @@ xC
 wZ
 wZ
 wZ
-gL
+Ky
 ZM
 iL
 sW
@@ -52878,9 +52818,9 @@ Ep
 ZS
 yv
 yR
-xh
+rX
 Bh
-pH
+rt
 wZ
 wZ
 wZ
@@ -53092,7 +53032,7 @@ wZ
 wZ
 wZ
 pH
-Bh
+jC
 iL
 sW
 Dh
@@ -53136,7 +53076,7 @@ iw
 Xv
 yR
 yR
-xh
+rX
 qb
 BA
 wZ
@@ -53350,7 +53290,7 @@ wZ
 wZ
 wZ
 pH
-Fz
+Jt
 iL
 sW
 cz
@@ -53394,9 +53334,9 @@ yR
 yR
 yR
 ZK
-xh
+rX
 NT
-gL
+Mq
 wZ
 wZ
 wZ
@@ -53647,14 +53587,14 @@ Fs
 wQ
 Ok
 pn
-MR
-MR
-MR
+Vg
+Vg
+Vg
 pn
 Na
 dR
-gL
-gL
+Mq
+Mq
 wZ
 wZ
 wZ
@@ -53865,7 +53805,7 @@ Yk
 wZ
 wZ
 wZ
-gL
+Ky
 oE
 Ug
 sW
@@ -53902,7 +53842,7 @@ Wl
 Sk
 Hm
 Mr
-fR
+Mr
 CT
 CT
 HG
@@ -53910,8 +53850,8 @@ Sl
 pW
 CT
 Cr
-gL
-gL
+Mq
+Mq
 wZ
 wZ
 wZ
@@ -54123,7 +54063,7 @@ Yk
 wZ
 wZ
 wZ
-gL
+Ky
 jJ
 rf
 sW
@@ -54167,8 +54107,8 @@ ay
 gL
 gL
 gL
-gL
-gL
+Mq
+Mq
 wZ
 wZ
 wZ
@@ -54381,7 +54321,7 @@ Yk
 Yk
 Yk
 Yk
-gL
+Ky
 pQ
 rf
 sW
@@ -54416,7 +54356,7 @@ gc
 lt
 sW
 Bh
-xh
+rX
 gL
 Bh
 Bh
@@ -54425,7 +54365,7 @@ Bh
 Bh
 Bh
 Bh
-gL
+Mq
 wZ
 wZ
 wZ
@@ -54639,7 +54579,7 @@ Yk
 wZ
 wZ
 wZ
-gL
+Ky
 GL
 MZ
 sW
@@ -54674,7 +54614,7 @@ lt
 lt
 sW
 Bh
-xh
+rX
 gL
 Bh
 Lt
@@ -54683,7 +54623,7 @@ Bh
 xn
 Bh
 xn
-gL
+Mq
 wZ
 wZ
 wZ
@@ -54897,7 +54837,7 @@ wZ
 wZ
 wZ
 wZ
-gL
+Ky
 Of
 zd
 FG
@@ -54932,7 +54872,7 @@ GC
 kt
 sW
 se
-xh
+rX
 gL
 Bh
 Bh
@@ -54941,7 +54881,7 @@ Jm
 xn
 Bh
 Bh
-gL
+Mq
 wZ
 wZ
 wZ
@@ -55155,8 +55095,8 @@ eY
 Yk
 Yk
 Yk
-gL
-Lt
+Ky
+gB
 iL
 sW
 qo
@@ -55190,7 +55130,7 @@ GC
 kt
 sW
 Nl
-xh
+rX
 gL
 Bh
 Bh
@@ -55199,7 +55139,7 @@ xn
 xn
 xn
 Fz
-gL
+Mq
 wZ
 Yk
 Yk
@@ -55413,7 +55353,7 @@ eY
 wZ
 wZ
 wZ
-gL
+Ky
 JA
 MZ
 sW
@@ -55457,7 +55397,7 @@ Bh
 Bh
 Bh
 bp
-gL
+Mq
 wZ
 wZ
 wZ
@@ -55671,7 +55611,7 @@ Yk
 wZ
 wZ
 wZ
-gL
+Ky
 xy
 iL
 sW
@@ -55705,17 +55645,17 @@ lK
 GC
 Wv
 sW
-QX
+ql
 wh
-gL
-gL
-gL
-gL
-gL
-gL
-gL
-gL
-gL
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
+Mq
 wZ
 wZ
 wZ
@@ -55929,7 +55869,7 @@ Yk
 VY
 Yk
 Yk
-gL
+Ky
 ET
 MZ
 sW
@@ -55965,7 +55905,7 @@ uG
 sW
 EW
 aQ
-gL
+Mq
 wZ
 wZ
 wZ
@@ -56188,7 +56128,7 @@ wZ
 wZ
 qq
 qq
-qq
+Do
 sl
 sW
 Ny
@@ -56222,8 +56162,8 @@ Rd
 vx
 sW
 ES
-MZ
-gL
+aV
+Mq
 wZ
 wZ
 wZ
@@ -56480,8 +56420,8 @@ kt
 uG
 sW
 Sk
-rf
-gL
+cv
+Mq
 wZ
 wZ
 wZ
@@ -56738,7 +56678,7 @@ sW
 sW
 sW
 Zr
-xh
+rX
 FV
 wZ
 wZ
@@ -56971,7 +56911,7 @@ hr
 fv
 RP
 cD
-iS
+MR
 bR
 eO
 ir
@@ -57224,7 +57164,7 @@ tW
 CC
 Pv
 HX
-qq
+Do
 cs
 mH
 tL
@@ -57252,9 +57192,9 @@ mH
 my
 mM
 Cl
-iS
+MR
 Lt
-xh
+rX
 FV
 wZ
 wZ
@@ -57483,37 +57423,37 @@ CC
 CC
 qq
 qq
-gL
+iS
 Fv
-Fv
-Fv
-Fv
-Fv
+Bu
+Bu
+Bu
+Bu
 ek
-Fv
+Bu
 pJ
-Fv
+Bu
 ek
 ek
-Fv
-Fv
-Fv
+Bu
+Bu
+Bu
 ek
 ek
-Fv
-Fv
-Fv
-Fv
-Fv
-Fv
-Fv
-Fv
-Fv
-Fv
-Fv
+Bu
+Bu
+Bu
+Bu
+Bu
+Bu
+Bu
+Bu
+Bu
+Bu
+Bu
 oH
-xh
-gL
+rX
+Mq
 Yk
 Yk
 Yk
@@ -57768,10 +57708,10 @@ pP
 pP
 Xc
 ea
-Fv
+Bu
 aS
-xh
-gL
+rX
+Mq
 wZ
 wZ
 wZ
@@ -58029,7 +57969,7 @@ zN
 DW
 gf
 km
-gL
+Mq
 wZ
 wZ
 wZ
@@ -58284,10 +58224,10 @@ py
 hz
 og
 Ls
-Fv
+Bu
 BL
-xy
-gL
+qf
+Mq
 wZ
 wZ
 eY
@@ -58543,9 +58483,9 @@ Fv
 Fv
 Fv
 Fv
-gL
-gL
-gL
+Mq
+Mq
+Mq
 wZ
 Du
 eY
@@ -59018,7 +58958,7 @@ wZ
 wZ
 wZ
 wZ
-Yk
+il
 eY
 eY
 wZ
@@ -59276,7 +59216,7 @@ wZ
 wZ
 wZ
 wZ
-Yk
+il
 lR
 eY
 eY
@@ -59534,9 +59474,9 @@ wZ
 wZ
 wZ
 wZ
-Yk
-Yk
-Yk
+il
+il
+il
 wZ
 wZ
 wZ
@@ -61107,9 +61047,9 @@ XU
 wZ
 wZ
 wZ
-Yk
+il
 VE
-Yk
+il
 wZ
 wZ
 wZ
@@ -61365,9 +61305,9 @@ wZ
 wZ
 wZ
 wZ
-Yk
-Yk
-Yk
+il
+il
+il
 wZ
 wZ
 wZ

--- a/maps/southern_cross/southern_cross-0.dmm
+++ b/maps/southern_cross/southern_cross-0.dmm
@@ -771,10 +771,9 @@
 /area/maintenance/zeroaft)
 "cL" = (
 /obj/structure/cable/yellow{
-	d1 = 2;
+	d1 = 1;
 	d2 = 4;
-	icon_state = "2-4";
-	dir = 4
+	icon_state = "1-4"
 	},
 /obj/structure/cable/yellow,
 /obj/effect/wingrille_spawn/reinforced,
@@ -3135,6 +3134,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/abchemistry)
+"mv" = (
+/obj/structure/bed/chair/wood,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/turfpack/station,
+/area/maintenance/ragecage)
 "mw" = (
 /obj/random/cash{
 	pixel_x = -5;
@@ -6070,10 +6083,9 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable/yellow{
-	d1 = 2;
+	d1 = 1;
 	d2 = 4;
-	icon_state = "2-4";
-	dir = 4
+	icon_state = "1-4"
 	},
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating/turfpack/station,
@@ -6362,6 +6374,14 @@
 "zn" = (
 /turf/simulated/wall/r_wall/turfpack/station,
 /area/maintenance/janitoral)
+"zo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/turfpack/station,
+/area/maintenance/ragecage)
 "zp" = (
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/abscience)
@@ -11124,11 +11144,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/ragecage)
@@ -48123,8 +48138,8 @@ wZ
 wZ
 Yh
 Is
-bV
-Is
+mv
+zo
 tj
 Is
 kS

--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -22502,10 +22502,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fpcenter)
-"lEA" = (
-/obj/structure/sign/warning/caution,
-/turf/simulated/wall/r_wall,
-/area/hallway/secondary/escape/firstdeck/ep_aftstarboard)
 "lEZ" = (
 /obj/structure/table/bench/standard,
 /obj/effect/floor_decal/borderfloor{
@@ -26886,9 +26882,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
-"pUA" = (
-/turf/simulated/floor/airless,
-/area/hallway/secondary/escape/firstdeck/ep_aftport)
 "pUZ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/effect/floor_decal/steeldecal/steel_decals5{
@@ -30383,9 +30376,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/starboard)
-"tsx" = (
-/turf/simulated/floor/airless,
-/area/hallway/secondary/escape/firstdeck/ep_aftstarboard)
 "tsz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34398,7 +34388,7 @@
 "xbp" = (
 /obj/structure/sign/warning/caution,
 /turf/simulated/wall/r_wall,
-/area/hallway/secondary/escape/firstdeck/ep_aftport)
+/area/space)
 "xbG" = (
 /obj/structure/sign/directions/medical{
 	dir = 8
@@ -64862,13 +64852,13 @@ ilU
 vBl
 pAh
 dWo
-pUA
-pUA
-pUA
+jVV
+jVV
+jVV
 xbp
-pUA
-pUA
-pUA
+jVV
+jVV
+jVV
 fCy
 rmj
 aSg
@@ -73118,13 +73108,13 @@ dXE
 eDP
 aLu
 nhA
-tsx
-tsx
-tsx
-lEA
-tsx
-tsx
-tsx
+jVV
+jVV
+jVV
+xbp
+jVV
+jVV
+jVV
 fCy
 rmj
 sxW

--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -9944,6 +9944,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/forestarboard)
 "beQ" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for shutters.";
+	id = "virologyquar";
+	name = "Virology Emergency Lockdown Control";
+	pixel_x = -25;
+	pixel_y = 3;
+	req_access = list(5)
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "bfF" = (
@@ -11480,18 +11493,26 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "ctY" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "virologyquar";
+	name = "Virology Emergency Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/dark,
 /area/medical/virology)
 "cuc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11937,7 +11958,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "cPr" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/machinery/computer/med_data/laptop,
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 1
 	},
@@ -12584,16 +12607,20 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/stationshuttle)
 "dwh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 6
+	},
+/turf/simulated/floor/airless,
+/area/rnd/xenobiology/xenoflora)
+"dwn" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	external_pressure_bound = 140;
 	external_pressure_bound_default = 140;
 	icon_state = "map_vent_out";
-	use_power = 1
+	use_power = 1;
+	dir = 8
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/airless,
-/area/rnd/xenobiology/xenoflora)
-"dwn" = (
 /turf/simulated/floor/airless,
 /area/rnd/xenobiology/xenoflora)
 "dwT" = (
@@ -15667,7 +15694,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/ai_monitored/storage/eva/aux)
 "eqM" = (
-/obj/item/weapon/storage/box/monkeycubes,
 /obj/structure/table/glass,
 /obj/structure/reagent_dispensers/virusfood{
 	pixel_x = 30
@@ -15683,6 +15709,7 @@
 	c_tag = "MED - Virology Starboard";
 	dir = 8
 	},
+/obj/item/weapon/storage/box/monkeycubes,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "erI" = (
@@ -16862,29 +16889,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/xenobiology)
-"fHt" = (
-/obj/structure/table/standard,
-/obj/item/weapon/storage/lockbox/vials,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/weapon/storage/fancy/vials,
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 9
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/device/radio/intercom/department/medbay{
-	dir = 8;
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
 "fHQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
@@ -18616,6 +18620,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/firstdeck/apcenter)
+"hsy" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/airless,
+/area/space)
 "hsI" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/simulated/floor/tiled/dark{
@@ -18664,25 +18678,12 @@
 /turf/simulated/wall/r_wall,
 /area/tcomm/computer)
 "hwu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/virology)
+/turf/simulated/floor/airless,
+/area/space)
 "hxU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20183,6 +20184,17 @@
 /obj/item/weapon/melee/umbrella/random,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/spacebus)
+"iZz" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "virologyquar";
+	name = "Virology Emergency Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/medical/virology)
 "jbn" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/tank/emergency/oxygen/engi,
@@ -20762,6 +20774,13 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /obj/machinery/light,
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = -26;
+	tag_exterior_door = "virology_airlock_exterior";
+	tag_interior_door = "virology_airlock_interior"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "jDV" = (
@@ -21727,19 +21746,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hangar/three)
 "kEe" = (
-/obj/structure/table/standard,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/machinery/computer/med_data/laptop,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/corner/blue/border,
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = -26;
-	tag_exterior_door = "virology_airlock_exterior";
-	tag_interior_door = "virology_airlock_interior"
-	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
 /area/medical/virology)
 "kEx" = (
 /obj/structure/cable{
@@ -24605,12 +24613,21 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/vaultcheckpoint)
 "nAO" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/lockbox/vials,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/weapon/storage/fancy/vials,
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
+/obj/item/device/antibody_scanner,
+/obj/item/device/antibody_scanner,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "nCB" = (
@@ -25385,10 +25402,14 @@
 /obj/item/weapon/hand_labeler,
 /obj/item/weapon/folder/white,
 /obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 9
+	},
+/obj/item/device/radio/intercom/department/medbay{
+	dir = 8;
+	pixel_x = -21
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -25503,7 +25524,8 @@
 /area/maintenance/firstdeck/centralport)
 "ozZ" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/wall/r_wall,
 /area/medical/virology)
@@ -81332,9 +81354,9 @@ kcv
 rYm
 bJP
 bJP
-bJP
-ppt
-bJP
+iZz
+ctY
+iZz
 tDq
 hvg
 hvg
@@ -81590,9 +81612,9 @@ fVu
 bjM
 bJP
 bJP
-dRk
-ybM
-iEb
+bJP
+ppt
+bJP
 tDq
 kJV
 uPj
@@ -81848,9 +81870,9 @@ fVu
 lrd
 bJP
 bJP
-yks
-tMg
-xgz
+dRk
+ybM
+iEb
 tDq
 rvW
 taP
@@ -82106,9 +82128,9 @@ bnA
 dLu
 bJP
 bJP
-bJP
-guZ
-bJP
+yks
+tMg
+xgz
 tDq
 exY
 thk
@@ -82363,10 +82385,10 @@ upc
 wDG
 mGR
 bJP
-fHt
-ctY
-hwu
-kEe
+bJP
+bJP
+guZ
+bJP
 tDq
 ipN
 npi
@@ -84946,9 +84968,9 @@ itV
 itV
 itV
 ozZ
-bJP
-bJP
-aaa
+kEe
+kEe
+hwu
 aaa
 aaa
 aaa
@@ -85206,7 +85228,7 @@ itV
 aaa
 aaa
 vYi
-aaa
+hsy
 aaa
 aaa
 aaa
@@ -87265,7 +87287,7 @@ bNe
 xSS
 fjS
 itV
-jVV
+aaa
 aaa
 aaa
 aaa
@@ -87523,7 +87545,7 @@ bNe
 qfl
 wmi
 lse
-jVV
+aaa
 aaa
 aaa
 aaa

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -14547,7 +14547,7 @@
 /obj/structure/disposalpipe/tagger/partial{
 	dir = 1;
 	name = "Sorting Office";
-	sort_tag = "Sorting Office"
+	sort_tag = "Disposal Sorting"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/warehouse)
@@ -16447,14 +16447,17 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Engine Power";
 	name_tag = "Engine Power"
+	},
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor,
 /area/engineering/engine_room)
@@ -18120,7 +18123,7 @@
 /obj/structure/disposalpipe/tagger/partial{
 	dir = 1;
 	name = "Sorting Office";
-	sort_tag = "Sorting Office"
+	sort_tag = "Disposal Sorting"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/apmaint)
@@ -73084,7 +73087,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/seconddeck/starboard)
 "tfv" = (
-/obj/structure/ladder,
+/obj/structure/ladder/updown,
 /turf/simulated/floor/plating,
 /area/maintenance/research_medical)
 "tfw" = (

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -72830,6 +72830,9 @@
 /area/hallway/primary/seconddeck/starboard)
 "sXG" = (
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/seconddeck/starboard)
 "sXK" = (
@@ -72904,6 +72907,9 @@
 	},
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/starboard)
@@ -74540,7 +74546,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor/plating,
 /area/hallway/primary/seconddeck/starboard)
 "ugI" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
@@ -76299,6 +76306,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/seconddeck/starboard)

--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -786,6 +786,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/vistor_room_3)
+"aEC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/foreport)
 "aEE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -1228,6 +1240,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
+"aXg" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/aftport)
 "aXo" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -1422,7 +1450,7 @@
 	},
 /obj/machinery/power/solar{
 	id = "aftportsolar";
-	name = "Port Solar Array"
+	name = "Aft-Port Solar Array"
 	},
 /turf/simulated/floor/plating/turfpack/airless{
 	icon_state = "solarpanel"
@@ -2749,6 +2777,14 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/solars/foreportsolar)
+"clX" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/turfpack/airless,
+/area/solar/forestarboardsolar)
 "cme" = (
 /obj/random/trash,
 /turf/simulated/floor/tiled/white,
@@ -2824,6 +2860,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/solars/foreportsolar)
+"cqf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/open,
+/area/maintenance/thirddeck/foreport)
 "cqo" = (
 /obj/structure/railing{
 	dir = 8
@@ -2863,6 +2905,16 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/thirddeck/foreport)
+"cqW" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "crglockdown";
+	name = "Cargo Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/aftport)
 "crb" = (
 /obj/structure/lattice,
 /obj/structure/cable{
@@ -3000,13 +3052,19 @@
 	name = "Third Deck Aft Maintenance"
 	})
 "cyo" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 1;
-	name = "Dorms";
-	sortType = "CMO Office"
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/r_wall,
-/area/hallway/primary/thirddeck/central)
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/forestarboard)
 "cyx" = (
 /obj/structure/table/darkglass,
 /obj/item/weapon/storage/toolbox/electrical,
@@ -3091,7 +3149,7 @@
 	},
 /obj/machinery/power/solar{
 	id = "forestarboardsolar";
-	name = "Starboard Solar Array"
+	name = "Fore-Starboard Solar Array"
 	},
 /turf/simulated/floor/plating/turfpack/airless{
 	icon_state = "solarpanel"
@@ -3460,6 +3518,13 @@
 	},
 /turf/simulated/floor/reinforced/turfpack/airless,
 /area/thirddeck/roof)
+"cRb" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/white,
+/area/maintenance/thirddeck/aftport)
 "cRk" = (
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -3477,6 +3542,14 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/maintenance/thirddeck/hiddenkitchen)
+"cSi" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/aftport)
 "cSJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -3667,6 +3740,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/thirddeck/vrroom)
+"dcS" = (
+/obj/random/trash,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/aftport)
 "dcT" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -3699,6 +3780,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/ai/ai_upload)
+"ddt" = (
+/obj/structure/table/steel,
+/obj/random/maintenance/clean,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "ddu" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -3775,6 +3864,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/foreport)
+"dhR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/forestarboard)
+"dhW" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "diJ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -4120,6 +4230,20 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/foreport)
+"dyI" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/foreport)
 "dyJ" = (
@@ -5512,6 +5636,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/primary/thirddeck/central)
+"enh" = (
+/obj/structure/catwalk,
+/obj/structure/lattice,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/open,
+/area/maintenance/thirddeck/aftport)
 "enk" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -5797,6 +5929,11 @@
 /obj/structure/railing,
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
 	},
 /turf/simulated/open,
 /area/maintenance/thirddeck/forestarboard)
@@ -6105,6 +6242,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "eHp" = (
@@ -6120,11 +6260,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "eHC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
@@ -6508,11 +6643,6 @@
 /area/maintenance/substation/dorms)
 "eTA" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/maintenance{
 	req_access = null;
 	req_one_access = null
@@ -6526,9 +6656,7 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/primary/thirddeck/port)
 "eTW" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/white,
-/turf/space,
+/turf/simulated/floor/plating/turfpack/airless,
 /area/solar/aftstarboardsolar)
 "eTX" = (
 /obj/structure/loot_pile/maint/junk,
@@ -6903,11 +7031,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/starboard)
 "ffT" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -6964,7 +7087,7 @@
 	},
 /obj/machinery/power/solar{
 	id = "aftstarboardsolar";
-	name = "Starboard Solar Array"
+	name = "Aft-Starboard Solar Array"
 	},
 /turf/simulated/floor/plating/turfpack/airless{
 	icon_state = "solarpanel"
@@ -7474,7 +7597,11 @@
 "fyI" = (
 /obj/machinery/power/solar{
 	id = "foreportsolar";
-	name = "Port Solar Array"
+	name = "Fore-Port Solar Array"
+	},
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating/turfpack/airless{
 	icon_state = "solarpanel"
@@ -7720,9 +7847,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
 "fFF" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/white,
-/turf/space,
+/turf/simulated/floor/plating/turfpack/airless,
 /area/solar/foreportsolar)
 "fGa" = (
 /turf/simulated/wall,
@@ -7773,7 +7898,7 @@
 	},
 /obj/machinery/power/solar{
 	id = "aftportsolar";
-	name = "Port Solar Array"
+	name = "Aft-Port Solar Array"
 	},
 /turf/simulated/floor/plating/turfpack/airless{
 	icon_state = "solarpanel"
@@ -8450,11 +8575,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -8475,7 +8595,7 @@
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
 	name = "Dorms";
-	sortType = "CMO Office"
+	sortType = "Dorms"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
@@ -8542,7 +8662,7 @@
 	},
 /obj/machinery/power/solar{
 	id = "forestarboardsolar";
-	name = "Starboard Solar Array"
+	name = "Fore-Starboard Solar Array"
 	},
 /turf/simulated/floor/plating/turfpack/airless{
 	icon_state = "solarpanel"
@@ -8565,9 +8685,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "ghY" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/white,
-/turf/space,
+/turf/simulated/floor/plating/turfpack/airless,
 /area/solar/aftportsolar)
 "gig" = (
 /obj/machinery/camera/network/third_deck{
@@ -8906,8 +9024,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
 "gwG" = (
-/turf/space,
-/area/thirddeck/roof)
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/starboard)
 "gwJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9101,7 +9222,7 @@
 	},
 /obj/machinery/power/solar{
 	id = "aftstarboardsolar";
-	name = "Starboard Solar Array"
+	name = "Aft-Starboard Solar Array"
 	},
 /turf/simulated/floor/plating/turfpack/airless{
 	icon_state = "solarpanel"
@@ -11224,6 +11345,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/cafeteria)
+"iBJ" = (
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/aftport)
 "iCa" = (
 /obj/structure/fitness/punchingbag,
 /turf/simulated/floor/boxing/gym,
@@ -12249,7 +12376,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating/turfpack/airless,
 /area/solar/aftstarboardsolar)
 "jBq" = (
@@ -12738,7 +12864,7 @@
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
 	name = "Bridge Conference room";
-	sortType = "CMO Office"
+	sortType = "Bridge Conference room"
 	},
 /turf/simulated/floor/tiled,
 /area/bridge)
@@ -12905,6 +13031,14 @@
 /obj/machinery/suit_cycler/captain,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/heads/sc/sd)
+"jYO" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "jZf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13158,6 +13292,13 @@
 /obj/item/clothing/under/swimsuit/striped,
 /turf/simulated/floor/tiled,
 /area/maintenance/thirddeck/aftport)
+"kng" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/aftport)
 "knK" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -13180,6 +13321,13 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/thirddeck/foreport)
+"kpl" = (
+/obj/random/trash,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/aftport)
 "kpp" = (
 /obj/structure/bed/double/padded,
 /obj/item/weapon/bedsheet/purpledouble,
@@ -13409,6 +13557,13 @@
 "kzt" = (
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
@@ -14161,6 +14316,13 @@
 /area/maintenance/thirddeck/dormsaft{
 	name = "Third Deck Aft Maintenance"
 	})
+"lkH" = (
+/obj/machinery/light{
+	dir = 8;
+	layer = 3
+	},
+/turf/simulated/open,
+/area/maintenance/thirddeck/foreport)
 "lmX" = (
 /obj/random/plushie,
 /turf/simulated/floor/wood,
@@ -15741,6 +15903,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
+"myM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/forestarboard)
 "myX" = (
 /obj/machinery/atmospherics/pipe/tank/air,
 /turf/simulated/floor/plating,
@@ -15856,6 +16032,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
+"mDJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/forestarboard)
 "mEk" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
@@ -17287,6 +17481,22 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/research/particleaccelerator)
+"nJR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/forestarboard)
 "nKZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
@@ -17802,6 +18012,20 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/aftdoorm)
+"obH" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/aftport)
 "obU" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18742,6 +18966,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/primary/thirddeck/stationgateway)
+"oOb" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/forestarboard)
 "oOk" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -18818,6 +19050,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftportcentral)
+"oRx" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Biohazard";
+	name = "Biohazard Shutter";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/forestarboard)
 "oRH" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -18891,6 +19133,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/primary/thirddeck/stationgateway)
+"oTs" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/aftport)
 "oTG" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 5
@@ -20679,6 +20927,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/vistor_room_5)
+"qni" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/foreport)
 "qnM" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -21011,6 +21273,16 @@
 /area/maintenance/thirddeck/dormsaft{
 	name = "Third Deck Aft Maintenance"
 	})
+"qzx" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#DDFFD3"
+	},
+/turf/simulated/open,
+/area/maintenance/thirddeck/dormsstarboard)
 "qzG" = (
 /obj/structure/table,
 /obj/item/toy/snappop,
@@ -21431,6 +21703,16 @@
 	},
 /turf/simulated/floor/carpet/retro_red,
 /area/crew_quarters/cafeteria)
+"qSp" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/aftport)
 "qSC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -22225,6 +22507,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
+"rvR" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 26;
+	pixel_y = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "rwO" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 9
@@ -23676,6 +23968,18 @@
 "sIO" = (
 /turf/simulated/floor/airless,
 /area/maintenance/thirddeck/hiddenkitchen)
+"sJo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/foreport)
 "sJA" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -23883,6 +24187,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
+"sRV" = (
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "sSh" = (
 /obj/machinery/door/airlock/glass{
 	name = "Cafeteria"
@@ -25060,6 +25368,16 @@
 /obj/structure/undies_wardrobe,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
+"tMP" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "englockdown";
+	name = "Engineering Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/foreport)
 "tMW" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/random/trash,
@@ -25537,6 +25855,13 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/toilet)
+"udo" = (
+/obj/structure/railing,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/open,
+/area/maintenance/thirddeck/aftport)
 "udT" = (
 /obj/machinery/newscaster{
 	pixel_y = 30
@@ -26008,6 +26333,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "uAl" = (
@@ -26282,6 +26610,12 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/thirddeck/aft)
+"uLJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/forestarboard)
 "uMq" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/thirddeck/hiddenkitchen)
@@ -27208,6 +27542,16 @@
 /obj/item/weapon/pen,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aftdoorm)
+"vsj" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "medbayquar";
+	name = "Medbay Emergency Lockdown Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/dormsstarboard)
 "vsu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27657,6 +28001,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
+"vDY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/thirddeck/forestarboard)
 "vEG" = (
 /obj/structure/table/bench/wooden,
 /obj/item/device/flashlight/lamp/green,
@@ -28773,6 +29131,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/vistor_room_7)
+"wpG" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/light{
+	layer = 3
+	},
+/turf/simulated/open,
+/area/maintenance/thirddeck/aftport)
 "wpN" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -30048,6 +30415,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/sleep/vistor_room_10)
+"xjU" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/maintenance/thirddeck/dormsstarboard)
 "xkS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31067,6 +31443,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftstarboard)
 "xRV" = (
@@ -31273,6 +31650,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "xWm" = (
@@ -31337,9 +31715,18 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_7)
 "xYl" = (
-/obj/structure/cable/yellow,
-/turf/simulated/floor/plating/turfpack/airless,
-/area/space)
+/obj/machinery/power/solar{
+	id = "foreportsolar";
+	name = "Fore-Port Solar Array"
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating/turfpack/airless{
+	icon_state = "solarpanel"
+	},
+/area/solar/foreportsolar)
 "xZl" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -31758,6 +32145,12 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_8)
+"ylC" = (
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/white,
+/area/maintenance/thirddeck/aftport)
 "ylL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -40397,19 +40790,19 @@ apc
 apc
 apc
 apc
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 fFF
 flb
 fFF
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 apc
 apc
 aqj
@@ -41429,19 +41822,19 @@ apc
 apc
 apc
 apc
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 fFF
 flb
 fFF
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 apc
 apc
 aqj
@@ -42461,19 +42854,19 @@ apc
 apc
 apc
 apc
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 fFF
 flb
 fFF
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 apc
 apc
 aqj
@@ -43493,19 +43886,19 @@ apc
 apc
 apc
 apc
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 fFF
 flb
 fFF
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 apc
 apc
 apc
@@ -44525,19 +44918,19 @@ apc
 apc
 apc
 apc
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 fFF
 flb
 fFF
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 aqj
 aqj
 aqj
@@ -45557,19 +45950,19 @@ apc
 apc
 apc
 apc
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 fFF
 flb
 fFF
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 apc
 apc
 apc
@@ -46365,12 +46758,12 @@ dgt
 dgt
 dgt
 dgt
-apc
-apc
-apc
-apc
-apc
-apc
+dgt
+dgt
+dgt
+dgt
+dgt
+dgt
 xbg
 apc
 apc
@@ -46589,19 +46982,19 @@ apc
 apc
 apc
 apc
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 fFF
 flb
 fFF
-fyI
-fyI
-fyI
-fyI
-fyI
+xYl
+xYl
+xYl
+xYl
+xYl
 dgt
 dgt
 dgt
@@ -47110,7 +47503,7 @@ fyI
 fyI
 fyI
 fyI
-fFF
+apc
 flb
 fFF
 fyI
@@ -47370,12 +47763,12 @@ apc
 apc
 apc
 flb
-gwG
-gwG
-gwG
-gwG
-gwG
-gwG
+dgt
+dgt
+dgt
+dgt
+dgt
+dgt
 dgt
 dgt
 dgt
@@ -50227,7 +50620,7 @@ pkH
 pkH
 pkH
 pkH
-pkH
+tcw
 tcw
 tcw
 tcw
@@ -50485,7 +50878,7 @@ rdY
 rdY
 rdY
 rdY
-rdY
+cSi
 qTm
 rdY
 rdY
@@ -50743,7 +51136,7 @@ pkH
 pkH
 pkH
 pkH
-pkH
+tcw
 tcw
 rdY
 tcw
@@ -53325,19 +53718,19 @@ dgt
 dgt
 dgt
 tcw
-rdY
+diJ
 ieB
 wty
 rdY
 wty
 lYz
 ieB
-wty
+ylC
 wty
 pkH
 cme
 rdY
-wty
+cRb
 ieB
 jGq
 eXY
@@ -53583,7 +53976,7 @@ dgt
 dgt
 dgt
 tcw
-rdY
+cqW
 ieB
 tSF
 peN
@@ -54106,8 +54499,8 @@ fFB
 diJ
 diJ
 qTm
-rdY
-rdY
+cqW
+oTs
 dOb
 rdY
 rdY
@@ -54335,7 +54728,7 @@ dgt
 dgt
 dgt
 bdC
-bDU
+aEC
 bdC
 iGW
 iGW
@@ -54358,14 +54751,14 @@ dgt
 dgt
 tcw
 tcw
-sbr
+enh
 vVx
 efk
 vVx
 sbr
 ieB
-eXY
-rdY
+kpl
+iBJ
 ieB
 wty
 wty
@@ -54593,14 +54986,14 @@ dgt
 dgt
 dgt
 bdC
-bDU
-bkm
+sJo
+dyI
 iGW
 yfg
 yfg
 yfg
 yfg
-yfg
+lkH
 yfg
 yfg
 yfg
@@ -54851,8 +55244,8 @@ dgt
 dgt
 dgt
 bdC
-bDU
-bkm
+sJo
+tMP
 bdC
 afx
 afx
@@ -55109,8 +55502,8 @@ dgt
 dgt
 dgt
 bdC
-bDU
-bkm
+sJo
+tMP
 eAx
 ukE
 ukE
@@ -55122,8 +55515,8 @@ ukE
 ukE
 ukE
 eAx
-rdY
-rdY
+qSp
+oTs
 rdY
 pkH
 dgt
@@ -55367,8 +55760,8 @@ dgt
 dgt
 dgt
 bdC
-bDU
-bkm
+sJo
+tMP
 bdC
 ssq
 ssq
@@ -55625,14 +56018,14 @@ dgt
 dgt
 dgt
 bdC
-bDU
-bkm
+sJo
+tMP
 iGW
 cEp
 yfg
 yfg
 yfg
-yfg
+cqf
 yfg
 yfg
 yfg
@@ -55648,11 +56041,11 @@ dgt
 dgt
 dgt
 tcw
-uWp
+udo
 vVx
 jVt
 vVx
-xym
+wpG
 ieB
 dtC
 rdY
@@ -55661,7 +56054,7 @@ yhv
 rdY
 rdY
 eXY
-rdY
+kng
 ieB
 jkX
 xes
@@ -55883,7 +56276,7 @@ dgt
 dgt
 dgt
 bdC
-bDU
+qni
 bdC
 iGW
 iGW
@@ -56424,7 +56817,7 @@ dgt
 dgt
 dgt
 pkH
-rdY
+cqW
 pkH
 dgt
 dgt
@@ -56682,7 +57075,7 @@ dgt
 dgt
 dgt
 pkH
-eXY
+kpl
 pkH
 dgt
 dgt
@@ -56697,7 +57090,7 @@ dgt
 tcw
 rdY
 ndR
-eXY
+dcS
 tcw
 dgt
 apc
@@ -57725,7 +58118,7 @@ dgt
 pkH
 ndR
 ieB
-nNp
+obH
 lxl
 ieB
 xes
@@ -57981,7 +58374,7 @@ dgt
 dgt
 dgt
 pkH
-ndR
+aXg
 ieB
 jkX
 nNp
@@ -64164,7 +64557,7 @@ iiZ
 iKs
 rhR
 fbp
-cyo
+fbp
 fbp
 kTs
 lsW
@@ -70346,7 +70739,7 @@ esF
 eHC
 eTA
 ffT
-fDg
+gwG
 gdl
 gEK
 fDg
@@ -71634,7 +72027,7 @@ dgt
 dgt
 cju
 toW
-bqJ
+qiO
 aIV
 dgt
 dgt
@@ -71870,8 +72263,8 @@ aqj
 apc
 apc
 apc
-apc
-apc
+dgt
+dgt
 dgt
 dgt
 dgt
@@ -71891,8 +72284,8 @@ dgt
 dgt
 dgt
 cju
-pRR
-bqJ
+vDY
+uLJ
 aIV
 dgt
 dgt
@@ -72129,7 +72522,7 @@ apc
 apc
 apc
 apc
-apc
+dgt
 dgt
 dgt
 dgt
@@ -72149,8 +72542,8 @@ dgt
 dgt
 dgt
 cju
-pRR
-bqJ
+mDJ
+oRx
 aIV
 dgt
 dgt
@@ -72176,7 +72569,7 @@ dgt
 dgt
 dgt
 qaU
-bCC
+fjK
 hAK
 ecn
 qQv
@@ -74210,11 +74603,11 @@ dgt
 dgt
 dgt
 aIV
-bUI
-cHn
+myM
+nJR
 uYx
 xWc
-bqJ
+oOb
 bqJ
 aIV
 dgt
@@ -74229,8 +74622,8 @@ bCC
 rRF
 bCC
 rRF
-bCC
-bCC
+sRV
+dhW
 sJM
 bCC
 lZq
@@ -74488,7 +74881,7 @@ vHd
 wPJ
 xQY
 uSG
-bCC
+vsj
 sJM
 lZq
 hsc
@@ -75001,7 +75394,7 @@ fED
 aoF
 lFu
 oJi
-oJi
+xjU
 fzy
 aoF
 aex
@@ -75016,7 +75409,7 @@ oci
 bFE
 bCC
 sJM
-bCC
+fjK
 qQv
 bCC
 sJM
@@ -75522,7 +75915,7 @@ qvE
 qvE
 gUE
 sJM
-fjK
+bCC
 lZq
 cKh
 lDy
@@ -76033,7 +76426,7 @@ fED
 aoF
 cqo
 ufx
-ufx
+qzx
 qRA
 aoF
 ove
@@ -76545,8 +76938,8 @@ dgt
 dgt
 dgt
 qaU
-bCC
-bCC
+vsj
+aex
 bCC
 bCC
 rQK
@@ -76794,7 +77187,7 @@ ggO
 rNB
 aIV
 bqJ
-bqJ
+oOb
 aIV
 dgt
 dgt
@@ -76825,7 +77218,7 @@ qRa
 bCC
 bCC
 sJM
-bCC
+fjK
 bCC
 sJM
 kOv
@@ -77079,7 +77472,7 @@ fls
 bCC
 bCC
 sJM
-xUo
+ddt
 omS
 xUK
 ssw
@@ -78369,7 +78762,7 @@ hLW
 dpO
 cLY
 sJM
-bCC
+fjK
 bCC
 qRa
 tUX
@@ -78875,7 +79268,7 @@ lZq
 lZq
 lZq
 bCC
-bCC
+jYO
 bCC
 smH
 lZq
@@ -79901,16 +80294,16 @@ pAE
 bqJ
 bqJ
 bqJ
-bqJ
+qiO
 cGT
 qRa
 xUo
 xpu
 sJM
-apR
+rvR
 oLY
 sJM
-bCC
+fjK
 opn
 bCC
 pzp
@@ -80665,7 +81058,7 @@ cGT
 cGT
 cGT
 pRR
-bqJ
+qiO
 cGT
 cGT
 lfv
@@ -81443,9 +81836,9 @@ cGT
 aWg
 luF
 bBZ
-bqJ
+qiO
 cGT
-bqJ
+qiO
 cGT
 cGT
 cGT
@@ -82730,11 +83123,11 @@ gmb
 nAK
 tKl
 shz
-pRR
+dhR
 cGT
 cPN
 xyc
-bqJ
+qiO
 cGT
 bqJ
 bqJ
@@ -83760,15 +84153,15 @@ xWh
 cHn
 cHn
 cHn
-cHn
+cyo
 uYx
 xWc
 cGT
 cPN
 xyc
-bqJ
+qiO
 cGT
-bqJ
+oOb
 bqJ
 aWg
 aIV
@@ -84792,14 +85185,14 @@ cAd
 aIV
 cPN
 xyc
-bqJ
+oOb
 cGT
 bqJ
 cPN
 cGT
 bqJ
 xyc
-bqJ
+qiO
 cGT
 luF
 wLN
@@ -86059,7 +86452,7 @@ apc
 apc
 apc
 apc
-aqj
+apc
 apc
 apc
 apc
@@ -86842,9 +87235,9 @@ cDq
 cDq
 cDq
 cDq
-apc
 tfe
-apc
+tfe
+tfe
 cDq
 cDq
 cDq
@@ -87092,15 +87485,15 @@ apc
 apc
 apc
 aqj
-aqj
-aqj
-aqj
+apc
+apc
+apc
 fya
 cko
 cko
 cko
 cko
-xYl
+nHS
 tfe
 fFq
 fgj
@@ -87349,18 +87742,18 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
-apc
+aqj
+aqj
+aqj
+aqj
 ggF
 ggF
 ggF
 ggF
 ggF
-apc
 tfe
-apc
+tfe
+tfe
 ggF
 ggF
 ggF
@@ -87607,26 +88000,26 @@ apc
 apc
 apc
 apc
-aqj
-apc
-apc
-apc
-apc
-apc
 apc
 apc
 apc
 apc
 tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
 apc
 apc
 apc
-apc
-apc
-apc
-apc
-apc
-aqj
 apc
 apc
 apc
@@ -87874,9 +88267,9 @@ cDq
 cDq
 cDq
 cDq
-apc
 tfe
-apc
+tfe
+tfe
 cDq
 cDq
 cDq
@@ -87884,7 +88277,7 @@ cDq
 cDq
 apc
 apc
-aqj
+apc
 apc
 apc
 apc
@@ -88124,9 +88517,9 @@ apc
 apc
 apc
 aqj
-aqj
-aqj
-aqj
+apc
+apc
+apc
 fya
 cko
 cko
@@ -88140,9 +88533,9 @@ fgj
 fgj
 fgj
 qqO
-aqj
-aqj
-aqj
+apc
+apc
+apc
 apc
 apc
 apc
@@ -88382,25 +88775,25 @@ apc
 apc
 apc
 aqj
-apc
-apc
-apc
-ggF
-ggF
-ggF
-ggF
-ggF
-apc
-tfe
-apc
-ggF
-ggF
-ggF
-ggF
-ggF
-apc
-apc
 aqj
+aqj
+aqj
+ggF
+ggF
+ggF
+ggF
+ggF
+tfe
+tfe
+tfe
+ggF
+ggF
+ggF
+ggF
+ggF
+apc
+apc
+apc
 apc
 apc
 apc
@@ -88643,19 +89036,19 @@ aqj
 apc
 apc
 apc
-apc
-apc
-apc
-apc
-apc
-apc
 tfe
-apc
-apc
-apc
-apc
-apc
-apc
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
 apc
 apc
 aqj
@@ -88897,7 +89290,7 @@ apc
 apc
 apc
 apc
-apc
+aqj
 apc
 apc
 apc
@@ -88906,9 +89299,9 @@ cDq
 cDq
 cDq
 cDq
-apc
 tfe
-apc
+tfe
+tfe
 cDq
 cDq
 cDq
@@ -89172,9 +89565,9 @@ fgj
 fgj
 fgj
 qqO
-apc
-apc
-apc
+aqj
+aqj
+aqj
 apc
 apc
 apc
@@ -89422,9 +89815,9 @@ ggF
 ggF
 ggF
 ggF
-apc
 tfe
-apc
+tfe
+tfe
 ggF
 ggF
 ggF
@@ -89432,7 +89825,7 @@ ggF
 ggF
 apc
 apc
-apc
+aqj
 apc
 apc
 apc
@@ -89671,23 +90064,23 @@ apc
 apc
 apc
 apc
-aqj
-apc
-apc
-apc
-apc
-apc
 apc
 apc
 apc
 apc
 tfe
-apc
-apc
-apc
-apc
-apc
-apc
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
 apc
 apc
 aqj
@@ -89938,9 +90331,9 @@ cDq
 cDq
 cDq
 cDq
-apc
 tfe
-apc
+tfe
+tfe
 cDq
 cDq
 cDq
@@ -90188,9 +90581,9 @@ apc
 apc
 apc
 aqj
-aqj
-aqj
-aqj
+apc
+apc
+apc
 fya
 cko
 cko
@@ -90204,9 +90597,9 @@ fgj
 fgj
 fgj
 qqO
-aqj
-aqj
-aqj
+apc
+apc
+apc
 apc
 apc
 apc
@@ -90446,25 +90839,25 @@ apc
 apc
 apc
 aqj
-apc
-apc
-apc
-ggF
-ggF
-ggF
-ggF
-ggF
-apc
-tfe
-apc
-ggF
-ggF
-ggF
-ggF
-ggF
-apc
-apc
 aqj
+aqj
+aqj
+ggF
+ggF
+ggF
+ggF
+ggF
+tfe
+tfe
+tfe
+ggF
+ggF
+ggF
+ggF
+ggF
+apc
+apc
+apc
 apc
 apc
 apc
@@ -90707,19 +91100,19 @@ aqj
 apc
 apc
 apc
-apc
-apc
-apc
-apc
-apc
-apc
 tfe
-apc
-apc
-apc
-apc
-apc
-apc
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
 apc
 apc
 aqj
@@ -90961,7 +91354,7 @@ apc
 apc
 apc
 apc
-apc
+aqj
 apc
 apc
 apc
@@ -90970,9 +91363,9 @@ cDq
 cDq
 cDq
 cDq
-apc
 tfe
-apc
+tfe
+tfe
 cDq
 cDq
 cDq
@@ -90980,7 +91373,7 @@ cDq
 cDq
 apc
 apc
-apc
+aqj
 apc
 apc
 apc
@@ -91221,8 +91614,8 @@ apc
 apc
 apc
 apc
-aqj
-aqj
+apc
+apc
 fya
 cko
 cko
@@ -91236,9 +91629,9 @@ fgj
 fgj
 fgj
 qqO
-apc
-apc
-apc
+aqj
+aqj
+aqj
 apc
 apc
 apc
@@ -91480,15 +91873,15 @@ apc
 apc
 apc
 aqj
-apc
+aqj
 ggF
 ggF
 ggF
 ggF
 ggF
-apc
 tfe
-apc
+tfe
+tfe
 ggF
 ggF
 ggF
@@ -91496,7 +91889,7 @@ ggF
 ggF
 apc
 apc
-apc
+aqj
 apc
 apc
 apc
@@ -91739,22 +92132,22 @@ apc
 apc
 aqj
 apc
-apc
-apc
-apc
-apc
-apc
-apc
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
 tfe
 apc
 apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
+aqj
 apc
 apc
 apc
@@ -91997,19 +92390,19 @@ apc
 apc
 aqj
 apc
-apc
-apc
-apc
-apc
-apc
-apc
-ruA
-apc
-apc
-apc
-apc
-apc
-apc
+cDq
+cDq
+cDq
+cDq
+cDq
+tfe
+tfe
+tfe
+cDq
+cDq
+cDq
+cDq
+cDq
 apc
 apc
 apc
@@ -92251,23 +92644,23 @@ apc
 apc
 apc
 apc
-xeL
-xeL
+apc
+apc
 aqj
 apc
-apc
-apc
-apc
-apc
-apc
-apc
-lbQ
-apc
-apc
-apc
-apc
-apc
-apc
+fya
+cko
+cko
+cko
+cko
+nHS
+tfe
+fFq
+fgj
+fgj
+fgj
+fgj
+qqO
 apc
 apc
 apc
@@ -92510,24 +92903,24 @@ apc
 apc
 apc
 xeL
-vtf
 xeL
 aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
+apc
+ggF
+ggF
+ggF
+ggF
+ggF
+tfe
+tfe
+tfe
+ggF
+ggF
+ggF
+ggF
+ggF
 apc
 apc
-apc
-apc
-apc
-aqj
-apc
-aqj
 apc
 apc
 apc
@@ -92768,31 +93161,31 @@ apc
 apc
 apc
 xeL
+vtf
 xeL
-xeL
-apc
-apc
-apc
-apc
-apc
-apc
-apc
 aqj
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
+tfe
 apc
 apc
 apc
 apc
 apc
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
+apc
+apc
+apc
+apc
 apc
 apc
 apc
@@ -93025,23 +93418,23 @@ apc
 apc
 apc
 apc
+xeL
+xeL
+xeL
 apc
-apc
-apc
-apc
-apc
-apc
-apc
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-aqj
-apc
-apc
+cDq
+cDq
+cDq
+cDq
+cDq
+tfe
+tfe
+tfe
+cDq
+cDq
+cDq
+cDq
+cDq
 apc
 apc
 apc
@@ -93287,19 +93680,19 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
+fya
+cko
+cko
+cko
+cko
+nHS
+tfe
+fFq
+fgj
+fgj
+fgj
+fgj
+qqO
 apc
 apc
 apc
@@ -93545,19 +93938,19 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
+ggF
+ggF
+ggF
+ggF
+ggF
+tfe
+tfe
+tfe
+ggF
+ggF
+ggF
+ggF
+ggF
 apc
 apc
 apc
@@ -93801,21 +94194,21 @@ apc
 apc
 apc
 apc
+aqj
+aqj
+aqj
+aqj
+aqj
+aqj
+aqj
+apc
+ruA
 apc
 apc
 apc
+aqj
 apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
+aqj
 apc
 apc
 apc
@@ -94065,24 +94458,24 @@ apc
 apc
 apc
 apc
+aqj
+apc
+clX
 apc
 apc
 apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
+aqj
+aqj
+aqj
+aqj
+aqj
+aqj
+aqj
+aqj
+aqj
+aqj
+aqj
+aqj
 apc
 apc
 apc
@@ -94320,14 +94713,14 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
+aqj
+aqj
+aqj
+aqj
+aqj
+lbQ
+aqj
+aqj
 apc
 apc
 apc

--- a/maps/southern_cross/southern_cross-5.dmm
+++ b/maps/southern_cross/southern_cross-5.dmm
@@ -10455,6 +10455,14 @@
 	name = "Station Intercom (General)";
 	pixel_y = -21
 	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Outpost Reactor Power";
+	name_tag = "Outpost Reactor Power"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/storage)
 "tr" = (
@@ -10666,12 +10674,17 @@
 /area/surface/outpost/main/corridor)
 "tF" = (
 /obj/structure/catwalk,
+/obj/machinery/light/small,
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/light/small,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/storage)
 "tG" = (
@@ -11670,11 +11683,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21439,7 +21447,8 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
@@ -25138,14 +25147,6 @@
 /turf/simulated/floor/outdoors/snow/sif/planetuse,
 /area/surface/outside/plains/normal)
 "UQ" = (
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Outpost Reactor Power";
-	name_tag = "Outpost Reactor Power"
-	},
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8

--- a/maps/southern_cross/southern_cross-8.dmm
+++ b/maps/southern_cross/southern_cross-8.dmm
@@ -2910,9 +2910,11 @@
 /turf/simulated/floor/holofloor/tiled,
 /area/holodeck/source_thunderdomecourt)
 "cdV" = (
-/obj/machinery/vending/emergencyfood/filled,
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 5
+	},
+/obj/machinery/gear_painter{
+	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/shadekin)
@@ -18203,10 +18205,10 @@
 /turf/space,
 /area/space)
 "qNB" = (
-/obj/machinery/vending/emergencyfood,
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 4
 	},
+/obj/machinery/vending/emergencyfood/filled,
 /turf/simulated/floor/reinforced,
 /area/shadekin)
 "qOj" = (

--- a/maps/southern_cross/southern_cross_areas.dm
+++ b/maps/southern_cross/southern_cross_areas.dm
@@ -1010,6 +1010,10 @@ z
 	name = "Atmospherics Substation"
 	ambience = AMBIENCE_SUBSTATION //CHOMP Addition
 
+/area/maintenance/substation/maintenance
+	name = "Maintenance Substation"
+	ambience = AMBIENCE_SUBSTATION
+
 /area/maintenance/emergencyeva
 	name = "\improper Emergency EVA Maintenance"
 	icon_state = "maint_eva"
@@ -2365,3 +2369,31 @@ End Chompstation Edit*/
 
 /area/maintenance/bar/dorms/dorm_2
 	name = "Maintenance Deck Bar Dorms 2"
+
+/area/maintenance/zerocent
+	name = "Maintenance Deck Central"
+	icon_state = "maintcentral"
+
+/area/maintenance/zeroport
+	name = "Maintenance Deck Port"
+	icon_state = "pmaint"
+
+/area/maintenance/zeroaft
+	name = "Maintenance Deck Aft"
+	icon_state = "amaint"
+
+/area/maintenance/zerostarboard
+	name = "Maintenance Deck Starboard"
+	icon_state = "smaint"
+
+/area/maintenance/zerofore
+	name = "Maintenance Deck Fore"
+	icon_state = "fmaint"
+
+/area/maintenance/gravlobby
+	name = "Gravity Generator Lobby"
+	icon_state = "engineering"
+
+/area/maintenance/zerobar
+	name = "Abandoned Bar"
+	icon_state = "maint_bar"

--- a/modular_chomp/maps/submaps/shelters/TradingShip-40x22.dmm
+++ b/modular_chomp/maps/submaps/shelters/TradingShip-40x22.dmm
@@ -376,23 +376,22 @@
 /area/survivalpod/superpose/TradingShip)
 "kU" = (
 /obj/machinery/access_button{
-	master_tag = null;
+	master_tag = "trade2_control";
 	pixel_x = 27;
 	pixel_y = -7;
 	req_one_access = null;
-	frequency = 1331
+	frequency = 1331;
+	command = "cycle_exterior"
 	},
 /obj/machinery/door/airlock/external{
-	frequency = null;
+	frequency = 1331;
 	icon_state = "door_locked";
-	id_tag = null;
+	id_tag = "trade2_outer";
 	locked = 1;
 	name = "Ship Hatch";
 	req_access = null
 	},
 /obj/structure/fans/hardlight,
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/effect/map_helper/airlock/button/ext_button,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/survivalpod/superpose/TradingShip)
 "kV" = (
@@ -581,16 +580,15 @@
 /area/survivalpod/superpose/TradingShip)
 "nh" = (
 /obj/machinery/door/airlock/external{
-	frequency = null;
+	frequency = 1331;
 	icon_state = "door_locked";
-	id_tag = null;
+	id_tag = "trade2_inner";
 	locked = 1;
 	name = "Ship Hatch";
 	req_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/fans/hardlight,
-/obj/effect/map_helper/airlock/door/int_door,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/survivalpod/superpose/TradingShip)
 "nC" = (
@@ -1046,24 +1044,23 @@
 "wz" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/airlock/external{
-	frequency = null;
+	frequency = 1331;
 	icon_state = "door_locked";
-	id_tag = null;
+	id_tag = "trade2_inner";
 	locked = 1;
 	name = "Ship Hatch";
 	req_access = null
 	},
 /obj/machinery/access_button{
 	dir = 1;
-	master_tag = null;
+	master_tag = "trade2_control";
 	pixel_x = -27;
 	pixel_y = 7;
 	req_one_access = null;
-	frequency = 1331
+	frequency = 1331;
+	command = "cycle_interior"
 	},
 /obj/structure/fans/hardlight,
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/effect/map_helper/airlock/button/int_button,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/survivalpod/superpose/TradingShip)
 "wT" = (
@@ -1250,16 +1247,15 @@
 	id_tag = "trade2_control";
 	pixel_x = -25;
 	req_access = list(160);
-	tag_airpump = null;
-	tag_chamber_sensor = null;
-	tag_exterior_door = null;
-	tag_interior_door = null
+	tag_airpump = "trade2_pump";
+	tag_chamber_sensor = "trade2_sensor";
+	tag_exterior_door = "trade2_outer";
+	tag_interior_door = "trade2_inner"
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1331;
-	id_tag = "d1fore_port2_pump"
+	id_tag = "trade2_pump"
 	},
 /turf/simulated/shuttle/floor/black,
 /area/survivalpod/superpose/TradingShip)
@@ -1422,15 +1418,14 @@
 /area/survivalpod/superpose/TradingShip)
 "FW" = (
 /obj/machinery/door/airlock/external{
-	frequency = null;
+	frequency = 1331;
 	icon_state = "door_locked";
-	id_tag = null;
+	id_tag = "trade2_outer";
 	locked = 1;
 	name = "Ship Hatch";
 	req_access = null
 	},
 /obj/structure/fans/hardlight,
-/obj/effect/map_helper/airlock/door/ext_door,
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/survivalpod/superpose/TradingShip)
 "Gb" = (
@@ -1456,15 +1451,14 @@
 	},
 /obj/machinery/airlock_sensor{
 	dir = 8;
-	id_tag = null;
-	pixel_x = 27
+	id_tag = "trade2_sensor";
+	pixel_x = 27;
+	frequency = 1331
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1331;
-	id_tag = "d1fore_port2_pump"
+	id_tag = "trade2_pump"
 	},
 /turf/simulated/shuttle/floor/black,
 /area/survivalpod/superpose/TradingShip)


### PR DESCRIPTION
## About The Pull Request
I felt pretty shitty about just cancelling all the fixes and creating a ton off issues so... here's my edited files without the wiring. Sorry for being a pain.

This PR also combines and builds on the mapping changes in Jasper's PR #8257 . This PR also fixes some of the mistakes made in the PR too (such as the solars wiring mistake and the viro disposals still hitting shields) but adds the exact same things Jasper added, so I'd recommend merging this branch instead.

Fixes issue #8256 
Fixes issue #8255 
Fixes issue #8254 
Fixes issue #8253 
Fixes issue #8252 
Fixes issue #8251 
Fixes issue #8250 
Fixes issue #8249 
Fixes issue #8248 
Fixes issue #8247 
Fixes issue #8246 
Fixes issue #8245 
Fixes issue #8233 
Fixes issue #7774 
## Changelog
:cl:
add: Added a colourmate to the shadekin hideout
add: Added air alarms to deck three maintenance areas that were missing them, including drop nom spots
add: Added antibody scanners to the relocated virology that had previously been missing
add: Adds a rusty old breaker to the rage cage for ease of electrifying the arena.
add: Added diffusors to some of the deck 0 PD turrets that were missing them to allow them to fire unobstructed
add: Added lockdown shutters back to virology - room scrungled a little smaller to compensate for the space needed
add: Added lights to drop-nom spots so all consistent and able to see
add: Adds departmental lockdown shutters to drop nom maints areas for security
add: Adds another set of doors to medbay corridor to provide a buffer for medbay in case the sci drop nom spot gets vented. Added an air alarm in the newly separated area to compensate
del: Deleted a cable that mistakenly hotwired the command subgrid to mains
del: Deleted a mistakenly placed dorms sort junction placed near the bridge in the walls
fix: Fixed some missing atmos pipes on deck 3
fix: Fixed a disposal junction facing the wrong way in the outpost reactor area
fix: Fixed the port solars - They now have cable coils placed underneath and work again
fix: Fixed a broken airlock on deck 0
fix: Fixed a broken airlock on the trading ship shelter capsule
fix: Fixed two sorting junctions having incorrect sorting tags, causing items to be missing from the tagger list and causing the CMO tag to be broken
fix: Moved the outpost reactor powernet sensor to be connected to the correct grid (Was previously connected to an "empty" grid)
fix: Fixed the engine room powernet not being correctly wired to the grid
fix: Fixed the applied tag on partial taggers in cargo to apply the correct tag
fix: Fixed an unconnected ladder set in medical maints between deck 2 and 3
fix: Fixes broken cable prefabs being used in rage cage
maptweak: Changed the wall on deck 0 big bedroom to be false as originally intended
maptweak: Removed the hallway area status from plating outside deck 1 escape pods to prevent vines and mucous from spawning there
maptweak: Tweaked the Fore-Starboard solars to be matching and more in line with the other new solar arrays, minus the start of shift wiring of course
maptweak: Renamed the solar arrays to be more appropriately distinct (Aft-Starboard etc)
maptweak: Added plating the gaps on the solar arrays so the gaps don't get filled with power wasting shields
maptweak: Replaced a few reinforced walls on deck 0 with basic walls to allow for easier locations for building projects in-round. Hazardous (eg space/elevator) and secure (eg grav gen) areas remain encased in reinforced walls for obvious reasons.
maptweak: Added new areas for deck zero and re-assigned these areas to the deck zero maints due to areas being doubled up, causing APC issues with some other maints areas. Removed some excess APCs.
maptweak: Slightly nudges the xenobotany gas vent to space to the side with its diffuser, so that the diffuser doesn't leave a vulnerable gap in the shields by the lab's window for meteors
maptweak: Extended the viro disposal chute and ended it with an outlet and a diffuser - to stop shields from blocking the disposal, and to control its direction of exit.
/:cl:
