### PR TITLE
Transfer Message Changes

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -191,13 +191,27 @@
 		"%prey slid into your %dest due to their struggling inside your %belly!")
 
 	var/list/primary_transfer_messages_prey = list(
-		"Your attempt to escape %pred's %belly has failed and your struggles only results in you sliding into pred's %dest!")
+		"Your attempt to escape %pred's %belly has failed and your struggles only results in you sliding into %pred's %dest!") //CHOMPEdit
 
 	var/list/secondary_transfer_messages_owner = list(
 		"%prey slid into your %dest due to their struggling inside your %belly!")
 
 	var/list/secondary_transfer_messages_prey = list(
-		"Your attempt to escape %pred's %belly has failed and your struggles only results in you sliding into pred's %dest!")
+		"Your attempt to escape %pred's %belly has failed and your struggles only results in you sliding into %pred's %dest!") //CHOMPEdit
+
+	//CHOMPAdd Start
+	var/list/primary_autotransfer_messages_owner = list(
+		"%prey moves along into your %dest!")
+
+	var/list/primary_autotransfer_messages_prey = list(
+		"%pred's %belly moves you along into their %dest!")
+
+	var/list/secondary_autotransfer_messages_owner = list(
+		"%prey moves along into your %dest!")
+
+	var/list/secondary_autotransfer_messages_prey = list(
+		"%pred's %belly moves you along into their %dest!")
+	//CHOMPAdd End
 
 	var/list/digest_chance_messages_owner = list(
 		"You feel your %belly beginning to become active!")
@@ -332,6 +346,10 @@
 	"primary_transfer_messages_prey",
 	"secondary_transfer_messages_owner",
 	"secondary_transfer_messages_prey",
+	"primary_autotransfer_messages_owner",		//CHOMPAdd
+	"primary_autotransfer_messages_prey",		//CHOMPAdd
+	"secondary_autotransfer_messages_owner",	//CHOMPAdd
+	"secondary_autotransfer_messages_prey",		//CHOMPAdd
 	"digest_chance_messages_owner",
 	"digest_chance_messages_prey",
 	"absorb_chance_messages_owner",
@@ -572,7 +590,7 @@
 			to_chat(M, "<span class='vnotice'><B>[formatted_desc]</B></span>")
 
 		var/taste
-		if(can_taste && (taste = M.get_taste_message(FALSE)))
+		if(can_taste && M.loc == src && (taste = M.get_taste_message(FALSE))) //CHOMPEdit - Prevent indirect tasting
 			to_chat(owner, "<span class='vnotice'>[M] tastes of [taste].</span>")
 		vore_fx(M, TRUE) //CHOMPEdit: update belleh
 		if(owner.previewing_belly == src) //CHOMPEdit
@@ -1246,7 +1264,7 @@
 // This is useful in customization boxes and such. The delimiter right now is \n\n so
 // in message boxes, this looks nice and is easily delimited.
 /obj/belly/proc/get_messages(type, delim = "\n\n")
-	ASSERT(type == "smo" || type == "smi" || type == "asmo" || type == "asmi" || type == "escao" || type == "escap" || type == "escp" || type == "esco" || type == "escout" || type == "escip" || type == "escio" || type == "esciout" || type == "escfp" || type == "escfo" || type == "aescao" || type == "aescap" || type == "aescp" || type == "aesco" || type == "aescout" || type == "aescfp" || type == "aescfo" || type == "trnspp" || type == "trnspo" || type == "trnssp" || type == "trnsso" || type == "stmodp" || type == "stmodo" || type == "stmoap" || type == "stmoao" || type == "dmo" || type == "dmp" || type == "amo" || type == "amp" || type == "uamo" || type == "uamp" || type == "em" || type == "ema" || type == "im_digest" || type == "im_hold" || type == "im_holdabsorbed" || type == "im_absorb" || type == "im_heal" || type == "im_drain" || type == "im_steal" || type == "im_egg" || type == "im_shrink" || type == "im_grow" || type == "im_unabsorb")
+	ASSERT(type == "smo" || type == "smi" || type == "asmo" || type == "asmi" || type == "escao" || type == "escap" || type == "escp" || type == "esco" || type == "escout" || type == "escip" || type == "escio" || type == "esciout" || type == "escfp" || type == "escfo" || type == "aescao" || type == "aescap" || type == "aescp" || type == "aesco" || type == "aescout" || type == "aescfp" || type == "aescfo" || type == "trnspp" || type == "trnspo" || type == "trnssp" || type == "trnsso" || type == "atrnspp" || type == "atrnspo" || type == "atrnssp" || type == "atrnsso" || type == "stmodp" || type == "stmodo" || type == "stmoap" || type == "stmoao" || type == "dmo" || type == "dmp" || type == "amo" || type == "amp" || type == "uamo" || type == "uamp" || type == "em" || type == "ema" || type == "im_digest" || type == "im_hold" || type == "im_holdabsorbed" || type == "im_absorb" || type == "im_heal" || type == "im_drain" || type == "im_steal" || type == "im_egg" || type == "im_shrink" || type == "im_grow" || type == "im_unabsorb") //CHOMPEdit
 
 	var/list/raw_messages
 	switch(type)
@@ -1300,6 +1318,16 @@
 			raw_messages = secondary_transfer_messages_owner
 		if("trnssp")
 			raw_messages = secondary_transfer_messages_prey
+		//CHOMPAdd Start
+		if("atrnspo")
+			raw_messages = primary_autotransfer_messages_owner
+		if("atrnspp")
+			raw_messages = primary_autotransfer_messages_prey
+		if("atrnsso")
+			raw_messages = secondary_autotransfer_messages_owner
+		if("atrnssp")
+			raw_messages = secondary_autotransfer_messages_prey
+		//CHOMPAdd End
 		if("stmodo")
 			raw_messages = digest_chance_messages_owner
 		if("stmodp")
@@ -1355,7 +1383,7 @@
 // replacement strings and linebreaks as delimiters (two \n\n by default).
 // They also sanitize the messages.
 /obj/belly/proc/set_messages(raw_text, type, delim = "\n\n")
-	ASSERT(type == "smo" || type == "smi" || type == "asmo" || type == "asmi" || type == "escao" || type == "escap" || type == "escp" || type == "esco" || type == "escout" || type == "escip" || type == "escio" || type == "esciout" || type == "escfp" || type == "escfo" || type == "aescao" || type == "aescap" || type == "aescp" || type == "aesco" || type == "aescout" || type == "aescfp" || type == "aescfo" || type == "trnspp" || type == "trnspo" || type == "trnssp" || type == "trnsso" || type == "stmodp" || type == "stmodo" || type == "stmoap" || type == "stmoao" || type == "dmo" || type == "dmp" || type == "amo" || type == "amp" || type == "uamo" || type == "uamp" || type == "em" || type == "ema" || type == "im_digest" || type == "im_hold" || type == "im_holdabsorbed" || type == "im_absorb" || type == "im_heal" || type == "im_drain" || type == "im_steal" || type == "im_egg" || type == "im_shrink" || type == "im_grow" || type == "im_unabsorb")
+	ASSERT(type == "smo" || type == "smi" || type == "asmo" || type == "asmi" || type == "escao" || type == "escap" || type == "escp" || type == "esco" || type == "escout" || type == "escip" || type == "escio" || type == "esciout" || type == "escfp" || type == "escfo" || type == "aescao" || type == "aescap" || type == "aescp" || type == "aesco" || type == "aescout" || type == "aescfp" || type == "aescfo" || type == "trnspp" || type == "trnspo" || type == "trnssp" || type == "trnsso" || type == "atrnspp" || type == "atrnspo" || type == "atrnssp" || type == "atrnsso" || type == "stmodp" || type == "stmodo" || type == "stmoap" || type == "stmoao" || type == "dmo" || type == "dmp" || type == "amo" || type == "amp" || type == "uamo" || type == "uamp" || type == "em" || type == "ema" || type == "im_digest" || type == "im_hold" || type == "im_holdabsorbed" || type == "im_absorb" || type == "im_heal" || type == "im_drain" || type == "im_steal" || type == "im_egg" || type == "im_shrink" || type == "im_grow" || type == "im_unabsorb") //CHOMPEdit
 
 	var/list/raw_list = splittext(html_encode(raw_text),delim)
 	if(raw_list.len > 10)
@@ -1430,6 +1458,16 @@
 			secondary_transfer_messages_owner = raw_list
 		if("trnssp")
 			secondary_transfer_messages_prey = raw_list
+		//CHOMPAdd Start
+		if("atrnspo")
+			primary_autotransfer_messages_owner = raw_list
+		if("atrnspp")
+			primary_autotransfer_messages_prey = raw_list
+		if("atrnsso")
+			secondary_autotransfer_messages_owner = raw_list
+		if("atrnssp")
+			secondary_autotransfer_messages_prey = raw_list
+		//CHOMPAdd End
 		if("stmodo")
 			digest_chance_messages_owner = raw_list
 		if("stmodp")
@@ -2291,52 +2329,34 @@
 		var/living_count = 0
 		for(var/mob/living/L in contents)
 			living_count++
+
+		var/autotransfer_owner_message = pick(primary_autotransfer_messages_owner)
+		var/autotransfer_prey_message = pick(primary_autotransfer_messages_prey)
 		if(dest_belly_name == autotransferlocation_secondary)
-			var/secondary_transfer_owner_message = pick(secondary_transfer_messages_owner)
-			var/secondary_transfer_prey_message = pick(secondary_transfer_messages_prey)
+			autotransfer_owner_message = pick(secondary_autotransfer_messages_owner)
+			autotransfer_prey_message = pick(secondary_autotransfer_messages_prey)
 
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%pred", owner)
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%prey", prey)
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%belly", lowertext(name))
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%countprey", living_count)
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%count", contents.len)
-			secondary_transfer_owner_message = replacetext(secondary_transfer_owner_message, "%dest", autotransferlocation_secondary)
+		autotransfer_owner_message = replacetext(autotransfer_owner_message, "%pred", owner)
+		autotransfer_owner_message = replacetext(autotransfer_owner_message, "%prey", prey)
+		autotransfer_owner_message = replacetext(autotransfer_owner_message, "%belly", lowertext(name))
+		autotransfer_owner_message = replacetext(autotransfer_owner_message, "%countprey", living_count)
+		autotransfer_owner_message = replacetext(autotransfer_owner_message, "%count", contents.len)
+		autotransfer_owner_message = replacetext(autotransfer_owner_message, "%dest", dest_belly_name)
 
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%pred", owner)
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%prey", prey)
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%belly", lowertext(name))
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%countprey", living_count)
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%count", contents.len)
-			secondary_transfer_prey_message = replacetext(secondary_transfer_prey_message, "%dest", autotransferlocation_secondary)
+		autotransfer_prey_message = replacetext(autotransfer_prey_message, "%pred", owner)
+		autotransfer_prey_message = replacetext(autotransfer_prey_message, "%prey", prey)
+		autotransfer_prey_message = replacetext(autotransfer_prey_message, "%belly", lowertext(name))
+		autotransfer_prey_message = replacetext(autotransfer_prey_message, "%countprey", living_count)
+		autotransfer_prey_message = replacetext(autotransfer_prey_message, "%count", contents.len)
+		autotransfer_prey_message = replacetext(autotransfer_prey_message, "%dest", dest_belly_name)
 
-			secondary_transfer_owner_message = "<span class='vwarning'>[secondary_transfer_owner_message]</span>"
-			secondary_transfer_prey_message = "<span class='vwarning'>[secondary_transfer_prey_message]</span>"
+		autotransfer_owner_message = "<span class='vwarning'>[autotransfer_owner_message]</span>"
+		autotransfer_prey_message = "<span class='vwarning'>[autotransfer_prey_message]</span>"
 
-			to_chat(prey, secondary_transfer_prey_message)
-			to_chat(owner, secondary_transfer_owner_message)
-		else if (dest_belly_name == autotransferlocation)
-			var/primary_transfer_owner_message = pick(primary_transfer_messages_owner)
-			var/primary_transfer_prey_message = pick(primary_transfer_messages_prey)
+		to_chat(prey, autotransfer_prey_message)
+		if(entrance_logs)
+			to_chat(owner, autotransfer_owner_message)
 
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%pred", owner)
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%prey", prey)
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%belly", lowertext(name))
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%countprey", living_count)
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%count", contents.len)
-			primary_transfer_owner_message = replacetext(primary_transfer_owner_message, "%dest", autotransferlocation)
-
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%pred", owner)
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%prey", prey)
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%belly", lowertext(name))
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%countprey", living_count)
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%count", contents.len)
-			primary_transfer_prey_message = replacetext(primary_transfer_prey_message, "%dest", autotransferlocation)
-
-			primary_transfer_owner_message = "<span class='vwarning'>[primary_transfer_owner_message]</span>"
-			primary_transfer_prey_message = "<span class='vwarning'>[primary_transfer_prey_message]</span>"
-
-			to_chat(prey, primary_transfer_prey_message)
-			to_chat(owner, primary_transfer_owner_message)
 	transfer_contents(prey, dest_belly)
 	return TRUE //CHOMPEdit end
 

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -895,6 +895,26 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 					if(new_secondary_transfer_messages_owner)
 						new_belly.set_messages(new_secondary_transfer_messages_owner,"trnsso")
 
+				if(islist(belly_data["primary_autotransfer_messages_prey"]))
+					var/new_primary_autotransfer_messages_prey = sanitize(jointext(belly_data["primary_autotransfer_messages_prey"],"\n\n"),MAX_MESSAGE_LEN,0,0,0)
+					if(new_primary_autotransfer_messages_prey)
+						new_belly.set_messages(new_primary_autotransfer_messages_prey,"atrnspp")
+
+				if(islist(belly_data["primary_autotransfer_messages_owner"]))
+					var/new_primary_autotransfer_messages_owner = sanitize(jointext(belly_data["primary_autotransfer_messages_owner"],"\n\n"),MAX_MESSAGE_LEN,0,0,0)
+					if(new_primary_autotransfer_messages_owner)
+						new_belly.set_messages(new_primary_autotransfer_messages_owner,"atrnspo")
+
+				if(islist(belly_data["secondary_autotransfer_messages_prey"]))
+					var/new_secondary_autotransfer_messages_prey = sanitize(jointext(belly_data["secondary_autotransfer_messages_prey"],"\n\n"),MAX_MESSAGE_LEN,0,0,0)
+					if(new_secondary_autotransfer_messages_prey)
+						new_belly.set_messages(new_secondary_autotransfer_messages_prey,"atrnssp")
+
+				if(islist(belly_data["secondary_autotransfer_messages_owner"]))
+					var/new_secondary_autotransfer_messages_owner = sanitize(jointext(belly_data["secondary_autotransfer_messages_owner"],"\n\n"),MAX_MESSAGE_LEN,0,0,0)
+					if(new_secondary_autotransfer_messages_owner)
+						new_belly.set_messages(new_secondary_autotransfer_messages_owner,"atrnsso")
+
 				if(islist(belly_data["digest_chance_messages_prey"]))
 					var/new_digest_chance_messages_prey = sanitize(jointext(belly_data["digest_chance_messages_prey"],"\n\n"),MAX_MESSAGE_LEN,0,0,0)
 					if(new_digest_chance_messages_prey)
@@ -2860,25 +2880,45 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 						host.vore_selected.set_messages(new_message,"aescfo")
 
 				if("trnspp")
-					var/new_message = sanitize(tgui_input_text(user,"These are sent to prey when they are automatically transferred into your primary destination. Write them in 2nd person ('you slide into Y'). Use %dest to refer to the target location in this type."+help,"Primary Transfer Message (to prey)",host.vore_selected.get_messages("trnspp"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0)
+					var/new_message = sanitize(tgui_input_text(user,"These are sent to prey when they struggle and are transferred into your primary destination. Write them in 2nd person ('you slide into Y'). Use %dest to refer to the target location in this type."+help,"Primary Transfer Message (to prey)",host.vore_selected.get_messages("trnspp"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0) //CHOMPEdit
 					if(new_message)
 						host.vore_selected.set_messages(new_message,"trnspp")
 
 				if("trnspo")
-					var/new_message = sanitize(tgui_input_text(user,"These are sent to you when prey is automatically transferred into your primary destination. Write them in 2nd person ('X slid into your Y'). Use %dest to refer to the target location in this type."+help,"Primary Transfer Message (to you)",host.vore_selected.get_messages("trnspo"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0)
+					var/new_message = sanitize(tgui_input_text(user,"These are sent to you when prey struggle and are transferred into your primary destination. Write them in 2nd person ('X slid into your Y'). Use %dest to refer to the target location in this type."+help,"Primary Transfer Message (to you)",host.vore_selected.get_messages("trnspo"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0) //CHOMPEdit
 					if(new_message)
 						host.vore_selected.set_messages(new_message,"trnspo")
 
 				if("trnssp")
-					var/new_message = sanitize(tgui_input_text(user,"These are sent to prey when they are automatically transferred into your secondary destination. Write them in 2nd person ('you slide into Y'). Use %dest to refer to the target location in this type."+help,"Secondary Transfer Message (to prey)",host.vore_selected.get_messages("trnssp"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0)
+					var/new_message = sanitize(tgui_input_text(user,"These are sent to prey when they struggle and are transferred into your secondary destination. Write them in 2nd person ('you slide into Y'). Use %dest to refer to the target location in this type."+help,"Secondary Transfer Message (to prey)",host.vore_selected.get_messages("trnssp"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0) //CHOMPEdit
 					if(new_message)
 						host.vore_selected.set_messages(new_message,"trnssp")
 
 				if("trnsso")
-					var/new_message = sanitize(tgui_input_text(user,"These are sent to you when prey is automatically transferred into your primary destination. Write them in 2nd person ('X slid into your Y'). Use %dest to refer to the target location in this type."+help,"Secondary Transfer Message (to you)",host.vore_selected.get_messages("trnsso"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0)
+					var/new_message = sanitize(tgui_input_text(user,"These are sent to you when prey struggle and are transferred into your primary destination. Write them in 2nd person ('X slid into your Y'). Use %dest to refer to the target location in this type."+help,"Secondary Transfer Message (to you)",host.vore_selected.get_messages("trnsso"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0) //CHOMPEdit
 					if(new_message)
 						host.vore_selected.set_messages(new_message,"trnsso")
+				//CHOMPAdd Start
+				if("atrnspp")
+					var/new_message = sanitize(tgui_input_text(user,"These are sent to prey when they are automatically transferred into your primary destination. Write them in 2nd person ('you slide into Y'). Use %dest to refer to the target location in this type."+help,"Primary Auto-Transfer Message (to prey)",host.vore_selected.get_messages("atrnspp"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0)
+					if(new_message)
+						host.vore_selected.set_messages(new_message,"atrnspp")
 
+				if("atrnspo")
+					var/new_message = sanitize(tgui_input_text(user,"These are sent to you when prey is automatically transferred into your primary destination. Write them in 2nd person ('X slid into your Y'). Use %dest to refer to the target location in this type."+help,"Primary Auto-Transfer Message (to you)",host.vore_selected.get_messages("atrnspo"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0)
+					if(new_message)
+						host.vore_selected.set_messages(new_message,"atrnspo")
+
+				if("atrnssp")
+					var/new_message = sanitize(tgui_input_text(user,"These are sent to prey when they are automatically transferred into your secondary destination. Write them in 2nd person ('you slide into Y'). Use %dest to refer to the target location in this type."+help,"Secondary Auto-Transfer Message (to prey)",host.vore_selected.get_messages("atrnssp"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0)
+					if(new_message)
+						host.vore_selected.set_messages(new_message,"atrnssp")
+
+				if("atrnsso")
+					var/new_message = sanitize(tgui_input_text(user,"These are sent to you when prey is automatically transferred into your primary destination. Write them in 2nd person ('X slid into your Y'). Use %dest to refer to the target location in this type."+help,"Secondary Auto-Transfer Message (to you)",host.vore_selected.get_messages("atrnsso"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0)
+					if(new_message)
+						host.vore_selected.set_messages(new_message,"atrnsso")
+				//CHOMPAdd End
 				if("stmodp")
 					var/new_message = sanitize(tgui_input_text(user,"These are sent to prey when they trigger the interaction digest chance. Write them in 2nd person ('you feel X')."+help,"Stomach Mode Digest Message (to prey)",host.vore_selected.get_messages("stmodp"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0)
 					if(new_message)
@@ -3024,6 +3064,10 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 						host.vore_selected.primary_transfer_messages_prey = initial(host.vore_selected.primary_transfer_messages_prey)
 						host.vore_selected.secondary_transfer_messages_owner = initial(host.vore_selected.secondary_transfer_messages_owner)
 						host.vore_selected.secondary_transfer_messages_prey = initial(host.vore_selected.secondary_transfer_messages_prey)
+						host.vore_selected.primary_autotransfer_messages_owner = initial(host.vore_selected.primary_autotransfer_messages_owner)		//CHOMPAdd
+						host.vore_selected.primary_autotransfer_messages_prey = initial(host.vore_selected.primary_autotransfer_messages_prey)			//CHOMPAdd
+						host.vore_selected.secondary_autotransfer_messages_owner = initial(host.vore_selected.secondary_autotransfer_messages_owner)	//CHOMPAdd
+						host.vore_selected.secondary_autotransfer_messages_prey = initial(host.vore_selected.secondary_autotransfer_messages_prey)		//CHOMPAdd
 						host.vore_selected.digest_chance_messages_owner = initial(host.vore_selected.digest_chance_messages_owner)
 						host.vore_selected.digest_chance_messages_prey = initial(host.vore_selected.digest_chance_messages_prey)
 						host.vore_selected.absorb_chance_messages_owner = initial(host.vore_selected.absorb_chance_messages_owner)

--- a/modular_chomp/code/modules/vore/eating/exportpanel_ch.dm
+++ b/modular_chomp/code/modules/vore/eating/exportpanel_ch.dm
@@ -154,6 +154,22 @@
 			for(var/msg in B.secondary_transfer_messages_prey)
 				belly_data["secondary_transfer_messages_prey"] += msg
 
+			belly_data["primary_autotransfer_messages_owner"] = list()
+			for(var/msg in B.primary_autotransfer_messages_owner)
+				belly_data["primary_autotransfer_messages_owner"] += msg
+
+			belly_data["primary_autotransfer_messages_prey"] = list()
+			for(var/msg in B.primary_autotransfer_messages_prey)
+				belly_data["primary_autotransfer_messages_prey"] += msg
+
+			belly_data["secondary_autotransfer_messages_owner"] = list()
+			for(var/msg in B.secondary_autotransfer_messages_owner)
+				belly_data["secondary_autotransfer_messages_owner"] += msg
+
+			belly_data["secondary_autotransfer_messages_prey"] = list()
+			for(var/msg in B.secondary_autotransfer_messages_prey)
+				belly_data["secondary_autotransfer_messages_prey"] += msg
+
 			belly_data["digest_chance_messages_owner"] = list()
 			for(var/msg in B.digest_chance_messages_owner)
 				belly_data["digest_chance_messages_owner"] += msg

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyDescriptions.tsx
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyDescriptions.tsx
@@ -408,6 +408,58 @@ const VoreSelectedBellyDescriptionsTransfer = (props) => {
           </Button>
         </>
       )}
+      {(message_mode ||
+        !!interacts.transferlocation ||
+        !!autotransfer.autotransferlocation) && (
+        <>
+          <Button
+            onClick={() =>
+              act('set_attribute', {
+                attribute: 'b_msgs',
+                msgtype: 'atrnspp',
+              })
+            }
+          >
+            Primary Auto-Transfer Message (to prey)
+          </Button>
+          <Button
+            onClick={() =>
+              act('set_attribute', {
+                attribute: 'b_msgs',
+                msgtype: 'atrnspo',
+              })
+            }
+          >
+            Primary Auto-Transfer Message (to you)
+          </Button>
+        </>
+      )}
+      {(message_mode ||
+        !!interacts.transferlocation_secondary ||
+        !!autotransfer.autotransferlocation_secondary) && (
+        <>
+          <Button
+            onClick={() =>
+              act('set_attribute', {
+                attribute: 'b_msgs',
+                msgtype: 'atrnssp',
+              })
+            }
+          >
+            Secondary Auto-Transfer Message (to prey)
+          </Button>
+          <Button
+            onClick={() =>
+              act('set_attribute', {
+                attribute: 'b_msgs',
+                msgtype: 'atrnsso',
+              })
+            }
+          >
+            Secondary Auto-Transfer Message (to you)
+          </Button>
+        </>
+      )}
     </LabeledList.Item>
   );
 };

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyDescriptions.tsx
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyDescriptions.tsx
@@ -356,8 +356,7 @@ const VoreSelectedBellyDescriptionsTransfer = (props) => {
 
   return (
     <LabeledList.Item label="Transfer Messages">
-      {(message_mode ||
-        !!interacts.transferlocation) && (
+      {(message_mode || !!interacts.transferlocation) && (
         <>
           <Button
             onClick={() =>
@@ -381,8 +380,7 @@ const VoreSelectedBellyDescriptionsTransfer = (props) => {
           </Button>
         </>
       )}
-      {(message_mode ||
-        !!interacts.transferlocation_secondary) && (
+      {(message_mode || !!interacts.transferlocation_secondary) && (
         <>
           <Button
             onClick={() =>
@@ -406,8 +404,7 @@ const VoreSelectedBellyDescriptionsTransfer = (props) => {
           </Button>
         </>
       )}
-      {(message_mode ||
-        !!autotransfer.autotransferlocation) && (
+      {(message_mode || !!autotransfer.autotransferlocation) && (
         <>
           <Button
             onClick={() =>
@@ -431,8 +428,7 @@ const VoreSelectedBellyDescriptionsTransfer = (props) => {
           </Button>
         </>
       )}
-      {(message_mode ||
-        !!autotransfer.autotransferlocation_secondary) && (
+      {(message_mode || !!autotransfer.autotransferlocation_secondary) && (
         <>
           <Button
             onClick={() =>

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyDescriptions.tsx
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyDescriptions.tsx
@@ -357,8 +357,7 @@ const VoreSelectedBellyDescriptionsTransfer = (props) => {
   return (
     <LabeledList.Item label="Transfer Messages">
       {(message_mode ||
-        !!interacts.transferlocation ||
-        !!autotransfer.autotransferlocation) && (
+        !!interacts.transferlocation) && (
         <>
           <Button
             onClick={() =>
@@ -383,8 +382,7 @@ const VoreSelectedBellyDescriptionsTransfer = (props) => {
         </>
       )}
       {(message_mode ||
-        !!interacts.transferlocation_secondary ||
-        !!autotransfer.autotransferlocation_secondary) && (
+        !!interacts.transferlocation_secondary) && (
         <>
           <Button
             onClick={() =>
@@ -409,7 +407,6 @@ const VoreSelectedBellyDescriptionsTransfer = (props) => {
         </>
       )}
       {(message_mode ||
-        !!interacts.transferlocation ||
         !!autotransfer.autotransferlocation) && (
         <>
           <Button
@@ -435,7 +432,6 @@ const VoreSelectedBellyDescriptionsTransfer = (props) => {
         </>
       )}
       {(message_mode ||
-        !!interacts.transferlocation_secondary ||
         !!autotransfer.autotransferlocation_secondary) && (
         <>
           <Button

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanelExport.tsx
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanelExport.tsx
@@ -203,6 +203,10 @@ type Belly = {
   primary_transfer_messages_prey: string[];
   secondary_transfer_messages_owner: string[];
   secondary_transfer_messages_prey: string[];
+  primary_autotransfer_messages_owner: string[];
+  primary_autotransfer_messages_prey: string[];
+  secondary_autotransfer_messages_owner: string[];
+  secondary_autotransfer_messages_prey: string[];
   digest_chance_messages_owner: string[];
   digest_chance_messages_prey: string[];
   absorb_chance_messages_owner: string[];
@@ -405,6 +409,10 @@ const generateBellyString = (belly: Belly, index: number) => {
     primary_transfer_messages_prey,
     secondary_transfer_messages_owner,
     secondary_transfer_messages_prey,
+    primary_autotransfer_messages_owner,
+    primary_autotransfer_messages_prey,
+    secondary_autotransfer_messages_owner,
+    secondary_autotransfer_messages_prey,
     digest_chance_messages_owner,
     digest_chance_messages_prey,
     absorb_chance_messages_owner,
@@ -731,6 +739,30 @@ const generateBellyString = (belly: Belly, index: number) => {
 
   result += '<div class="tab-pane fade" id="secondaryTransferMessagesPrey' + index + '" role="messagesTabpanel">';
   secondary_transfer_messages_prey?.forEach((msg) => {
+    result += msg + '<br>';
+  });
+  result += '</div>';
+
+  result += '<div class="tab-pane fade" id="primaryAutoTransferMessagesOwner' + index + '" role="messagesTabpanel">';
+  primary_autotransfer_messages_owner?.forEach((msg) => {
+    result += msg + '<br>';
+  });
+  result += '</div>';
+
+  result += '<div class="tab-pane fade" id="primaryAutoTransferMessagesPrey' + index + '" role="messagesTabpanel">';
+  primary_autotransfer_messages_prey?.forEach((msg) => {
+    result += msg + '<br>';
+  });
+  result += '</div>';
+
+  result += '<div class="tab-pane fade" id="secondaryAutoTransferMessagesOwner' + index + '" role="messagesTabpanel">';
+  secondary_autotransfer_messages_owner?.forEach((msg) => {
+    result += msg + '<br>';
+  });
+  result += '</div>';
+
+  result += '<div class="tab-pane fade" id="secondaryAutoTransferMessagesPrey' + index + '" role="messagesTabpanel">';
+  secondary_autotransfer_messages_prey?.forEach((msg) => {
     result += msg + '<br>';
   });
   result += '</div>';


### PR DESCRIPTION

## About The Pull Request
Splits transfer messages, keeping the original for struggle transfers as they were intended and adding in new ones for auto-transfers. Disabling Entrance Logs will stop the pred from being spammed with these messages when auto-transfer happens, especially useful for belly loops. Also fixed bellies tasting prey entering them that aren't directly being eaten, like prey inside containers or being held by others.
## Changelog
:cl:
add: Separated messages for auto-transfers versus struggle transfers
qol: Disabling Entrance Logs also stops the pred from seeing auto-transfer messages
fix: Fixed tasting things not directly entering a belly, such as in boxes or held by others 
/:cl:
