### PR TITLE
Makes bone breaks in bellies only audible in whisper range

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1088,11 +1088,14 @@ Note that amputating the affected organ does in fact remove the infection from t
 			owner.emote("scream")
 		jostle_bone()	//VOREStation Edit End
 
-	playsound(src, "fracture", 90, 1, -2) // CHOMPedit: Much more audible bonebreaks.
+	if(istype(owner.loc, /obj/belly)) //CHOMPedit, bone breaks in bellys should be whisper range to prevent bar wide blender prefbreak. This is a hacky passive hardcode, if a pref gets added, remove this if else
+		playsound(src, "fracture", 90, 1, -6.5)
+	else
+		playsound(src, "fracture", 90, 1, -2) // CHOMPedit: Much more audible bonebreaks.
 	status |= ORGAN_BROKEN
 	broken_description = pick("broken","fracture","hairline fracture")
 
-	// Fractures have a chance of getting you out of restraints
+	// Fractures have a	 chance of getting you out of restraints
 	if (prob(25))
 		release_restraints()
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1095,7 +1095,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	status |= ORGAN_BROKEN
 	broken_description = pick("broken","fracture","hairline fracture")
 
-	// Fractures have a	 chance of getting you out of restraints
+	// Fractures have a chance of getting you out of restraints
 	if (prob(25))
 		release_restraints()
 


### PR DESCRIPTION

## About The Pull Request
This is a hacky hard code to a hard code, but if a bone break happens within a belly it will only be audible if you're directly next to the pred doing the blendering. 

If a graphic pref ever gets added, it should replace this code.
## Changelog
:cl:
qol: Bone breaks inside guts are now only audible to people in whisper range, have fun blendering.
/:cl:
