### PR TITLE
Makes sure that souls caught in the vore soulcatcher actually have their prefs.

### DIFF
--- a/html/changelogs_ch/AutoChangeLog-pr-8744.yml
+++ b/html/changelogs_ch/AutoChangeLog-pr-8744.yml
@@ -1,0 +1,4 @@
+author: "Kashargul"
+delete-after: True
+changes:
+  - bugfix: "self transfer to mmis not working"

--- a/modular_chomp/code/modules/vore/eating/soulcatcher.dm
+++ b/modular_chomp/code/modules/vore/eating/soulcatcher.dm
@@ -169,7 +169,7 @@
 	//Announce to host and other minds
 	notify_holder("New mind loaded: [brainmob.name]")
 	show_vore_fx(brainmob, TRUE)
-	brainmob.copy_from_prefs_vr()//CHOMPEDIT - The caught soul needs their prefs and only their prefs
+	brainmob.copy_from_prefs_vr(bellies = FALSE)
 	return TRUE
 
 // Allows to adjust the interior of the soulcatcher

--- a/modular_chomp/code/modules/vore/eating/soulcatcher.dm
+++ b/modular_chomp/code/modules/vore/eating/soulcatcher.dm
@@ -169,6 +169,7 @@
 	//Announce to host and other minds
 	notify_holder("New mind loaded: [brainmob.name]")
 	show_vore_fx(brainmob, TRUE)
+	brainmob.copy_from_prefs_vr()//CHOMPEDIT - The caught soul needs their prefs and only their prefs
 	return TRUE
 
 // Allows to adjust the interior of the soulcatcher


### PR DESCRIPTION

## About The Pull Request
After testing the vore soulcatcher locally, I found that caught souls didn't have their prefs after being caught (or at least the ones that matter for a caught soul). This PR fixes that.
Hopefully the proc I called is fine for this.
## Changelog
:cl:
fix: Souls caught in the vore soulcatcher will now actually have their prefs.
/:cl:
