### PR TITLE
Removes round start sci PA, Moves ore storage to cargo warehouse.

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -24554,10 +24554,6 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/brown/bordercorner2,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "bxt" = (
@@ -27168,6 +27164,10 @@
 "bEx" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
 "bEy" = (
@@ -57713,21 +57713,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
 "kar" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/fans/tiny,
 /obj/machinery/smartfridge/sheets/persistent_lossy{
 	desc = "An industrial sized storage unit for materials. Following company policy with B-Shift, this particular storage unit will retain a percentage of its material in-between crew transfers.";
 	name = "\improper Persistent Industrial Sheet Storage"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	health = 1e+006
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/office)
+/turf/simulated/wall,
+/area/quartermaster/warehouse)
 "kay" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -101096,7 +101087,7 @@ aOj
 aQI
 aSR
 bxr
-bGn
+kar
 bAG
 qmn
 bEy
@@ -104188,7 +104179,7 @@ bYD
 bRG
 bqo
 bqn
-kar
+bsn
 bug
 bCU
 bEJ

--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -389,10 +389,6 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/seconddeck/gym)
 "akk" = (
-/obj/machinery/particle_accelerator/control_box{
-	anchored = 1;
-	construction_state = 1
-	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/particleaccelerator)
@@ -13820,11 +13816,6 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "kQJ" = (
-/obj/structure/particle_accelerator/particle_emitter/center{
-	anchored = 1;
-	construction_state = 1;
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
@@ -13921,11 +13912,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/bridge)
 "kTO" = (
-/obj/structure/particle_accelerator/fuel_chamber{
-	anchored = 1;
-	construction_state = 1;
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/research/particleaccelerator)
@@ -14899,11 +14885,6 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/thirddeck/dormsstarboard/maintbar)
 "lPC" = (
-/obj/structure/particle_accelerator/end_cap{
-	anchored = 1;
-	construction_state = 1;
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -15416,11 +15397,6 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "mhK" = (
-/obj/structure/particle_accelerator/particle_emitter/left{
-	anchored = 1;
-	construction_state = 1;
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -16146,11 +16122,6 @@
 /turf/simulated/floor/tiled,
 /area/bridge)
 "mKT" = (
-/obj/structure/particle_accelerator/particle_emitter/right{
-	anchored = 1;
-	construction_state = 1;
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple{
 	dir = 6
@@ -32114,11 +32085,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/sleep/vistor_room_5)
 "ylp" = (
-/obj/structure/particle_accelerator/power_box{
-	anchored = 1;
-	construction_state = 1;
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 6


### PR DESCRIPTION

## About The Pull Request
After internal discussion. It was decided that the Particle Accelerator will no longer be available round start to discourage getting anomaly easily in solo play within 30 minutes. Now you will have to order it from cargo. 

The persistent ore fridge is moved in the warehouse area of cargo, to encourage people to interact with cargo personnel for their materials.
## Changelog
:cl:
maptweak: Science PA has been removed from round start. 
maptweak: Ore Storage is now in the Cargo Warehouse.
/:cl:
