### PR TITLE
Outsider Buff - Fiber Addition

### DIFF
--- a/code/game/turfs/simulated/outdoors/grass_ch.dm
+++ b/code/game/turfs/simulated/outdoors/grass_ch.dm
@@ -135,12 +135,14 @@ GLOBAL_LIST_INIT(grass_grass,list(
 		),
 	"sif" = list(
 		/obj/structure/flora/sif/eyes = 1,
-		/obj/structure/flora/sif/tendrils = 10
+		/obj/structure/flora/sif/tendrils = 5,
+		/obj/structure/flora/bush = 5
 		),
 	"sifforest" = list(
 		/obj/structure/flora/sif/frostbelle = 1,
 		/obj/structure/flora/sif/eyes = 5,
-		/obj/structure/flora/sif/tendrils = 30
+		/obj/structure/flora/sif/tendrils = 20,
+		/obj/structure/flora/bush = 10
 		),
 	"valley" = list(
 		/obj/structure/flora/sif/eyes = 20,

--- a/modular_chomp/code/datums/crafting/recipes.dm
+++ b/modular_chomp/code/datums/crafting/recipes.dm
@@ -123,3 +123,19 @@
 	time = 60
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
+
+
+//SS13 survivial part 1 aka me giving outsiders easier access to some things.
+/datum/crafting_recipe/sandstone
+	name = "sandstone brick"
+	result = /obj/item/stack/material/sandstone
+	reqs = list(/obj/item/weapon/ore/glass = 4)
+	time = 10 //Not realstic but I don't want to waste too much time.
+	category = CAT_PRIMAL
+
+/datum/crafting_recipe/marble
+	name = "sandstone brick"
+	result = /obj/item/stack/material/marble
+	reqs = list(/obj/item/weapon/ore/marble = 4)
+	time = 10 //Not realstic but I don't want to waste too much time.
+	category = CAT_PRIMAL

--- a/modular_chomp/code/datums/crafting/recipes.dm
+++ b/modular_chomp/code/datums/crafting/recipes.dm
@@ -134,7 +134,7 @@
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/marble
-	name = "sandstone brick"
+	name = "marble brick"
 	result = /obj/item/stack/material/marble
 	reqs = list(/obj/item/weapon/ore/marble = 4)
 	time = 10 //Not realstic but I don't want to waste too much time.

--- a/modular_chomp/code/game/objects/structures/flora.dm
+++ b/modular_chomp/code/game/objects/structures/flora.dm
@@ -1,0 +1,2 @@
+/obj/structure/flora/bush
+	max_harvests = 6 //Buffing this so outsiders aren't at each others throats for fiber.

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4747,6 +4747,7 @@
 #include "modular_chomp\code\game\objects\random\mapping.dm"
 #include "modular_chomp\code\game\objects\random\misc.dm"
 #include "modular_chomp\code\game\objects\structures\desert_planet_structures.dm"
+#include "modular_chomp\code\game\objects\structures\flora.dm"
 #include "modular_chomp\code\game\objects\structures\gargoyle.dm"
 #include "modular_chomp\code\game\objects\structures\holosign.dm"
 #include "modular_chomp\code\game\objects\structures\loot_pile.dm"


### PR DESCRIPTION
Short version, outsiders have easier access to things.
## About The Pull Request
Grabbed an existing bush. It looked snowy, yeeted it into the spawn pool of sif grass types.
It can give up to six fiber.

Also made so sandstone and marble can be created if you gather the raw mineralx4 then wait 10 seconds  for one.
Is 10 seconds unrealistic, yes. But I try to value time, and you're trying out the primal outsider stuff if you're messing with this. Giving yall a gentle pat.
## Changelog
:cl:
qol: New snowish looking bushes have been added to sif grass spawn pool. They can give six fiber used in primal stuff
qol: Sandstone and marble bricks can be manually created at a cost of 4 to 1, and 10 seconds.
/:cl:
