### PR TITLE
Persistant Storage Alterations

### DIFF
--- a/code/modules/persistence/storage/smartfridge.dm
+++ b/code/modules/persistence/storage/smartfridge.dm
@@ -32,8 +32,10 @@
 
 /datum/persistent/storage/smartfridge/sheet_storage/lossy
 	name = "sheet storage lossy"
-	min_storage = 20	//if the amount is at or below this, don't cull
-	max_storage = 500	//if the amount is above this, cull it to this amount THEN do math
+	min_retained = 50 //CHOMPedit: Altering how many items can be held between rounds.
+	max_retained = 50 //CHOMPedit: Altering how many items can be held between rounds.
+	min_storage = 1	//if the amount is at or below this, don't cull //CHOMPedit: Altering how many items can be held between rounds.
+	max_storage = 2500	//if the amount is above this, cull it to this amount THEN do math //CHOMPedit: Altering how many items can be held between rounds.
 	stacks_go_missing = TRUE
 	minimum_storage_reserve = TRUE
 


### PR DESCRIPTION

## About The Pull Request

balance: culling of materials happens at 2500 instead of the previous 500
balance: material loss is 50% instead of the roughly 22% average of before.
balance: material loss can happen until a single material remains.

## Changelog
:cl:
balance: culling of materials happens at 2500 instead of the previous 500
balance: material loss is 50% instead of the roughly 22% average of before.
balance: material loss can happen until a single material remains.
/:cl:
