### PR TITLE
fixes phantom blood stains

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -493,6 +493,7 @@
 	if(istype(blood_DNA, /list))
 		blood_DNA = null
 		return TRUE
+	blood_color = null //chompfixy, cleaning objects saved its future blood color no matter what
 
 /atom/proc/on_rag_wipe(var/obj/item/weapon/reagent_containers/glass/rag/R)
 	clean_blood()


### PR DESCRIPTION

## About The Pull Request
If you at any point stain yourself or an object with blood, the first color of blood will always be what color the bloodstain is no matter what. This fixes that, thank god everything is in one proc. This should fix soap, hand washing, showers, etc. Did surface level testing and found no runtimes.
## Changelog
:cl:
fix: fixes blood cleaning on objects.
/:cl:
