### PR TITLE
Phoron dragon blood distilling

### DIFF
--- a/modular_chomp/code/modules/hydro/plants.dm
+++ b/modular_chomp/code/modules/hydro/plants.dm
@@ -29,7 +29,7 @@
 	seed_name = "cherrybomb"
 	seed_noun = "pits"
 	display_name = "cherry bomb tree"
-	chems = list("nutriment" = list(1,15), "neoliquidfire" = list(1,15), "cherryjelly" = list(10,15))
+	chems = list("nutriment" = list(1,15), "liquidfire" = list(1,15), "cherryjelly" = list(10,15))
 
 /datum/seed/cherries/cherrybomb/New()
 	..()

--- a/modular_chomp/code/modules/reagents/reactions/instant/instant.dm
+++ b/modular_chomp/code/modules/reagents/reactions/instant/instant.dm
@@ -133,3 +133,12 @@
 	required_reagents = list("ethanol" = 2, "sodium" = 2, "phoron" = 0.1)
 	catalysts = list("phoron" = 5)
 	result_amount = 4
+
+//Xenobotany update
+/decl/chemical_reaction/instant/neoliquidfire
+	name = "neoliquidfire" //distil phoron dragon blood from basic dragon blood
+	id = "neoliquidfire"
+	result = "neoliquidfire"
+	required_reagents = list("liquidfire" = 1, "sulfur" = 1, "phoron" = 0.1)
+	catalysts = list("phoron" = 5)
+	result_amount = 1


### PR DESCRIPTION

## About The Pull Request
Allows phoron dragon reagent to be created from dragon blood reagent, to hopefully increase availability and allow for niche recipes to be made more often. Also changed the cherry bomb fruit to give basic liquid fire instead, with the option to upgrade it to neo liquid fire by using the new reaction. I have plans to add more fun plants and stuff but... until plant icons get fixed those plants are on hold for now.
## Changelog
:cl:
add: Added a reaction to change liquid fire to neo liquid fire (liquid fire, sulfur and a small amount of phoron + catalyst)
balance: Changed the reagents in cherry bomb to liquid fire instead of neo liquid fire
/:cl:
