### PR TITLE
Vend-B-Gone

### DIFF
--- a/maps/southern_cross/southern_cross-8.dmm
+++ b/maps/southern_cross/southern_cross-8.dmm
@@ -1410,8 +1410,8 @@
 	},
 /area/centcom/bar)
 "aQp" = (
-/obj/machinery/vending/loadout/gadget,
 /obj/effect/floor_decal/techfloor/orange,
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor/reinforced,
 /area/shadekin)
 "aQu" = (
@@ -1793,8 +1793,8 @@
 /area/centcom/bar)
 "bfZ" = (
 /obj/machinery/vending/boozeomat{
-	pixel_y = 16;
-	req_log_access = null
+	req_access = null;
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/milspec/color/silver,
 /turf/simulated/floor/tiled/techmaint,
@@ -2412,10 +2412,7 @@
 /turf/unsimulated/beach/sand,
 /area/beach)
 "bIF" = (
-/obj/machinery/vending/hydroseeds,
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 8
-	},
+/obj/machinery/vending/weeb,
 /turf/simulated/floor/reinforced,
 /area/shadekin)
 "bIK" = (
@@ -11215,15 +11212,6 @@
 	icon_state = "vault"
 	},
 /area/centcom/specops)
-"jQF" = (
-/obj/machinery/vending/boozeomat{
-	req_access = null
-	},
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shadekin)
 "jQU" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -12624,9 +12612,11 @@
 	},
 /area/centcom/bar)
 "kVf" = (
-/obj/machinery/vending/tool,
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 4
+	},
+/obj/machinery/vending/blood{
+	req_access = null
 	},
 /turf/simulated/floor/reinforced,
 /area/shadekin)
@@ -15288,13 +15278,6 @@
 /obj/structure/flight_right,
 /turf/simulated/shuttle/floor/darkred,
 /area/shuttle/skipjack)
-"nzI" = (
-/obj/machinery/vending/engineering{
-	req_access = null
-	},
-/obj/effect/floor_decal/techfloor/orange,
-/turf/simulated/floor/reinforced,
-/area/shadekin)
 "nAe" = (
 /obj/machinery/door/window/westright{
 	name = "Storefront";
@@ -15548,13 +15531,6 @@
 	icon_state = "dark"
 	},
 /area/centcom/creed)
-"nLo" = (
-/obj/machinery/vending/weeb,
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 9
-	},
-/turf/simulated/floor/reinforced,
-/area/shadekin)
 "nMG" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 8;
@@ -16150,10 +16126,6 @@
 /obj/structure/window/reinforced/survival_pod,
 /turf/simulated/floor,
 /area/shadekin)
-"orQ" = (
-/obj/machinery/vending/dinnerware,
-/turf/simulated/floor/reinforced,
-/area/shadekin)
 "osb" = (
 /obj/machinery/computer/cloning,
 /turf/unsimulated/floor{
@@ -16634,13 +16606,6 @@
 	icon_state = "wood"
 	},
 /area/centcom/bar)
-"pbJ" = (
-/obj/machinery/vending/cigarette,
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 10
-	},
-/turf/simulated/floor/reinforced,
-/area/shadekin)
 "pcd" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin,
@@ -16815,12 +16780,10 @@
 /turf/simulated/shuttle/wall/no_join,
 /area/shuttle/supply)
 "pkK" = (
-/obj/machinery/vending/engivend{
-	req_access = null
-	},
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/machinery/vending/bepis,
 /turf/simulated/floor/reinforced,
 /area/shadekin)
 "plX" = (
@@ -20486,15 +20449,6 @@
 /obj/machinery/floodlight,
 /turf/simulated/shuttle/plating,
 /area/shuttle/skipjack)
-"sPq" = (
-/obj/machinery/vending/blood{
-	req_access = null
-	},
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shadekin)
 "sQM" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -22925,13 +22879,6 @@
 	icon_state = "white"
 	},
 /area/centcom/medical)
-"vdq" = (
-/obj/machinery/vending/bepis,
-/obj/effect/floor_decal/techfloor/orange{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced,
-/area/shadekin)
 "vdG" = (
 /obj/effect/floor_decal/corner/red/full,
 /turf/simulated/floor/holofloor/tiled,
@@ -61563,12 +61510,12 @@ wRY
 wKW
 pyc
 wKW
-nLo
-vdq
-sPq
-jQF
-bIF
-pbJ
+oSi
+owZ
+owZ
+owZ
+owZ
+wRY
 dRZ
 bMy
 oTO
@@ -62082,9 +62029,9 @@ wKW
 kzy
 wee
 ifb
-orQ
 faE
-nzI
+rtJ
+qhK
 qfC
 bMy
 vvS
@@ -62599,7 +62546,7 @@ pkK
 eAT
 sYR
 bST
-eAT
+bIF
 aQp
 eay
 bMy


### PR DESCRIPTION

## About The Pull Request
This may require staff discussion before merging to check that my train of thought makes sense. Some of the vending machines still dispense dummy useful gear that shadekin shouldn't be using otherwise they'll be rulebreaking anyways most likely. In the event that they need this stuff anyway, there's always station sources and the autolathe still in place too. See list below for detail on my thought process. This also makes more room in case further vending machines come along that'd be neat to add, like maybe the departmental uniform vendors?

Cigarette Machine - Let the shadekin smoke (kept it)
MegaSeed Servitor - Removed. Shadekin already have seed storage and hydroponics elsewhere
Booze-O-Mat - Removed. They have one in the kitchen already and it makes more sense there. removed access lock from that vend.
Blood-Onator - Hrmmm... was tempted to remove this, but for the very rare case of obligate bloodsucker shadekin, this stays. It's borderline though.
Bepis - No reason to remove really
Nippon-tan! - Eh, just food, it's fine
Hot drinks machine - More food and drink
Robust drinks - F&D
Soft Robustdrinks - More of the same
Dinnerware - Removed. They already have two of these in the kitchen
Donk-Soft - Tempted to remove to encourage the use of the station one instead but actually the hideout could be a neat place for a donksoft fight so I decided to keep this
Robco Tool Maker - Explicitly busted. Free insuls, mesons and heavy duty cables? Nah, shadekin shouldn't need these
Chips Co. - A lot of computer tech and circuit tech that shadekin probably shouldn't be using. i removed this but if someone wants to use em as shadekin I'd recommend using the station vend instead. (Also, mini translocator)
Thespian's Delight - Scene gear. Decided to keep it though was tempted to remove and encourage use of station vend instead, but eh, they can keep it
General Jump - It's fine, just clothing
Looty Inc. - Same as above
Duplicate Thespian's delight - Eh? Not sure why this was here, removed
Engi-Vend - More engineering gear that shadekin shouldn't really need including free AR-E's. Removed
Bits and Bobs - Gaming stuff, they can keep this
Big D's Best - More cosmetic stuff, all good.
The Basics - What more needs to be said? All fine
A ton fo food vendors I can't be bothered to list - All totally fine, gosh there's a lot of food
AlliCo Baubles etc - Yay more plushies. Keep
Loot Trawler - Wasn't sure on this one as shadekin and fishing seems a bit odd, but in the end I decided to leave it. Nobody's gonna complain if it stays
A ton more food vendors...
YouTool vend - Removed. Shadekin already have a youtool in the autolathe room anyway
ColorMate - Good to have, keep it 
## Changelog
:cl:
maptweak: Moved and removed some vending machines in the dark which were unnecessary or gave shadekin loot they shouldn't be using
/:cl:
