### PR TITLE
Re-enables spawn in belly verb for ghosts

### DIFF
--- a/code/modules/vore/eating/inbelly_spawn.dm
+++ b/code/modules/vore/eating/inbelly_spawn.dm
@@ -27,7 +27,7 @@ Please do not abuse this ability.
 			continue
 		if(ishuman(pred))
 			var/mob/living/carbon/human/H = pred
-			if(!H.allow_inbelly_spawning)
+			if(!H.latejoin_vore) //CHOMPEdit - Changes pref to the same as vorespawn pred
 				continue
 			eligible_targets += H
 			continue
@@ -35,7 +35,7 @@ Please do not abuse this ability.
 			var/mob/living/silicon/S = pred
 			if(isAI(S))
 				continue						// Sorry, AI buddies. Your vore works too differently.
-			if(!S.allow_inbelly_spawning)
+			if(!S.latejoin_vore) //CHOMPEdit - Changes pref to the same as vorespawn pred
 				continue
 			eligible_targets += S
 			continue
@@ -43,7 +43,7 @@ Please do not abuse this ability.
 			var/mob/living/simple_mob/SM = pred
 			if(!SM.vore_active)						// No vore, no bellies, no inbelly spawning
 				continue
-			if(!SM.allow_inbelly_spawning)
+			if(!SM.latejoin_vore) //CHOMPEdit - Changes pref to the same as vorespawn pred
 				continue
 			eligible_targets += SM
 			continue
@@ -68,7 +68,7 @@ Please do not abuse this ability.
 		return
 
 	// Are we cool with this prey spawning in at all?
-	var/answer = tgui_alert(src, "[potential_prey.ckey] (as [potential_prey.prefs.real_name]) wants to spawn in one of your bellies. Do you accept?", "Inbelly Spawning", list("Yes", "No"))
+	var/answer = tgui_alert(src, "[potential_prey.prefs.real_name] wants to spawn in one of your bellies. Do you accept?", "Inbelly Spawning", list("Yes", "No")) //CHOMPEdit - hides ckey
 	if(answer != "Yes")
 		to_chat(potential_prey, "<span class=notice>Your request was turned down.</span>")
 		return

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4485,6 +4485,7 @@
 #include "code\modules\vore\eating\contaminate_vr.dm"
 #include "code\modules\vore\eating\digest_act_vr.dm"
 #include "code\modules\vore\eating\exportpanel_vr.dm"
+#include "code\modules\vore\eating\inbelly_spawn.dm"
 #include "code\modules\vore\eating\leave_remains_vr.dm"
 #include "code\modules\vore\eating\living_ch.dm"
 #include "code\modules\vore\eating\living_vr.dm"


### PR DESCRIPTION

## About The Pull Request
Title, really. This PR re-enables Virgo's "Spawn in Belly" verb for ghosts here, in addition to vorespawn. It differs from vorespawn by having the pred picking where prey spawns and spawning prey without any gear or loadout. Prey is also not added to the manifest.
The verb just now uses the same prefs for Chomp's late join vorespawn AND hides ckey.

This is something that was requested downstream but would be nice to have here as well...! Thanks Kashargul for the suggestion PR here directly. I have tested it locally and it is TM'd in Torch with no issues so far, but I would appreciate it if more peeps could test it too.
## Changelog
:cl:
add: Adds "Spawn in Belly" verb for ghosts
/:cl:
