### PR TITLE
limit vacuum size

### DIFF
--- a/modular_chomp/code/game/objects/items/devices/vacpack.dm
+++ b/modular_chomp/code/game/objects/items/devices/vacpack.dm
@@ -212,7 +212,7 @@
 		return
 	if(istype(target,/obj/item))
 		var/obj/item/I = target
-		if(is_type_in_list(I,item_vore_blacklist))
+		if(is_type_in_list(I,item_vore_blacklist) || I.w_class >= ITEMSIZE_HUGE)
 			return
 		if(vac_power > I.w_class)
 			if(vac_power == 7)


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:
balance: limits item size of suitable vacuumable items to everything smaller than huge size
/:cl:
