### PR TITLE
Shadekin Dark Respite now fixes severe infections.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -240,7 +240,7 @@
 			H.adjustBruteLoss((-0.25))
 			H.adjustToxLoss((-0.25))
 			H.heal_organ_damage(3, 0)
-			H.add_chemical_effect(CE_ANTIBIOTIC, ANTIBIO_NORM)
+			H.add_chemical_effect(CE_ANTIBIOTIC, ANTIBIO_SUPER)
 			for(var/obj/item/organ/I in H.internal_organs)
 				if(I.robotic >= ORGAN_ROBOT)
 					continue

--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -240,7 +240,7 @@
 			H.adjustBruteLoss((-0.25))
 			H.adjustToxLoss((-0.25))
 			H.heal_organ_damage(3, 0)
-			H.add_chemical_effect(CE_ANTIBIOTIC, ANTIBIO_SUPER)
+			H.add_chemical_effect(CE_ANTIBIOTIC, ANTIBIO_SUPER) //CHOMP Edit - increased ANTIBIO from Normal to Super
 			for(var/obj/item/organ/I in H.internal_organs)
 				if(I.robotic >= ORGAN_ROBOT)
 					continue


### PR DESCRIPTION

Improves shadekin Dark Respite antibiotic level from 'normal' to 'super'
This allows it to fix severe viruses and infections, on par with corophizine.

I've been told that this is the intended behavior, and currently a shadekin who gets a severe infection and then undergoes an emergency warp will still have the infection, never heal it, go into crit, but then never actually die. This softlocks them into crit until they use the succumb to death verb or an admin intervenes (usually the infection is unfixable by the time they're found by others, and they can't leave the dark due to a recent emergency warp).
## Changelog
:cl:
balance: Dark Respite antibio improved
fix: Infections no longer deathlock shadekin
/:cl:
