### PR TITLE
Fixes borg hand interactions with force-buckled mobs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_vr.dm
+++ b/code/modules/mob/living/silicon/robot/robot_vr.dm
@@ -84,7 +84,7 @@
 	return
 
 /mob/living/silicon/robot/attack_hand(mob/user as mob)
-	if(LAZYLEN(buckled_mobs))
+	if(LAZYLEN(buckled_mobs) && riding_datum) //CHOMPEdit
 		//We're getting off!
 		if(user in buckled_mobs)
 			riding_datum.force_dismount(user)


### PR DESCRIPTION

## About The Pull Request
Fixes the same bug i fixed with taurs a while ago.
## Changelog
:cl:
fix: Fixed empty hand interactions not working on borgs with forced buckling.
/:cl:
