### PR TITLE
Increase main menu window height to kill the scrollbar

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -122,7 +122,7 @@
 		client.prefs.lastlorenews = GLOB.news_data.newsindex
 		SScharacter_setup.queue_preferences_save(client.prefs)
 
-	panel = new(src, "Welcome","Welcome", 210, 400, src) // VOREStation Edit //ChompEDIT, height 300 -> 400
+	panel = new(src, "Welcome","Welcome", 210, 500, src) // VOREStation Edit //ChompEDIT, height 300 -> 500
 	panel.set_window_options("can_close=0")
 	panel.set_content(output)
 	panel.open()


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:
fix: Increase the main menu window height to kill the scrollbar on default load
/:cl:
