### PR TITLE
Re-adds stealth removed signaler deadman switch.

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -15,7 +15,7 @@
 	var/airlock_wire = null
 	var/datum/wires/connected = null
 	var/datum/radio_frequency/radio_connection
-	var/deadman = FALSE
+	var/deadman = FALSE //CHOMPAdd
 
 /obj/item/device/assembly/signaler/Initialize()
 	. = ..()

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -15,6 +15,7 @@
 	var/airlock_wire = null
 	var/datum/wires/connected = null
 	var/datum/radio_frequency/radio_connection
+	var/deadman = FALSE
 
 /obj/item/device/assembly/signaler/Initialize()
 	. = ..()
@@ -129,6 +130,28 @@
 	radio_controller.remove_object(src, frequency)
 	frequency = new_frequency
 	radio_connection = radio_controller.add_object(src, frequency, RADIO_CHAT)
+//CHOMPedit BEGIN re-adds stealth removal
+/obj/item/device/assembly/signaler/process()
+	if(!deadman)
+		STOP_PROCESSING(SSobj, src)
+	var/mob/M = src.loc
+	if(!M || !ismob(M))
+		if(prob(5))
+			signal()
+		deadman = FALSE
+		STOP_PROCESSING(SSobj, src)
+	else if(prob(5))
+		M.visible_message("[M]'s finger twitches a bit over [src]'s signal button!")
+
+/obj/item/device/assembly/signaler/verb/deadman_it()
+	set src in usr
+	set name = "Threaten to push the button!"
+	set desc = "BOOOOM!"
+	deadman = TRUE
+	START_PROCESSING(SSobj, src)
+	log_and_message_admins("is threatening to trigger a signaler deadman's switch")
+	usr.visible_message("<font color='red'>[usr] moves their finger over [src]'s signal button...</font>")
+//CHOMPedit end
 
 /obj/item/device/assembly/signaler/Destroy()
 	if(radio_controller)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -100,6 +100,14 @@
 			ai_holder.react_to_attack(L)
 
 /mob/living/bullet_act(var/obj/item/projectile/P, var/def_zone)
+	//CHOMPedit begin, re-adds stealth removed feature
+	if(istype(get_active_hand(),/obj/item/device/assembly/signaler))
+		var/obj/item/device/assembly/signaler/signaler = get_active_hand()
+		if(signaler.deadman && prob(80))
+			log_and_message_admins("has triggered a signaler deadman's switch")
+			src.visible_message("<font color='red'>[src] triggers their deadman's switch!</font>")
+			signaler.signal()
+	//CHOMPedit end
 
 	if(ai_holder && P.firer)
 		ai_holder.react_to_attack(P.firer)


### PR DESCRIPTION

## About The Pull Request
This was stealth removed in #5470, not even commented out, just straight deleted, adding it back out of principle 
## Changelog
:cl:
add: Re-Adds deadman interaction with signalers again.
/:cl:
