### PR TITLE
Paradox Gen Friendliness Update

### DIFF
--- a/maps/southern_cross/southern_cross-6.dmm
+++ b/maps/southern_cross/southern_cross-6.dmm
@@ -25,24 +25,24 @@
 	id = "anolongstorage"
 	},
 /turf/simulated/floor/plating{
-	temperature = 243.15;
+	nitrogen = 93.7835;
 	oxygen = 20.7263;
-	nitrogen = 93.7835
+	temperature = 243.15
 	},
 /area/surface/outpost/research/xenoarcheology)
 "ai" = (
 /turf/simulated/floor/plating{
-	temperature = 243.15;
+	nitrogen = 93.7835;
 	oxygen = 20.7263;
-	nitrogen = 93.7835
+	temperature = 243.15
 	},
 /area/surface/outpost/research/xenoarcheology)
 "aj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
-	temperature = 243.15;
+	nitrogen = 93.7835;
 	oxygen = 20.7263;
-	nitrogen = 93.7835
+	temperature = 243.15
 	},
 /area/surface/outpost/research/xenoarcheology)
 "ak" = (
@@ -51,18 +51,18 @@
 	req_access = list(65)
 	},
 /turf/simulated/floor/plating{
-	temperature = 243.15;
+	nitrogen = 93.7835;
 	oxygen = 20.7263;
-	nitrogen = 93.7835
+	temperature = 243.15
 	},
 /area/surface/outpost/research/xenoarcheology)
 "al" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
-	temperature = 243.15;
+	nitrogen = 93.7835;
 	oxygen = 20.7263;
-	nitrogen = 93.7835
+	temperature = 243.15
 	},
 /area/surface/outpost/research/xenoarcheology)
 "am" = (
@@ -4189,11 +4189,6 @@
 	},
 /turf/simulated/wall/solidrock,
 /area/surface/cave/unexplored/normal)
-"jK" = (
-/obj/structure/table/marble,
-/obj/item/weapon/book/manual/anomaly_testing,
-/turf/simulated/floor/concrete,
-/area/surface/cave/explored/trader)
 "jU" = (
 /obj/structure/table/marble,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/specialwhiskey,
@@ -4347,6 +4342,14 @@
 	temperature = 243.15
 	},
 /area/surface/outpost/research/xenoarcheology/exterior)
+"tS" = (
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/surface/cave/explored/trader)
 "xh" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating{
@@ -4388,6 +4391,12 @@
 	temperature = 243.15
 	},
 /area/surface/outpost/mining_main/cave)
+"BX" = (
+/obj/structure/bed,
+/obj/item/weapon/bedsheet/cosmos,
+/mob/living/simple_mob/humanoid/starhunter/trader/farmer,
+/turf/simulated/floor/concrete,
+/area/surface/cave/explored/trader)
 "Co" = (
 /obj/machinery/light{
 	dir = 8
@@ -4462,10 +4471,7 @@
 /turf/simulated/floor/concrete,
 /area/surface/cave/explored/trader)
 "In" = (
-/obj/structure/bed,
-/obj/item/weapon/bedsheet/cosmos,
-/mob/living/simple_mob/humanoid/starhunter/trader/farmer,
-/turf/simulated/floor/concrete,
+/turf/simulated/floor/plating,
 /area/surface/cave/explored/trader)
 "Jk" = (
 /obj/effect/map_effect/portal/line/side_a,
@@ -4536,6 +4542,17 @@
 	temperature = 243.15
 	},
 /area/surface/outpost/research/xenoarcheology/exterior)
+"QY" = (
+/obj/machinery/power/apc/alarms_hidden{
+	dir = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable/blue{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/surface/cave/explored/trader)
 "RM" = (
 /turf/simulated/wall/sandstone,
 /area/surface/cave/explored/trader)
@@ -4567,6 +4584,14 @@
 /obj/effect/map_effect/portal/master/side_a/caves_to_wilderness/river,
 /turf/simulated/wall/solidrock,
 /area/surface/outpost/wall)
+"UB" = (
+/obj/machinery/power/rtg/advanced,
+/obj/structure/cable/blue{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/surface/cave/explored/trader)
 "VK" = (
 /obj/structure/cable/heavyduty{
 	icon_state = "4-8"
@@ -4586,6 +4611,19 @@
 	outdoors = 0
 	},
 /area/surface/cave/explored/normal)
+"WQ" = (
+/obj/structure/table/marble,
+/obj/item/weapon/book/manual/anomaly_testing,
+/turf/simulated/floor/concrete,
+/area/surface/cave/explored/trader)
+"Xk" = (
+/obj/structure/cable/blue{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/surface/cave/explored/trader)
 "YU" = (
 /turf/simulated/floor/concrete,
 /area/surface/cave/explored/trader)
@@ -68575,10 +68613,10 @@ ae
 ae
 ae
 RM
-YU
-YU
-YU
-sH
+BX
+WQ
+kx
+RM
 YU
 YU
 YU
@@ -68836,7 +68874,7 @@ RM
 YU
 YU
 YU
-RM
+sH
 YU
 YU
 YU
@@ -69608,8 +69646,8 @@ ae
 ae
 RM
 In
-jK
-kx
+In
+UB
 RM
 St
 oO
@@ -69865,9 +69903,9 @@ ae
 ae
 ae
 RM
-YU
-YU
-YU
+QY
+Xk
+tS
 RM
 YU
 YU
@@ -70123,9 +70161,9 @@ ae
 ae
 ae
 RM
-YU
-YU
-YU
+In
+In
+In
 sH
 YU
 YU

--- a/modular_chomp/code/game/machinery/paradox.dm
+++ b/modular_chomp/code/game/machinery/paradox.dm
@@ -1,6 +1,7 @@
 /obj/machinery/paradoxrift
 	name = "Paradoxical Rift Generator"
-	idle_power_usage = 50000000
+	idle_power_usage = 2500000
+	use_power = USE_POWER_OFF
 	icon = 'modular_chomp/icons/obj/machines/defense.dmi'
 	icon_state = "paradox"
 	circuit = /obj/item/weapon/circuitboard/paradoxrift
@@ -82,24 +83,26 @@
 	icon_state = "medicalkit"
 
 /obj/random/greaterportalloot/item_to_spawn()
-	return pick(prob(2);/obj/item/weapon/stock_parts/capacitor/omni,
-				prob(2);/obj/item/weapon/stock_parts/manipulator/omni,
-				prob(2);/obj/item/weapon/stock_parts/scanning_module/omni,
-				prob(2);/obj/item/weapon/stock_parts/matter_bin/omni,
-				prob(2);/obj/item/weapon/stock_parts/micro_laser/omni,
-				prob(2);/obj/item/stack/material/phoron,
-				prob(2);/obj/item/stack/material/deuterium,
-				prob(2);/obj/item/stack/material/tritium,
-				prob(2);/obj/item/stack/material/uranium,
-				prob(6);/obj/item/weapon/rcd,
-				prob(6);/obj/item/weapon/rcd/shipwright,
-				prob(6);/obj/item/weapon/rcd/advanced,
+	return pick(prob(6);/obj/item/weapon/stock_parts/capacitor/omni,
+				prob(6);/obj/item/weapon/stock_parts/manipulator/omni,
+				prob(6);/obj/item/weapon/stock_parts/scanning_module/omni,
+				prob(6);/obj/item/weapon/stock_parts/matter_bin/omni,
+				prob(6);/obj/item/weapon/stock_parts/micro_laser/omni,
+				prob(4);/obj/random/smes_coil,
+				prob(4);/obj/random/bomb_supply,
+				prob(4);/obj/random/powercell,
+				prob(4);/obj/random/tool/powermaint,
+				prob(1);/obj/item/weapon/rcd,
+				prob(4);/obj/item/weapon/rcd/advanced,
 				prob(1);/obj/vehicle/bike/random,
 				prob(1);/obj/vehicle/train/engine/quadbike/random,
-				prob(1);/obj/vehicle/bike/random,
-				prob(6);/obj/structure/closet/crate/secure/lootsafe/numberlock,
-				prob(6);/obj/structure/closet/crate/secure/loot
-
+				prob(4);/obj/random/material,
+				prob(4);/obj/random/material/refined,
+				prob(4);/obj/random/material/precious,
+				prob(1);/obj/random/bluespace,
+				prob(4);/obj/random/tool/alien,
+				prob(1);/obj/item/weapon/circuitboard/paradoxrift,
+				prob(4);/obj/item/prop/alien/junk
 				)
 
 /obj/random/mob/interspace
@@ -112,11 +115,12 @@
 	mob_wander_distance = 7
 
 /obj/random/mob/interspace/item_to_spawn()
-	return pick(prob(5);/mob/living/simple_mob/humanoid/starhunter/trader/miner,
-				prob(5);/mob/living/simple_mob/humanoid/starhunter/trader/reliccollecter,
-				prob(5);/mob/living/simple_mob/humanoid/starhunter/trader/farmer,
+	return pick(prob(5);/mob/living/simple_mob/vore/sonadile,
+				prob(5);/mob/living/simple_mob/vore/solargrub,
+				prob(5);/mob/living/simple_mob/vore/stalker,
 				prob(1);/mob/living/simple_mob/vore/bigdragon,
 				prob(1);/mob/living/simple_mob/humanoid/cultist/magus/rift,
+				prob(1);/mob/living/simple_mob/vore/cryptdrake,
 				prob(15);/mob/living/simple_mob/vore/demonAI,
 				prob(25);/mob/living/simple_mob/shadekin,
 				prob(25);/mob/living/simple_mob/vore/solargrub,


### PR DESCRIPTION
Spins
makes this wierd item a bit easier to use.
Adjusts it's pulls
And makes it so the area to nab it should have power.
## About The Pull Request
## Changelog
:cl:
balance: Paradox gen requires to be wired like an emitter
balance: Paradox gen requires 1/20th of the power now. Loot pool is adjusted
/:cl:
