### PR TITLE
Miscellaneous ZAS Fixes and Optimizations

### DIFF
--- a/code/ZAS/Fire.dm
+++ b/code/ZAS/Fire.dm
@@ -113,7 +113,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	icon = 'icons/effects/fire.dmi'
 	icon_state = "1"
 	light_color = "#ED9200"
-	layer = TURF_LAYER
+	layer = GASFIRE_LAYER		// CHOMPEdit
 
 	var/firelevel = 1 //Calculated by gas_mixture.calculate_firelevel()
 

--- a/code/ZAS/Turf.dm
+++ b/code/ZAS/Turf.dm
@@ -1,3 +1,21 @@
+// CHOMPAdd
+#define GET_ZONE_NEIGHBOURS(T, ret) \
+	ret = 0; \
+	if (T.zone) { \
+		for (var/_gzn_dir in GLOB.gzn_check) { \
+			var/turf/simulated/other = get_step(T, _gzn_dir); \
+			if (istype(other) && other.zone == T.zone) { \
+				var/block; \
+				ATMOS_CANPASS_TURF(block, other, T); \
+				if (!(block & AIR_BLOCKED)) { \
+					ret |= _gzn_dir; \
+				} \
+			} \
+		} \
+	}
+
+// CHOMPEnd
+
 /turf/simulated/var/zone/zone
 /turf/simulated/var/open_directions
 
@@ -52,8 +70,8 @@
 */
 
 /turf/simulated/proc/can_safely_remove_from_zone()
-
-
+	// CHOMPEdit Start
+	/*
 	if(!zone) return 1
 
 	var/check_dirs = get_zone_neighbours(src)
@@ -64,15 +82,36 @@
 	#else
 	var/to_check = cornerdirs
 	#endif
+*/
 
-	for(var/dir in to_check)
+	if(!zone)
+		return TRUE
+
+	var/check_dirs
+	GET_ZONE_NEIGHBOURS(src, check_dirs)
+
+	if (!(. & (. - 1)))
+		return TRUE
+
+	for(var/dir in GLOB.csrfz_check) // CHOMPEdit
 		//for each pair of "adjacent" cardinals (e.g. NORTH and WEST, but not NORTH and SOUTH)
 		if((dir & check_dirs) == dir)
+		/*
 			//check that they are connected by the corner turf
 			var/connected_dirs = get_zone_neighbours(get_step(src, dir))
 			if(connected_dirs && (dir & reverse_dir[connected_dirs]) == dir)
 				unconnected_dirs &= ~dir //they are, so unflag the cardinals in question
+			*/
+			var/turf/simulated/T = get_step(src, dir)
+			if (!istype(T))
+				. &= ~dir
+				continue
 
+			var/connected_dirs
+			GET_ZONE_NEIGHBOURS(T, connected_dirs)
+			if(connected_dirs && (dir & GLOB.reverse_dir[connected_dirs]) == dir)
+				. &= ~dir //they are, so unflag the cardinals in question
+/*
 	//it is safe to remove src from the zone if all cardinals are connected by corner turfs
 	return !unconnected_dirs
 
@@ -89,6 +128,9 @@
 			var/turf/simulated/other = get_step(T, dir)
 			if(istype(other) && other.zone == T.zone && !(other.c_airblock(T) & AIR_BLOCKED) && get_dist(src, other) <= 1)
 				. |= dir
+*/
+		return !.
+// CHOMPEdit End
 
 /turf/simulated/update_air_properties()
 
@@ -96,7 +138,8 @@
 		c_copy_air()
 		zone = null //Easier than iterating through the list at the zone.
 
-	var/s_block = c_airblock(src)
+	var/s_block // CHOMPEdit
+	ATMOS_CANPASS_TURF(s_block, src, src)
 	if(s_block & AIR_BLOCKED)
 		#ifdef ZASDBG
 		if(verbose) to_world("Self-blocked.")
@@ -106,6 +149,7 @@
 			var/zone/z = zone
 
 			if(can_safely_remove_from_zone()) //Helps normal airlocks avoid rebuilding zones all the time
+				c_copy_air() // CHOMPAdd
 				z.remove(src)
 			else
 				z.rebuild()

--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -11,3 +11,132 @@
 #define ATMOS_PASS_NO			2	// Never blocks air or zones.
 #define ATMOS_PASS_DENSITY		3	// Blocks air and zones if density = TRUE, allows both if density = FALSE
 #define ATMOS_PASS_PROC			4	// Call CanZASPass() using c_airblock
+
+// CHOMPAdd Start
+
+#define NORTHUP (NORTH|UP)
+#define EASTUP (EAST|UP)
+#define SOUTHUP (SOUTH|UP)
+#define WESTUP (WEST|UP)
+#define NORTHDOWN (NORTH|DOWN)
+#define EASTDOWN (EAST|DOWN)
+#define SOUTHDOWN (SOUTH|DOWN)
+#define WESTDOWN (WEST|DOWN)
+
+#ifdef MULTIZAS
+
+GLOBAL_LIST_INIT(gzn_check, list(
+	NORTH,
+	SOUTH,
+	EAST,
+	WEST,
+	UP,
+	DOWN
+))
+
+GLOBAL_LIST_INIT(csrfz_check, list(
+	NORTHEAST,
+	NORTHWEST,
+	SOUTHEAST,
+	SOUTHWEST,
+	NORTHUP,
+	EASTUP,
+	WESTUP,
+	SOUTHUP,
+	NORTHDOWN,
+	EASTDOWN,
+	WESTDOWN,
+	SOUTHDOWN
+))
+
+#define ATMOS_CANPASS_TURF(ret,A,B) \
+	if (A.blocks_air & AIR_BLOCKED || B.blocks_air & AIR_BLOCKED) { \
+		ret = BLOCKED; \
+	} \
+	else if (B.z != A.z) { \
+		if (B.z < A.z) { \
+			ret = istype(A, /turf/simulated/open) ? ZONE_BLOCKED : BLOCKED; \
+		} \
+		else { \
+			ret = istype(B, /turf/simulated/open) ? ZONE_BLOCKED : BLOCKED; \
+		} \
+	} \
+	else if (A.blocks_air & ZONE_BLOCKED || B.blocks_air & ZONE_BLOCKED) { \
+		ret = (A.z == B.z) ? ZONE_BLOCKED : AIR_BLOCKED; \
+	} \
+	else if (A.contents.len) { \
+		ret = 0;\
+		for (var/thing in A) { \
+			var/atom/movable/AM = thing; \
+			switch (AM.can_atmos_pass) { \
+				if (ATMOS_PASS_YES) { \
+					continue; \
+				} \
+				if (ATMOS_PASS_DENSITY) { \
+					if (AM.density) { \
+						ret |= AIR_BLOCKED; \
+					} \
+				} \
+				if (ATMOS_PASS_PROC) { \
+					ret |= AM.c_airblock(B); \
+				} \
+				if (ATMOS_PASS_NO) { \
+					ret = BLOCKED; \
+				} \
+			} \
+			if (ret == BLOCKED) { \
+				break;\
+			}\
+		}\
+	}
+#else
+
+GLOBAL_LIST_INIT(csrfz_check, list(
+	NORTHEAST,
+	NORTHWEST,
+	SOUTHEAST,
+	SOUTHWEST
+))
+
+GLOBAL_LIST_INIT(gzn_check, list(
+	NORTH,
+	SOUTH,
+	EAST,
+	WEST
+))
+
+#define ATMOS_CANPASS_TURF(ret,A,B) \
+	if (A.blocks_air & AIR_BLOCKED || B.blocks_air & AIR_BLOCKED) { \
+		ret = BLOCKED; \
+	} \
+	else if (A.blocks_air & ZONE_BLOCKED || B.blocks_air & ZONE_BLOCKED) { \
+		ret = ZONE_BLOCKED; \
+	} \
+	else if (A.contents.len) { \
+		ret = 0;\
+		for (var/thing in A) { \
+			var/atom/movable/AM = thing; \
+			switch (AM.atmos_canpass) { \
+				if (ATMOS_PASS_YES) { \
+					continue; \
+				} \
+				if (ATMOS_PASS_DENSITY) { \
+					if (AM.density) { \
+						ret |= AIR_BLOCKED; \
+					} \
+				} \
+				if (ATMOS_PASS_PROC) { \
+					ret |= AM.c_airblock(B); \
+				} \
+				if (ATMOS_PASS_NO) { \
+					ret = BLOCKED; \
+				} \
+			} \
+			if (ret == BLOCKED) { \
+				break;\
+			}\
+		}\
+	}
+#endif
+
+// CHOMPEdit End

--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -71,6 +71,7 @@ What is the naming convention for planes or layers?
 	#define UNDERWATER_LAYER	2.5 // Anything on this layer will render under the water layer.
 	#define WATER_LAYER			3.0 // Layer for water overlays.
 	#define ABOVE_TURF_LAYER	3.1	// Snow and wallmounted/floormounted equipment
+	#define GASFIRE_LAYER		5.05 // Any fires that occur use this layer. CHOMPADD
 #define DECAL_PLANE				-44 // Permanent decals
 	#define DECAL_LAYER			10
 #define DIRTY_PLANE				-43 // Nonpermanent decals

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -199,7 +199,7 @@ var/list/debug_verbs = list (
 	var/icon/yellow = new('icons/misc/debug_group.dmi', "yellow")
 
 	for(var/turf/T in Z.contents)
-		images += image(yellow, T, "zasdebug", TURF_LAYER)
+		images += image(yellow, T, "zasdebug", PLANE_ADMIN2) // CHOMPEDIT
 		testZAScolors_turfs += T
 	for(var/connection_edge/zone/edge in Z.edges)
 		var/zone/connected = edge.get_connected_zone(Z)
@@ -235,13 +235,13 @@ var/list/debug_verbs = list (
 
 	testZAScolors_zones += location.zone
 	for(var/turf/T in location.zone.contents)
-		images += image(green, T,"zasdebug", TURF_LAYER)
+		images += image(green, T,"zasdebug", PLANE_ADMIN2) // CHOMPEDIT
 		testZAScolors_turfs += T
 	for(var/connection_edge/zone/edge in location.zone.edges)
 		var/zone/Z = edge.get_connected_zone(location.zone)
 		testZAScolors_zones += Z
 		for(var/turf/T in Z.contents)
-			images += image(blue, T,"zasdebug",TURF_LAYER)
+			images += image(blue, T,"zasdebug",PLANE_ADMIN2) // CHOMPEDIT
 			testZAScolors_turfs += T
 		for(var/connection_edge/zone/z_edge in Z.edges)
 			var/zone/connected = z_edge.get_connected_zone(Z)
@@ -254,7 +254,7 @@ var/list/debug_verbs = list (
 			continue
 		if(T in testZAScolors_turfs)
 			continue
-		images += image(red, T, "zasdebug", TURF_LAYER)
+		images += image(red, T, "zasdebug", PLANE_ADMIN2) // CHOMPEDIT
 		testZAScolors_turfs += T
 
 /client/proc/testZAScolors_remove()

--- a/code/modules/xgm/xgm_gas_data.dm
+++ b/code/modules/xgm/xgm_gas_data.dm
@@ -40,17 +40,33 @@
 		gas_data.specific_heat[gas.id] = gas.specific_heat
 		gas_data.molar_mass[gas.id] = gas.molar_mass
 		if(gas.tile_overlay)
-			gas_data.tile_overlay[gas.id] = new /atom/movable/gas_visuals(null, gas.tile_overlay)
-		if(gas.overlay_limit)	
+			gas_data.tile_overlay[gas.id] = gas.tile_overlay // CHOMPEdit
+		if(gas.overlay_limit)
 			gas_data.overlay_limit[gas.id] = gas.overlay_limit
 		gas_data.flags[gas.id] = gas.flags
 
 	return 1
 
-/atom/movable/gas_visuals
+// CHOMPEdit Start
+/obj/effect/gas_overlay
+	name = "gas"
+	desc = "You shouldn't be clicking this."
 	icon = 'icons/effects/tile_effects.dmi'
+	icon_state = "generic"
+	layer = GASFIRE_LAYER
+	appearance_flags = PIXEL_SCALE | RESET_COLOR
 	mouse_opacity = 0
+/*
 	plane = ABOVE_MOB_PLANE
 /atom/movable/gas_visuals/New(newloc, ico)
 	..()
 	icon_state = ico
+*/
+	var/gas_id
+
+/obj/effect/gas_overlay/Initialize(mapload, gas)
+	. = ..()
+	gas_id = gas
+	if(gas_data.tile_overlay[gas_id])
+		icon_state = gas_data.tile_overlay[gas_id]
+// CHOMPEdit End

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -13,7 +13,9 @@
 	var/group_multiplier = 1
 
 	//List of active tile overlays for this gas_mixture.  Updated by check_tile_graphic()
-	var/list/graphic
+	var/list/graphic = list() // CHOMPAdd
+
+	var/list/tile_overlay_cache	// COMPAdd
 
 /datum/gas_mixture/New(vol = CELL_VOLUME)
 	volume = vol
@@ -334,11 +336,13 @@
 	zburn(null, force_burn=0, no_check=0) //could probably just call zburn() here with no args but I like being explicit.
 
 
+// CHOMPEdit Start
 //Rechecks the gas_mixture and adjusts the graphic list if needed.
 //Two lists can be passed by reference if you need know specifically which graphics were added and removed.
 /datum/gas_mixture/proc/check_tile_graphic(list/graphic_add = null, list/graphic_remove = null)
-	var/list/cur_graphic = graphic // Cache for sanic speed
+	// var/list/cur_graphic = graphic // Cache for sanic speed
 	for(var/g in gas_data.overlay_limit)
+/*
 		if(cur_graphic && cur_graphic.Find(gas_data.tile_overlay[g]))
 			//Overlay is already applied for this gas, check if it's still valid.
 			if(gas[g] <= gas_data.overlay_limit[g])
@@ -347,7 +351,14 @@
 			//Overlay isn't applied for this gas, check if it's valid and needs to be added.
 			if(gas[g] > gas_data.overlay_limit[g])
 				LAZYADD(graphic_add, gas_data.tile_overlay[g])
+*/
+		if(gas[g] > gas_data.overlay_limit[g])
+			var/tile_overlay = get_tile_overlay(g)
+			if(!(tile_overlay in graphic))
+				LAZYADD(graphic_add, tile_overlay)
 
+	. = FALSE
+/*
 	. = 0
 	//Apply changes
 	if(LAZYLEN(graphic_add))
@@ -356,7 +367,14 @@
 	if(LAZYLEN(graphic_remove))
 		LAZYREMOVE(graphic, graphic_remove)
 		. = 1
-
+*/
+	if(graphic_add && graphic_add.len)
+		graphic |= graphic_add
+		. = TRUE
+	if(graphic_remove && graphic_remove.len)
+		graphic -= graphic_remove
+		. = TRUE
+// CHOMPEdit End
 
 //Simpler version of merge(), adjusts gas amounts directly and doesn't account for temperature or group_multiplier.
 /datum/gas_mixture/proc/add(datum/gas_mixture/right_side)
@@ -374,6 +392,12 @@
 
 	update_values()
 	return 1
+
+// Gets the gas overlay for a given gas, and returns the appropriate overlay. Caches. - CHOMPADD
+/datum/gas_mixture/proc/get_tile_overlay(gas_id)
+	if(!LAZYACCESS(tile_overlay_cache, gas_id))
+		LAZYSET(tile_overlay_cache, gas_id, new/obj/effect/gas_overlay(null, gas_id))
+	return tile_overlay_cache[gas_id]
 
 
 //Multiply all gas amounts by a factor.


### PR DESCRIPTION

## About The Pull Request

Earlyport from https://github.com/VOREStation/VOREStation/pull/14347, because it's been there for over a year. So why not just take it for us instead-

Ports
https://github.com/discordia-space/CEV-Eris/pull/7390
https://github.com/Baystation12/Baystation12/pull/32291
https://github.com/discordia-space/CEV-Eris/pull/1615

## Changelog
:cl:
fix: Fixes ZAS debug overlays not properly overlaying over everything they should
code: Some minor weirdness fixes to logic.
qol: Makes gas overlays marginally less laggy by caching icons and using effects instead of atoms to render
code: Turns get_zone_neighbors into a define
add: ATMOS_CANPASS_TURF
/:cl:
