### PR TITLE
Fixes vore sprites breaking for non-humanoid shaped xenochimera

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_abilities_vr.dm
@@ -148,6 +148,7 @@
 	revive()
 	mutations.Remove(HUSK)
 	setBrainLoss(braindamage)
+	species.update_vore_belly_def_variant() //CHOMPedit fixes vore sprites for teshari xenochimera
 
 	if(!uninjured)
 		nutrition = old_nutrition * 0.5


### PR DESCRIPTION

## About The Pull Request
Teshari chimera real.
## Changelog
:cl:
fix: Reconstituting as a teshari xeno chimera should no longer break vore sprites.
/:cl:
