### PR TITLE
rebalance lost

### DIFF
--- a/code/modules/mob/living/silicon/robot/subtypes/gravekeeper.dm
+++ b/code/modules/mob/living/silicon/robot/subtypes/gravekeeper.dm
@@ -26,3 +26,16 @@
 	laws = new /datum/ai_laws/gravekeeper()
 
 	playsound(src, 'sound/mecha/nominalsyndi.ogg', 75, 0)
+
+//CHOMPAdd Start
+/mob/living/silicon/robot/gravekeeper/proc/scramble_hardware(var/chance)
+	if(prob(chance))  //Small chance to spawn with a scrambled
+		emag_items = 1
+
+/mob/living/silicon/robot/gravekeeper/handle_special_unlocks()
+	if(!emag_items)
+		scramble_hardware(10)
+	if (churn_count == 5)
+		module.emag += new /obj/item/device/self_repair_system/advanced(module)
+		hud_used.update_robot_modules_display()
+//CHOMPAdd End

--- a/code/modules/mob/living/silicon/robot/subtypes/lost_drone.dm
+++ b/code/modules/mob/living/silicon/robot/subtypes/lost_drone.dm
@@ -23,7 +23,7 @@
 	if(!cell)
 		cell = new /obj/item/weapon/cell/high(src) // 15k cell, as recharging stations are a lot more rare on the Surface.
 
-	scramble_hardware()
+	scramble_hardware(20)
 
 	playsound(src, 'sound/mecha/nominalsyndi.ogg', 75, 0)
 
@@ -31,7 +31,7 @@
 	return "synthetic_evil"
 
 /mob/living/silicon/robot/lost/proc/scramble_hardware(var/chance)
-	if(prob(20))  //Small chance to spawn with a scrambled
+	if(prob(chance))  //Small chance to spawn with a scrambled
 		emag_items = 1
 
 /mob/living/silicon/robot/lost/proc/apply_new_laws()
@@ -333,3 +333,12 @@
 						return new /datum/ai_laws/tyrant()
 
 	return
+
+//CHOMPAdd Start
+/mob/living/silicon/robot/lost/handle_special_unlocks()
+	if(!emag_items)
+		scramble_hardware(20)
+	if (churn_count == 5)
+		module.emag += new /obj/item/device/self_repair_system/advanced(module)
+		hud_used.update_robot_modules_display()
+//CHOMPAdd End

--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -366,6 +366,9 @@
 	if(M.ckey)
 		GLOB.prey_digested_roundstat++
 
+	owner.churn_count++ //CHOMPAdd
+	owner.handle_special_unlocks() //CHOMPAdd
+
 	var/personal_nutrition_modifier = M.get_digestion_nutrition_modifier()
 	var/pred_digestion_efficiency = owner.get_digestion_efficiency_modifier()
 

--- a/code/modules/vore/eating/living_ch.dm
+++ b/code/modules/vore/eating/living_ch.dm
@@ -7,6 +7,7 @@
 	var/mute_entry = FALSE					//Toggleable vorgan entry logs.
 	var/parasitic = FALSE					//Digestion immunity and nutrition leeching variable
 	var/liquidbelly_visuals = TRUE			//Toggle for liquidbelly level visuals.
+	var/churn_count = 0						//Counter for digested livings
 
 	var/passtable_reset		// For crawling
 	var/passtable_crawl_checked = FALSE
@@ -14,6 +15,9 @@
 	// CHOMP vore icons refactor (Now on living)
 	var/vore_icons = 0					// Bitfield for which fields we have vore icons for.
 	var/vore_eyes = FALSE				// For mobs with fullness specific eye overlays.
+
+/mob/living/proc/handle_special_unlocks()
+	return
 
 // Update fullness based on size & quantity of belly contents
 /mob/proc/update_fullness(var/returning = FALSE)

--- a/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
@@ -58,14 +58,18 @@
 	else
 		return 1
 
+// To repair a single module
 /obj/item/device/self_repair_system
 	name = "plating repair system"
 	desc = "A nanite control system to repair damaged armour plating and wiring while not moving. Destroyed armour can't be restored."
 	icon = 'icons/obj/robot_component.dmi'
 	icon_state = "armor"
+	var/repair_time = 25
+	var/repair_amount = 2.5
+	var/power_tick = 25
 	var/disabled_icon = "armor"
 	var/active_icon = "armor_broken"
-	var/target_component = "armour"
+	var/list/target_components = list("armour")
 	var/repairing = FALSE
 
 /obj/item/device/self_repair_system/New()
@@ -76,30 +80,42 @@
 	if(repairing)
 		return
 	var/mob/living/silicon/robot/R = user
-	var/datum/robot_component/C = R.components[target_component]
-	if(C && !istype(C.wrapped, /obj/item/broken_device))
-		if(C.brute_damage == 0 && C.electronics_damage == 0)
-			to_chat(R, "<span class='warning'>No brute or burn damage detected in [target_component].</span>")
-			return
-		to_chat(R, "<span class='notice'>Repair system initializated. Repairing plating and wiring.</span>")
-		icon_state = active_icon
-		update_icon()
-		repairing = TRUE
-		src.self_repair(R, C, 25, 2.5)
-		repairing = FALSE
-		icon_state = disabled_icon
-		update_icon()
-	else
-		to_chat(R, "<span class='warning'>Repair system initialization failed. Can't repair destroyed [target_component]'s plating or wiring.</span>")
+	var/destroyed_components = FALSE
+	var/list/repairable_components = list()
+	for(var/target_component in target_components)
+		var/datum/robot_component/C = R.components[target_component]
+		if(!C)
+			continue
+		if(istype(C.wrapped, /obj/item/broken_device))
+			destroyed_components = TRUE
+		else if (C.brute_damage != 0 || C.electronics_damage != 0)
+			repairable_components += C
+	if(!repairable_components.len && destroyed_components)
+		to_chat(R, span_warning("Repair system initialization failed. Can't repair destroyed [target_components.len == 1 ? "[R.components[target_components[1]]]'s" : "component's"] plating or wiring."))
+		return
+	if(!repairable_components.len)
+		to_chat(R, span_warning("No brute or burn damage detected [target_components.len == 1 ? "in [R.components[target_components[1]]]" : ""]."))
+		return
+	if(destroyed_components)
+		to_chat(R, span_warning("WARNING! Destroyed modules detected. Those can not be repaired!"))
+	icon_state = active_icon
+	update_icon()
+	repairing = TRUE
+	for(var/datum/robot_component/C in repairable_components)
+		to_chat(R, span_notice("Repair system initializated. Repairing plating and wiring of [C]."))
+		src.self_repair(R, C, repair_time, repair_amount)
+	repairing = FALSE
+	icon_state = disabled_icon
+	update_icon()
 
 /obj/item/device/self_repair_system/proc/self_repair(mob/living/silicon/robot/R, datum/robot_component/C, var/tick_delay, var/heal_per_tick)
 	if(!C || !R.cell)
 		return
 	if(C.brute_damage == 0 && C.electronics_damage == 0)
-		to_chat(R, "<span class='notice'>Repair of [target_component] completed.</span>")
+		to_chat(R, span_notice("Repair of [C] completed."))
 		return
-	if(!R.use_direct_power(50,  500)) //We don't want to drain ourselves too far down during exploration
-		to_chat(R, "<span class='warning'>Not enough power to initialize the repair system.</span>")
+	if(!R.use_direct_power(power_tick,  500)) //We don't want to drain ourselves too far down during exploration
+		to_chat(R, span_warning("Not enough power to initialize the repair system."))
 		return
 	if(do_after(R, tick_delay))
 		if(!C)
@@ -108,3 +124,12 @@
 		C.electronics_damage -= min(C.electronics_damage, heal_per_tick)
 		R.updatehealth()
 		src.self_repair(R, C, tick_delay, heal_per_tick)
+
+// To repair multiple modules
+/obj/item/device/self_repair_system/advanced
+	name = "self repair system"
+	desc = "A nanite control system to repair damaged components while not moving. Destroyed components can't be restored."
+	target_components = list("actuator", "radio", "power cell", "diagnosis unit", "camera", "comms", "armour")
+	power_tick = 10
+	repair_time = 15
+	repair_amount = 3


### PR DESCRIPTION
## About The Pull Request
## Changelog
:cl:
balance: lost and gravekeeper drones now have a small chance to unlock the scrambled module by digesting mobs
balance: lost and gravekeeper get access to an advanced self repair module when digesting 5 mobs (stats are experimental and could change in the future)
add: advanced self repair module which can repair all modules, but only one after another
/:cl:
