### PR TITLE
Nifs are now logged, and sec accessible

### DIFF
--- a/modular_chomp/code/game/machinery/vending.dm
+++ b/modular_chomp/code/game/machinery/vending.dm
@@ -199,3 +199,8 @@
 		/obj/item/stack/material/bronze = 12,
 		/obj/item/weapon/circuitboard/defenseonelisk = 5000
 		)
+
+//Some stuff to let sec do things
+/obj/machinery/vending/nifsoft_shop
+	req_log_access = access_security
+	has_logs = 1


### PR DESCRIPTION
Gives NIF vendors logs, well turns on that variable
Lets security access said logs.

Side note, the tool vendor dispense basic tools in the tool area near the bar has logs, but the one next to it with timers, igniters and signalers doesn't. But the normal tools are just...on the tables and easily grabbable from anywhere.
## About The Pull Request
## Changelog
:cl:
balance: Nif vendors have logs now. Sec can check them
/:cl:
