### PR TITLE
FS Fixes

### DIFF
--- a/modular_chomp/code/modules/projectiles/guns/pump.dm
+++ b/modular_chomp/code/modules/projectiles/guns/pump.dm
@@ -15,10 +15,10 @@
 	phase_power = 30 //Same as sniper.
 	projectile_type = /obj/item/projectile/scatter/frontierlaser
 	move_delay = 0
-	charge_cost = 360
+	charge_cost = 400
 	fire_delay = 8
 	firemodes = list(
-		list(mode_name="full", projectile_type=/obj/item/projectile/scatter/frontierlaser, charge_cost = 360),
+		list(mode_name="full", projectile_type=/obj/item/projectile/scatter/frontierlaser, charge_cost = 400),
 		list(mode_name="conserve", projectile_type=/obj/item/projectile/beam/phaser/shotgun, charge_cost = 120),
 	)
 
@@ -26,7 +26,7 @@
 /obj/item/projectile/scatter/frontierlaser
 	submunition_spread_max = 120
 	submunition_spread_min = 60
-
+	spread_submunition_damage = FALSE
 	submunitions = list(
 		/obj/item/projectile/beam/phaser/shotgun = 5
 		)


### PR DESCRIPTION

## About The Pull Request
Today I learned of an interesting override.
Made the shotgun not as good as it shoot be.
~Why does this override exist. Why. Why. Agggg~
Also noticed a few extra pumps after the 6th charge was obtained. Altered numbers to remove that.
No real balancing until proper feedback is able to be obtained from in round usage.

## Changelog
:cl:
fix: overide left on a projectile has been switched off.
fix: Needing extra pumps on full power frontier shotgun mode to end the sequence.
/:cl:
