### PR TITLE
Adjusts diver visibility in shallow water

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -447,7 +447,7 @@
 
 #define MAX_NUTRITION	6000 //VOREStation Edit
 
-#define FAKE_INVIS_ALPHA_THRESHOLD 127 // If something's alpha var is at or below this number, certain things will pretend it is invisible.
+#define FAKE_INVIS_ALPHA_THRESHOLD 64 //CHOMPEdit. 25% down from 50% // If something's alpha var is at or below this number, certain things will pretend it is invisible.
 
 #define DEATHGASP_NO_MESSAGE "no message"
 

--- a/code/modules/mob/_modifiers/modifiers_vr.dm
+++ b/code/modules/mob/_modifiers/modifiers_vr.dm
@@ -77,6 +77,10 @@
 		var/turf/simulated/floor/water/water_floor = holder.loc
 		if(water_floor.depth < 1) //You're not in deep enough water anymore.
 			expire(silent = FALSE)
+		if(water_floor.depth > 1)
+			holder.alpha = 50
+		else
+			holder.alpha = 128
 	else
 		expire(silent = FALSE)
 

--- a/code/modules/mob/_modifiers/modifiers_vr.dm
+++ b/code/modules/mob/_modifiers/modifiers_vr.dm
@@ -77,10 +77,10 @@
 		var/turf/simulated/floor/water/water_floor = holder.loc
 		if(water_floor.depth < 1) //You're not in deep enough water anymore.
 			expire(silent = FALSE)
-		if(water_floor.depth > 1)
+		if(water_floor.depth > 1) //CHOMPAdd Start
 			holder.alpha = 50
 		else
-			holder.alpha = 128
+			holder.alpha = 128 //CHOMPAdd End
 	else
 		expire(silent = FALSE)
 

--- a/code/modules/mob/_modifiers/modifiers_vr.dm
+++ b/code/modules/mob/_modifiers/modifiers_vr.dm
@@ -80,7 +80,7 @@
 		if(water_floor.depth > 1) //CHOMPAdd Start
 			holder.alpha = 50
 		else
-			holder.alpha = 128 //CHOMPAdd End
+			holder.alpha = 65 //CHOMPAdd End
 	else
 		expire(silent = FALSE)
 


### PR DESCRIPTION
## About The Pull Request
Fixes a cheese strat of aquatic gamers turning themselves invisible to aggro mobs by jumping into puddles and going piranha mode on their ankles.
## Changelog
:cl:
balance: Adjusted diver visibility in shallow water.
balance: Simplemob targeting ai invisibility threshold changed from 50% to 25%.
/:cl:
