### PR TITLE
Nutrition from absorbed piles now scales with vorgan nutrition percent

### DIFF
--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -244,7 +244,7 @@
 		if(istype(B) && B.storing_nutrition)
 			return FALSE
 		else if(isliving(B.owner))
-			B.owner.nutrition += stored_nutrition
+			B.owner.nutrition += stored_nutrition * (B.nutrition_percent / 100)
 			stored_nutrition = 0
 			qdel(src)
 			return w_class


### PR DESCRIPTION

## About The Pull Request
Raw nutrition piles reclaimed by nutrition absorbing vorgans scale their gains according to the absorbing vorgan's nutrition percent settings.
## Changelog
:cl:
fix: Fixed reclaimed nutrition pile gains not scaling with absorbing vorgan's nutrition percent settings.
/:cl:
