### PR TITLE
Re-Enables wormholes event

### DIFF
--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -83,5 +83,6 @@
 	P.failchance = 0
 	P.icon_state = "bhole3" // CHOMPEdit - Better icon as well
 	P.name = "wormhole"
+	P.event = TRUE // CHOMPAdd
 	spawn(rand(min_duration,max_duration))
 		qdel(P)

--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -1,12 +1,27 @@
 /proc/wormhole_event(var/set_duration = 5 MINUTES, var/wormhole_duration_modifier = 1)
 	spawn()
+	// CHOMPEdit Start - Only allowing these to go to the station
 		var/list/pick_turfs = list()
+		var/list/exits = list()
 		var/list/Z_choices = list()
+
 		Z_choices |= using_map.get_map_levels(1, FALSE)
+		Z_choices -= global.using_map.sealed_levels
+	// CHOMPEdit End
 		for(var/turf/simulated/floor/T in world)
 			if(T.z in Z_choices)
 				if(!T.block_tele)
 					pick_turfs += T
+		// CHOMPAdd Start - Chance to end up in a belly. Fun (:
+		for(var/mob/living/mob in player_list)
+			if(mob.can_be_drop_pred && isturf(mob.loc))
+				if(mob.vore_selected)
+					exits += mob.vore_selected
+				else if(mob.vore_organs.len)
+					exits += pick(mob.vore_organs)
+
+		exits |= pick_turfs
+		// CHOMPAdd End
 
 		if(pick_turfs.len)
 
@@ -47,7 +62,7 @@
 				pick_turfs -= enter							//remove it from pickable turfs list
 				if( !enter || !istype(enter) )	continue	//sanity
 
-				var/turf/simulated/floor/exit = pick(pick_turfs)
+				var/atom/exit = pick(exits) // CHOMPEdit
 //				pick_turfs -= exit
 				if( !exit || !istype(exit) )	continue	//sanity
 
@@ -57,7 +72,7 @@
 
 
 //maybe this proc can even be used as an admin tool for teleporting players without ruining immulsions?
-/proc/create_wormhole(var/turf/enter as turf, var/turf/exit as turf, var/min_duration = 30 SECONDS, var/max_duration = 60 SECONDS)
+/proc/create_wormhole(var/turf/enter as turf, var/atom/exit, var/min_duration = 30 SECONDS, var/max_duration = 60 SECONDS) // CHOMPEdit
 	set waitfor = FALSE
 	var/obj/effect/portal/P = new /obj/effect/portal( enter )
 	P.target = exit

--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -14,11 +14,13 @@
 					pick_turfs += T
 		// CHOMPAdd Start - Chance to end up in a belly. Fun (:
 		for(var/mob/living/mob in player_list)
-			if(mob.can_be_drop_pred && isturf(mob.loc))
-				if(mob.vore_selected)
-					exits += mob.vore_selected
-				else if(mob.vore_organs.len)
-					exits += pick(mob.vore_organs)
+			if(mob.can_be_drop_pred && isfloor(mob.loc))
+				var/turf/simulated/floor/T = get_turf(mob.loc)
+				if(!T.block_tele)
+					if(mob.vore_selected)
+						exits += mob.vore_selected
+					else if(mob.vore_organs.len)
+						exits += pick(mob.vore_organs)
 
 		exits |= pick_turfs
 		// CHOMPAdd End

--- a/code/game/gamemodes/events/wormholes.dm
+++ b/code/game/gamemodes/events/wormholes.dm
@@ -81,7 +81,7 @@
 	P.creator = null
 	P.icon = 'icons/obj/objects.dmi'
 	P.failchance = 0
-	P.icon_state = "anom"
+	P.icon_state = "bhole3" // CHOMPEdit - Better icon as well
 	P.name = "wormhole"
 	spawn(rand(min_duration,max_duration))
 		qdel(P)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -61,9 +61,18 @@ GLOBAL_LIST_BOILERPLATE(all_portals, /obj/effect/portal)
 				for(var/rider in L.buckled_mobs)
 					R.force_dismount(rider)
 		//VOREStation Addition End: Prevent taurriding abuse
+		// CHOMPAdd Start
+		if(isbelly(target))
+			if(target == M)
+				return
+			if(istype(M, /mob/living))
+				var/mob/living/L = M
+				if(L.can_be_drop_prey && L.devourable)
+					do_teleport(M, target)
+					return
+		// CHOMPAdd End
 		if(prob(failchance)) //oh dear a problem, put em in deep space
 			src.icon_state = "portal1"
 			do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0)
 		else
 			do_teleport(M, target, 1) ///You will appear adjacent to the beacon
-

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -11,6 +11,7 @@ GLOBAL_LIST_BOILERPLATE(all_portals, /obj/effect/portal)
 	var/obj/item/target = null
 	var/creator = null
 	anchored = TRUE
+	var/event = FALSE // CHOMPAdd
 
 /obj/effect/portal/Bumped(mob/M as mob|obj)
 	if(istype(M,/mob) && !(istype(M,/mob/living)))
@@ -21,8 +22,14 @@ GLOBAL_LIST_BOILERPLATE(all_portals, /obj/effect/portal)
 	return
 
 /obj/effect/portal/Crossed(atom/movable/AM as mob|obj)
+	// CHOMPEdit Start - Dephase kins on crossed
 	if(AM.is_incorporeal())
-		return
+		if(event)
+			if(iscarbon(AM))
+				var/mob/living/carbon/human/H = AM
+				H.attack_dephase()
+		else return
+	// CHOMPEdit End
 	if(istype(AM,/mob) && !(istype(AM,/mob/living)))
 		return	//do not send ghosts, zshadows, ai eyes, etc
 	spawn(0)

--- a/modular_chomp/code/modules/event/event_container_ch.dm
+++ b/modular_chomp/code/modules/event/event_container_ch.dm
@@ -104,6 +104,7 @@
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Spider Infestation",		/datum/event/spider_infestation, 		-20,	list(ASSIGNMENT_SECURITY = 30, ASSIGNMENT_HOS = 20, ASSIGNMENT_WARDEN = 20), 0, min_jobs = list(ASSIGNMENT_SECURITY = 1)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Supply Demand",			/datum/event/supply_demand,				0,		list(ASSIGNMENT_ANY = 5, ASSIGNMENT_SCIENCE = 15, ASSIGNMENT_GARDENER = 10, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 15), 1),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Virology Breach",			/datum/event/prison_break/virology,		0,		list(ASSIGNMENT_MEDICAL = 100), 1, min_jobs = list(ASSIGNMENT_MEDICAL = 1)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Wormholes",				/datum/event/wormholes,	 				20,		list(ASSIGNMENT_ANY = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Xenobiology Breach",		/datum/event/prison_break/xenobiology,	0,		list(ASSIGNMENT_SCIENCE = 100), 1, min_jobs = list(ASSIGNMENT_SCIENTIST = 1), min_jobs = list(ASSIGNMENT_SCIENTIST = 1, ASSIGNMENT_SECURITY =1)),
 	)
 	add_disabled_events(list(
@@ -111,8 +112,6 @@
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Random Antagonist",		/datum/event/random_antag,		 		2.5,	list(ASSIGNMENT_SECURITY = 1), 1, 0, 5),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Carp School",				/datum/event/carp_migration,			-20, 	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_SECURITY = 30, ASSIGNMENT_HOS = 10, ASSIGNMENT_WARDEN = 5), 1, min_jobs = list(ASSIGNMENT_SECURITY = 2)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Supply Demand",			/datum/event/supply_demand,				0,		list(ASSIGNMENT_ANY = 5, ASSIGNMENT_SCIENCE = 15, ASSIGNMENT_GARDENER = 10, ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_MEDICAL = 15), 1),
-		//Check if wormhole code is good and then move to enabled.
-//		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Wormholes",				/datum/event/wormholes,	 				20,		list(ASSIGNMENT_ANY = 5)),
 //		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Lost Spiders",				/datum/event/spider_migration,			0, 		list(ASSIGNMENT_SECURITY = 30), 1), //YW EDIT //CHOMPStation Edit: Moved to disabled. This is a YW feature that spawns spiders on carp spawns.
 	))
 

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -2538,6 +2538,7 @@
 #include "code\modules\events\supply_demand_vr.dm"
 #include "code\modules\events\viral_infection.dm"
 #include "code\modules\events\wallrot.dm"
+#include "code\modules\events\wormholes.dm"
 #include "code\modules\examine\examine.dm"
 #include "code\modules\examine\stat_icons.dm"
 #include "code\modules\examine\descriptions\armor.dm"


### PR DESCRIPTION

Re-Enables the wormhole event + gives it a chance to end up with the exit being a belly (and thrown into it if preferences align)
For a belly to be chosen as an exist, the owner of the belly must be on a turf and not in protected places. If preferences don't align, you'll be simply thrown to the adjacent turf.
These portals also won't throw you down on Sif, so no accidentally ending up in the middle of the valley.
## Changelog
:cl:
add: Re-Enabled wormhole event
add: Wormholes have a chance to pick a belly as an exit
qol: Wormholes won't throw you into Sif anymore
/:cl:
