### PR TITLE
show the borgs name, not 1 when authenticated

### DIFF
--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -38,8 +38,8 @@ var/list/adminfaxes = list()	//cache for faxes that have been sent to admins
 /obj/machinery/photocopier/faxmachine/attack_hand(mob/user as mob) // CH edit begins here; this allows borgs to use fax machines, meant for the Unity and Clerical modules.
 	user.set_machine(src)
 
-	if(issilicon(usr))
-		authenticated = 1
+	if(issilicon(user))
+		authenticated = user.name
 		tgui_interact(user)
 	else
 		tgui_interact(user)


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:
fix: showing borg name on the fax instead of just 1
/:cl:
