### PR TITLE
rebalance melee explo borg

### DIFF
--- a/code/modules/mining/shelter_atoms_vr.dm
+++ b/code/modules/mining/shelter_atoms_vr.dm
@@ -124,6 +124,7 @@ GLOBAL_LIST_EMPTY(unique_deployable)
 	desc = "A cozy cabin; crammed into a survival capsule."
 	template_id = "shelter_cab"
 
+//CHOMPKeep Start
 /obj/item/device/survivalcapsule/dropship
 	name = "dropship surfluid shelter capsule"
 	desc = "A military dropship in a capsule. Contains everything an assault squad would need, minus the squad itself. This capsule is significantly larger than most. There's a license for use printed on the bottom."
@@ -131,6 +132,7 @@ GLOBAL_LIST_EMPTY(unique_deployable)
 	unique_id = "shelter_6"
 	is_ship = TRUE
 	w_class = ITEMSIZE_SMALL
+//CHOMPKeep End
 
 //Custom Shelter Capsules
 /obj/item/device/survivalcapsule/tabiranth

--- a/maps/offmap_vr/common_offmaps.dm
+++ b/maps/offmap_vr/common_offmaps.dm
@@ -594,7 +594,7 @@
 #include "../offmap_vr/om_ships/aro2.dm"
 #include "../offmap_vr/om_ships/aro3.dm"
 #include "../offmap_vr/om_ships/bearcat.dm"
-#include "../offmap_vr/om_ships/cruiser.dm"
+#include "../offmap_vr/om_ships/cruiser.dm" //CHOMPKeep
 #include "../offmap_vr/om_ships/vespa.dm"
 #include "../offmap_vr/om_ships/generic_shuttle.dm"
 #include "../offmap_vr/om_ships/salamander.dm"
@@ -611,7 +611,7 @@
 //////////////////////////////////////////////////////////////////////////////
 //Capsule deployed ships
 #include "../offmap_vr/om_ships/shelter_5.dm"
-#include "../offmap_vr/om_ships/shelter_6.dm"
+#include "../offmap_vr/om_ships/shelter_6.dm" //CHOMPKeep
 
 //////////////////////////////////////////////////////////////////////////////
 //Offmap Spawn Locations

--- a/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
@@ -17,9 +17,9 @@
 	description_info = "This creates a shield in a straight line perpendicular to the direction where the user was facing when it was activated. \
 	The shield allows projectiles to leave from inside but blocks projectiles from outside.  Everything else can pass through the shield freely, \
 	including other people and thrown objects.  The shield also cannot block certain effects which take place over an area, such as flashbangs or explosions."
-	shield_health = 70
-	max_shield_health = 70
-	shield_regen_amount = 20
+	shield_health = 90
+	max_shield_health = 90
+	shield_regen_amount = 25
 	line_length = 7			// How long the line is.  Recommended to be an odd number.
 	offset_from_center = 2	// How far from the projector will the line's center be.
 

--- a/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/dogborg/dog_modules.dm
@@ -17,16 +17,16 @@
 	description_info = "This creates a shield in a straight line perpendicular to the direction where the user was facing when it was activated. \
 	The shield allows projectiles to leave from inside but blocks projectiles from outside.  Everything else can pass through the shield freely, \
 	including other people and thrown objects.  The shield also cannot block certain effects which take place over an area, such as flashbangs or explosions."
-	shield_health = 35
-	max_shield_health = 35
-	shield_regen_amount = 10
+	shield_health = 70
+	max_shield_health = 70
+	shield_regen_amount = 20
 	line_length = 7			// How long the line is.  Recommended to be an odd number.
 	offset_from_center = 2	// How far from the projector will the line's center be.
 
 /obj/item/weapon/melee/combat_borgblade/explotailspear
 	name = "energy tail"
 	desc = "A glowing tail spear with a moderate range. It appears to be extremely sharp."
-	force = 25
+	force = 45
 	armor_penetration = 25 //30 to try and make it not useless against armored mobs but not fully nullify it.
 	reach = 3
 	projectile_parry_chance = 15.
@@ -34,7 +34,7 @@
 /obj/item/weapon/melee/dogborg/jaws/big/explojaws
 	name = "explo jaws"
 	desc = "Highly lethal jaws for close range combat."
-	force = 40
+	force = 60
 	armor_penetration = 25 //To try and make it not useless against armored mobs but not fully nullify it
 	projectile_parry_chance = 15
 


### PR DESCRIPTION
## About The Pull Request
With most bullets dealing a much higher damage now, the explo borg should not be left with less than pistol damage as a melee only class. Also the shield should be raised to be at least partially useful against the higher bullet damage.
## Changelog
:cl:
balance: energy shield life 35 -> 90
balance: energy shield regen 10 -> 25
balance: combat spear damage 25 -> 45 damage
balance: explo jaws: 40 -> 60 damage
/:cl:
