### PR TITLE
Vorespawn Pref Tweaks

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -689,7 +689,7 @@ var/global/datum/controller/occupations/job_master
 				if(!isliving(V.mob))
 					continue
 				var/mob/living/M = V.mob
-				if(M.stat == UNCONSCIOUS || M.stat == DEAD || M.client.is_afk(10 MINUTES))
+				if(M.stat == UNCONSCIOUS || M.stat == DEAD || (M.client.is_afk(10 MINUTES) && !M.no_latejoin_vore_warning)) //CHOMPEdit
 					continue
 				if(!M.latejoin_vore)
 					continue
@@ -749,7 +749,8 @@ var/global/datum/controller/occupations/job_master
 				log_admin("[key_name(C)] has vore spawned into [key_name(pred)]")
 				message_admins("[key_name(C)] has vore spawned into [key_name(pred)]")
 				to_chat(C, "<span class='notice'>You have been spawned via vore. You are free to roleplay how you got there as you please, such as teleportation or having had already been there.</span>")
-				to_chat(pred, "<span class='notice'>Your prey has spawned via vore. You are free to roleplay this how you please, such as teleportation or having had already been there.</span>")
+				if(vore_spawn_gut.entrance_logs) //CHOMPEdit
+					to_chat(pred, "<span class='notice'>Your prey has spawned via vore. You are free to roleplay this how you please, such as teleportation or having had already been there.</span>")
 			else
 				to_chat(C, "<span class='warning'>No predators were available to accept you.</span>")
 				return
@@ -761,7 +762,7 @@ var/global/datum/controller/occupations/job_master
 				if(!isliving(V.mob))
 					continue
 				var/mob/living/M = V.mob
-				if(M.stat == UNCONSCIOUS || M.stat == DEAD || M.client.is_afk(10 MINUTES))
+				if(M.stat == UNCONSCIOUS || M.stat == DEAD || (M.client.is_afk(10 MINUTES) && !M.no_latejoin_prey_warning)) //CHOMPEdit
 					continue
 				if(!M.latejoin_prey)
 					continue


### PR DESCRIPTION

## About The Pull Request
Two small changes. Changed the check for inactivity when vore spawning pred or prey so that if the target has auto-accept on it doesn't matter if they're inactive. One of the main points of turning that auto-accept on is so you don't have to be there to click accept, and friends not being able to join me while I idle has been annoying. Secondly, changed it so the pred doesn't need to see the vore spawn message if the belly the prey spawns into has entrance logs disabled.
## Changelog
:cl:
qol: Vorespawns with auto-accept on aren't affected by inactivity
add: Vorespawns into a belly with entrance logs disabled don't announce the entrance to the pred
/:cl:
