### PR TITLE
[READY TO MERGE] Port's RS's anti job camping to Anomoly

### DIFF
--- a/code/controllers/configuration_ch.dm
+++ b/code/controllers/configuration_ch.dm
@@ -33,6 +33,7 @@
 	var/discord_ahelps_disabled = 0		//Turn this off if you don't want the TGS bot sending you messages whenever an ahelp ticket is created.
 	var/discord_ahelps_all = 0			//Turn this on if you want all admin-PMs to go to be sent to discord, and not only the first message of a ticket.
 
+
 	var/list/ip_whitelist = list()
 
 /hook/startup/proc/read_ch_config()
@@ -102,6 +103,8 @@
 				config.role_request_id_expedition = value
 			if ("role_request_id_silicon")
 				config.role_request_id_silicon = value
+			if("job_camp_time_limit")
+				config.job_camp_time_limit = value MINUTES
 
 
 	var/list/ip_whitelist_lines = file2list("config/ip_whitelist.txt")

--- a/code/controllers/configuration_ch/entries/chompstation.dm
+++ b/code/controllers/configuration_ch/entries/chompstation.dm
@@ -65,3 +65,6 @@
 
 /datum/config_entry/str_list/ip_whitelist
 	protection = CONFIG_ENTRY_LOCKED | CONFIG_ENTRY_HIDDEN
+
+/datum/config_entry/number/job_camp_time_limit
+    default = 10 MINUTES

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -10,12 +10,20 @@ SUBSYSTEM_DEF(job)
 	var/list/department_datums = list()
 	var/debug_messages = FALSE
 
+	var/savepath = "data/job_camp_list.json"	// CHOMPadd
+	var/list/shift_keys = list()				// CHOMPadd
+	var/list/restricted_keys = list()			// CHOMPadd
+
 
 /datum/controller/subsystem/job/Initialize() // CHOMPEdit
 	if(!department_datums.len)
 		setup_departments()
 	if(!occupations.len)
 		setup_occupations()
+	//CHOMPadd begin
+	if(CONFIG_GET(number/job_camp_time_limit))
+		load_camp_lists()
+	//CHOMPadd end
 	return SS_INIT_SUCCESS // CHOMPEdit
 
 /datum/controller/subsystem/job/proc/setup_occupations(faction = "Station")
@@ -141,3 +149,25 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/job_debug_message(message)
 	if(debug_messages)
 		log_debug("JOB DEBUG: [message]")
+
+//CHOMPadd start
+/datum/controller/subsystem/job/proc/load_camp_lists()
+	if(fexists(savepath))
+		restricted_keys = json_decode(file2text(savepath))
+		fdel(savepath)
+
+/datum/controller/subsystem/job/Shutdown(Addr, Natural)
+	. = ..()
+	if(fexists(savepath))
+		fdel(savepath)
+	var/json_to_file = json_encode(shift_keys)
+	if(!json_to_file)
+		to_world("failed to write to json")
+		log_debug("Saving: [savepath] failed jsonencode")
+		return
+
+	//Write it out
+	rustg_file_write(json_to_file, savepath)
+	if(!fexists(savepath))
+		log_debug("Saving: failed to save [savepath]")
+//CHOMPadd end

--- a/code/controllers/subsystems/job.dm
+++ b/code/controllers/subsystems/job.dm
@@ -162,7 +162,6 @@ SUBSYSTEM_DEF(job)
 		fdel(savepath)
 	var/json_to_file = json_encode(shift_keys)
 	if(!json_to_file)
-		to_world("failed to write to json")
 		log_debug("Saving: [savepath] failed jsonencode")
 		return
 

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -39,6 +39,10 @@
 	// Description of the job's role and minimum responsibilities.
 	var/job_description = "This Job doesn't have a description! Please report it!"
 
+	var/camp_protection = FALSE				//CHOMPadd
+	var/list/restricted_keys = list()		//CHOMPadd
+	var/list/shift_keys = list()			//CHOMPadd
+
 /datum/job/New()
 	. = ..()
 	department_accounts = department_accounts || departments_managed
@@ -188,6 +192,13 @@
 	if(brain_type in banned_job_species)
 		return TRUE
 	*/
+
+//CHOMPadd start
+/datum/job/proc/register_shift_key(key)
+	if(key)
+		var/list/keylist = list(key)
+		SSjob.shift_keys[title] += keylist
+//CHOMPadd end
 
 //CHOMPAdd Start
 /datum/job/proc/update_limit(var/comperator)

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -72,6 +72,10 @@ var/global/datum/controller/occupations/job_master
 			player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 			unassigned -= player
 			job.current_positions++
+			//CHOMPadd START
+			if(job.camp_protection && round_duration_in_ds < transfer_controller.shift_hard_end - 30 MINUTES)
+				job.register_shift_key(player.client.ckey)
+			//CHOMPadd END
 			return 1
 	Debug("AR has failed, Player: [player], Rank: [rank]")
 	return 0

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -182,7 +182,7 @@
 		if(SSjob.restricted_keys.len)
 			var/list/check = SSjob.restricted_keys[newjob.title]
 			if(usr.client.ckey in check)
-				span_danger("[newjob.title] is not presently selectable because you played as it last round. It will become available to you in [round((CONFIG_GET(number/job_camp_time_limit) - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
+				span_danger("[newjob.title] is not presently selectable because you played as it last round. It will become available to you in [round((CONFIG_GET(number/job_camp_time_limit) - round_duration_in_ds) / 600)] minutes, if slots remain open.")
 				return
 	//CHOMPadd END
 

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -182,7 +182,7 @@
 		if(SSjob.restricted_keys.len)
 			var/list/check = SSjob.restricted_keys[newjob.title]
 			if(usr.client.ckey in check)
-				to_chat(user,span_danger("[newjob.title] is not presently selectable because you played as it last round. It will become available to you in [round((CONFIG_GET(number/job_camp_time_limit) - round_duration_in_ds) / 600)] minutes, if slots remain open."))
+				to_chat(usr,span_danger("[newjob.title] is not presently selectable because you played as it last round. It will become available to you in [round((CONFIG_GET(number/job_camp_time_limit) - round_duration_in_ds) / 600)] minutes, if slots remain open."))
 				return
 	//CHOMPadd END
 

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -177,7 +177,17 @@
 		return
 	if(newassignment != newjob.title && !(newassignment in newjob.alt_titles))
 		return
+	//CHOMPadd START
+	if(newjob.camp_protection && round_duration_in_ds < CONFIG_GET(number/job_camp_time_limit))
+		if(SSjob.restricted_keys.len)
+			var/list/check = SSjob.restricted_keys[newjob.title]
+			if(usr.client.ckey in check)
+				to_chat(src,"<span class = 'danger'>[newjob.title] is not presently selectable because you played as it last round. It will become available to you in [round((CONFIG_GET(number/job_camp_time_limit) - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
+				return
+	//CHOMPadd END
+
 	if(newjob)
+		newjob.register_shift_key(usr.client.ckey)//CHOMPadd
 		card.access = newjob.get_access()
 		card.rank = newjob.title
 		card.assignment = newassignment

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -182,7 +182,7 @@
 		if(SSjob.restricted_keys.len)
 			var/list/check = SSjob.restricted_keys[newjob.title]
 			if(usr.client.ckey in check)
-				to_chat(src,"<span class = 'danger'>[newjob.title] is not presently selectable because you played as it last round. It will become available to you in [round((CONFIG_GET(number/job_camp_time_limit) - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
+				span_danger("[newjob.title] is not presently selectable because you played as it last round. It will become available to you in [round((CONFIG_GET(number/job_camp_time_limit) - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
 				return
 	//CHOMPadd END
 

--- a/code/game/machinery/computer/timeclock_vr.dm
+++ b/code/game/machinery/computer/timeclock_vr.dm
@@ -182,7 +182,7 @@
 		if(SSjob.restricted_keys.len)
 			var/list/check = SSjob.restricted_keys[newjob.title]
 			if(usr.client.ckey in check)
-				span_danger("[newjob.title] is not presently selectable because you played as it last round. It will become available to you in [round((CONFIG_GET(number/job_camp_time_limit) - round_duration_in_ds) / 600)] minutes, if slots remain open.")
+				to_chat(user,span_danger("[newjob.title] is not presently selectable because you played as it last round. It will become available to you in [round((CONFIG_GET(number/job_camp_time_limit) - round_duration_in_ds) / 600)] minutes, if slots remain open."))
 				return
 	//CHOMPadd END
 

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -74,14 +74,14 @@
 		if(points_left < 0 || traits_left < 0)
 			pass = FALSE
 			to_chat(src,"<span class='warning'>Your custom species is not playable. Reconfigure your traits on the VORE tab.</span>")
-//RS ADD START
+//CHOMPadd start
 	if(J.camp_protection && round_duration_in_ds < CONFIG_GET(number/job_camp_time_limit))
 		if(SSjob.restricted_keys.len)
 			var/list/check = SSjob.restricted_keys[J.title]
 			if(client.ckey in check)
-				to_chat(src,"<span class = 'danger'>[J.title] is not presently selectable because you played as it last round. It will become available to you in [round(CONFIG_GET(number/job_camp_time_limit - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
+				span_danger("[J.title] is not presently selectable because you played as it last round. It will become available to you in [round(CONFIG_GET(number/job_camp_time_limit - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
 				pass = FALSE
-	//RS ADD END
+	//CHOMPadd end
 
 	//CHOMP Addition Begin
 	if(client?.prefs?.neu_traits)

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -79,7 +79,7 @@
 		if(SSjob.restricted_keys.len)
 			var/list/check = SSjob.restricted_keys[J.title]
 			if(client.ckey in check)
-				span_danger("[J.title] is not presently selectable because you played as it last round. It will become available to you in [round(CONFIG_GET(number/job_camp_time_limit - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
+				span_danger("[J.title] is not presently selectable because you played as it last round. It will become available to you in [round(CONFIG_GET(number/job_camp_time_limit - round_duration_in_ds) / 600)] minutes, if slots remain open.")
 				pass = FALSE
 	//CHOMPadd end
 

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -79,7 +79,7 @@
 		if(SSjob.restricted_keys.len)
 			var/list/check = SSjob.restricted_keys[J.title]
 			if(client.ckey in check)
-				span_danger("[J.title] is not presently selectable because you played as it last round. It will become available to you in [round(CONFIG_GET(number/job_camp_time_limit - round_duration_in_ds) / 600)] minutes, if slots remain open.")
+				to_chat(client,span_danger("[J.title] is not presently selectable because you played as it last round. It will become available to you in [round(CONFIG_GET(number/job_camp_time_limit - round_duration_in_ds) / 600)] minutes, if slots remain open."))
 				pass = FALSE
 	//CHOMPadd end
 

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -79,7 +79,7 @@
 		if(SSjob.restricted_keys.len)
 			var/list/check = SSjob.restricted_keys[J.title]
 			if(client.ckey in check)
-				to_chat(src,"<span class = 'danger'>[J.title] is not presently selectable because you played as it last round. It will become available to you in [round((CONFIG_GET(number/job_camp_time_limit - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
+				to_chat(src,"<span class = 'danger'>[J.title] is not presently selectable because you played as it last round. It will become available to you in [round(CONFIG_GET(number/job_camp_time_limit - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
 				pass = FALSE
 	//RS ADD END
 

--- a/code/modules/mob/new_player/new_player_vr.dm
+++ b/code/modules/mob/new_player/new_player_vr.dm
@@ -74,6 +74,14 @@
 		if(points_left < 0 || traits_left < 0)
 			pass = FALSE
 			to_chat(src,"<span class='warning'>Your custom species is not playable. Reconfigure your traits on the VORE tab.</span>")
+//RS ADD START
+	if(J.camp_protection && round_duration_in_ds < CONFIG_GET(number/job_camp_time_limit))
+		if(SSjob.restricted_keys.len)
+			var/list/check = SSjob.restricted_keys[J.title]
+			if(client.ckey in check)
+				to_chat(src,"<span class = 'danger'>[J.title] is not presently selectable because you played as it last round. It will become available to you in [round((CONFIG_GET(number/job_camp_time_limit - round_duration_in_ds) / 600)] minutes, if slots remain open.</span>")
+				pass = FALSE
+	//RS ADD END
 
 	//CHOMP Addition Begin
 	if(client?.prefs?.neu_traits)

--- a/modular_chomp/code/game/jobs/job/noncrew.dm
+++ b/modular_chomp/code/game/jobs/job/noncrew.dm
@@ -32,22 +32,23 @@
  */
 
 /datum/job/shadekin
-    title = JOB_ANOMALY
-    disallow_jobhop = TRUE
-    total_positions = 5
-    spawn_positions = 5
-    supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property. Please read <a href='https://wiki.chompstation13.net/index.php/Rules#Shadekin/%22Anomaly%22_Guidelines'>the Shadekin Guidelines</a> clearly before playing"
+	title = JOB_ANOMALY
+	disallow_jobhop = TRUE
+	total_positions = 5
+	spawn_positions = 5
+	supervisors = "nobody, but you fall under NanoTrasen's Unauthorized Personnel SOP while on NT property. Please read <a href='https://wiki.chompstation13.net/index.php/Rules#Shadekin/%22Anomaly%22_Guidelines'>the Shadekin Guidelines</a> clearly before playing"
 
-    flag = NONCREW
-    departments = list(DEPARTMENT_NONCREW)
-    department_flag = OTHER
-    faction = "Station"
-    assignable = FALSE
-    account_allowed = 0
-    offmap_spawn = TRUE
+	flag = NONCREW
+	departments = list(DEPARTMENT_NONCREW)
+	department_flag = OTHER
+	faction = "Station"
+	assignable = FALSE
+	account_allowed = 0
+	offmap_spawn = TRUE
+	camp_protection = TRUE //So far leave this for shadekin
 
-    outfit_type = /decl/hierarchy/outfit/noncrew
-    job_description = {"Players taking a role of an outsider not employed by NT with no special mechanics. One superpose pod is provided.
+	outfit_type = /decl/hierarchy/outfit/noncrew
+	job_description = {"Players taking a role of an outsider not employed by NT with no special mechanics. One superpose pod is provided.
 		-----Server rules still apply to the fullest
 		-----Outsiders are considered unauthorized personnel on Southern Cross.
 		-----Outsiders are not allowed to take part in events and mini-event areas unless the EM says otherwise.


### PR DESCRIPTION
## About The Pull Request
Makes it so that if you played anomoly last shift, you will have to wait 10 minutes the next shift to be able to play again to give other people a chance to play shadekin. This should help with the same people camping the same job slot multiple shifts in the row and gives people that aren't as online a chance to play.

Code is by VerySoft and currently this affects anomaly only, can be put for future jobs.
## Changelog
:cl:
add: Added anti-job-camping to Anomalys
/:cl:
