### PR TITLE
Makes in-shoe deaths count as vore death

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -72,7 +72,7 @@
 	if(stat == DEAD)
 		return 0
 	SEND_SIGNAL(src, COMSIG_MOB_DEATH, gibbed)
-	if(src.loc && istype(loc,/obj/belly) || istype(loc,/obj/item/device/dogborg/sleeper)) deathmessage = "no message" //VOREStation Add - Prevents death messages from inside mobs
+	if(src.loc && istype(loc,/obj/belly) || istype(loc,/obj/item/device/dogborg/sleeper) || istype(loc, /obj/item/clothing/shoes)) deathmessage = "no message" //VOREStation Add - Prevents death messages from inside mobs - CHOMPEdit: Added in-shoe as well
 	facing_dir = null
 
 	if(!gibbed && deathmessage != DEATHGASP_NO_MESSAGE)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -84,6 +84,11 @@
 
 	callHook("death", list(src, gibbed))
 
+	// CHOMPAdd - Shoe steppy. I was going to make a hook but- It isn't much.
+	if(istype(loc, /obj/item/clothing/shoes))
+		mind?.vore_death = TRUE
+	// CHOMPEdit End
+
 	if(mind)
 		// SSgame_master.adjust_danger(gibbed ? 40 : 20)  // VOREStation Edit - We don't use SSgame_master yet.
 		for(var/mob/observer/dead/O in mob_list)


### PR DESCRIPTION

## About The Pull Request

Pretty much just title. Allows to get auto-resleeved faster after steppy deaths happens, and also no more messages when in-shoe death happens.

## Changelog
:cl:
qol: Shorter autoresleeve time after steps mechanics are applied
qol: Shoes muffle the death message 
/:cl:
