### PR TITLE
dullahan cargo/miner fix

### DIFF
--- a/modular_chomp/code/modules/mob/living/silicon/robot/sprites/mining.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/sprites/mining.dm
@@ -84,14 +84,14 @@
 	rest_sprite_options = list("Default", "Sit")
 
 /datum/robot_sprite/dogborg/tall/mining/dullahanminermodule/dullahanmineralt
-	name = "Dullahan Mining unit"
+	name = "Dullahan Mining unit v2"
 	sprite_icon_state = "dullahanmine_alt"
 	has_eye_light_sprites = TRUE
 	has_custom_open_sprites = TRUE
 	has_vore_belly_sprites = TRUE
 	rest_sprite_options = list("Default", "Sit")
 
-/datum/robot_sprite/dogborg/tall/mining/dullahancargo
+/datum/robot_sprite/dogborg/tall/mining/dullahancargomodule
 	sprite_icon = 'modular_chomp/icons/mob/dullahanborg/dullahan_cargo.dmi'
 	pixel_x = 0
 


### PR DESCRIPTION
fixing dullahan sprite names, and code in the cargo model and mining model
## About The Pull Request
Dullahan had issues with sprites not showing up for cargo and miner units, this change fixes them so that they show up

cargo class was fixed and miner names were fixed

## Changelog
:cl:
fix: dullahancargomodule class
fix: second dullahan miner name -> v2
/:cl:
