### PR TITLE
Adds teppi plushies to the vending machine

### DIFF
--- a/code/modules/economy/vending_machines.dm
+++ b/code/modules/economy/vending_machines.dm
@@ -818,7 +818,8 @@
 					/obj/item/toy/plushie/green_dragon = 1,
 					/obj/item/toy/plushie/red_eastdragon = 1,
 					/obj/item/toy/plushie/green_eastdragon = 1,
-					/obj/item/toy/plushie/gold_eastdragon = 1
+					/obj/item/toy/plushie/gold_eastdragon = 1,
+					/obj/item/toy/plushie/teppi = 1
 					//CHOMPStation Add End
 					)
 	premium = list(/obj/item/weapon/reagent_containers/food/drinks/bottle/champagne = 1,
@@ -875,7 +876,8 @@
 					/obj/item/toy/plushie/green_dragon = 50,
 					/obj/item/toy/plushie/red_eastdragon = 50,
 					/obj/item/toy/plushie/green_eastdragon = 50,
-					/obj/item/toy/plushie/gold_eastdragon = 500
+					/obj/item/toy/plushie/gold_eastdragon = 500,
+					/obj/item/toy/plushie/teppi = 50
 					//CHOMPStation Add End
 					)
 


### PR DESCRIPTION
## About The Pull Request

Whoops. I knew I was forgetting something. Adds teppi plushies to the plushie vending machines.

## Changelog
:cl:
add: Teppi plushies are obtainable in the vending machines now
:/cl:
