### PR TITLE
move asset cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ vchat.db*
 #Ignore everything in datafolder and subdirectories
 /data/**/*
 /tmp/**/*
+/cache/**/*
 
 #Ignore byond config folder.
 /cfg/**/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM i386/ubuntu:xenial as base
 
-ARG BYOND_MAJOR=514
-ARG BYOND_MINOR=1589
+ARG BYOND_MAJOR=515
+ARG BYOND_MINOR=1640
 
 RUN apt-get update \
     && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get install -y --no-install-recommends \
     gcc-multilib \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-host i686-unknown-linux-gnu \
     && git init \
-    && git remote add origin https://github.com/VOREStation/rust-g
+    && git remote add origin https://github.com/tgstation/rust-g
 
 COPY _build_dependencies.sh .
 

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -1,4 +1,4 @@
-#define ASSET_CROSS_ROUND_CACHE_DIRECTORY "tmp/assets"
+#define ASSET_CROSS_ROUND_CACHE_DIRECTORY "cache/assets" //CHOMPEdit, moved there as we clear the tmp folder like TG does
 
 //These datums are used to populate the asset cache, the proc "register()" does this.
 //Place any asset datums you create in asset_list_items.dm


### PR DESCRIPTION

## About The Pull Request
We also use the server main subsystem, so persistent assets shouldn't be in tmp anymore.
## Changelog
:cl:
server: move the asset cache dir in the same way TG did
/:cl:
