### PR TITLE
Outsider pod nerfs

### DIFF
--- a/modular_chomp/code/modules/mining/shelters_ch.dm
+++ b/modular_chomp/code/modules/mining/shelters_ch.dm
@@ -134,18 +134,18 @@
 	mappath = "modular_chomp/maps/submaps/shelters/NewHotel-18x22.dmm"
 	name = "New Hotel."
 	description = "An new not-worn down wooden hotel, not heavily damaged but with enough materials to do whatever."
-
+/* Commented out due to poor implemantation, might be re-added as an outsider OM object.
 /datum/map_template/shelter/superpose/ScienceShip
 	shelter_id = "ScienceShip"
 	mappath = "modular_chomp/maps/submaps/shelters/ScienceShip-25x33.dmm"
 	name = "Science ship."
 	description = "An expedition science ship with all the needs to host a small team."
-
+*/
 /datum/map_template/shelter/superpose/SmallCombatShip
 	shelter_id = "SmallCombatShip"
 	mappath = "modular_chomp/maps/submaps/shelters/SmallCombatShip-9x11.dmm"
 	name = "Small combat ship."
-	description = "A small combat ship with the bear minimum needs for survival."
+	description = "A small combat ship with the bare minimum needs for survival."
 
 /datum/map_template/shelter/superpose/SurvivalBarracks
 	shelter_id = "SurvivalBarracks"
@@ -248,13 +248,13 @@
 	mappath = "modular_chomp/maps/submaps/shelters/SurvivalQuarters-9x9.dmm"
 	name = "Survival living quarters."
 	description = "NT patented survival quarters pod, loaded with survival equipment and enough beds for 4 crewmates."
-
+/* Commented out due to powergame
 /datum/map_template/shelter/superpose/SurvivalScience
 	shelter_id = "SurvivalScience"
 	mappath = "modular_chomp/maps/submaps/shelters/SurvivalScience-9x9.dmm"
 	name = "Survival science dep."
 	description = "NT patented science survival pod, loaded with research terminals, mech fabricator, autolathe and everything to do field research."
-
+*/
 /datum/map_template/shelter/superpose/SurvivalSecurity
 	shelter_id = "SurvivalSecurity"
 	mappath = "modular_chomp/maps/submaps/shelters/SurvivalSecurity-9x9.dmm"
@@ -327,13 +327,13 @@
 	mappath = "modular_chomp/maps/submaps/shelters/SurvivalMethLab-9x10.dmm"
 	name = "Survival Meth Lab"
 	description = "A medium survival pod, repurposed and locked for the production of illegal chems. Don't get caught."
-
+/* Removed due to powergaming
 /datum/map_template/shelter/superpose/SurvivalScienceV2
 	shelter_id = "SurvivalScienceV2"
 	mappath = "modular_chomp/maps/submaps/shelters/SurvivalScience2-9x9.dmm"
 	name = "Survival Science V2"
 	description = "NT patented science survival pod, loaded with research terminals, mech fabricator, autolathe and everything to do field research."
-
+*/
 /datum/map_template/shelter/superpose/SurvivalSecurityV2
 	shelter_id = "SurvivalSecurityV2"
 	mappath = "modular_chomp/maps/submaps/shelters/SurvivalSecurity2-9x9.dmm"

--- a/modular_chomp/maps/submaps/shelters/MechFabShip-27x24.dmm
+++ b/modular_chomp/maps/submaps/shelters/MechFabShip-27x24.dmm
@@ -59,16 +59,19 @@
 /area/survivalpod/superpose/MechFabShip)
 "bL" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/cryopod/robot/door/gateway/quiet,
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
 /obj/machinery/light/poi{
 	dir = 1
 	},
-/obj/machinery/computer/cryopod/gateway{
-	pixel_y = 32
-	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/mecha_equipment/tool/rcd,
+/obj/item/mecha_parts/mecha_equipment/tool/sleeper,
+/obj/item/mecha_parts/mecha_equipment/tool/syringe_gun,
+/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,
+/obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill,
+/obj/item/mecha_parts/mecha_equipment/tool/jetpack,
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "bP" = (
@@ -94,6 +97,7 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "dz" = (
@@ -165,19 +169,20 @@
 /turf/simulated/floor/tiled/milspec,
 /area/survivalpod/superpose/MechFabShip)
 "hu" = (
-/obj/machinery/cryopod/robot{
-	base_icon_state = "borg_pod_closed";
-	dir = 4;
-	icon = 'icons/obj/structures.dmi';
-	icon_state = "borg_pod_closed";
-	occupied_icon_state = "borg_pod_opened"
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
 /obj/structure/sign/department/drones{
 	pixel_y = 32
 	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/part/gygax_head,
+/obj/item/mecha_parts/part/gygax_left_arm,
+/obj/item/mecha_parts/part/gygax_left_leg,
+/obj/item/mecha_parts/part/gygax_right_arm,
+/obj/item/mecha_parts/part/gygax_right_leg,
+/obj/item/mecha_parts/part/gygax_torso,
+/obj/item/mecha_parts/part/gygax_armour,
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "hz" = (
@@ -306,8 +311,6 @@
 /obj/item/clothing/glasses/welding,
 /obj/item/device/bodysnatcher,
 /obj/item/weapon/card/emag,
-/obj/item/weapon/cell/super,
-/obj/item/weapon/cell/super,
 /obj/item/weapon/cell/device/super,
 /obj/item/weapon/cell/device/super,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -833,6 +836,7 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "AK" = (
@@ -941,11 +945,11 @@
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Dj" = (
-/obj/machinery/r_n_d/protolathe,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
+/obj/structure/table/steel_reinforced,
+/obj/item/weapon/storage/part_replacer/adv/discount_bluespace,
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "Dm" = (
@@ -981,6 +985,11 @@
 	name = "Port Cannons"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
+/area/survivalpod/superpose/MechFabShip)
+"Fc" = (
+/obj/machinery/mech_recharger,
+/obj/mecha/working/ripley,
+/turf/simulated/floor/tiled/milspec,
 /area/survivalpod/superpose/MechFabShip)
 "FC" = (
 /obj/structure/window/plastitanium/full,
@@ -1110,8 +1119,20 @@
 /obj/structure/sign/electricshock{
 	pixel_y = 32
 	},
+/obj/machinery/cryopod/robot{
+	base_icon_state = "borg_pod_closed";
+	dir = 4;
+	icon = 'icons/obj/structures.dmi';
+	icon_state = "borg_pod_closed";
+	occupied_icon_state = "borg_pod_opened"
+	},
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
+"Jy" = (
+/obj/effect/spawner/parts/t2,
+/obj/effect/spawner/parts/t2,
+/turf/template_noop,
+/area/template_noop)
 "JW" = (
 /obj/structure/salvageable/console_os{
 	name = "Turret control console"
@@ -1135,6 +1156,23 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/milspec/sterile,
+/area/survivalpod/superpose/MechFabShip)
+"Ka" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/structure/sign/department/drones{
+	pixel_y = 32
+	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/chassis/odysseus,
+/obj/item/mecha_parts/part/odysseus_head,
+/obj/item/mecha_parts/part/odysseus_left_arm,
+/obj/item/mecha_parts/part/odysseus_left_leg,
+/obj/item/mecha_parts/part/odysseus_right_arm,
+/obj/item/mecha_parts/part/odysseus_right_leg,
+/obj/item/mecha_parts/part/odysseus_torso,
+/turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "KC" = (
 /obj/structure/cable/green{
@@ -1292,8 +1330,7 @@
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Nr" = (
-/obj/structure/table/steel_reinforced,
-/obj/item/weapon/storage/part_replacer/adv/discount_bluespace,
+/obj/machinery/r_n_d/destructive_analyzer,
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
@@ -1507,10 +1544,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/survivalpod/superpose/MechFabShip)
 "RE" = (
-/obj/machinery/recharge_station,
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 5
 	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/mecha_equipment/weapon/phoron_bore,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/flamer,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/taser,
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "Sh" = (
@@ -1619,7 +1659,16 @@
 /area/survivalpod/superpose/MechFabShip)
 "VZ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/foodcart,
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/component/electrical/high_current,
+/obj/item/mecha_parts/component/armor/military,
+/obj/item/mecha_parts/component/armor/lightweight,
+/obj/item/mecha_parts/component/hull/lightweight,
+/obj/item/mecha_parts/component/hull,
+/obj/item/mecha_parts/component/gas/reinforced,
+/obj/item/mecha_parts/component/actuator/hispeed,
+/obj/item/weapon/cell/super,
+/obj/item/weapon/cell/super,
 /turf/simulated/floor/tiled/milspec,
 /area/survivalpod/superpose/MechFabShip)
 "Wl" = (
@@ -1746,8 +1795,11 @@
 /turf/simulated/floor/plating,
 /area/survivalpod/superpose/MechFabShip)
 "Yt" = (
-/obj/machinery/r_n_d/destructive_analyzer,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/table/rack/shelf/steel,
+/obj/effect/spawner/parts/t2,
+/obj/effect/spawner/parts/t2,
+/obj/effect/spawner/parts/t2,
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "YM" = (
@@ -1791,10 +1843,13 @@
 /turf/simulated/floor/tiled/red,
 /area/survivalpod/superpose/MechFabShip)
 "ZH" = (
-/obj/machinery/recharge_station,
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 9
 	},
+/obj/structure/table/rack/shelf/steel,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/laser,
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/medigun,
+/obj/item/mecha_parts/mecha_equipment/wormhole_generator,
 /turf/simulated/floor/tiled/techmaint,
 /area/survivalpod/superpose/MechFabShip)
 "ZY" = (
@@ -2069,7 +2124,7 @@ ph
 He
 yN
 qf
-tC
+Fc
 ph
 ph
 Bz
@@ -2144,7 +2199,7 @@ qX
 YM
 Dj
 ph
-hu
+Ka
 dz
 Zm
 VZ
@@ -2399,7 +2454,7 @@ iC
 iC
 iC
 iC
-iC
+Jy
 iC
 iC
 ph

--- a/modular_chomp/maps/submaps/shelters/MechStorageFab-32x24.dmm
+++ b/modular_chomp/maps/submaps/shelters/MechStorageFab-32x24.dmm
@@ -451,7 +451,7 @@
 /obj/item/mecha_parts/component/gas/reinforced,
 /obj/item/mecha_parts/mecha_equipment/hardpoint_actuator,
 /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay,
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/cannon,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg,
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/grenade/rigged,
 /obj/item/mecha_parts/mecha_equipment/wormhole_generator,
 /turf/simulated/floor/plating/external,
@@ -930,7 +930,7 @@
 /obj/item/mecha_parts/mecha_equipment/omni_shield,
 /obj/item/mecha_parts/mecha_equipment/tool/jetpack,
 /obj/item/mecha_parts/mecha_equipment/tool/passenger,
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/cannon,
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg,
 /turf/simulated/floor/plating/external,
 /area/survivalpod/superpose/MechStorageFab)
 "Mx" = (

--- a/modular_chomp/maps/submaps/surface_submaps/plains/oldhotel.dmm
+++ b/modular_chomp/maps/submaps/surface_submaps/plains/oldhotel.dmm
@@ -260,9 +260,6 @@
 /area/submap/oldhotel)
 "vA" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/telecube/randomized{
-	name = "Odd artifact"
-	},
 /turf/simulated/floor/wood,
 /area/submap/oldhotel)
 "vM" = (
@@ -424,15 +421,6 @@
 /obj/item/weapon/flame/lighter/random,
 /obj/item/weapon/flame/lighter/random,
 /obj/item/weapon/melee/umbrella/random,
-/turf/simulated/floor/wood,
-/area/submap/oldhotel)
-"Ha" = (
-/obj/structure/table/woodentable,
-/obj/item/trash/candle,
-/obj/item/weapon/paper{
-	info = "This is a stupid tresure hunt task, that thing is not taking us anywhere. Go on and have fun finding a waste of time.";
-	name = "Wrinkled sheet of paper"
-	},
 /turf/simulated/floor/wood,
 /area/submap/oldhotel)
 "Ik" = (
@@ -877,7 +865,7 @@ hQ
 qg
 Se
 ly
-Ha
+rK
 hQ
 MU
 gA


### PR DESCRIPTION

## About The Pull Request
After some internal discussion, a few of the pods that have full R&D setups have been removed from the superpose pod spawn pool. 

We decided to keep a half-RD setup in the mechfab ship pictured below, with prebuilt mechparts in exchange for a protolathe. This will encourage outsiders to get research via trade and interaction.

Also removed like two 1000 damage guns  and a locus spawn.

Science ship is poorly implemented and will be re-added later as an OM object once outsider OM is supported.
![dreamseeker_paVYrCewE6](https://github.com/user-attachments/assets/ac60d6fb-5ec3-4d91-aac0-96a39d4bccc9)
## Changelog
:cl:
del: Removes overpowered mecha weapon from MechFabStorage pod
del: Removes the protolathe from MechFabShip pod and replaces it with mecha parts and prebuilt mechs.
del: Removes Locus spawner in Oldhotel.
del: Removed the SciencePod, Sciencepodv2 and Science ship from the superpose pod spawn list.
/:cl:
