### PR TITLE
reduce nutrition gain from trash on sleepers

### DIFF
--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -664,6 +664,7 @@
 				//CHOMPAdd Start
 				if(T.reagents)
 					volume = T.reagents.total_volume
+				var/is_trash = istype(T, /obj/item/trash)
 				//CHOMPAdd End
 				var/digested = T.digest_act(item_storage = src)
 				if(!digested)
@@ -694,7 +695,7 @@
 								if(material == "wood" && wood)
 									wood.add_charge(total_material)
 					//CHOMPEdit Start
-					if(istype(target, /obj/item/trash))
+					if(is_trash)
 						hound.nutrition += digested
 					else
 						hound.nutrition += 5 * digested //drain(-50 * digested)

--- a/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
+++ b/code/modules/mob/living/silicon/robot/dogborg/dog_sleeper_vr.dm
@@ -693,7 +693,12 @@
 									plastic.add_charge(total_material)
 								if(material == "wood" && wood)
 									wood.add_charge(total_material)
-					hound.nutrition += 5 * digested //drain(-50 * digested) //CHOMPEdit
+					//CHOMPEdit Start
+					if(istype(target, /obj/item/trash))
+						hound.nutrition += digested
+					else
+						hound.nutrition += 5 * digested //drain(-50 * digested)
+					//CHOMPEdit End
 			else if(istype(target,/obj/effect/decal/remains))
 				qdel(target)
 				hound.nutrition += 10 //drain(-100) //CHOMPEdit


### PR DESCRIPTION
## About The Pull Request
## Changelog
:cl:
qol: reduces nutrition gain of trash for sleepers from 5 to 1, there's enough ways to get nutrition and some units, like janitors can collect a lot of trash into their sleeper
/:cl:

closes #8709