### PR TITLE
Buff orange/red eye energy gain

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -480,7 +480,7 @@
 		if(RED_EYES)
 			total_health = 150 //ChompEDIT - balance tweaks
 			energy_light = -1
-			energy_dark = 0.1
+			energy_dark = 0.5 //ChompEDIT
 			nutrition_conversion_scaling = 2 //CHOMPEdit - Add nutrition <-> dark energy conversion
 		if(PURPLE_EYES)
 			total_health = 100 //ChompEDIT - balance tweaks
@@ -500,7 +500,7 @@
 		if(ORANGE_EYES)
 			total_health = 125 //ChompEDIT - balance tweaks
 			energy_light = -0.5
-			energy_dark = 0.25
+			energy_dark = 0.5 //ChompEDIT
 			nutrition_conversion_scaling = 1.5 //CHOMPEdit - Add nutrition <-> dark energy conversion
 
 	H.maxHealth = total_health


### PR DESCRIPTION
Changes shadekin:

Red eyed energy gain in dark 0.1 --> 0.5
Orange eyed energy gain in dark 0.25 --> 0.5

The energy gain/loss values seem a little too swingy, bordering the point of tedious if one runs out. Purple-to-red being a energy gain loss of 90% seems a bit spicy

:cl:
balance: Buff red-eye kin energy gain in dark from 0.1 to 0.5
balance: Buff orange-eye kin energy gain in dark from 0.25 to 0.5
/:cl:
