### PR TITLE
Flexible Digestion Damage

### DIFF
--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -18,6 +18,7 @@
 	var/human_prey_swallow_time = 100		// Time in deciseconds to swallow /mob/living/carbon/human
 	var/nonhuman_prey_swallow_time = 30		// Time in deciseconds to swallow anything else
 	var/nutrition_percent = 100				// Nutritional percentage per tick in digestion mode
+	var/digest_max = 36						// CHOMPEdit; maximum total damage across all types
 	var/digest_brute = 0.5					// Brute damage per tick in digestion mode
 	var/digest_burn = 0.5					// Burn damage per tick in digestion mode
 	var/digest_oxy = 0						// Oxy damage per tick in digestion mode
@@ -470,7 +471,8 @@
 	"entrance_logs",
 	"noise_freq",
 	"private_struggle",
-	"item_digest_logs", //CHOMP end of variables from CHOMP
+	"item_digest_logs",
+	"digest_max", //CHOMP end of variables from CHOMP
 	"egg_type",
 	"save_digest_mode",
 	"eating_privacy_local",
@@ -1516,6 +1518,26 @@
 			emote_lists[DM_UNABSORB] = raw_list
 
 	return
+
+//CHOMPEdit Start - new procs for handling digestion damage as a total rather than per-type
+// Returns the current total digestion damage per tick of a belly.
+/obj/belly/proc/get_total_digestion_damage()
+	var/total = digest_brute + digest_burn + digest_oxy + digest_tox + digest_clone
+	return total
+
+// Returns the remaining 'budget' of digestion damage between the current and the maximum.
+/obj/belly/proc/get_unused_digestion_damage()
+	var/total = digest_brute + digest_burn + digest_oxy + digest_tox + digest_clone
+	return max(digest_max - total, 0)
+
+/obj/belly/proc/set_zero_digestion_damage()
+	digest_brute = 0
+	digest_burn = 0
+	digest_oxy = 0
+	digest_tox = 0
+	digest_clone = 0
+	return
+// CHOMPEdit End
 
 // Handle the death of a mob via digestion.
 // Called from the process_Life() methods of bellies that digest prey.
@@ -2592,7 +2614,8 @@
 	dupe.is_feedable = is_feedable
 	dupe.entrance_logs = entrance_logs
 	dupe.noise_freq = noise_freq
-	dupe.item_digest_logs = item_digest_logs //CHOMP end of variables from CHOMP
+	dupe.item_digest_logs = item_digest_logs
+	dupe.digest_max = digest_max //CHOMP end of variables from CHOMP
 
 	dupe.belly_fullscreen = belly_fullscreen
 	dupe.disable_hud = disable_hud

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -1522,13 +1522,11 @@
 //CHOMPEdit Start - new procs for handling digestion damage as a total rather than per-type
 // Returns the current total digestion damage per tick of a belly.
 /obj/belly/proc/get_total_digestion_damage()
-	var/total = digest_brute + digest_burn + digest_oxy + digest_tox + digest_clone
-	return total
+	return (digest_brute + digest_burn + digest_oxy + digest_tox + digest_clone)
 
 // Returns the remaining 'budget' of digestion damage between the current and the maximum.
 /obj/belly/proc/get_unused_digestion_damage()
-	var/total = digest_brute + digest_burn + digest_oxy + digest_tox + digest_clone
-	return max(digest_max - total, 0)
+	return max(digest_max - get_total_digestion_damage(), 0)
 
 /obj/belly/proc/set_zero_digestion_damage()
 	digest_brute = 0

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -3266,51 +3266,40 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 			. = TRUE
 		// CHOMPEdit Start - modified these to be flexible rather than maxing at 6/6/12/6/6
 		if("b_burn_dmg")
-			var/old_damage = host.vore_selected.digest_burn
-			var/max_total_damage = host.vore_selected.digest_max
-			var/unused_damage = host.vore_selected.get_unused_digestion_damage() + old_damage // since we don't care what this field's damage was already set to.
-			// the line below does the input clamping for us already
-			var/new_damage = tgui_input_number(user, "Choose the amount of burn damage prey will take per tick. Max of [max_total_damage] across all damage types. [unused_damage] remaining.", "Set Belly Burn Damage.", old_damage, unused_damage, 0, round_value=FALSE)
+			var/new_damage = tgui_input_number(user, "Choose the amount of burn damage prey will take per tick. Max of [host.vore_selected.digest_max] across all damage types. [host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_burn] remaining.", "Set Belly Burn Damage.", host.vore_selected.digest_burn, host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_burn, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
+			new_damage = CLAMP(new_damage, 0, host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_burn) // sanity check following tgui input
 			host.vore_selected.digest_burn = new_damage
 			host.vore_selected.items_preserved.Cut() //CHOMPAdd
 			. = TRUE
 		if("b_brute_dmg")
-			var/old_damage = host.vore_selected.digest_brute
-			var/max_total_damage = host.vore_selected.digest_max
-			var/unused_damage = host.vore_selected.get_unused_digestion_damage() + old_damage // since we don't care what this field's damage was already set to.
-			var/new_damage = tgui_input_number(user, "Choose the amount of brute damage prey will take per tick. Max of [max_total_damage] across all damage types. [unused_damage] remaining.", "Set Belly Brute Damage.", old_damage, unused_damage, 0, round_value=FALSE)
+			var/new_damage = tgui_input_number(user, "Choose the amount of brute damage prey will take per tick. Max of [host.vore_selected.digest_max] across all damage types. [host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_brute] remaining.", "Set Belly Brute Damage.", host.vore_selected.digest_brute, host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_brute, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
+			new_damage = CLAMP(new_damage, 0, host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_brute)
 			host.vore_selected.digest_brute = new_damage
 			host.vore_selected.items_preserved.Cut() //CHOMPAdd
 			. = TRUE
 		if("b_oxy_dmg")
-			var/old_damage = host.vore_selected.digest_oxy
-			var/max_total_damage = host.vore_selected.digest_max
-			var/unused_damage = host.vore_selected.get_unused_digestion_damage() + old_damage // since we don't care what this field's damage was already set to.
-			var/new_damage = tgui_input_number(user, "Choose the amount of oxygen damage prey will take per tick. Max of [max_total_damage] across all damage types. [unused_damage] remaining.", "Set Belly Oxygen Damage.", old_damage, unused_damage, 0, round_value=FALSE)
+			var/new_damage = tgui_input_number(user, "Choose the amount of oxygen damage prey will take per tick. Max of [host.vore_selected.digest_max] across all damage types. [host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_oxy] remaining.", "Set Belly Oxygen Damage.", host.vore_selected.digest_oxy, host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_oxy, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
+			new_damage = CLAMP(new_damage, 0, host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_oxy)
 			host.vore_selected.digest_oxy = new_damage
 			. = TRUE
 		if("b_tox_dmg")
-			var/old_damage = host.vore_selected.digest_tox
-			var/max_total_damage = host.vore_selected.digest_max
-			var/unused_damage = host.vore_selected.get_unused_digestion_damage() + old_damage // since we don't care what this field's damage was already set to.
-			var/new_damage = tgui_input_number(user, "Choose the amount of toxin damage prey will take per tick. Max of [max_total_damage] across all damage types. [unused_damage] remaining.", "Set Belly Toxin Damage.", old_damage, unused_damage, 0, round_value=FALSE)
+			var/new_damage = tgui_input_number(user, "Choose the amount of toxin damage prey will take per tick. Max of [host.vore_selected.digest_max] across all damage types. [host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_tox] remaining.", "Set Belly Toxin Damage.", host.vore_selected.digest_tox, host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_tox, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
+			new_damage = CLAMP(new_damage, 0, host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_tox)
 			host.vore_selected.digest_tox = new_damage
 			. = TRUE
 		if("b_clone_dmg")
-			var/old_damage = host.vore_selected.digest_clone
-			var/max_total_damage = host.vore_selected.digest_max
-			var/unused_damage = host.vore_selected.get_unused_digestion_damage() + old_damage // since we don't care what this field's damage was already set to.
-			var/new_damage = tgui_input_number(user, "Choose the amount of genetic (clone) damage prey will take per tick. Max of [max_total_damage] across all damage types. [unused_damage] remaining.", "Set Belly Clone Damage.", old_damage, unused_damage, 0, round_value=FALSE)
+			var/new_damage = tgui_input_number(user, "Choose the amount of genetic (clone) damage prey will take per tick. Max of [host.vore_selected.digest_max] across all damage types. [host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_clone] remaining.", "Set Belly Genetic Damage.", host.vore_selected.digest_clone, host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_clone, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
+			new_damage = CLAMP(new_damage, 0, host.vore_selected.get_unused_digestion_damage() + host.vore_selected.digest_clone)
 			host.vore_selected.digest_clone = new_damage
 			. = TRUE
 		// CHOMPEdit End

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -1070,7 +1070,7 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 					var/new_emote_time = belly_data["emote_time"]
 					new_belly.emote_time = CLAMP(new_emote_time, 60, 600)
 
-				new_belly.set_zero_digestion_damage // CHOMP Edit; needed for importing a belly to overwrite an existing belly; otherwise pre-existing values throw off the unused digestion damage.
+				new_belly.set_zero_digestion_damage() // CHOMP Edit; needed for importing a belly to overwrite an existing belly; otherwise pre-existing values throw off the unused digestion damage.
 
 				if(isnum(belly_data["digest_brute"]))
 					var/new_digest_brute = belly_data["digest_brute"]

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -3264,88 +3264,56 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 			var/new_new_nutrition = CLAMP(new_nutrition, 0.01, 100)
 			host.vore_selected.nutrition_percent = new_new_nutrition
 			. = TRUE
+		// CHOMPEdit Start - modified these to be flexible rather than maxing at 6/6/12/6/6
 		if("b_burn_dmg")
-			// var/new_damage = tgui_input_number(user, "Choose the amount of burn damage prey will take per tick. Ranges from 0 to 6.", "Set Belly Burn Damage.", host.vore_selected.digest_burn, 6, 0, round_value=FALSE)
-			// CHOMP Edit
 			var/old_damage = host.vore_selected.digest_burn
 			var/max_total_damage = host.vore_selected.digest_max
-			var/current_total_damage = host.vore_selected.get_total_digestion_damage()
-			var/new_damage = tgui_input_number(user, "Choose the amount of burn damage prey will take per tick. Max of 36 across all damage types.", "Set Belly Burn Damage.", old_damage, max_total_damage, 0, round_value=FALSE)
+			var/unused_damage = host.vore_selected.get_unused_digestion_damage() + old_damage // since we don't care what this field's damage was already set to.
+			// the line below does the input clamping for us already
+			var/new_damage = tgui_input_number(user, "Choose the amount of burn damage prey will take per tick. Max of [max_total_damage] across all damage types. [unused_damage] remaining.", "Set Belly Burn Damage.", old_damage, unused_damage, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
-			// the highest we're allowed to set this damage type (ignore the damage type itself, since that's what we're changing)
-			var/max_allowed = max(max_total_damage - current_total_damage + old_damage, 0)
-			// var/new_new_damage = CLAMP(new_damage, 0, 6)
-			var/new_new_damage = CLAMP(new_damage, 0, max_allowed)
-			// End CHOMP Edit
-			host.vore_selected.digest_burn = new_new_damage
+			host.vore_selected.digest_burn = new_damage
 			host.vore_selected.items_preserved.Cut() //CHOMPAdd
 			. = TRUE
 		if("b_brute_dmg")
-			// var/new_damage = tgui_input_number(user, "Choose the amount of brute damage prey will take per tick. Ranges from 0 to 6", "Set Belly Brute Damage.", host.vore_selected.digest_brute, 6, 0, round_value=FALSE)
-			// CHOMP Edit
 			var/old_damage = host.vore_selected.digest_brute
 			var/max_total_damage = host.vore_selected.digest_max
-			var/current_total_damage = host.vore_selected.get_total_digestion_damage()
-			var/new_damage = tgui_input_number(user, "Choose the amount of brute damage prey will take per tick. Max of 36 across all damage types.", "Set Belly Brute Damage.", old_damage, max_total_damage, 0, round_value=FALSE)
+			var/unused_damage = host.vore_selected.get_unused_digestion_damage() + old_damage // since we don't care what this field's damage was already set to.
+			var/new_damage = tgui_input_number(user, "Choose the amount of brute damage prey will take per tick. Max of [max_total_damage] across all damage types. [unused_damage] remaining.", "Set Belly Brute Damage.", old_damage, unused_damage, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
-			// the highest we're allowed to set this damage type (ignore the damage type itself, since that's what we're changing)
-			var/max_allowed = max(max_total_damage - current_total_damage + old_damage, 0)
-			// var/new_new_damage = CLAMP(new_damage, 0, 6)
-			var/new_new_damage = CLAMP(new_damage, 0, max_allowed)
-			// End CHOMP Edit
-			host.vore_selected.digest_brute = new_new_damage
+			host.vore_selected.digest_brute = new_damage
 			host.vore_selected.items_preserved.Cut() //CHOMPAdd
 			. = TRUE
 		if("b_oxy_dmg")
-			// var/new_damage = tgui_input_number(user, "Choose the amount of suffocation damage prey will take per tick. Ranges from 0 to 12.", "Set Belly Suffocation Damage.", host.vore_selected.digest_oxy, 12, 0, round_value=FALSE)
-			// CHOMP Edit
 			var/old_damage = host.vore_selected.digest_oxy
 			var/max_total_damage = host.vore_selected.digest_max
-			var/current_total_damage = host.vore_selected.get_total_digestion_damage()
-			var/new_damage = tgui_input_number(user, "Choose the amount of suffocation damage prey will take per tick. Max of 36 across all damage types.", "Set Belly Suffocation Damage.", old_damage, max_total_damage, 0, round_value=FALSE)
+			var/unused_damage = host.vore_selected.get_unused_digestion_damage() + old_damage // since we don't care what this field's damage was already set to.
+			var/new_damage = tgui_input_number(user, "Choose the amount of oxygen damage prey will take per tick. Max of [max_total_damage] across all damage types. [unused_damage] remaining.", "Set Belly Oxygen Damage.", old_damage, unused_damage, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
-			// the highest we're allowed to set this damage type (ignore the damage type itself, since that's what we're changing)
-			var/max_allowed = max(max_total_damage - current_total_damage + old_damage, 0)
-			// var/new_new_damage = CLAMP(new_damage, 0, 12)
-			var/new_new_damage = CLAMP(new_damage, 0, max_allowed)
-			// End CHOMP Edit
-			host.vore_selected.digest_oxy = new_new_damage
+			host.vore_selected.digest_oxy = new_damage
 			. = TRUE
 		if("b_tox_dmg")
-			// var/new_damage = tgui_input_number(user, "Choose the amount of toxins damage prey will take per tick. Ranges from 0 to 6", "Set Belly Toxins Damage.", host.vore_selected.digest_tox, 6, 0, round_value=FALSE)
-			// CHOMP Edit
 			var/old_damage = host.vore_selected.digest_tox
 			var/max_total_damage = host.vore_selected.digest_max
-			var/current_total_damage = host.vore_selected.get_total_digestion_damage()
-			var/new_damage = tgui_input_number(user, "Choose the amount of toxins damage prey will take per tick. Max of 36 across all damage types.", "Set Belly Toxins Damage.", old_damage, max_total_damage, 0, round_value=FALSE)
+			var/unused_damage = host.vore_selected.get_unused_digestion_damage() + old_damage // since we don't care what this field's damage was already set to.
+			var/new_damage = tgui_input_number(user, "Choose the amount of toxin damage prey will take per tick. Max of [max_total_damage] across all damage types. [unused_damage] remaining.", "Set Belly Toxin Damage.", old_damage, unused_damage, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
-			// the highest we're allowed to set this damage type (ignore the damage type itself, since that's what we're changing)
-			var/max_allowed = max(max_total_damage - current_total_damage + old_damage, 0)
-			// var/new_new_damage = CLAMP(new_damage, 0, 6)
-			var/new_new_damage = CLAMP(new_damage, 0, max_allowed)
-			// End CHOMP Edit
-			host.vore_selected.digest_tox = new_new_damage
+			host.vore_selected.digest_tox = new_damage
 			. = TRUE
 		if("b_clone_dmg")
-			// var/new_damage = tgui_input_number(user, "Choose the amount of brute DNA damage (clone) prey will take per tick. Ranges from 0 to 6", "Set Belly Clone Damage.", host.vore_selected.digest_clone, 6, 0, round_value=FALSE)
-			// CHOMP Edit
 			var/old_damage = host.vore_selected.digest_clone
 			var/max_total_damage = host.vore_selected.digest_max
-			var/current_total_damage = host.vore_selected.get_total_digestion_damage()
-			var/new_damage = tgui_input_number(user, "Choose the amount of brute DNA damage (clone) prey will take per tick. Max of 36 across all damage types.", "Set Belly Clone Damage.", old_damage, max_total_damage, 0, round_value=FALSE)
+			var/unused_damage = host.vore_selected.get_unused_digestion_damage() + old_damage // since we don't care what this field's damage was already set to.
+			var/new_damage = tgui_input_number(user, "Choose the amount of genetic (clone) damage prey will take per tick. Max of [max_total_damage] across all damage types. [unused_damage] remaining.", "Set Belly Clone Damage.", old_damage, unused_damage, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
-			// the highest we're allowed to set this damage type (ignore the damage type itself, since that's what we're changing)
-			var/max_allowed = max(max_total_damage - current_total_damage + old_damage, 0)
-			// var/new_new_damage = CLAMP(new_damage, 0, 6)
-			var/new_new_damage = CLAMP(new_damage, 0, max_allowed)
-			// End CHOMP Edit
-			host.vore_selected.digest_clone = new_new_damage
+			host.vore_selected.digest_clone = new_damage
 			. = TRUE
+		// CHOMPEdit End
 		if("b_drainmode")
 			var/list/menu_list = host.vore_selected.drainmodes.Copy()
 			var/new_drainmode = tgui_input_list(user, "Choose Mode (currently [host.vore_selected.digest_mode])", "Mode Choice", menu_list) //ChompEDIT - user, not usr

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -1070,25 +1070,27 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 					var/new_emote_time = belly_data["emote_time"]
 					new_belly.emote_time = CLAMP(new_emote_time, 60, 600)
 
+				new_belly.set_zero_digestion_damage // CHOMP Edit; needed for importing a belly to overwrite an existing belly; otherwise pre-existing values throw off the unused digestion damage.
+
 				if(isnum(belly_data["digest_brute"]))
 					var/new_digest_brute = belly_data["digest_brute"]
-					new_belly.digest_brute = CLAMP(new_digest_brute, 0, 6)
+					new_belly.digest_brute = CLAMP(new_digest_brute, 0, new_belly.get_unused_digestion_damage()) // CHOMP Edit; clamped to unused damage instead of 6
 
 				if(isnum(belly_data["digest_burn"]))
 					var/new_digest_burn = belly_data["digest_burn"]
-					new_belly.digest_burn = CLAMP(new_digest_burn, 0, 6)
+					new_belly.digest_burn = CLAMP(new_digest_burn, 0, new_belly.get_unused_digestion_damage()) // CHOMP Edit; clamped to unused damage instead of 6
 
 				if(isnum(belly_data["digest_oxy"]))
 					var/new_digest_oxy = belly_data["digest_oxy"]
-					new_belly.digest_oxy = CLAMP(new_digest_oxy, 0, 12)
+					new_belly.digest_oxy = CLAMP(new_digest_oxy, 0, new_belly.get_unused_digestion_damage()) // CHOMP Edit; clamped to unused damage instead of 12
 
 				if(isnum(belly_data["digest_tox"]))
 					var/new_digest_tox = belly_data["digest_tox"]
-					new_belly.digest_tox = CLAMP(new_digest_tox, 0, 6)
+					new_belly.digest_tox = CLAMP(new_digest_tox, 0, new_belly.get_unused_digestion_damage()) // CHOMP Edit; clamped to unused damage instead of 6
 
 				if(isnum(belly_data["digest_clone"]))
 					var/new_digest_clone = belly_data["digest_clone"]
-					new_belly.digest_clone = CLAMP(new_digest_clone, 0, 6)
+					new_belly.digest_clone = CLAMP(new_digest_clone, 0, new_belly.get_unused_digestion_damage()) // CHOMP Edit; clamped to unused damage instead of 6
 
 				if(isnum(belly_data["shrink_grow_size"]))
 					var/new_shrink_grow_size = belly_data["shrink_grow_size"]
@@ -3263,40 +3265,85 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 			host.vore_selected.nutrition_percent = new_new_nutrition
 			. = TRUE
 		if("b_burn_dmg")
-			var/new_damage = tgui_input_number(user, "Choose the amount of burn damage prey will take per tick. Ranges from 0 to 6.", "Set Belly Burn Damage.", host.vore_selected.digest_burn, 6, 0, round_value=FALSE)
+			// var/new_damage = tgui_input_number(user, "Choose the amount of burn damage prey will take per tick. Ranges from 0 to 6.", "Set Belly Burn Damage.", host.vore_selected.digest_burn, 6, 0, round_value=FALSE)
+			// CHOMP Edit
+			var/old_damage = host.vore_selected.digest_burn
+			var/max_total_damage = host.vore_selected.digest_max
+			var/current_total_damage = host.vore_selected.get_total_digestion_damage()
+			var/new_damage = tgui_input_number(user, "Choose the amount of burn damage prey will take per tick. Max of 36 across all damage types.", "Set Belly Burn Damage.", old_damage, max_total_damage, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
-			var/new_new_damage = CLAMP(new_damage, 0, 6)
+			// the highest we're allowed to set this damage type (ignore the damage type itself, since that's what we're changing)
+			var/max_allowed = max(max_total_damage - current_total_damage + old_damage, 0)
+			// var/new_new_damage = CLAMP(new_damage, 0, 6)
+			var/new_new_damage = CLAMP(new_damage, 0, max_allowed)
+			// End CHOMP Edit
 			host.vore_selected.digest_burn = new_new_damage
 			host.vore_selected.items_preserved.Cut() //CHOMPAdd
 			. = TRUE
 		if("b_brute_dmg")
-			var/new_damage = tgui_input_number(user, "Choose the amount of brute damage prey will take per tick. Ranges from 0 to 6", "Set Belly Brute Damage.", host.vore_selected.digest_brute, 6, 0, round_value=FALSE)
+			// var/new_damage = tgui_input_number(user, "Choose the amount of brute damage prey will take per tick. Ranges from 0 to 6", "Set Belly Brute Damage.", host.vore_selected.digest_brute, 6, 0, round_value=FALSE)
+			// CHOMP Edit
+			var/old_damage = host.vore_selected.digest_brute
+			var/max_total_damage = host.vore_selected.digest_max
+			var/current_total_damage = host.vore_selected.get_total_digestion_damage()
+			var/new_damage = tgui_input_number(user, "Choose the amount of brute damage prey will take per tick. Max of 36 across all damage types.", "Set Belly Brute Damage.", old_damage, max_total_damage, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
-			var/new_new_damage = CLAMP(new_damage, 0, 6)
+			// the highest we're allowed to set this damage type (ignore the damage type itself, since that's what we're changing)
+			var/max_allowed = max(max_total_damage - current_total_damage + old_damage, 0)
+			// var/new_new_damage = CLAMP(new_damage, 0, 6)
+			var/new_new_damage = CLAMP(new_damage, 0, max_allowed)
+			// End CHOMP Edit
 			host.vore_selected.digest_brute = new_new_damage
 			host.vore_selected.items_preserved.Cut() //CHOMPAdd
 			. = TRUE
 		if("b_oxy_dmg")
-			var/new_damage = tgui_input_number(user, "Choose the amount of suffocation damage prey will take per tick. Ranges from 0 to 12.", "Set Belly Suffocation Damage.", host.vore_selected.digest_oxy, 12, 0, round_value=FALSE)
+			// var/new_damage = tgui_input_number(user, "Choose the amount of suffocation damage prey will take per tick. Ranges from 0 to 12.", "Set Belly Suffocation Damage.", host.vore_selected.digest_oxy, 12, 0, round_value=FALSE)
+			// CHOMP Edit
+			var/old_damage = host.vore_selected.digest_oxy
+			var/max_total_damage = host.vore_selected.digest_max
+			var/current_total_damage = host.vore_selected.get_total_digestion_damage()
+			var/new_damage = tgui_input_number(user, "Choose the amount of suffocation damage prey will take per tick. Max of 36 across all damage types.", "Set Belly Suffocation Damage.", old_damage, max_total_damage, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
-			var/new_new_damage = CLAMP(new_damage, 0, 12)
+			// the highest we're allowed to set this damage type (ignore the damage type itself, since that's what we're changing)
+			var/max_allowed = max(max_total_damage - current_total_damage + old_damage, 0)
+			// var/new_new_damage = CLAMP(new_damage, 0, 12)
+			var/new_new_damage = CLAMP(new_damage, 0, max_allowed)
+			// End CHOMP Edit
 			host.vore_selected.digest_oxy = new_new_damage
 			. = TRUE
 		if("b_tox_dmg")
-			var/new_damage = tgui_input_number(user, "Choose the amount of toxins damage prey will take per tick. Ranges from 0 to 6", "Set Belly Toxins Damage.", host.vore_selected.digest_tox, 6, 0, round_value=FALSE)
+			// var/new_damage = tgui_input_number(user, "Choose the amount of toxins damage prey will take per tick. Ranges from 0 to 6", "Set Belly Toxins Damage.", host.vore_selected.digest_tox, 6, 0, round_value=FALSE)
+			// CHOMP Edit
+			var/old_damage = host.vore_selected.digest_tox
+			var/max_total_damage = host.vore_selected.digest_max
+			var/current_total_damage = host.vore_selected.get_total_digestion_damage()
+			var/new_damage = tgui_input_number(user, "Choose the amount of toxins damage prey will take per tick. Max of 36 across all damage types.", "Set Belly Toxins Damage.", old_damage, max_total_damage, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
-			var/new_new_damage = CLAMP(new_damage, 0, 6)
+			// the highest we're allowed to set this damage type (ignore the damage type itself, since that's what we're changing)
+			var/max_allowed = max(max_total_damage - current_total_damage + old_damage, 0)
+			// var/new_new_damage = CLAMP(new_damage, 0, 6)
+			var/new_new_damage = CLAMP(new_damage, 0, max_allowed)
+			// End CHOMP Edit
 			host.vore_selected.digest_tox = new_new_damage
 			. = TRUE
 		if("b_clone_dmg")
-			var/new_damage = tgui_input_number(user, "Choose the amount of brute DNA damage (clone) prey will take per tick. Ranges from 0 to 6", "Set Belly Clone Damage.", host.vore_selected.digest_clone, 6, 0, round_value=FALSE)
+			// var/new_damage = tgui_input_number(user, "Choose the amount of brute DNA damage (clone) prey will take per tick. Ranges from 0 to 6", "Set Belly Clone Damage.", host.vore_selected.digest_clone, 6, 0, round_value=FALSE)
+			// CHOMP Edit
+			var/old_damage = host.vore_selected.digest_clone
+			var/max_total_damage = host.vore_selected.digest_max
+			var/current_total_damage = host.vore_selected.get_total_digestion_damage()
+			var/new_damage = tgui_input_number(user, "Choose the amount of brute DNA damage (clone) prey will take per tick. Max of 36 across all damage types.", "Set Belly Clone Damage.", old_damage, max_total_damage, 0, round_value=FALSE)
 			if(new_damage == null)
 				return FALSE
-			var/new_new_damage = CLAMP(new_damage, 0, 6)
+			// the highest we're allowed to set this damage type (ignore the damage type itself, since that's what we're changing)
+			var/max_allowed = max(max_total_damage - current_total_damage + old_damage, 0)
+			// var/new_new_damage = CLAMP(new_damage, 0, 6)
+			var/new_new_damage = CLAMP(new_damage, 0, max_allowed)
+			// End CHOMP Edit
 			host.vore_selected.digest_clone = new_new_damage
 			. = TRUE
 		if("b_drainmode")


### PR DESCRIPTION
Lets you pick any amount of damage up to a combined total of 36 for belly digestion damage, rather than a max of 6/6/12/6/6

Damage above the normal limit is already something you can ahelp to be given, and keeping the same overall damage limit means that this isn't particularly more exploitable by bad actors or problem players. The only real difference would be better availability of bellies with bone-crunchy noises. Which... if we don't trust our players even that much then what's the point?

This also adds a digestion_max variable to voregans that controls the maximum total values allowed, and it can be changed in the view variables menu by admins. This value saves alongside a belly (but cannot be exported/imported), and persists between rounds if changed.
## Changelog
:cl:
qol: digestion damage types can be set higher; the max total damage is still the same.
/:cl:
