### PR TITLE
Changes loci to address some issues

### DIFF
--- a/code/modules/artifice/telecube.dm
+++ b/code/modules/artifice/telecube.dm
@@ -23,12 +23,12 @@
 	description_info = "Ctrl-Clicking on this object will attempt to activate its unique ability."
 	icon = 'icons/obj/props/telecube.dmi'
 	icon_state = "cube"
-	w_class = ITEMSIZE_SMALL
+	w_class = ITEMSIZE_NO_CONTAINER //CHOMPEdit - Made impossible to store to help resolve a certain repeated issue that has been happening with these.
 	origin_tech = list(TECH_MATERIAL = 7, TECH_POWER = 6, TECH_BLUESPACE = 7, TECH_ARCANE = 2, TECH_PRECURSOR = 2)
 
 	catalogue_data = list(/datum/category_item/catalogue/anomalous/precursor_a/telecube)
 
-	slowdown = 2.5
+	//slowdown = 2.5 //CHOMPEdit - Removes slowdown in exchange for being impossible to store in backpacks.
 
 	throw_range = 2
 


### PR DESCRIPTION

## About The Pull Request
Pair of issues. Loci are supposed to be somewhat difficult to transport, this was previously accomplished with a heavy slowdown to people transporting the locus. This was nullified with a single trait, and due to another issue with people keeping loci in backpacks and inadvertently cryo'ing with them and triggering an explosion, I am swapping this slowdown for an inability to store loci inside of backpacks.
## Changelog
:cl:
balance: rebalanced how locus difficulty of transport is handled. In the process makes it much harder to accidentally destroy the station with loci
/:cl:
