### PR TITLE
Fix config default for radiation to match live

### DIFF
--- a/code/controllers/configuration_ch/entries/general.dm
+++ b/code/controllers/configuration_ch/entries/general.dm
@@ -571,7 +571,7 @@
 /// 0 / RAD_RESIST_CALC_DIV = Each turf absorbs some fraction of the working radiation level
 /// 1 / RAD_RESIST_CALC_SUB = Each turf absorbs a fixed amount of radiation
 /datum/config_entry/flag/radiation_resistance_calc_mode
-	default = RAD_RESIST_CALC_SUB
+	default = RAD_RESIST_CALC_DIV
 
 /datum/config_entry/flag/radiation_resistance_calc_mode/ValidateAndSet(str_val)
 	if(!VASProcCallGuard(str_val))

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -502,7 +502,7 @@ RADIATION_MATERIAL_RESISTANCE_DIVISOR 16
 ## 0:1 subtraction:division for computing effective radiation on a turf
 ## 0 / RAD_RESIST_CALC_DIV = Each turf absorbs some fraction of the working radiation level
 ## 1 / RAD_RESIST_CALC_SUB = Each turf absorbs a fixed amount of radiation
-RADIATION_RESISTANCE_CALC_MODE 1
+RADIATION_RESISTANCE_CALC_MODE 0
 
 ## IP Reputation Checking
 # Enable/disable IP reputation checking (present/nonpresent)


### PR DESCRIPTION

## About The Pull Request
I figure this was probably set to subtract by default in error at some point, but we've always used divide as default, and it's currently being used on live. Having it set to subtract was causing some confusion about why local instances were acting differently than live, so I figured we should probably just fix the defaults.
## Changelog
:cl:
server: default for rad resistance is back to being divide
/:cl:
