### PR TITLE
linear anomaly limit

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -470,6 +470,7 @@ var/global/list/PDA_Manifest = list()
 		hidden_general += G
 	else
 		general += G
+		job_master.update_limit(JOB_ANOMALY, general.len)
 
 	return G
 

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -470,7 +470,7 @@ var/global/list/PDA_Manifest = list()
 		hidden_general += G
 	else
 		general += G
-		job_master.update_limit(JOB_ANOMALY, general.len)
+		job_master.update_limit(JOB_ANOMALY, general.len) //CHOMPAdd
 
 	return G
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -188,3 +188,8 @@
 	if(brain_type in banned_job_species)
 		return TRUE
 	*/
+
+//CHOMPAdd Start
+/datum/job/proc/update_limit(var/comperator)
+	return
+//CHOMPAdd End

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -76,6 +76,7 @@ var/global/datum/controller/occupations/job_master
 			player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 			unassigned -= player
 			job.current_positions++
+			update_limit(JOB_ANOMALY, data_core.general.len + 1) //CHOMPAdd
 			return 1
 	Debug("AR has failed, Player: [player], Rank: [rank]")
 	return 0
@@ -86,6 +87,15 @@ var/global/datum/controller/occupations/job_master
 		job.total_positions++
 		return 1
 	return 0
+
+//CHOMPAdd Start
+/datum/controller/occupations/proc/update_limit(var/rank, var/comperator)
+	var/datum/job/job = GetJob(rank)
+	if(job && job.total_positions != -1)
+		job.update_limit(comperator)
+		return 1
+	return 0
+//CHOMPAdd End
 
 /datum/controller/occupations/proc/FindOccupationCandidates(datum/job/job, level, flag)
 	Debug("Running FOC, Job: [job], Level: [level], Flag: [flag]")

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -76,7 +76,6 @@ var/global/datum/controller/occupations/job_master
 			player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 			unassigned -= player
 			job.current_positions++
-			update_limit(JOB_ANOMALY, data_core.general.len + 1) //CHOMPAdd
 			return 1
 	Debug("AR has failed, Player: [player], Rank: [rank]")
 	return 0

--- a/modular_chomp/code/game/jobs/job/noncrew.dm
+++ b/modular_chomp/code/game/jobs/job/noncrew.dm
@@ -34,8 +34,8 @@
 /datum/job/shadekin
     title = JOB_ANOMALY
     disallow_jobhop = TRUE
-    total_positions = 5
-    spawn_positions = 5
+    total_positions = 2
+    spawn_positions = 2
     supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property. Please read <a href='https://wiki.chompstation13.net/index.php/Rules#Shadekin/%22Anomaly%22_Guidelines'>the Shadekin Guidelines</a> clearly before playing"
 
     flag = NONCREW
@@ -63,6 +63,11 @@
 		return TRUE
 	else
 		return FALSE
+
+/datum/job/shadekin/update_limit(var/comperator)
+	var/current_limit = clamp(comperator / 5, 2, 5) + round(comperator / 50)
+	if(current_limit > total_positions)
+		total_positions = current_limit
 
 /datum/job/vr_avatar //So VR avatars dont spawn with PDAs and flood the servers
 	title = JOB_VR

--- a/modular_chomp/code/game/jobs/job/noncrew.dm
+++ b/modular_chomp/code/game/jobs/job/noncrew.dm
@@ -34,8 +34,8 @@
 /datum/job/shadekin
     title = JOB_ANOMALY
     disallow_jobhop = TRUE
-    total_positions = 2
-    spawn_positions = 2
+    total_positions = 3
+    spawn_positions = 3
     supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property. Please read <a href='https://wiki.chompstation13.net/index.php/Rules#Shadekin/%22Anomaly%22_Guidelines'>the Shadekin Guidelines</a> clearly before playing"
 
     flag = NONCREW
@@ -65,7 +65,7 @@
 		return FALSE
 
 /datum/job/shadekin/update_limit(var/comperator)
-	var/current_limit = clamp(comperator / 5, 2, 5) + round(comperator / 50)
+	var/current_limit = clamp(comperator / 5, 3, 5) + round(comperator / 50)
 	if(current_limit > total_positions)
 		total_positions = current_limit
 


### PR DESCRIPTION
## About The Pull Request
## Changelog
After internal discussion, anomaly should be rarer compared to crew. Having 5 of them and only 5 crew feels overwhelming. (Just drafted for now)

We'll allow more during high pop, but keep it lower during empty shifts.

New limit: clamp(crew/5, 3, 5) + round(crew/50)

As Table:
0-19: 3 slots
20-24: 4 slots
25-49: 5 slots
50-99: 6 slots
100-149: 7 slots
150-199: 8 slots
etc.
:cl:
qol: linearizes the anomaly limit
/:cl:
