### PR TITLE
Allows mind-binded creatures to use any emote (FIXED!!)

### DIFF
--- a/code/modules/mob/living/voice/voice.dm
+++ b/code/modules/mob/living/voice/voice.dm
@@ -150,6 +150,6 @@
 
 //CHOMPEdit Start: Emotes!
 /mob/living/voice/get_available_emotes()
-	. |= global._simple_mob_default_emotes.Copy()
+	. = global._simple_mob_default_emotes.Copy()
 	return
 //CHOMPEdit End

--- a/code/modules/mob/living/voice/voice.dm
+++ b/code/modules/mob/living/voice/voice.dm
@@ -148,3 +148,8 @@
 		..(m_type,message,range)
 	//CHOMPEdit End
 
+//CHOMPEdit Start: Emotes!
+/mob/living/voice/get_available_emotes()
+	. = global._simple_mob_default_emotes.Copy()
+	return
+//CHOMPEdit End

--- a/code/modules/mob/living/voice/voice.dm
+++ b/code/modules/mob/living/voice/voice.dm
@@ -150,6 +150,6 @@
 
 //CHOMPEdit Start: Emotes!
 /mob/living/voice/get_available_emotes()
-	. = global._simple_mob_default_emotes.Copy()
+	. |= global._simple_mob_default_emotes.Copy()
 	return
 //CHOMPEdit End


### PR DESCRIPTION

## About The Pull Request

Previously, if you mind-binded to an object, you could only use a handful of random emotes. Now, every emote that's available to simplemobs is now available to mind-binded creatures
## Changelog
:cl:
add: More emotes for mind-binded individuals
/:cl:
