### PR TITLE
Vorespawn Whitelist and Absorb

### DIFF
--- a/code/__defines/belly_modes_ch.dm
+++ b/code/__defines/belly_modes_ch.dm
@@ -43,4 +43,4 @@
 
 //Vorespawn flags
 #define VS_FLAG_ABSORB_YES		0x1
-#define VS_FLAG_ABSORB_CHOICE	0x2
+#define VS_FLAG_ABSORB_PREY		0x2

--- a/code/__defines/belly_modes_ch.dm
+++ b/code/__defines/belly_modes_ch.dm
@@ -40,3 +40,7 @@
 #define AT_FLAG_ORES			0x40
 #define AT_FLAG_CLOTHES			0x80
 #define AT_FLAG_FOOD			0x100
+
+//Vorespawn flags
+#define VS_FLAG_ABSORB_YES		0x1
+#define VS_FLAG_ABSORB_CHOICE	0x2

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -673,6 +673,7 @@ var/global/datum/controller/occupations/job_master
 	var/datum/spawnpoint/spawnpos
 	var/fail_deadly = FALSE
 	var/obj/belly/vore_spawn_gut
+	var/absorb_choice = "No" //CHOMPAdd - Ability to start absorbed with vorespawn
 	var/mob/living/prey_to_nomph
 	var/obj/item/item_to_be //CHOMPEdit - Item TF spawning
 	var/mob/living/item_carrier //CHOMPEdit - Capture crystal spawning
@@ -708,6 +709,10 @@ var/global/datum/controller/occupations/job_master
 				for(var/obj/belly/Y in pred.vore_organs)
 					if(Y.vorespawn_blacklist)
 						continue
+					//CHOMPAdd Start
+					if(LAZYLEN(Y.vorespawn_whitelist) && !(C.ckey in Y.vorespawn_whitelist))
+						continue
+					//CHOMPAdd End
 					available_bellies += Y
 				var/backup = alert(C, "Do you want a mind backup?", "Confirm", "Yes", "No")
 				if(backup == "Yes")
@@ -715,6 +720,14 @@ var/global/datum/controller/occupations/job_master
 				vore_spawn_gut = input(C, "Choose a Belly.", "Belly Spawnpoint") as null|anything in available_bellies
 				if(!vore_spawn_gut)
 					return
+				//CHOMPAdd Start
+				if(vore_spawn_gut.vorespawn_absorbed == "Yes")
+					absorb_choice = alert(C, "[pred]'s [vore_spawn_gut] will start with you absorbed. Continue?", "Confirm", "Yes", "No")
+					if(absorb_choice != "Yes")
+						return
+				if(vore_spawn_gut.vorespawn_absorbed == "Prey Choice")
+					absorb_choice = alert(C, "Do you want to start absorbed into [pred]'s [vore_spawn_gut]?", "Confirm", "Yes", "No")
+				//CHOMPAdd End
 				to_chat(C, "<b><span class='warning'>[pred] has received your spawn request. Please wait.</span></b>")
 				log_admin("[key_name(C)] has requested to vore spawn into [key_name(pred)]")
 				message_admins("[key_name(C)] has requested to vore spawn into [key_name(pred)]")
@@ -722,11 +735,21 @@ var/global/datum/controller/occupations/job_master
 				var/confirm
 				if(pred.no_latejoin_vore_warning)
 					if(pred.no_latejoin_vore_warning_time > 0)
-						confirm = tgui_alert(pred, "[C.prefs.real_name] is attempting to spawn into your [vore_spawn_gut]. Let them?", "Confirm", list("No", "Yes"), pred.no_latejoin_vore_warning_time SECONDS)
+						//CHOMPEdit Start
+						if(absorb_choice == "Yes")
+							confirm = tgui_alert(pred, "[C.prefs.real_name] is attempting to spawn absorbed as your [vore_spawn_gut]. Let them?", "Confirm", list("No", "Yes"), pred.no_latejoin_vore_warning_time SECONDS)
+						else
+							confirm = tgui_alert(pred, "[C.prefs.real_name] is attempting to spawn into your [vore_spawn_gut]. Let them?", "Confirm", list("No", "Yes"), pred.no_latejoin_vore_warning_time SECONDS)
+						//CHOMPEdit End
 					if(!confirm)
 						confirm = "Yes"
 				else
-					confirm = alert(pred, "[C.prefs.real_name] is attempting to spawn into your [vore_spawn_gut]. Let them?", "Confirm", "No", "Yes")
+					//CHOMPEdit Start
+					if(absorb_choice == "Yes")
+						confirm = alert(pred, "[C.prefs.real_name] is attempting to spawn absorbed as your [vore_spawn_gut]. Let them?", "Confirm", "No", "Yes")
+					else
+						confirm = alert(pred, "[C.prefs.real_name] is attempting to spawn into your [vore_spawn_gut]. Let them?", "Confirm", "No", "Yes")
+					//CHOMPEdit End
 				if(confirm != "Yes")
 					to_chat(C, "<span class='warning'>[pred] has declined your spawn request.</span>")
 					var/message = sanitizeSafe(input(pred,"Do you want to leave them a message?")as text|null)
@@ -784,6 +807,7 @@ var/global/datum/controller/occupations/job_master
 				vore_spawn_gut = input(C, "Choose your Belly.", "Belly Spawnpoint") as null|anything in available_bellies
 				if(!vore_spawn_gut)
 					return
+				absorb_choice = alert(C, "Do you want to instantly absorb them?", "Confirm", "Yes", "No") //CHOMPAdd
 				to_chat(C, "<b><span class='warning'>[prey] has received your spawn request. Please wait.</span></b>")
 				log_admin("[key_name(C)] has requested to pred spawn onto [key_name(prey)]")
 				message_admins("[key_name(C)] has requested to pred spawn onto [key_name(prey)]")
@@ -791,11 +815,21 @@ var/global/datum/controller/occupations/job_master
 				var/confirm
 				if(prey.no_latejoin_prey_warning)
 					if(prey.no_latejoin_prey_warning_time > 0)
-						confirm = tgui_alert(prey, "[C.prefs.real_name] is attempting to televore you into their [vore_spawn_gut]. Let them?", "Confirm", list("No", "Yes"), prey.no_latejoin_prey_warning_time SECONDS)
+						//CHOMPEdit Start
+						if(absorb_choice == "Yes")
+							confirm = tgui_alert(prey, "[C.prefs.real_name] is attempting to televore and instantly absorb you with their [vore_spawn_gut]. Let them?", "Confirm", list("No", "Yes"), prey.no_latejoin_prey_warning_time SECONDS)
+						else
+							confirm = tgui_alert(prey, "[C.prefs.real_name] is attempting to televore you into their [vore_spawn_gut]. Let them?", "Confirm", list("No", "Yes"), prey.no_latejoin_prey_warning_time SECONDS)
+						//CHOMPEdit End
 					if(!confirm)
 						confirm = "Yes"
 				else
-					confirm = alert(prey, "[C.prefs.real_name] is attempting to televore you into their [vore_spawn_gut]. Let them?", "Confirm", "No", "Yes")
+					//CHOMPEdit Start
+					if(absorb_choice == "Yes")
+						confirm = alert(prey, "[C.prefs.real_name] is attempting to televore and instantly absorb you with their [vore_spawn_gut]. Let them?", "Confirm", "No", "Yes")
+					else
+						confirm = alert(prey, "[C.prefs.real_name] is attempting to televore you into their [vore_spawn_gut]. Let them?", "Confirm", "No", "Yes")
+					//CHOMPEdit End
 				if(confirm != "Yes")
 					to_chat(C, "<span class='warning'>[prey] has declined your spawn request.</span>")
 					var/message = sanitizeSafe(input(prey,"Do you want to leave them a message?")as text|null)
@@ -932,6 +966,7 @@ var/global/datum/controller/occupations/job_master
 	. = list("turf","msg", "voreny", "prey", "itemtf", "vorgans", "carrier") //CHOMPEdit - Item TF spawnpoints, spawn as mob
 	if(vore_spawn_gut)
 		.["voreny"] = vore_spawn_gut
+		.["absorb"] = absorb_choice //CHOMPAdd
 	if(prey_to_nomph)
 		.["prey"] = prey_to_nomph	//We pass this on later to reverse the vorespawn in new_player.dm
 	//CHOMPEdit Start - Item TF spawnpoints

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -673,7 +673,7 @@ var/global/datum/controller/occupations/job_master
 	var/datum/spawnpoint/spawnpos
 	var/fail_deadly = FALSE
 	var/obj/belly/vore_spawn_gut
-	var/absorb_choice = "No" //CHOMPAdd - Ability to start absorbed with vorespawn
+	var/absorb_choice = 0 //CHOMPAdd - Ability to start absorbed with vorespawn
 	var/mob/living/prey_to_nomph
 	var/obj/item/item_to_be //CHOMPEdit - Item TF spawning
 	var/mob/living/item_carrier //CHOMPEdit - Capture crystal spawning
@@ -721,12 +721,13 @@ var/global/datum/controller/occupations/job_master
 				if(!vore_spawn_gut)
 					return
 				//CHOMPAdd Start
-				if(vore_spawn_gut.vorespawn_absorbed == "Yes")
-					absorb_choice = alert(C, "[pred]'s [vore_spawn_gut] will start with you absorbed. Continue?", "Confirm", "Yes", "No")
-					if(absorb_choice != "Yes")
+				if(vore_spawn_gut.vorespawn_absorbed == 1)
+					if(alert(C, "[pred]'s [vore_spawn_gut] will start with you absorbed. Continue?", "Confirm", "Yes", "No") != "Yes")
 						return
-				if(vore_spawn_gut.vorespawn_absorbed == "Prey Choice")
-					absorb_choice = alert(C, "Do you want to start absorbed into [pred]'s [vore_spawn_gut]?", "Confirm", "Yes", "No")
+					absorb_choice = 1
+				if(vore_spawn_gut.vorespawn_absorbed == 2)
+					if(alert(C, "Do you want to start absorbed into [pred]'s [vore_spawn_gut]?", "Confirm", "Yes", "No") == "Yes")
+						absorb_choice = 1
 				//CHOMPAdd End
 				to_chat(C, "<b><span class='warning'>[pred] has received your spawn request. Please wait.</span></b>")
 				log_admin("[key_name(C)] has requested to vore spawn into [key_name(pred)]")
@@ -736,7 +737,7 @@ var/global/datum/controller/occupations/job_master
 				if(pred.no_latejoin_vore_warning)
 					if(pred.no_latejoin_vore_warning_time > 0)
 						//CHOMPEdit Start
-						if(absorb_choice == "Yes")
+						if(absorb_choice)
 							confirm = tgui_alert(pred, "[C.prefs.real_name] is attempting to spawn absorbed as your [vore_spawn_gut]. Let them?", "Confirm", list("No", "Yes"), pred.no_latejoin_vore_warning_time SECONDS)
 						else
 							confirm = tgui_alert(pred, "[C.prefs.real_name] is attempting to spawn into your [vore_spawn_gut]. Let them?", "Confirm", list("No", "Yes"), pred.no_latejoin_vore_warning_time SECONDS)
@@ -745,7 +746,7 @@ var/global/datum/controller/occupations/job_master
 						confirm = "Yes"
 				else
 					//CHOMPEdit Start
-					if(absorb_choice == "Yes")
+					if(absorb_choice)
 						confirm = alert(pred, "[C.prefs.real_name] is attempting to spawn absorbed as your [vore_spawn_gut]. Let them?", "Confirm", "No", "Yes")
 					else
 						confirm = alert(pred, "[C.prefs.real_name] is attempting to spawn into your [vore_spawn_gut]. Let them?", "Confirm", "No", "Yes")
@@ -807,7 +808,10 @@ var/global/datum/controller/occupations/job_master
 				vore_spawn_gut = input(C, "Choose your Belly.", "Belly Spawnpoint") as null|anything in available_bellies
 				if(!vore_spawn_gut)
 					return
-				absorb_choice = alert(C, "Do you want to instantly absorb them?", "Confirm", "Yes", "No") //CHOMPAdd
+				//CHOMPAdd Start
+				if(alert(C, "Do you want to instantly absorb them?", "Confirm", "Yes", "No") == "Yes")
+					absorb_choice = 1
+				//CHOMPAdd End
 				to_chat(C, "<b><span class='warning'>[prey] has received your spawn request. Please wait.</span></b>")
 				log_admin("[key_name(C)] has requested to pred spawn onto [key_name(prey)]")
 				message_admins("[key_name(C)] has requested to pred spawn onto [key_name(prey)]")
@@ -816,7 +820,7 @@ var/global/datum/controller/occupations/job_master
 				if(prey.no_latejoin_prey_warning)
 					if(prey.no_latejoin_prey_warning_time > 0)
 						//CHOMPEdit Start
-						if(absorb_choice == "Yes")
+						if(absorb_choice)
 							confirm = tgui_alert(prey, "[C.prefs.real_name] is attempting to televore and instantly absorb you with their [vore_spawn_gut]. Let them?", "Confirm", list("No", "Yes"), prey.no_latejoin_prey_warning_time SECONDS)
 						else
 							confirm = tgui_alert(prey, "[C.prefs.real_name] is attempting to televore you into their [vore_spawn_gut]. Let them?", "Confirm", list("No", "Yes"), prey.no_latejoin_prey_warning_time SECONDS)
@@ -825,7 +829,7 @@ var/global/datum/controller/occupations/job_master
 						confirm = "Yes"
 				else
 					//CHOMPEdit Start
-					if(absorb_choice == "Yes")
+					if(absorb_choice)
 						confirm = alert(prey, "[C.prefs.real_name] is attempting to televore and instantly absorb you with their [vore_spawn_gut]. Let them?", "Confirm", "No", "Yes")
 					else
 						confirm = alert(prey, "[C.prefs.real_name] is attempting to televore you into their [vore_spawn_gut]. Let them?", "Confirm", "No", "Yes")

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -673,7 +673,7 @@ var/global/datum/controller/occupations/job_master
 	var/datum/spawnpoint/spawnpos
 	var/fail_deadly = FALSE
 	var/obj/belly/vore_spawn_gut
-	var/absorb_choice = 0 //CHOMPAdd - Ability to start absorbed with vorespawn
+	var/absorb_choice = FALSE //CHOMPAdd - Ability to start absorbed with vorespawn
 	var/mob/living/prey_to_nomph
 	var/obj/item/item_to_be //CHOMPEdit - Item TF spawning
 	var/mob/living/item_carrier //CHOMPEdit - Capture crystal spawning
@@ -721,13 +721,13 @@ var/global/datum/controller/occupations/job_master
 				if(!vore_spawn_gut)
 					return
 				//CHOMPAdd Start
-				if(vore_spawn_gut.vorespawn_absorbed == 1)
-					if(alert(C, "[pred]'s [vore_spawn_gut] will start with you absorbed. Continue?", "Confirm", "Yes", "No") != "Yes")
+				if(vore_spawn_gut.vorespawn_absorbed & VS_FLAG_ABSORB_YES)
+					absorb_choice = TRUE
+					if(vore_spawn_gut.vorespawn_absorbed & VS_FLAG_ABSORB_PREY)
+						if(alert(C, "Do you want to start absorbed into [pred]'s [vore_spawn_gut]?", "Confirm", "Yes", "No") != "Yes")
+							absorb_choice = FALSE
+					else if(alert(C, "[pred]'s [vore_spawn_gut] will start with you absorbed. Continue?", "Confirm", "Yes", "No") != "Yes")
 						return
-					absorb_choice = 1
-				if(vore_spawn_gut.vorespawn_absorbed == 2)
-					if(alert(C, "Do you want to start absorbed into [pred]'s [vore_spawn_gut]?", "Confirm", "Yes", "No") == "Yes")
-						absorb_choice = 1
 				//CHOMPAdd End
 				to_chat(C, "<b><span class='warning'>[pred] has received your spawn request. Please wait.</span></b>")
 				log_admin("[key_name(C)] has requested to vore spawn into [key_name(pred)]")
@@ -810,7 +810,7 @@ var/global/datum/controller/occupations/job_master
 					return
 				//CHOMPAdd Start
 				if(alert(C, "Do you want to instantly absorb them?", "Confirm", "Yes", "No") == "Yes")
-					absorb_choice = 1
+					absorb_choice = TRUE
 				//CHOMPAdd End
 				to_chat(C, "<b><span class='warning'>[prey] has received your spawn request. Please wait.</span></b>")
 				log_admin("[key_name(C)] has requested to pred spawn onto [key_name(prey)]")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -587,6 +587,7 @@
 			if(imp.handle_implant(character,character.zone_sel.selecting))
 				imp.post_implant(character)
 	var/gut = join_props["voreny"]
+	var/start_absorbed = join_props["absorb"] //CHOMPAdd
 	var/mob/living/prey = join_props["prey"]
 	//CHOMPEdit Start - Item TF
 	if(itemtf && istype(itemtf, /obj/item/capture_crystal))
@@ -613,9 +614,17 @@
 		tele.set_up("#00FFFF", get_turf(prey))
 		tele.start()
 		character.forceMove(get_turf(prey))
+		//CHOMPAdd Start
+		if(start_absorbed == "Yes")
+			prey.absorbed = 1
+		//CHOMPAdd End
 		prey.forceMove(gut_to_enter)
 	else
 		if(gut)
+			//CHOMPAdd Start
+			if(start_absorbed == "Yes")
+				character.absorbed = 1
+			//CHOMPAdd End
 			character.forceMove(gut)
 
 	character.client.init_verbs() // init verbs for the late join

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -615,14 +615,14 @@
 		tele.start()
 		character.forceMove(get_turf(prey))
 		//CHOMPAdd Start
-		if(start_absorbed == "Yes")
+		if(start_absorbed)
 			prey.absorbed = 1
 		//CHOMPAdd End
 		prey.forceMove(gut_to_enter)
 	else
 		if(gut)
 			//CHOMPAdd Start
-			if(start_absorbed == "Yes")
+			if(start_absorbed)
 				character.absorbed = 1
 			//CHOMPAdd End
 			character.forceMove(gut)

--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -57,7 +57,6 @@
 	var/vorespawn_blacklist = FALSE
 	var/vorespawn_whitelist = list()
 	var/vorespawn_absorbed = 0
-	var/tmp/static/list/vorespawn_absorbed_flags_list = list("No" = 0, "Yes" = VS_FLAG_ABSORB_YES, "Prey Choice" = VS_FLAG_ABSORB_CHOICE)
 
 	var/list/fullness1_messages = list(
 		"%pred's %belly looks empty"

--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -55,6 +55,8 @@
 	var/liquid_fullness4_messages = FALSE
 	var/liquid_fullness5_messages = FALSE
 	var/vorespawn_blacklist = FALSE
+	var/vorespawn_whitelist = list()
+	var/vorespawn_absorbed = "No"
 
 	var/list/fullness1_messages = list(
 		"%pred's %belly looks empty"

--- a/code/modules/vore/eating/belly_obj_ch.dm
+++ b/code/modules/vore/eating/belly_obj_ch.dm
@@ -56,7 +56,8 @@
 	var/liquid_fullness5_messages = FALSE
 	var/vorespawn_blacklist = FALSE
 	var/vorespawn_whitelist = list()
-	var/vorespawn_absorbed = "No"
+	var/vorespawn_absorbed = 0
+	var/tmp/static/list/vorespawn_absorbed_flags_list = list("No" = 0, "Yes" = VS_FLAG_ABSORB_YES, "Prey Choice" = VS_FLAG_ABSORB_CHOICE)
 
 	var/list/fullness1_messages = list(
 		"%pred's %belly looks empty"

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -430,6 +430,8 @@
 	"fullness4_messages",
 	"fullness5_messages",
 	"vorespawn_blacklist",
+	"vorespawn_whitelist",
+	"vorespawn_absorbed",
 	"vore_sprite_flags",
 	"affects_vore_sprites",
 	"count_absorbed_prey_for_sprite",
@@ -2586,6 +2588,8 @@
 	dupe.reagent_transfer_verb = reagent_transfer_verb
 	dupe.custom_max_volume = custom_max_volume
 	dupe.vorespawn_blacklist = vorespawn_blacklist
+	dupe.vorespawn_whitelist = vorespawn_whitelist
+	dupe.vorespawn_absorbed = vorespawn_absorbed
 	dupe.vore_sprite_flags = vore_sprite_flags
 	dupe.affects_vore_sprites = affects_vore_sprites
 	dupe.count_absorbed_prey_for_sprite = count_absorbed_prey_for_sprite

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -2214,10 +2214,8 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 				if(1)
 					host.soulcatcher_pref_flags ^= SOULCATCHER_ALLOW_DELETION_INSTANT
 				if(2)
-					if(host.soulcatcher_pref_flags & SOULCATCHER_ALLOW_DELETION)
-						host.soulcatcher_pref_flags ^= SOULCATCHER_ALLOW_DELETION
-					if(host.soulcatcher_pref_flags & SOULCATCHER_ALLOW_DELETION_INSTANT)
-						host.soulcatcher_pref_flags ^= SOULCATCHER_ALLOW_DELETION_INSTANT
+					host.soulcatcher_pref_flags &= ~(SOULCATCHER_ALLOW_DELETION)
+					host.soulcatcher_pref_flags &= ~(SOULCATCHER_ALLOW_DELETION_INSTANT)
 			if(host.client.prefs_vr)
 				host.client.prefs_vr.soulcatcher_pref_flags = host.soulcatcher_pref_flags
 			unsaved_changes = TRUE

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -1154,11 +1154,9 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 					var/new_vorespawn_whitelist = splittext(sanitize(lowertext(jointext(belly_data["vorespawn_whitelist"],"\n")),MAX_MESSAGE_LEN,0,0,0),"\n")
 					new_belly.vorespawn_whitelist = new_vorespawn_whitelist
 
-				if(istext(belly_data["vorespawn_absorbed"]))
-					var/new_vorespawn_absorbed = sanitize(belly_data["vorespawn_absorbed"],MAX_MESSAGE_LEN,0,0,0)
-					if(new_vorespawn_absorbed)
-						if(new_vorespawn_absorbed in list("Yes","No","Prey Choice"))
-							new_belly.vorespawn_absorbed = new_vorespawn_absorbed
+				if(isnum(belly_data["vorespawn_absorbed"]))
+					var/new_vorespawn_absorbed = belly_data["vorespawn_absorbed"]
+					new_belly.vorespawn_absorbed = sanitize_integer(new_vorespawn_absorbed, 0, 2, initial(new_belly.vorespawn_absorbed))
 
 				if(istext(belly_data["egg_type"]))
 					var/new_egg_type = sanitize(belly_data["egg_type"],MAX_MESSAGE_LEN,0,0,0)
@@ -3868,9 +3866,10 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 				host.vore_selected.vorespawn_whitelist = list()
 			. = TRUE
 		if("b_vorespawn_absorbed") //CHOMP Addition
-			var/new_vorespawn_absorbed = tgui_input_list(user, "Do you want prey who vorespawn this belly to start absorbed? Prey Choice lets the prey choose when spawning.","Absorbed Choice", list("Yes","No","Prey Choice"))
+			var/list/menu_list = host.vore_selected.vorespawn_absorbed_flags_list.Copy()
+			var/new_vorespawn_absorbed = tgui_input_list(user, "Do you want prey who vorespawn this belly to start absorbed? Prey Choice lets the prey choose when spawning.","Absorbed Choice", menu_list)
 			if(new_vorespawn_absorbed)
-				host.vore_selected.vorespawn_absorbed = new_vorespawn_absorbed
+				host.vore_selected.vorespawn_absorbed = menu_list[new_vorespawn_absorbed]
 			. = TRUE
 		if("b_belly_sprite_to_affect") //CHOMP Addition
 			var/belly_choice = tgui_input_list(user, "Which belly sprite do you want your [lowertext(host.vore_selected.name)] to affect?","Select Region", host.vore_icon_bellies) //ChompEDIT - user, not usr

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -283,7 +283,7 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 			"custom_ingested_alpha" = selected.custom_ingested_alpha,
 			"vorespawn_blacklist" = selected.vorespawn_blacklist,
 			"vorespawn_whitelist" = selected.vorespawn_whitelist,
-			"vorespawn_absorbed" = selected.vorespawn_absorbed,
+			"vorespawn_absorbed" = (global_flag_check(selected.vorespawn_absorbed, VS_FLAG_ABSORB_YES) + global_flag_check(selected.vorespawn_absorbed, VS_FLAG_ABSORB_PREY)),
 			"sound_volume" = selected.sound_volume,
 			"affects_voresprite" = selected.affects_vore_sprites,
 			"absorbed_voresprite" = selected.count_absorbed_prey_for_sprite,
@@ -1155,8 +1155,14 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 					new_belly.vorespawn_whitelist = new_vorespawn_whitelist
 
 				if(isnum(belly_data["vorespawn_absorbed"]))
-					var/new_vorespawn_absorbed = belly_data["vorespawn_absorbed"]
-					new_belly.vorespawn_absorbed = sanitize_integer(new_vorespawn_absorbed, 0, 2, initial(new_belly.vorespawn_absorbed))
+					var/new_vorespawn_absorbed = 0
+					var/updated_vorespawn_absorbed = belly_data["vorespawn_absorbed"]
+					if(updated_vorespawn_absorbed & VS_FLAG_ABSORB_YES)
+						new_vorespawn_absorbed |= VS_FLAG_ABSORB_YES
+					if(updated_vorespawn_absorbed & VS_FLAG_ABSORB_PREY)
+						new_vorespawn_absorbed |= VS_FLAG_ABSORB_YES
+						new_vorespawn_absorbed |= VS_FLAG_ABSORB_PREY
+					new_belly.vorespawn_absorbed = new_vorespawn_absorbed
 
 				if(istext(belly_data["egg_type"]))
 					var/new_egg_type = sanitize(belly_data["egg_type"],MAX_MESSAGE_LEN,0,0,0)
@@ -3866,11 +3872,17 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 				host.vore_selected.vorespawn_whitelist = list()
 			. = TRUE
 		if("b_vorespawn_absorbed") //CHOMP Addition
-			var/list/menu_list = host.vore_selected.vorespawn_absorbed_flags_list.Copy()
-			var/new_vorespawn_absorbed = tgui_input_list(user, "Do you want prey who vorespawn this belly to start absorbed? Prey Choice lets the prey choose when spawning.","Absorbed Choice", menu_list)
-			if(new_vorespawn_absorbed)
-				host.vore_selected.vorespawn_absorbed = menu_list[new_vorespawn_absorbed]
-			. = TRUE
+			var/current_number = global_flag_check(host.vore_selected.vorespawn_absorbed, VS_FLAG_ABSORB_YES) + global_flag_check(host.vore_selected.vorespawn_absorbed, VS_FLAG_ABSORB_PREY)
+			switch(current_number)
+				if(0)
+					host.vore_selected.vorespawn_absorbed |= VS_FLAG_ABSORB_YES
+				if(1)
+					host.vore_selected.vorespawn_absorbed |= VS_FLAG_ABSORB_PREY
+				if(2)
+					host.vore_selected.vorespawn_absorbed &= ~(VS_FLAG_ABSORB_YES)
+					host.vore_selected.vorespawn_absorbed &= ~(VS_FLAG_ABSORB_PREY)
+			unsaved_changes = TRUE
+			return TRUE
 		if("b_belly_sprite_to_affect") //CHOMP Addition
 			var/belly_choice = tgui_input_list(user, "Which belly sprite do you want your [lowertext(host.vore_selected.name)] to affect?","Select Region", host.vore_icon_bellies) //ChompEDIT - user, not usr
 			if(!belly_choice) //They cancelled, no changes

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -282,6 +282,8 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 			"custom_ingested_color" = selected.custom_ingested_color,
 			"custom_ingested_alpha" = selected.custom_ingested_alpha,
 			"vorespawn_blacklist" = selected.vorespawn_blacklist,
+			"vorespawn_whitelist" = selected.vorespawn_whitelist,
+			"vorespawn_absorbed" = selected.vorespawn_absorbed,
 			"sound_volume" = selected.sound_volume,
 			"affects_voresprite" = selected.affects_vore_sprites,
 			"absorbed_voresprite" = selected.count_absorbed_prey_for_sprite,
@@ -1147,6 +1149,16 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 						new_belly.vorespawn_blacklist = FALSE
 					if(new_vorespawn_blacklist == 1)
 						new_belly.vorespawn_blacklist = TRUE
+
+				if(islist(belly_data["vorespawn_whitelist"]))
+					var/new_vorespawn_whitelist = splittext(sanitize(lowertext(jointext(belly_data["vorespawn_whitelist"],"\n")),MAX_MESSAGE_LEN,0,0,0),"\n")
+					new_belly.vorespawn_whitelist = new_vorespawn_whitelist
+
+				if(istext(belly_data["vorespawn_absorbed"]))
+					var/new_vorespawn_absorbed = sanitize(belly_data["vorespawn_absorbed"],MAX_MESSAGE_LEN,0,0,0)
+					if(new_vorespawn_absorbed)
+						if(new_vorespawn_absorbed in list("Yes","No","Prey Choice"))
+							new_belly.vorespawn_absorbed = new_vorespawn_absorbed
 
 				if(istext(belly_data["egg_type"]))
 					var/new_egg_type = sanitize(belly_data["egg_type"],MAX_MESSAGE_LEN,0,0,0)
@@ -3847,6 +3859,18 @@ var/global/list/belly_colorable_only_fullscreens = list("a_synth_flesh_mono",
 			. = TRUE
 		if("b_vorespawn_blacklist") //CHOMP Addition
 			host.vore_selected.vorespawn_blacklist = !host.vore_selected.vorespawn_blacklist
+			. = TRUE
+		if("b_vorespawn_whitelist") //CHOMP Addition
+			var/new_vorespawn_whitelist = sanitize(tgui_input_text(user,"Input ckeys allowed to vorespawn on separate lines. Cancel will clear the list.","Allowed Players",jointext(host.vore_selected.vorespawn_whitelist,"\n"), multiline = TRUE, prevent_enter = TRUE),MAX_MESSAGE_LEN,0,0,0)
+			if(new_vorespawn_whitelist)
+				host.vore_selected.vorespawn_whitelist = splittext(lowertext(new_vorespawn_whitelist),"\n")
+			else
+				host.vore_selected.vorespawn_whitelist = list()
+			. = TRUE
+		if("b_vorespawn_absorbed") //CHOMP Addition
+			var/new_vorespawn_absorbed = tgui_input_list(user, "Do you want prey who vorespawn this belly to start absorbed? Prey Choice lets the prey choose when spawning.","Absorbed Choice", list("Yes","No","Prey Choice"))
+			if(new_vorespawn_absorbed)
+				host.vore_selected.vorespawn_absorbed = new_vorespawn_absorbed
 			. = TRUE
 		if("b_belly_sprite_to_affect") //CHOMP Addition
 			var/belly_choice = tgui_input_list(user, "Which belly sprite do you want your [lowertext(host.vore_selected.name)] to affect?","Select Region", host.vore_icon_bellies) //ChompEDIT - user, not usr

--- a/modular_chomp/code/modules/vore/eating/exportpanel_ch.dm
+++ b/modular_chomp/code/modules/vore/eating/exportpanel_ch.dm
@@ -290,6 +290,8 @@
 			belly_data["emote_time"] = B.emote_time
 			belly_data["shrink_grow_size"] = B.shrink_grow_size
 			belly_data["vorespawn_blacklist"] = B.vorespawn_blacklist
+			belly_data["vorespawn_whitelist"] = B.vorespawn_whitelist
+			belly_data["vorespawn_absorbed"] = B.vorespawn_absorbed
 			belly_data["egg_type"] = B.egg_type
 			belly_data["egg_name"] = B.egg_name
 			belly_data["egg_size"] = B.egg_size

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyTabs/VoreSelectedBellyOptions.tsx
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyTabs/VoreSelectedBellyOptions.tsx
@@ -2,6 +2,7 @@ import { capitalize } from 'common/string';
 
 import { useBackend } from '../../../../backend';
 import { Button, Flex, LabeledList } from '../../../../components';
+import { vorespawnAbsorbedColor, vorespawnAbsorbedText } from '../constants';
 import { hostMob, selectedData } from '../types';
 import { VoreSelectedMobTypeBellyButtons } from './VoreSelectedMobTypeBellyButtons';
 
@@ -276,22 +277,13 @@ export const VoreSelectedBellyOptions = (props: {
               </LabeledList.Item>
               <LabeledList.Item label="Vore Spawn Absorbed">
                 <Button
-                  color={
-                    vorespawn_absorbed === 0
-                      ? undefined
-                      : vorespawn_absorbed === 1
-                        ? 'green'
-                        : 'orange'
-                  }
+                  color={vorespawnAbsorbedColor[vorespawn_absorbed]}
+                  tooltip="Click to toggle between No, Yes and Prey's Choice."
                   onClick={() =>
                     act('set_attribute', { attribute: 'b_vorespawn_absorbed' })
                   }
                 >
-                  {vorespawn_absorbed === 0
-                    ? 'No'
-                    : vorespawn_absorbed === 1
-                      ? 'Yes'
-                      : 'Prey Choice'}
+                  {vorespawnAbsorbedText[vorespawn_absorbed]}
                 </Button>
               </LabeledList.Item>
             </>

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyTabs/VoreSelectedBellyOptions.tsx
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyTabs/VoreSelectedBellyOptions.tsx
@@ -277,9 +277,9 @@ export const VoreSelectedBellyOptions = (props: {
               <LabeledList.Item label="Vore Spawn Absorbed">
                 <Button
                   color={
-                    vorespawn_absorbed === 'No'
+                    vorespawn_absorbed === 0
                       ? undefined
-                      : vorespawn_absorbed === 'Yes'
+                      : vorespawn_absorbed === 1
                         ? 'green'
                         : 'orange'
                   }
@@ -287,7 +287,11 @@ export const VoreSelectedBellyOptions = (props: {
                     act('set_attribute', { attribute: 'b_vorespawn_absorbed' })
                   }
                 >
-                  {vorespawn_absorbed}
+                  {vorespawn_absorbed === 0
+                    ? 'No'
+                    : vorespawn_absorbed === 1
+                      ? 'Yes'
+                      : 'Prey Choice'}
                 </Button>
               </LabeledList.Item>
             </>

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyTabs/VoreSelectedBellyOptions.tsx
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanel/VoreSelectedBellyTabs/VoreSelectedBellyOptions.tsx
@@ -40,6 +40,8 @@ export const VoreSelectedBellyOptions = (props: {
     save_digest_mode,
     eating_privacy_local,
     vorespawn_blacklist,
+    vorespawn_whitelist,
+    vorespawn_absorbed,
     private_struggle,
     drainmode,
   } = belly;
@@ -256,6 +258,40 @@ export const VoreSelectedBellyOptions = (props: {
               {vorespawn_blacklist ? 'Yes' : 'No'}
             </Button>
           </LabeledList.Item>
+          {vorespawn_blacklist ? (
+            ''
+          ) : (
+            <>
+              <LabeledList.Item label="Vore Spawn Whitelist">
+                <Button
+                  onClick={() =>
+                    act('set_attribute', { attribute: 'b_vorespawn_whitelist' })
+                  }
+                  icon="pen"
+                >
+                  {vorespawn_whitelist.length
+                    ? vorespawn_whitelist.join(', ')
+                    : 'Anyone!'}
+                </Button>
+              </LabeledList.Item>
+              <LabeledList.Item label="Vore Spawn Absorbed">
+                <Button
+                  color={
+                    vorespawn_absorbed === 'No'
+                      ? undefined
+                      : vorespawn_absorbed === 'Yes'
+                        ? 'green'
+                        : 'orange'
+                  }
+                  onClick={() =>
+                    act('set_attribute', { attribute: 'b_vorespawn_absorbed' })
+                  }
+                >
+                  {vorespawn_absorbed}
+                </Button>
+              </LabeledList.Item>
+            </>
+          )}
           <LabeledList.Item label="Egg Type">
             <Button
               onClick={() => act('set_attribute', { attribute: 'b_egg_type' })}

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanel/constants.ts
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanel/constants.ts
@@ -1,4 +1,10 @@
 export const stats: (string | undefined)[] = [undefined, 'average', 'bad'];
+export const vorespawnAbsorbedText: string[] = ['No', 'Yes', 'Prey Choice'];
+export const vorespawnAbsorbedColor: (string | undefined)[] = [
+  undefined,
+  'green',
+  'orange',
+];
 
 export const digestModeToColor = {
   Default: undefined,

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanel/types.ts
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanel/types.ts
@@ -123,6 +123,8 @@ export type selectedData = {
   custom_ingested_color: string;
   custom_ingested_alpha: number;
   vorespawn_blacklist: BooleanLike;
+  vorespawn_whitelist: string[];
+  vorespawn_absorbed: string;
   sound_volume: number;
   affects_voresprite: BooleanLike;
   absorbed_voresprite: BooleanLike;

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanel/types.ts
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanel/types.ts
@@ -124,7 +124,7 @@ export type selectedData = {
   custom_ingested_alpha: number;
   vorespawn_blacklist: BooleanLike;
   vorespawn_whitelist: string[];
-  vorespawn_absorbed: string;
+  vorespawn_absorbed: number;
   sound_volume: number;
   affects_voresprite: BooleanLike;
   absorbed_voresprite: BooleanLike;

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanelExport/VorePanelExportBellyString.tsx
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanelExport/VorePanelExportBellyString.tsx
@@ -40,6 +40,8 @@ export const generateBellyString = (belly: Belly, index: number) => {
     emote_time,
     shrink_grow_size,
     vorespawn_blacklist,
+    vorespawn_whitelist,
+    vorespawn_absorbed,
     egg_type,
     egg_name,
     selective_preference,
@@ -633,6 +635,8 @@ export const generateBellyString = (belly: Belly, index: number) => {
   result += '<li class="list-group-item">Idle Emote Delay: ' + emote_time + ' seconds</li>';
   result += '<li class="list-group-item">Shrink/Grow Size: ' + shrink_grow_size * 100 + '%</li>';
   result += '<li class="list-group-item">Vore Spawn Blacklist: ' + (vorespawn_blacklist ? '<span style="color: green;">Yes' : '<span style="color: red;">No') + '</li>';
+  result += '<li class="list-group-item">Vore Spawn Whitelist: ' + (vorespawn_whitelist.length ? vorespawn_whitelist.join(', ') : 'Anyone!') + '</li>';
+  result += '<li class="list-group-item">Vore Spawn Absorbed: ' + (vorespawn_absorbed === 'No' ? '<span style="color: red;">No' : vorespawn_absorbed === 'Yes' ? '<span style="color: green;">Yes' : '<span style="color: orange;">Prey Choice') + '</li>';
   result += '<li class="list-group-item">Egg Type: ' + egg_type + '</li>';
   result += '<li class="list-group-item">Selective Mode Preference: ' + selective_preference + '</li>';
   result += '</ul>';

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanelExport/VorePanelExportBellyString.tsx
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanelExport/VorePanelExportBellyString.tsx
@@ -636,7 +636,7 @@ export const generateBellyString = (belly: Belly, index: number) => {
   result += '<li class="list-group-item">Shrink/Grow Size: ' + shrink_grow_size * 100 + '%</li>';
   result += '<li class="list-group-item">Vore Spawn Blacklist: ' + (vorespawn_blacklist ? '<span style="color: green;">Yes' : '<span style="color: red;">No') + '</li>';
   result += '<li class="list-group-item">Vore Spawn Whitelist: ' + (vorespawn_whitelist.length ? vorespawn_whitelist.join(', ') : 'Anyone!') + '</li>';
-  result += '<li class="list-group-item">Vore Spawn Absorbed: ' + (vorespawn_absorbed === 'No' ? '<span style="color: red;">No' : vorespawn_absorbed === 'Yes' ? '<span style="color: green;">Yes' : '<span style="color: orange;">Prey Choice') + '</li>';
+  result += '<li class="list-group-item">Vore Spawn Absorbed: ' + (vorespawn_absorbed === 0 ? '<span style="color: red;">No' : vorespawn_absorbed === 1 ? '<span style="color: green;">Yes' : '<span style="color: orange;">Prey Choice') + '</li>';
   result += '<li class="list-group-item">Egg Type: ' + egg_type + '</li>';
   result += '<li class="list-group-item">Selective Mode Preference: ' + selective_preference + '</li>';
   result += '</ul>';

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanelExport/types.ts
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanelExport/types.ts
@@ -39,6 +39,8 @@ export type Belly = {
   emote_time: number;
   shrink_grow_size: number;
   vorespawn_blacklist: BooleanLike;
+  vorespawn_whitelist: string[];
+  vorespawn_absorbed: string;
   egg_type: string;
   egg_name: string;
   selective_preference: string;

--- a/tgui/packages/tgui/interfaces/chompstation/VorePanelExport/types.ts
+++ b/tgui/packages/tgui/interfaces/chompstation/VorePanelExport/types.ts
@@ -40,7 +40,7 @@ export type Belly = {
   shrink_grow_size: number;
   vorespawn_blacklist: BooleanLike;
   vorespawn_whitelist: string[];
-  vorespawn_absorbed: string;
+  vorespawn_absorbed: number;
   egg_type: string;
   egg_name: string;
   selective_preference: string;


### PR DESCRIPTION

## About The Pull Request
Adds two new belly options for vorespawns. A whitelist to only show the belly on vorespawn for particular ckeys, and a preference on whether that belly absorbs preyspawns or not.

The whitelist allows hiding of certain bellies so only those the pred would want spawning in them can attempt to. This should assist in more graphic belly names not being so easily visible but still vore spawnable for continued scenes.

The vorespawn absorb is a belly choice with three options. Defaulted to No, where all prey spawns will just be regular vore. The Yes option will make prey spawning there absorbed, but the prey get a warning prompt saying this will happen before the request is sent to the pred. The Prey Choice option lets the prey choose between being absorbed to start or not, and if the prey chooses to be absorbed the pred will see this in the notification they receive before accepting.

In addition, the vorespawn pred now has an additional option to instantly absorb those they spawn on. This is articulated to the prey receiving the request. It doesn't require any belly specific options set for either party.
## Changelog
:cl:
add: Two new belly options for vorespawn. Whitelisting ckeys and whether the belly absorbs prey on spawn.
add: Added a prompt for vorespawn preds to instantly absorb their chosen prey.
/:cl:
