### PR TITLE
Fixes a handful of weapons shooting the wrong projectile, phase weapon nerf, floragun buff, one merc nerf.

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/humanoid/mercs/mercs.dm
@@ -167,6 +167,7 @@
 /mob/living/simple_mob/humanoid/merc/ranged/smg
 	icon_state = "syndicateranged_smg"
 	icon_living = "syndicateranged_smg"
+	projectiletype = /obj/item/projectile/bullet/a10mm //CHOMPedit, 20 instead of 35, SMG
 
 	loot_list = list(/obj/item/weapon/gun/projectile/automatic/c20r = 100)
 

--- a/code/modules/projectiles/guns/energy/phase.dm
+++ b/code/modules/projectiles/guns/energy/phase.dm
@@ -10,7 +10,7 @@
 	item_state = "phasecarbine"
 	wielded_item_state = "phasecarbine-wielded"
 	slot_flags = SLOT_BACK|SLOT_BELT
-	charge_cost = 80  //Chompedit Bringing charge cost down for all phase weapons.
+	charge_cost = 160  //Chompedit Bringing charge cost down for all phase weapons. 15 shots on normal cell
 	projectile_type = /obj/item/projectile/energy/phase
 	one_handed_penalty = 15
 	recoil_mode = 0 //CHOMP Addition: Removes recoil for micros.
@@ -27,7 +27,7 @@
 	one_handed_penalty = 0
 
 /obj/item/weapon/gun/energy/locked/phasegun/unlocked/mounted/cyborg
-	charge_cost = 80  //ChompEdit  Reduced from 480 to 200, further reduced to 80 to match normal phase guns
+	charge_cost = 160  //ChompEdit  Reduced from 480 to 200, further reduced to 80 to match normal phase guns
 	recharge_time = 16  //ChompEdit  set up to 16 due to lower charge cost
 
 /obj/item/weapon/gun/energy/locked/phasegun/pistol
@@ -37,7 +37,7 @@
 	item_state = "taser"	//I don't have an in-hand sprite, taser will be fine
 	w_class = ITEMSIZE_NORMAL
 	slot_flags = SLOT_BELT|SLOT_HOLSTER
-	charge_cost = 80  //Chompedit Bringing charge cost down for all phase weapons.
+	charge_cost = 160  //Chompedit Bringing charge cost down for all phase weapons. 15 shots on normal cell
 	projectile_type = /obj/item/projectile/energy/phase/light
 	one_handed_penalty = 0
 	move_delay = 0 // CHOMPEdit: Pistols have move_delay of 0
@@ -54,7 +54,7 @@
 	use_external_power = 1
 
 /obj/item/weapon/gun/energy/locked/phasegun/pistol/unlocked/mounted/cyborg
-	charge_cost = 80  //Chompedit, bringing in line with normal phase weapons
+	charge_cost = 160  //Chompedit, bringing in line with normal phase weapons
 	recharge_time = 7
 
 
@@ -62,11 +62,11 @@
 	name = "EW31 Orion" //ChompEDIT
 	desc = "The RayZar EW31 Orion, also known as the 'phase rifle', is a specialist energy-based weapon intended for use against hostile wildlife. This one has a safety interlock that prevents firing while in proximity to the facility." //ChompEDIT
 	icon_state = "phaserifle"
-	item_state = "phaserifle" 
+	item_state = "phaserifle"
 	wielded_item_state = "phaserifle-wielded"
 	w_class = ITEMSIZE_LARGE
 	slot_flags = SLOT_BACK
-	charge_cost = 80  //Chompedit Bringing charge cost down for all phase weapons.
+	charge_cost = 160  //Chompedit Bringing charge cost down for all phase weapons. 15 shots on normal cell
 	projectile_type = /obj/item/projectile/energy/phase/heavy
 	accuracy = 15
 	one_handed_penalty = 30
@@ -85,7 +85,7 @@
 	wielded_item_state = "phasecannon-wielded"	//TODO: New Sprites
 	w_class = ITEMSIZE_HUGE		// This thing is big.
 	slot_flags = SLOT_BACK
-	charge_cost = 80  //Chompedit Bringing charge cost down for all phase weapons.
+	charge_cost = 160  //Chompedit Bringing charge cost down for all phase weapons. 15 shots on normal cell
 	projectile_type = /obj/item/projectile/energy/phase/heavy/cannon
 	accuracy = 15
 	one_handed_penalty = 65

--- a/code/modules/projectiles/guns/projectile/zz_ballistics_ch.dm
+++ b/code/modules/projectiles/guns/projectile/zz_ballistics_ch.dm
@@ -1008,6 +1008,7 @@
 	auto_loading_type = OPEN_BOLT
 	muzzle_velocity = 860
 	one_handed_penalty = 90
+	fire_sound = 'sound/weapons/serdy/strela.ogg'
 
 //commented this out because it seems to be breaking the Kord -- Ocelot
 /*

--- a/modular_chomp/code/modules/projectiles/ammo_refactor/ammo_overrides.dm
+++ b/modular_chomp/code/modules/projectiles/ammo_refactor/ammo_overrides.dm
@@ -738,7 +738,7 @@ Medium Weapons
 
 /obj/item/weapon/gun/projectile/automatic/serdy/rpd
 	caliber = "medium"
-	projectile_type = /obj/item/projectile/bullet/rifle/a762
+	projectile_type = /obj/item/projectile/bullet/rifle/a762/sniper
 	allowed_magazines = list(/obj/item/ammo_magazine/medium_box)
 	magazine_type = /obj/item/ammo_magazine/medium_box
 

--- a/modular_chomp/code/modules/projectiles/ammo_refactor/ammo_overrides.dm
+++ b/modular_chomp/code/modules/projectiles/ammo_refactor/ammo_overrides.dm
@@ -43,8 +43,8 @@ Small Weapons
 
 /obj/item/weapon/gun/projectile/revolver/detective45
 	caliber = "small"
-	ammo_type = /obj/item/ammo_casing/simple/small
-	projectile_type = /obj/item/projectile/bullet/pistol/rubber
+	ammo_type = /obj/item/ammo_casing/simple/small/rubber
+	projectile_type = /obj/item/projectile/bullet/pistol/medium
 
 /obj/item/weapon/gun/projectile/revolver/lombardi
 	caliber = "small"
@@ -586,19 +586,19 @@ Medium Weapons
 
 /obj/item/weapon/gun/projectile/automatic/serdy/krinkov
 	caliber = "medium"
-	projectile_type = /obj/item/projectile/bullet/rifle/a762x39
+	projectile_type = /obj/item/projectile/bullet/rifle/a762
 	allowed_magazines = list(/obj/item/ammo_magazine/medium,/obj/item/ammo_magazine/medium_small)
 	magazine_type = /obj/item/ammo_magazine/medium
 
 /obj/item/weapon/gun/projectile/automatic/serdy/akm
 	caliber = "medium"
-	projectile_type = /obj/item/projectile/bullet/rifle/a762x39
+	projectile_type = /obj/item/projectile/bullet/rifle/a762
 	allowed_magazines = list(/obj/item/ammo_magazine/medium,/obj/item/ammo_magazine/medium_small)
 	magazine_type = /obj/item/ammo_magazine/medium
 
 /obj/item/weapon/gun/projectile/automatic/serdy/scrapak
 	caliber = "medium"
-	projectile_type = /obj/item/projectile/bullet/rifle/a762x39
+	projectile_type = /obj/item/projectile/bullet/rifle/a762
 	allowed_magazines = list(/obj/item/ammo_magazine/medium,/obj/item/ammo_magazine/medium_small)
 	magazine_type = /obj/item/ammo_magazine/medium
 
@@ -676,7 +676,7 @@ Medium Weapons
 /obj/item/weapon/gun/projectile/automatic/serdy/sks
 	caliber = "medium"
 	ammo_type = /obj/item/ammo_casing/simple/medium
-	projectile_type = /obj/item/projectile/bullet/rifle/a762x39
+	projectile_type = /obj/item/projectile/bullet/rifle/a762
 
 /obj/item/weapon/gun/projectile/automatic/serdy/mosin
 	caliber = "medium"
@@ -702,19 +702,19 @@ Medium Weapons
 
 /obj/item/weapon/gun/projectile/automatic/serdy/memegun
 	caliber = "medium"
-	projectile_type = /obj/item/projectile/bullet/rifle/a762x39
+	projectile_type = /obj/item/projectile/bullet/rifle/a762
 	allowed_magazines = list(/obj/item/ammo_magazine/medium,/obj/item/ammo_magazine/medium_small)
 	magazine_type = /obj/item/ammo_magazine/medium
 
 /obj/item/weapon/gun/projectile/automatic/serdy/tkb408
 	caliber = "medium"
-	projectile_type = /obj/item/projectile/bullet/rifle/a762x39
+	projectile_type = /obj/item/projectile/bullet/rifle/a762
 	allowed_magazines = list(/obj/item/ammo_magazine/medium,/obj/item/ammo_magazine/medium_small)
 	magazine_type = /obj/item/ammo_magazine/medium
 
 /obj/item/weapon/gun/projectile/automatic/serdy/groza
 	caliber = "medium"
-	projectile_type = /obj/item/projectile/bullet/rifle/a762x39
+	projectile_type = /obj/item/projectile/bullet/rifle/a762
 	allowed_magazines = list(/obj/item/ammo_magazine/medium,/obj/item/ammo_magazine/medium_small)
 	magazine_type = /obj/item/ammo_magazine/medium
 
@@ -738,13 +738,13 @@ Medium Weapons
 
 /obj/item/weapon/gun/projectile/automatic/serdy/rpd
 	caliber = "medium"
-	projectile_type = /obj/item/projectile/bullet/rifle/a762x39
+	projectile_type = /obj/item/projectile/bullet/rifle/a762
 	allowed_magazines = list(/obj/item/ammo_magazine/medium_box)
 	magazine_type = /obj/item/ammo_magazine/medium_box
 
 /obj/item/weapon/gun/projectile/automatic/serdy/rpk
 	caliber = "medium"
-	projectile_type = /obj/item/projectile/bullet/rifle/a762x39
+	projectile_type = /obj/item/projectile/bullet/rifle/a762
 	allowed_magazines = list(/obj/item/ammo_magazine/medium,/obj/item/ammo_magazine/medium_drum)
 	magazine_type = /obj/item/ammo_magazine/medium_drum
 

--- a/modular_chomp/code/modules/projectiles/ammo_refactor/ammo_overrides.dm
+++ b/modular_chomp/code/modules/projectiles/ammo_refactor/ammo_overrides.dm
@@ -676,7 +676,7 @@ Medium Weapons
 /obj/item/weapon/gun/projectile/automatic/serdy/sks
 	caliber = "medium"
 	ammo_type = /obj/item/ammo_casing/simple/medium
-	projectile_type = /obj/item/projectile/bullet/rifle/a762
+	projectile_type = /obj/item/projectile/bullet/rifle/a762/sniper
 
 /obj/item/weapon/gun/projectile/automatic/serdy/mosin
 	caliber = "medium"
@@ -738,7 +738,7 @@ Medium Weapons
 
 /obj/item/weapon/gun/projectile/automatic/serdy/rpd
 	caliber = "medium"
-	projectile_type = /obj/item/projectile/bullet/rifle/a762/sniper
+	projectile_type = /obj/item/projectile/bullet/rifle/a762
 	allowed_magazines = list(/obj/item/ammo_magazine/medium_box)
 	magazine_type = /obj/item/ammo_magazine/medium_box
 

--- a/modular_chomp/code/modules/projectiles/guns/bullet.dm
+++ b/modular_chomp/code/modules/projectiles/guns/bullet.dm
@@ -1,12 +1,43 @@
 /obj/item/projectile/bullet
 	damage = 25 //seems many bullets use this value for some reason
 
+//These are projectiles that do not have damage defined anywhere. Gonna follow laser weapons sorta with a extra kick, 25/35/60
 /obj/item/projectile/bullet/a38 //These projectiles are used but dont exist, revolvers were super underpowered forever
 	damage = 25 //.38 pretty bwoomp
 
-/obj/item/projectile/bullet/rifle/a45lc
-	damage = 35 //.45 used by a single revolver
+/obj/item/projectile/bullet/a10mm
+	damage = 20 //CR-20 do 20 lol
 
+/obj/item/projectile/bullet/rifle/a45lc
+	damage = 35 //.45 used by a one revolver
+
+/obj/item/projectile/bullet/rifle/a762/lmg
+	damage = 30
+
+/obj/item/projectile/bullet/a57 //P90s pack a punch?
+	damage = 30
+
+/obj/item/projectile/bullet/rifle/a545
+	fire_sound = 'sound/weapons/Gunshot_light.ogg'
+	damage = 30
+	hud_state = "rifle"
+
+/obj/item/projectile/bullet/rifle/a545/ap
+	damage = 25
+	armor_penetration = 50 // At 40 or more armor, this will do more damage than standard rounds.
+	hud_state = "rifle_ap"
+
+/obj/item/projectile/bullet/rifle/a545/hp
+	damage = 40
+	armor_penetration = -50
+	penetrating = 0
+	hud_state = "hivelo_iff"
+
+/obj/item/projectile/bullet/rifle/a545/hunter
+	damage = 15
+	SA_bonus_damage = 35 // 50 total on animals.
+	SA_vulnerability = SA_ANIMAL
+	hud_state = "rifle_heavy"
 
 /* Combat refactor walkback, default bullets do 60 damage I think so im keeping this, were not getting the CR20 incident again lol
 /obj/item/projectile/bullet/pistol

--- a/modular_chomp/code/modules/projectiles/guns/energy/laser.dm
+++ b/modular_chomp/code/modules/projectiles/guns/energy/laser.dm
@@ -1,4 +1,8 @@
-//File has been unticked due to combat refactor walk-back, things do more damage now
+/obj/item/weapon/gun/energy/floragun
+	charge_cost = 80
+
+/*
+//Combat refactor walk-back
 /obj/item/weapon/gun/energy
 	charge_cost = 80
 
@@ -92,3 +96,4 @@
 		list(mode_name="laser", fire_delay = 8, projectile_type=/obj/item/projectile/beam, modifystate="x01laser", fire_sound='sound/weapons/Laser.ogg', charge_cost = 160),
 		list(mode_name="gauss", fire_delay=15, projectile_type=/obj/item/projectile/energy/gauss, modifystate="x01gauss", fire_sound='sound/weapons/gauss_shoot.ogg', charge_cost = 120)
 		)
+*/

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -5016,6 +5016,7 @@
 #include "modular_chomp\code\modules\projectiles\guns\phase.dm"
 #include "modular_chomp\code\modules\projectiles\guns\special.dm"
 #include "modular_chomp\code\modules\projectiles\guns\staffs.dm"
+#include "modular_chomp\code\modules\projectiles\guns\energy\laser.dm"
 #include "modular_chomp\code\modules\projectiles\guns\energy\special.dm"
 #include "modular_chomp\code\modules\projectiles\guns\projectile\revolver.dm"
 #include "modular_chomp\code\modules\projectiles\precursor\eclipse.dm"


### PR DESCRIPTION

## About The Pull Request
Turns out there are allot of guns using the default fallback damage value by pointing at projectiles that don't have damage values attached to them. This fixes a good chunk of weapons, damage changes at changelog.

Phase rifles, doing lots of damage against simplemobs have pretty much been the only meta weapon for exploring against mobs, and the fact their mag capacity gave them a extremely high damage potential on a simple cell. (72 damage on a phase cannon + 30 shots on a basic cell was lots of potential damage). So capacity has been halved to 15 shots. Still more then most laser weapons with the tradeoff of only being useful against unarmored simplemobs. This should encourage people to use real weapons (that are now fixed) against non-animal mobs.

LMG projectile fixed

Makes SMG merc shoot SMG shots.

the Somataray now has a capacity of 30.
## Changelog
:cl:
balance: All AK type weapons 25 -> 35 (7.62 supreme)
balance: AK-74s damage 25 -> 30 (They use 5.56)
balance: SKS damage 25 -> 35 + hitscan
balance: CR-20 damage 25 -> 20
balance: SMG mercs damage 25 -> 20
balance: Phase weapon capacity halved. 30 -> 15
qol: Floragun capacity 10 -> 30
fix: LMG projectile shoots properly, 30 damage now.
fix: 7.62 weapons now point to the right projectile path.
fix: The detectives .45 revolver now wont TF real bullets to rubber bullets if loaded with such.
/:cl:
