### PR TITLE
 Reduces bloodloss from getting burns

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -134,6 +134,7 @@
 
 	mutations.Add(HUSK)
 	status_flags |= DISFIGURED	//makes them unknown without fucking up other stuff like admintools
+	remove_blood(560) //CHOMPedit
 	update_icons_body()
 	return
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -547,12 +547,9 @@ This function completely restores a damaged organ to perfect condition.
 		wounds += I
 		owner.custom_pain("You feel something rip in your [name]!", 50)
 
-//Burn damage can cause fluid loss due to blistering and cook-off //CHOMPEDIT START, remove the burn boiling off blood mechanic, it messes with lasers too much and is too hard coded. Blood is removed from husking still.
-/*
 	if((damage > 5 || damage + burn_dam >= 15) && type == BURN && (robotic < ORGAN_ROBOT) && !(species.flags & NO_BLOOD))
-		var/fluid_loss = 0.4 * (damage/(owner.getMaxHealth() - CONFIG_GET(number/health_threshold_dead))) * owner.species.blood_volume*(1 - owner.species.blood_level_fatal) // CHOMPEdit
+		var/fluid_loss = 0.1 * (damage/(owner.getMaxHealth() - CONFIG_GET(number/health_threshold_dead))) * owner.species.blood_volume*(1 - owner.species.blood_level_fatal) // CHOMPEdit //CHOMPedit 2, reduce fluid loss 4-fold so lasers dont suck your blood
 		owner.remove_blood(fluid_loss)
-*/ //CHOMPEDIT end
 	// first check whether we can widen an existing wound
 	if(wounds.len > 0 && prob(max(50+(number_wounds-1)*10,90)))
 		if((type == CUT || type == BRUISE) && damage >= 5)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -547,12 +547,12 @@ This function completely restores a damaged organ to perfect condition.
 		wounds += I
 		owner.custom_pain("You feel something rip in your [name]!", 50)
 
-//Burn damage can cause fluid loss due to blistering and cook-off
-
+//Burn damage can cause fluid loss due to blistering and cook-off //CHOMPEDIT START, remove the burn boiling off blood mechanic, it messes with lasers too much and is too hard coded. Blood is removed from husking still.
+/*
 	if((damage > 5 || damage + burn_dam >= 15) && type == BURN && (robotic < ORGAN_ROBOT) && !(species.flags & NO_BLOOD))
 		var/fluid_loss = 0.4 * (damage/(owner.getMaxHealth() - CONFIG_GET(number/health_threshold_dead))) * owner.species.blood_volume*(1 - owner.species.blood_level_fatal) // CHOMPEdit
 		owner.remove_blood(fluid_loss)
-
+*/ //CHOMPEDIT end
 	// first check whether we can widen an existing wound
 	if(wounds.len > 0 && prob(max(50+(number_wounds-1)*10,90)))
 		if((type == CUT || type == BRUISE) && damage >= 5)


### PR DESCRIPTION
## About The Pull Request
There was a polaris change 6 years ago that makes ALL burns boil off your blood, and looking at the context it was more meant for things like phoron fires and lava baths to dry someone up, with lasers being a unintentional side effect on vaporizing your blood. This reduces the mechanic by 4x and puts the bloodloss into the husk proc instead.

Not implemented in the way I like but other methods will be worked on.
## Changelog
:cl:
balance: 75% reduction in blood loss from burns
/:cl:
