### PR TITLE
Illell Adjustment

### DIFF
--- a/code/modules/mob/living/carbon/human/species/lleill/lleill.dm
+++ b/code/modules/mob/living/carbon/human/species/lleill/lleill.dm
@@ -40,8 +40,8 @@
 
 	darksight = 10 //Can see in dark
 
-	burn_mod = 0.25 //Very resistant to fire
-	pain_mod = 0.25 //Whilst not resistant to brute or stunning, they are quite resistant to pain, making them tanky in their own way.
+	//burn_mod = 0.25 //Very resistant to fire CHOMPedit: Less overtune species stats pleas
+	//pain_mod = 0.25 //Whilst not resistant to brute or stunning, they are quite resistant to pain, making them tanky in their own way.CHOMPedit: See above
 
 	warning_low_pressure = 50
 	hazard_low_pressure = -1


### PR DESCRIPTION

## About The Pull Request

Removes the 75% damage reduction of burn and pain on Illell.
I do think the concept and abilities are cool. Stealthy trickster from redspace.
I don't really have intentions of pushing or nudging folks here to add them officially/whitelist.
But if this two stats removal lets admin spawns be a bit acceptable cool.
Because the ring teleportation and invisibility cloaking seems nifty. Also transforming.
## Changelog
:cl:
balance: Illell have normal pain and burn mods
/:cl:
