### PR TITLE
Frontier Shotgun

### DIFF
--- a/code/modules/mining/ore_redemption_machine/survey_vendor.dm
+++ b/code/modules/mining/ore_redemption_machine/survey_vendor.dm
@@ -55,6 +55,7 @@
 		EQUIPMENT("Defense Equipment - Razor Drone Deployer",	/obj/item/weapon/grenade/spawnergrenade/manhacks/station/locked,	100),
 		EQUIPMENT("Defense Equipment - Sentry Drone Deployer",	/obj/item/weapon/grenade/spawnergrenade/ward,						150),
 		EQUIPMENT("Defense Equipment - Marksman Frontier Phaser", 	/obj/item/weapon/gun/energy/locked/frontier/rifle,				800), //CHOMPADD
+		EQUIPMENT("Defense Equipment - Frontier Shotgun", 	/obj/item/weapon/gun/energy/locked/frontier/shotgun,				800), //CHOMPADD
 		EQUIPMENT("Defense Equipment - Frontier Carbine",		/obj/item/weapon/gun/energy/locked/frontier/carbine,				800), //CHOMPEDIT
 		EQUIPMENT("Defense Equipment - Frontier Phaser",		/obj/item/weapon/gun/energy/locked/frontier,					600), //CHOMPADD
 		EQUIPMENT("Defense Equipment - Holdout Frontier Phaser", 	/obj/item/weapon/gun/energy/locked/frontier/holdout,				300), //CHOMPADD

--- a/modular_chomp/code/modules/projectiles/guns/pump.dm
+++ b/modular_chomp/code/modules/projectiles/guns/pump.dm
@@ -32,8 +32,8 @@
 		)
 
 /obj/item/projectile/beam/phaser/shotgun
-	damage = 10
-	SA_bonus_damage = 10
+	damage = 7
+	SA_bonus_damage = 7
 	range = 4
 	icon_state = "phaser_heavy"
 	light_range = 3

--- a/modular_chomp/code/modules/projectiles/guns/pump.dm
+++ b/modular_chomp/code/modules/projectiles/guns/pump.dm
@@ -1,0 +1,43 @@
+/obj/item/weapon/gun/energy/locked/frontier/rifle
+	fire_delay = 12
+
+/obj/item/weapon/gun/energy/locked/frontier/shotgun
+	name = "frontier shotgun"
+	desc = "A much larger, heavier weapon than the typical frontier-type weapons. This one has a safety interlock that prevents firing while in proximity to the facility."
+	icon = 'icons/obj/gun_vr.dmi'
+	icon_state = "oldphaser" //note to self, make a unquie more fitting sprite at some point.
+	item_state = "sniper"
+	item_state_slots = list(slot_r_hand_str = "lsniper", slot_l_hand_str = "lsniper")
+	wielded_item_state = "lsniper-wielded"
+	w_class = ITEMSIZE_LARGE
+	item_icons = list(slot_l_hand_str = 'icons/mob/items/lefthand_guns.dmi', slot_r_hand_str = 'icons/mob/items/righthand_guns.dmi')
+	one_handed_penalty = 30 //A bit easier to aim then a sniper to aim but still not accurate
+	phase_power = 30 //Same as frontier.
+	projectile_type = /obj/item/projectile/scatter/frontierlaser
+	move_delay = 0
+	charge_cost = 360
+	fire_delay = 8
+	firemodes = list(
+		list(mode_name="full", projectile_type=/obj/item/projectile/scatter/frontierlaser, charge_cost = 360),
+		list(mode_name="conserve", projectile_type=/obj/item/projectile/beam/phaser/shotgun, charge_cost = 120),
+	)
+
+
+/obj/item/projectile/scatter/frontierlaser
+	submunition_spread_max = 120
+	submunition_spread_min = 60
+
+	submunitions = list(
+		/obj/item/projectile/beam/phaser/shotgun = 5
+		)
+
+/obj/item/projectile/beam/phaser/shotgun
+	damage = 10
+	SA_bonus_damage = 10
+	range = 4
+	icon_state = "phaser_heavy"
+	light_range = 3
+	light_power = 1
+	muzzle_type = /obj/effect/projectile/muzzle/phaser/heavy
+	tracer_type = /obj/effect/projectile/tracer/phaser/heavy
+	impact_type = /obj/effect/projectile/impact/phaser/heavy

--- a/modular_chomp/code/modules/projectiles/guns/pump.dm
+++ b/modular_chomp/code/modules/projectiles/guns/pump.dm
@@ -12,7 +12,7 @@
 	w_class = ITEMSIZE_LARGE
 	item_icons = list(slot_l_hand_str = 'icons/mob/items/lefthand_guns.dmi', slot_r_hand_str = 'icons/mob/items/righthand_guns.dmi')
 	one_handed_penalty = 30 //A bit easier to aim then a sniper to aim but still not accurate
-	phase_power = 30 //Same as frontier.
+	phase_power = 30 //Same as sniper.
 	projectile_type = /obj/item/projectile/scatter/frontierlaser
 	move_delay = 0
 	charge_cost = 360

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -5025,6 +5025,7 @@
 #include "modular_chomp\code\modules\projectiles\guns\bullet.dm"
 #include "modular_chomp\code\modules\projectiles\guns\magnetic.dm"
 #include "modular_chomp\code\modules\projectiles\guns\phase.dm"
+#include "modular_chomp\code\modules\projectiles\guns\pump.dm"
 #include "modular_chomp\code\modules\projectiles\guns\special.dm"
 #include "modular_chomp\code\modules\projectiles\guns\staffs.dm"
 #include "modular_chomp\code\modules\projectiles\guns\energy\laser.dm"


### PR DESCRIPTION

## About The Pull Request
Added a frontier shotgun. Obtainable from explo vendor.
Has two firemodes. The full power, proper shotgun mode, or one where you fire a single shot.
fire delay - 8 (Note, base fire delay is 6)
Burst - 5 projectiles, charge cost 360
Converse - 1 projectile, charge cost 120
Projectile damage - 7 normal, and 7 SA damage. Range of 4.

Might adjust projectile spread
So, getting up close you could deal 70 damage.
Note, the sniper rifle has 60 damage, long range and better charge cost, albeit slower fire speed.
May have been too cautious. Will see.

## Changelog
:cl:
add: Frontier shotgun is added to the game, and exploration vendor.
fix: Frontier Marksmen Rifle not starting with the correct firing speed
/:cl:
