### PR TITLE
add 30 minute job timeout to integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
         run: tools/build/build --ci lint tgui-test
 
   unit_tests:
+    timeout-minutes: 30
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Integration Tests
     # needs: ['run_linters', 'dreamchecker']


### PR DESCRIPTION

## About The Pull Request
in an effort to be respectful to the free computing resources that github gives us, should probably do our best to limit this. Integration tests here should never longer than like 10 minutes probably, 30 is more than enough.
