### PR TITLE
limit visible message for objects

### DIFF
--- a/modular_chomp/code/datums/components/hearer.dm
+++ b/modular_chomp/code/datums/components/hearer.dm
@@ -77,7 +77,7 @@
 				M.create_chat_message(source, "[runemessage]", FALSE, list("emote"), audible = FALSE)
 		else if(blind_message)
 			M.show_message(blind_message, AUDIBLE_MESSAGE)
-	else
+	else if (source.invisibility <= SEE_INVISIBLE_LIVING)
 		parent_atom.show_message(message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
 
 //Atom definition (base)


### PR DESCRIPTION
## About The Pull Request
TM only for now, not sure if it doesn't break something.
## Changelog
:cl:
fix: all objects picking up ALL visible messages, even those they shouldn't
/:cl:
