### PR TITLE
Vac-Pacs can now be put on back and belt. (Also fixes 2 improper nouns)

### DIFF
--- a/modular_chomp/code/game/objects/items/devices/radio/headset.dm
+++ b/modular_chomp/code/game/objects/items/devices/radio/headset.dm
@@ -88,7 +88,7 @@
 
 
 /obj/item/device/radio/headset/outsider
-	name = "Generic headset"
+	name = "generic headset"
 	desc = "Headset used by those upon the planet, or in other words, outsiders."
 	icon_state = "exp_headset"
 	adhoc_fallback = TRUE

--- a/modular_chomp/code/game/objects/items/devices/vacpack.dm
+++ b/modular_chomp/code/game/objects/items/devices/vacpack.dm
@@ -6,6 +6,7 @@
 	icon_override = 'modular_chomp/icons/mob/vacpack.dmi'
 	icon_state = "sucker_drop"
 	item_state = "sucker"
+	slot_flags = SLOT_BELT | SLOT_BACK
 	var/vac_power = 0
 	var/output_dest = null
 	var/list/vac_settings = list(

--- a/modular_chomp/code/game/objects/items/devices/vacpack.dm
+++ b/modular_chomp/code/game/objects/items/devices/vacpack.dm
@@ -1,6 +1,6 @@
 //Vac attachment
 /obj/item/device/vac_attachment
-	name = "Vac-Pack attachment"
+	name = "\improper Vac-Pack attachment"
 	desc = "Useful for slurping mess off the floors. Even things and stuff depending on settings. Can be connected to a trash bag or vore belly. On-mob sprites can be toggled via verb in Objects tab."
 	icon = 'modular_chomp/icons/mob/vacpack.dmi'
 	icon_override = 'modular_chomp/icons/mob/vacpack.dmi'


### PR DESCRIPTION
## About The Pull Request
No worn sprites for now but now you can clip the tube to your belt or back.

This also makes the Vac-Pac and the Outsider headset a improper noun
## Changelog
:cl:
qol: Vac-Pacs are now belt and back equippable.
fix: Vap-Pac is less proper. Same with the generic headset.
/:cl:
