### PR TITLE
Makes vacpack belly nutrition scale with the belly setting

### DIFF
--- a/modular_chomp/code/game/objects/items/devices/vacpack.dm
+++ b/modular_chomp/code/game/objects/items/devices/vacpack.dm
@@ -176,7 +176,7 @@
 					continue
 				if(istype(F,/obj/effect/decal/cleanable))
 					if(isbelly(output_dest))
-						user.adjust_nutrition(1)
+						output_dest.owner_adjust_nutrition(1)
 					qdel(F)
 					continue
 				if(istype(output_dest,/obj/item/weapon/storage/bag/trash))
@@ -201,7 +201,7 @@
 			if(istype(target, /turf/simulated))
 				var/turf/simulated/T = target
 				if(isbelly(output_dest) && T.dirt > 50)
-					user.adjust_nutrition((T.dirt - 50) / 10) //Max tile dirt is 101. so about 5 nutrition from a disgusting floor, I think that's okay.
+					output_dest.owner_adjust_nutrition((T.dirt - 50) / 10) //Max tile dirt is 101. so about 5 nutrition from a disgusting floor, I think that's okay.
 				T.dirt = 0
 				T.clean_blood()
 		return

--- a/modular_chomp/code/game/objects/items/devices/vacpack.dm
+++ b/modular_chomp/code/game/objects/items/devices/vacpack.dm
@@ -176,7 +176,8 @@
 					continue
 				if(istype(F,/obj/effect/decal/cleanable))
 					if(isbelly(output_dest))
-						output_dest.owner_adjust_nutrition(1)
+						var/obj/belly/B = output_dest
+						B.owner_adjust_nutrition(1)
 					qdel(F)
 					continue
 				if(istype(output_dest,/obj/item/weapon/storage/bag/trash))
@@ -201,7 +202,8 @@
 			if(istype(target, /turf/simulated))
 				var/turf/simulated/T = target
 				if(isbelly(output_dest) && T.dirt > 50)
-					output_dest.owner_adjust_nutrition((T.dirt - 50) / 10) //Max tile dirt is 101. so about 5 nutrition from a disgusting floor, I think that's okay.
+					var/obj/belly/B = output_dest
+					B.owner_adjust_nutrition((T.dirt - 50) / 10) //Max tile dirt is 101. so about 5 nutrition from a disgusting floor, I think that's okay.
 				T.dirt = 0
 				T.clean_blood()
 		return


### PR DESCRIPTION

## About The Pull Request
Belly-linked vac-pack now uses the nutrition percentage of the target belly. A belly-linked vac-pack run through Mud Kingdom station is no longer a forced trip to Megachonkville for the janitor should they choose to adjust their receiving vorgan's nut gain.
## Changelog
:cl:
fix: Belly-linked vac-pack dirt nutrition gain now scales with target vorgan's gain setting.
/:cl:
