### PR TITLE
Gives a dummy variable a use. hud_enabled

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -967,6 +967,9 @@
 
 /obj/screen/ammo/proc/add_hud(var/mob/living/user, var/obj/item/weapon/gun/G)
 
+	if(G.hud_enabled == FALSE)
+		return
+
 	if(!user?.client)
 		return
 


### PR DESCRIPTION

## About The Pull Request
So turns out the weapon/gun variable hud_enabled literally did nothing, this now makes the variable actually toggle the ammo HUD. Currently this doesn't affect anything gameplay wise, and is only accessable via admins, that will be for a future PR, but now you can varedit a gun to have a hud or not.
## Changelog
:cl:
code: 'hud_enabled' variable for guns actually works now!
/:cl:
