### PR TITLE
Blank Mail Envelopes

### DIFF
--- a/code/controllers/subsystems/mail_ch.dm
+++ b/code/controllers/subsystems/mail_ch.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(mail)
 
 	var/mail_waiting = 0					// Pending mail
 	var/mail_per_process = 0.45				// Mail to be generated
+	var/admin_mail = list()					// Mail added by Spawn Mail
 
 /datum/controller/subsystem/mail/fire()
 	mail_waiting += mail_per_process
@@ -42,5 +43,10 @@ SUBSYSTEM_DEF(mail)
 			mail_recipients -= mail_to
 		else
 			new_mail.junk_mail()
+	// Admin mail
+	if(admin_mail)
+		for(var/obj/item/mail/ad_mail in admin_mail)
+			ad_mail.loc = mailcrate
+		clearlist(admin_mail)
 	mail_waiting = 0
 	return mailcrate

--- a/code/game/objects/items/mail_ch.dm
+++ b/code/game/objects/items/mail_ch.dm
@@ -44,6 +44,11 @@
 	var/stamp_offset_y = 2
 	var/opening = FALSE
 
+/obj/item/mail/container_resist(mob/living/M)
+	if(istype(M, /mob/living/voice)) return
+	M.forceMove(get_turf(src))
+	to_chat(M, span_warning("You climb out of \the [src]."))
+
 /obj/item/mail/envelope
 	name = "envelope"
 	icon_state = "mail_large"

--- a/code/modules/admin/admin_verb_lists_vr.dm
+++ b/code/modules/admin/admin_verb_lists_vr.dm
@@ -189,6 +189,7 @@ var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/check_custom_items,
 	/datum/admins/proc/spawn_plant,
 	/datum/admins/proc/spawn_atom,		//allows us to spawn instances,
+	/datum/admins/proc/spawn_mail,	// CHOMPStation Add
 	/client/proc/cmd_admin_droppod_spawn,
 	/client/proc/respawn_character,
 	/client/proc/spawn_character_mob,  //VOREStation Add,

--- a/maps/southern_cross/southern_cross-1.dmm
+++ b/maps/southern_cross/southern_cross-1.dmm
@@ -1786,6 +1786,21 @@
 	dir = 4
 	},
 /obj/structure/closet/crate/mail,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "ahk" = (
@@ -32239,6 +32254,7 @@
 	pixel_x = -5;
 	pixel_y = -5
 	},
+/obj/item/mail/blank,
 /turf/simulated/floor/tiled,
 /area/quartermaster/delivery)
 "vbP" = (

--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -24599,6 +24599,8 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 9
 	},
+/obj/item/mail/blank,
+/obj/item/mail/blank,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "bxA" = (
@@ -26628,6 +26630,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
+/obj/item/mail/blank,
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "bCU" = (
@@ -55322,6 +55325,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
 /turf/simulated/floor/wood/alt/parquet,
 /area/library)
 "iQe" = (
@@ -61001,6 +61009,9 @@
 	pixel_y = 5
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
+/obj/item/mail/blank,
 /turf/simulated/floor/carpet,
 /area/hallway/secondary/entry/docking_lounge)
 "lVD" = (

--- a/modular_chomp/code/datums/supplypacks/supply.dm
+++ b/modular_chomp/code/datums/supplypacks/supply.dm
@@ -1,0 +1,12 @@
+/datum/supply_pack/supply/postal_service
+	name = "Postal Service Supplies"
+	contains = list(
+		/obj/item/mail/blank = 10,
+		/obj/item/weapon/pen/fountain,
+		/obj/item/weapon/pen/multi,
+		/obj/item/device/destTagger,
+		/obj/item/weapon/storage/bag/mail
+	)
+	cost = 15
+	containertype = /obj/structure/closet/crate/nanotrasen
+	containername = "Postal Service crate"

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4705,6 +4705,7 @@
 #include "modular_chomp\code\datums\supplypacks\misc.dm"
 #include "modular_chomp\code\datums\supplypacks\science.dm"
 #include "modular_chomp\code\datums\supplypacks\security.dm"
+#include "modular_chomp\code\datums\supplypacks\supply.dm"
 #include "modular_chomp\code\datums\underwear\socks.dm"
 #include "modular_chomp\code\game\atoms\atoms.dm"
 #include "modular_chomp\code\game\gamemodes\meteor\meteors.dm"


### PR DESCRIPTION
## About The Pull Request

Tired of the same mug or cup coffee you ALWAYS get in the mail, no matter how hard you try to get something else? Well say goodbye to that, this blank envelope will allow you to stuff whatever you wish into an envelope (Yes, this DOES include micros). You can also write who the sender was, and choose the recipient. Make sure to seal it, and let the mail flow!

When choosing for the recipient, you'll get the option to pick one from everyone, including outsiders, anomalies and borgs, that chose to show up in the character directory.

Along with this, there's a new spawn type for EMs. Spawn-Mail works similar to the normal Spawn verb, but this one puts the item inside an envelope, for a specific player. This can be spawned into place or sent through the shuttle like usual.

## Changelog
:cl:
add: Added "Blank Mail Envelope"
add: Added Spawn-Mail proc, staff only.
add: Added Postal Services supply crate
add: Added Blank Mail Envelopes in some points of the station
/:cl:
