### PR TITLE
Fixes some bullets doing improper damage.

### DIFF
--- a/modular_chomp/code/modules/projectiles/guns/bullet.dm
+++ b/modular_chomp/code/modules/projectiles/guns/bullet.dm
@@ -1,5 +1,13 @@
 /obj/item/projectile/bullet
-	damage = 25 //seems many bullets use this vaule for some reason
+	damage = 25 //seems many bullets use this value for some reason
+
+/obj/item/projectile/bullet/a38 //These projectiles are used but dont exist, revolvers were super underpowered forever
+	damage = 25 //.38 pretty bwoomp
+
+/obj/item/projectile/bullet/rifle/a45lc
+	damage = 35 //.45 used by a single revolver
+
+
 /* Combat refactor walkback, default bullets do 60 damage I think so im keeping this, were not getting the CR20 incident again lol
 /obj/item/projectile/bullet/pistol
 	damage = 10


### PR DESCRIPTION

## About The Pull Request
A handful of revolvers were using projectiles that had no damage define anywhere, making them all do 10 damage. This fixes it.
Small caliber revolvers (like the detectives .38 special) now do 25 damage.
Medium caliber revolvers like the Colt single-action now do 35 damage.
## Changelog
:cl:
balance: Colt-Single-Action 25 -> 35
balance: Most small caliber revolvers 10 -> 25
fix: Fixed a bug that made half of the lower caliber revolvers doing the improper amount of damage.
/:cl:
