### PR TITLE
Adds a new spawnpoint to spacefarers, the fuel depot.

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -46,6 +46,10 @@
 			GLOB.latejoin_plainspath += loc
 			delete_me = 1
 			return
+		if("JoinLateFuelDepot")
+			GLOB.latejoin_fueldepot += loc
+			delete_me = 1
+			return
 		//CHOMPEdit End
 		if("JoinLateElevator")
 			latejoin_elevator += loc

--- a/maps/southern_cross/overmap/space/fueldepot.dm
+++ b/maps/southern_cross/overmap/space/fueldepot.dm
@@ -27,6 +27,7 @@
 	known = TRUE
 	//start_x  = 10 // Future note: remove these two vars if we ever want this to have a random spawn location on the overmap. //Yes c:
 	//start_y  = 11
+	docking_codes = null
 
 
 // -- Areas -- //

--- a/maps/southern_cross/overmap/space/fueldepot.dm
+++ b/maps/southern_cross/overmap/space/fueldepot.dm
@@ -25,8 +25,8 @@
 	icon_state = "fueldepot_g"
 	unknown_state = "station"
 	known = TRUE
-	start_x  = 10 // Future note: remove these two vars if we ever want this to have a random spawn location on the overmap.
-	start_y  = 11
+	//start_x  = 10 // Future note: remove these two vars if we ever want this to have a random spawn location on the overmap. //Yes c:
+	//start_y  = 11
 
 
 // -- Areas -- //
@@ -36,6 +36,12 @@
 	icon = 'icons/turf/areas_vr.dmi'
 	icon_state = "dark"
 	lightswitch = FALSE
+
+/area/sc_away/fueldepotspawn
+	name = "Away Mission - Fuel Depot Sleeping Quarters"
+	icon = 'icons/turf/areas_vr.dmi'
+	icon_state = "dark"
+	lightswitch = TRUE
 
 
 // -- Landmarks -- //

--- a/maps/southern_cross/overmap/space/fueldepot.dmm
+++ b/maps/southern_cross/overmap/space/fueldepot.dmm
@@ -10,8 +10,6 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
@@ -42,8 +40,6 @@
 /area/sc_away/fueldepot)
 "ae" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/aux{
@@ -82,8 +78,6 @@
 /area/sc_away/fueldepot)
 "ai" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -108,8 +102,6 @@
 /area/sc_away/fueldepot)
 "al" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -141,8 +133,6 @@
 "ao" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -154,36 +144,25 @@
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "aq" = (
-/obj/machinery/power/solar,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 9
-	},
-/turf/simulated/shuttle/plating/airless,
-/area/sc_away/fueldepot)
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "ar" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "as" = (
-/obj/machinery/power/solar,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /obj/effect/floor_decal/industrial/warning/dust{
-	dir = 5
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
@@ -243,19 +222,8 @@
 /turf/space,
 /area/space)
 "aD" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "aE" = (
@@ -291,39 +259,26 @@
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "aJ" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"aK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/shuttle/plating/airless,
-/area/sc_away/fueldepot)
-"aK" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techmaint/airless,
 /area/sc_away/fueldepot)
 "aL" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/sc_away/fueldepot)
 "aM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/effect/floor_decal/industrial/warning/dust,
+/obj/machinery/power/tracker,
+/obj/structure/cable,
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "aN" = (
@@ -337,14 +292,17 @@
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "aO" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable,
-/turf/simulated/shuttle/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint/airless,
 /area/sc_away/fueldepot)
 "aP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint/airless,
@@ -432,12 +390,11 @@
 /area/sc_away/fueldepot)
 "aX" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/cable{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/sc_away/fueldepot)
@@ -470,16 +427,14 @@
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "bc" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 8
 	},
 /obj/structure/catwalk,
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "be" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
@@ -490,6 +445,7 @@
 	dir = 1
 	},
 /obj/structure/catwalk,
+/obj/machinery/vending/weeb,
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "bg" = (
@@ -530,13 +486,12 @@
 /area/sc_away/fueldepot)
 "bk" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/sc_away/fueldepot)
 "bl" = (
@@ -553,8 +508,6 @@
 /area/sc_away/fueldepot)
 "bm" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -570,10 +523,11 @@
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/sc_away/fueldepot)
 "bo" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 8
 	},
 /obj/structure/catwalk,
+/obj/machinery/light/floortube,
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "bp" = (
@@ -596,8 +550,8 @@
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "br" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 1
 	},
 /obj/structure/catwalk,
 /turf/simulated/shuttle/plating/airless,
@@ -682,8 +636,6 @@
 /area/sc_away/fueldepot)
 "bA" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -698,13 +650,9 @@
 /area/sc_away/fueldepot)
 "bB" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -722,8 +670,6 @@
 /area/sc_away/fueldepot)
 "bD" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/aux,
@@ -836,8 +782,6 @@
 /area/sc_away/fueldepot)
 "bO" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/aux{
@@ -851,8 +795,6 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
@@ -932,8 +874,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/aux,
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/catwalk_plated/dark,
@@ -1086,8 +1026,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -1127,8 +1065,6 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/shuttle/plating/airless,
@@ -1202,8 +1138,6 @@
 /area/sc_away/fueldepot)
 "cF" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/aux{
@@ -1230,8 +1164,6 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/effect/catwalk_plated/dark,
@@ -1242,8 +1174,6 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
@@ -1253,6 +1183,12 @@
 	dir = 10
 	},
 /obj/effect/catwalk_plated/dark,
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"ec" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "es" = (
@@ -1266,23 +1202,102 @@
 /obj/structure/catwalk,
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
+"eL" = (
+/obj/structure/fans/hardlight,
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"eX" = (
+/obj/machinery/pointdefense_control{
+	id_tag = "depot_pd"
+	},
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/sc_away/fueldepot)
 "fl" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/toolbox,
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/sc_away/fueldepot)
 "ft" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /obj/structure/catwalk,
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
+"fZ" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"hQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/fans/hardlight,
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"ib" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/sc_away/fueldepot)
+"if" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"ii" = (
+/obj/structure/lattice,
+/turf/space,
+/area/sc_away/fueldepot)
+"iF" = (
+/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
 "ja" = (
 /obj/structure/catwalk,
 /obj/structure/table/rack/steel,
 /obj/item/weapon/tool/crowbar/red,
 /obj/item/weapon/tool/wrench,
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"jm" = (
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"jC" = (
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"lN" = (
+/mob/living/simple_mob/vore/alienanimals/catslug/custom/spaceslug,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"nn" = (
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "om" = (
@@ -1295,6 +1310,55 @@
 	},
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
+"oJ" = (
+/obj/effect/wingrille_spawn/reinforced,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepotspawn)
+"oO" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/pointdefense{
+	id_tag = "depot_pd"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"pK" = (
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/structure/curtain/open/shower,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/kafel_full,
+/area/sc_away/fueldepotspawn)
+"pS" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/sc_away/fueldepot)
+"qH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"rh" = (
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/sc_away/fueldepot)
 "rE" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/aux{
 	dir = 1
@@ -1304,6 +1368,109 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"rV" = (
+/turf/simulated/wall/rshull,
+/area/sc_away/fueldepotspawn)
+"sg" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"sq" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/kafel_full,
+/area/sc_away/fueldepotspawn)
+"sM" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"sX" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 9
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"uc" = (
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner,
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"un" = (
+/obj/machinery/power/rtg,
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/sc_away/fueldepot)
+"vF" = (
+/obj/effect/floor_decal/industrial/warning/dust,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"wz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepotspawn)
+"wC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	dir = 1;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel,
+/obj/structure/catwalk,
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"zb" = (
+/obj/machinery/light_switch{
+	pixel_y = 26
+	},
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/sc_away/fueldepot)
+"Au" = (
+/obj/structure/bed/padded,
+/obj/effect/landmark{
+	name = "JoinLateFuelDepot"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"AT" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"Bu" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "BA" = (
@@ -1319,6 +1486,20 @@
 /obj/structure/catwalk,
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
+"BD" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"BI" = (
+/obj/structure/bed/padded,
+/obj/effect/landmark{
+	name = "JoinLateFuelDepot"
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
 "DC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 8
@@ -1328,17 +1509,99 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"DL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/rust,
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"EO" = (
+/obj/structure/table/steel_reinforced,
+/obj/item/device/bluespaceradio/southerncross_prelinked{
+	pixel_x = -8
+	},
+/obj/item/device/spaceflare{
+	pixel_y = 12;
+	pixel_x = 4
+	},
+/obj/item/device/spaceflare{
+	pixel_y = 0;
+	pixel_x = 4
+	},
+/obj/item/device/spaceflare{
+	pixel_y = 4;
+	pixel_x = 4
+	},
+/obj/item/device/spaceflare{
+	pixel_y = 8;
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"Fe" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"Fp" = (
+/obj/machinery/vending/tool,
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"Fq" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"FH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "FK" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/powercell,
 /turf/simulated/floor/tiled/techmaint/airless,
+/area/sc_away/fueldepot)
+"Ho" = (
+/obj/machinery/door/airlock/hatch{
+	req_one_access = null
+	},
+/turf/simulated/floor/tiled/kafel_full,
+/area/sc_away/fueldepotspawn)
+"HC" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"HW" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/pointdefense{
+	id_tag = "depot_pd"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"IB" = (
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "IR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/aux{
@@ -1350,6 +1613,69 @@
 	},
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
+"Jf" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
+"Jr" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/kafel_full,
+/area/sc_away/fueldepotspawn)
+"Km" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"Lo" = (
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"Ls" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/vending/sovietsoda,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"LN" = (
+/obj/machinery/gear_dispenser/suit/autolok,
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"MO" = (
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"MQ" = (
+/turf/simulated/floor/tiled/kafel_full,
+/area/sc_away/fueldepotspawn)
 "Nq" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/tool,
@@ -1361,10 +1687,77 @@
 /obj/item/weapon/storage/toolbox/electrical,
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/sc_away/fueldepot)
+"Pr" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/pointdefense{
+	id_tag = "depot_pd"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
 "Qg" = (
 /obj/structure/table/rack/steel,
 /obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/techmaint/airless,
+/area/sc_away/fueldepot)
+"QT" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"Ro" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/space)
+"Tq" = (
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/floor_decal/rust,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"Tt" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"TC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"TX" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"Ul" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/space)
+"Vq" = (
+/obj/machinery/power/solar,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/warning/dust/corner{
+	dir = 8
+	},
+/turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "Vy" = (
 /obj/structure/cable{
@@ -1373,10 +1766,69 @@
 /obj/structure/catwalk,
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
+"WJ" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"Xb" = (
+/obj/structure/bed/padded,
+/obj/effect/landmark{
+	name = "JoinLateFuelDepot"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"XE" = (
+/obj/machinery/light_switch{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/sc_away/fueldepot)
+"XG" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
 "Ys" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/sc_away/fueldepot)
+"Yw" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/shuttle/plating/airless,
+/area/sc_away/fueldepot)
+"YT" = (
+/obj/effect/floor_decal/rust,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/sc_away/fueldepotspawn)
+"ZZ" = (
+/obj/structure/railing,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 
 (1,1,1) = {"
 aa
@@ -9412,9 +9864,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+jC
+jC
+HW
 aa
 aa
 aa
@@ -9554,9 +10006,9 @@ aa
 aa
 aa
 aa
+jC
 aa
-aa
-aa
+aK
 aa
 aa
 aa
@@ -9675,30 +10127,30 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ay
+aJ
+aJ
+aJ
+aJ
+aJ
+aJ
+jC
+jC
+ZZ
 bz
 bN
-aC
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fZ
+jC
+jC
+jC
+sX
+at
+at
+at
+at
+at
+Lo
+FH
+TX
 aa
 aa
 aa
@@ -9815,14 +10267,14 @@ aa
 aa
 aa
 aa
+HW
+aa
+jC
 aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+jC
 aa
 aa
 ay
@@ -9832,13 +10284,13 @@ aC
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+AT
+cw
+cw
+cw
+cw
+cw
+cy
 aa
 aa
 aa
@@ -9957,15 +10409,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Fq
+WJ
+aF
+aF
+aF
+aF
+aF
+aF
+jC
 aa
 ay
 bz
@@ -9974,13 +10426,13 @@ aC
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+as
+uc
+aE
+aE
+aE
+aE
+aN
 aa
 aa
 aa
@@ -10097,17 +10549,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+aJ
+jC
+aF
+HC
+Yw
+Yw
+Yw
+Yw
+Yw
+IB
+jC
 aa
 ay
 bz
@@ -10116,13 +10568,13 @@ aC
 aa
 aa
 aa
+Km
+aM
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+ii
+ii
 aa
 aa
 aa
@@ -10239,16 +10691,16 @@ aa
 aa
 aa
 aa
+aJ
 aa
-aa
-aa
-aa
-aq
-at
-at
-at
-aI
-aa
+aF
+MO
+bn
+bn
+bn
+bn
+aG
+XG
 aF
 aF
 aF
@@ -10257,14 +10709,14 @@ bN
 aF
 aF
 aF
-aa
-aq
+jC
+as
+Vq
+at
 at
 at
 at
 aI
-aa
-aa
 aa
 aa
 aa
@@ -10381,15 +10833,15 @@ aa
 aa
 aa
 aa
+aJ
 aa
-aa
-aa
-aa
+aF
+vF
 ar
 aD
 aD
 aD
-aJ
+bC
 aO
 aF
 aW
@@ -10404,9 +10856,9 @@ cs
 cw
 cw
 cw
+cw
+cw
 cy
-aa
-aa
 aa
 aa
 aa
@@ -10523,32 +10975,32 @@ aa
 aa
 aa
 aa
+aJ
 aa
-aa
-aa
-aa
-as
-aE
-aE
-aE
-aK
-aP
+aF
+MO
+bp
+bp
+bp
+bp
+aG
+ib
 aP
 aX
 bk
-bA
+wC
 bO
-aP
-aP
-aP
-aP
+aL
+aL
+aL
+aL
 ct
 aE
 aE
 aE
+aE
+aE
 aN
-aa
-aa
 aa
 aa
 aa
@@ -10665,16 +11117,16 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+aJ
+jC
+aF
+ec
+Tt
+Tt
+Tt
+if
 aG
-aa
+jC
 aF
 aY
 bl
@@ -10683,14 +11135,14 @@ bN
 aG
 OG
 aF
-aa
+jC
 aG
 aa
+jC
 aa
 aa
 aa
-aa
-aa
+jC
 aa
 aa
 aa
@@ -10807,12 +11259,12 @@ aa
 aa
 aa
 aa
+jC
 aa
-aa
-aa
-aa
-aa
-aa
+jC
+jC
+aF
+aF
 aF
 aF
 aG
@@ -10832,7 +11284,7 @@ aF
 aa
 aa
 aa
-aa
+jC
 aa
 aa
 aa
@@ -10949,7 +11401,7 @@ aa
 aw
 aw
 aw
-aa
+jC
 aa
 aa
 aa
@@ -10974,7 +11426,7 @@ aF
 aa
 aa
 aa
-aa
+jC
 aa
 aa
 aw
@@ -11091,7 +11543,7 @@ au
 ad
 ah
 ja
-ax
+sM
 aw
 aw
 aw
@@ -11102,9 +11554,9 @@ aH
 aG
 aG
 aR
-bn
-bn
-aj
+rh
+rh
+rh
 bQ
 ap
 ap
@@ -11116,7 +11568,7 @@ aF
 aw
 aw
 aw
-aw
+Jf
 aw
 au
 cz
@@ -11246,8 +11698,8 @@ ao
 aS
 bc
 bo
-bC
-rE
+lN
+bQ
 cc
 cn
 aU
@@ -11388,7 +11840,7 @@ ap
 cp
 br
 ft
-bC
+ft
 rE
 cc
 cn
@@ -11528,9 +11980,9 @@ aH
 aG
 aG
 bq
-bp
-bp
-aj
+pS
+pS
+pS
 bW
 cd
 cd
@@ -11542,7 +11994,7 @@ aF
 av
 av
 av
-av
+aq
 av
 az
 ja
@@ -11668,7 +12120,7 @@ aa
 aF
 FK
 aG
-aG
+eX
 aV
 bD
 bD
@@ -11684,7 +12136,7 @@ aF
 aa
 aa
 aa
-aa
+jC
 aa
 aa
 av
@@ -11805,13 +12257,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aF
-aF
-aG
-aF
-aF
+jC
+rV
+rV
+rV
+eL
+rV
+rV
 bf
 aj
 bz
@@ -11826,7 +12278,7 @@ aF
 aa
 aa
 aa
-aa
+jC
 aa
 aa
 aa
@@ -11947,28 +12399,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aG
-aa
-aF
-aG
+rV
+Fp
+EO
+LN
+BD
+Tq
+rV
+zb
 aG
 bz
 IR
 aG
-aG
+XE
 aF
-aa
+jC
 aG
 aa
+jC
 aa
 aa
 aa
-aa
-aa
+jC
 aa
 aa
 aa
@@ -12089,28 +12541,28 @@ aa
 aa
 aa
 aa
-aq
-at
-at
-at
+rV
+Ls
+TC
+TC
+DL
+DL
+hQ
 aL
-aP
-aP
-aP
-aP
+aL
 bA
 BA
-aP
-aP
-aP
-aP
+aL
+aL
+aL
+aL
 cu
 at
 at
 at
+at
+at
 aI
-aa
-aa
 aa
 aa
 aa
@@ -12231,14 +12683,14 @@ aa
 aa
 aa
 aa
-ar
-aD
-aD
-aD
-aM
-aa
-aF
-aG
+rV
+qH
+BD
+iF
+YT
+QT
+oJ
+un
 bs
 bz
 bN
@@ -12250,9 +12702,9 @@ cv
 cw
 cw
 cw
+cw
+cw
 cy
-aa
-aa
 aa
 aa
 aa
@@ -12371,15 +12823,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-as
-aE
-aE
-aE
-aN
-aa
-aF
+jC
+Ul
+wz
+Fe
+BD
+Xb
+Au
+BI
+rV
 aF
 aF
 bz
@@ -12387,14 +12839,14 @@ bN
 aF
 aF
 aF
-aa
+jC
 as
+uc
+aE
 aE
 aE
 aE
 aN
-aa
-aa
 aa
 aa
 aa
@@ -12513,15 +12965,15 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jC
+Ro
+rV
+rV
+Ho
+rV
+rV
+rV
+rV
 aa
 ay
 bz
@@ -12530,13 +12982,13 @@ aC
 aa
 aa
 aa
+as
+MO
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+ii
+ii
 aa
 aa
 aa
@@ -12655,13 +13107,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Pr
+TX
+jm
+rV
+MQ
+sq
+rV
 aa
 aa
 aa
@@ -12672,13 +13124,13 @@ aC
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+as
+Vq
+at
+at
+at
+at
+aI
 aa
 aa
 aa
@@ -12800,10 +13252,10 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
+rV
+Jr
+pK
+rV
 aa
 aa
 aa
@@ -12814,13 +13266,13 @@ aC
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Bu
+cw
+cw
+cw
+cw
+cw
+cy
 aa
 aa
 aa
@@ -12942,29 +13394,29 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-ay
+rV
+rV
+rV
+rV
+jC
+jC
+jC
+ZZ
 bz
 bN
-aC
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+fZ
+jC
+jC
+jC
+sg
+aE
+aE
+aE
+aE
+aE
+nn
+FH
+WJ
 aa
 aa
 aa
@@ -13085,8 +13537,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+jC
+jC
 aa
 aa
 aa
@@ -13104,9 +13556,9 @@ aa
 aa
 aa
 aa
+jC
 aa
-aa
-aa
+aK
 aa
 aa
 aa
@@ -13246,9 +13698,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+jC
+jC
+oO
 aa
 aa
 aa

--- a/maps/southern_cross/southern_cross_defines.dm
+++ b/maps/southern_cross/southern_cross_defines.dm
@@ -104,7 +104,7 @@ but they don't actually change anything about the load order
 							NETWORK_SUPPLY
 							)
 	usable_email_tlds = list("freemail.nt")
-	allowed_spawns = list("Arrivals Shuttle","Gateway", "Cryogenic Storage", "Cyborg Storage", "Station gateway", "Sif plains")
+	allowed_spawns = list("Arrivals Shuttle","Gateway", "Cryogenic Storage", "Cyborg Storage", "Station gateway", "Sif plains", "Fuel Depot")
 	default_skybox = /datum/skybox_settings/southern_cross
 	unit_test_exempt_areas = list(/area/ninja_dojo, /area/shuttle/ninja)
 	unit_test_exempt_from_atmos = list(/area/tcomm/chamber)

--- a/modular_chomp/code/global.dm
+++ b/modular_chomp/code/global.dm
@@ -4,6 +4,7 @@ GLOBAL_LIST_INIT(shell_module_blacklist, list(
 	))
 GLOBAL_LIST_EMPTY(latejoin_gatewaystation)
 GLOBAL_LIST_EMPTY(latejoin_plainspath)
+GLOBAL_LIST_EMPTY(latejoin_fueldepot)
 
 var/list/talk_sound_map = rlist(
 								list(

--- a/modular_chomp/code/modules/client/preferences_spawnpoints.dm
+++ b/modular_chomp/code/modules/client/preferences_spawnpoints.dm
@@ -32,3 +32,12 @@
 /datum/spawnpoint/plainspath/New()
 	..()
 	turfs = GLOB.latejoin_plainspath
+
+/datum/spawnpoint/fueldepot
+	display_name = "Fuel Depot"
+	msg = "woke up in the fuel depot"
+	restrict_job = list(JOB_OUTSIDER)
+
+/datum/spawnpoint/fueldepot/New()
+	..()
+	turfs = GLOB.latejoin_fueldepot

--- a/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
+++ b/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
@@ -46,7 +46,7 @@
 	dir = 4
 	},
 /turf/simulated/shuttle/plating/airless/carry,
-/area/template_noop)
+/area/shuttle/cybershuttle)
 "g" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
@@ -61,7 +61,7 @@
 	dir = 1
 	},
 /turf/simulated/shuttle/plating/airless/carry,
-/area/template_noop)
+/area/shuttle/cybershuttle)
 "k" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/portables_connector{
@@ -166,6 +166,14 @@
 	},
 /obj/item/weapon/dice/d20,
 /obj/item/weapon/deck/tarot,
+/obj/item/weapon/material/sword/katana{
+	pixel_y = -4;
+	pixel_x = 5
+	},
+/obj/item/clothing/head/fedora{
+	pixel_x = -4;
+	pixel_y = 10
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
 "D" = (
@@ -198,9 +206,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
-"P" = (
-/turf/simulated/wall/rthull,
-/area/template_noop)
 "Q" = (
 /obj/machinery/ion_engine{
 	dir = 1
@@ -209,7 +214,7 @@
 	dir = 8
 	},
 /turf/simulated/shuttle/plating/airless/carry,
-/area/template_noop)
+/area/shuttle/cybershuttle)
 "R" = (
 /obj/effect/shuttle_landmark/shuttle_initializer/cybershuttle,
 /obj/structure/cable/yellow{
@@ -331,7 +336,7 @@ g
 C
 h
 l
-P
+l
 "}
 (5,1,1) = {"
 a
@@ -370,7 +375,7 @@ R
 w
 l
 l
-P
+l
 "}
 (8,1,1) = {"
 a

--- a/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
+++ b/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
@@ -2,9 +2,18 @@
 "a" = (
 /turf/template_noop,
 /area/template_noop)
+"b" = (
+/obj/machinery/ion_engine{
+	dir = 1
+	},
+/obj/structure/window/plastitanium{
+	dir = 4
+	},
+/turf/simulated/shuttle/plating/airless/carry,
+/area/template_noop)
 "c" = (
 /obj/machinery/computer/ship/helm{
-	req_one_access = newlist()
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
@@ -49,7 +58,7 @@
 	dir = 8
 	},
 /turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/cybershuttle)
+/area/template_noop)
 "k" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/tank/air/full{
@@ -61,12 +70,10 @@
 /turf/simulated/wall/rthull,
 /area/shuttle/cybershuttle)
 "m" = (
-/obj/machinery/power/terminal{
-	dir = 2
-	},
 /obj/structure/cable/yellow{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
@@ -81,6 +88,10 @@
 /area/shuttle/cybershuttle)
 "q" = (
 /obj/machinery/computer/shuttle_control/explore/cybershuttle,
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
 "r" = (
@@ -169,21 +180,22 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
+"K" = (
+/obj/machinery/power/terminal{
+	dir = 2
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/cybershuttle)
 "P" = (
 /obj/machinery/ion_engine{
 	dir = 1
 	},
-/obj/structure/window/plastitanium{
-	dir = 4
-	},
 /turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/cybershuttle)
+/area/template_noop)
 "Q" = (
-/obj/machinery/ion_engine{
-	dir = 1
-	},
-/turf/simulated/shuttle/plating/airless/carry,
-/area/shuttle/cybershuttle)
+/turf/simulated/wall/rthull,
+/area/template_noop)
 "R" = (
 /obj/effect/shuttle_landmark/shuttle_initializer/cybershuttle,
 /obj/structure/cable/yellow{
@@ -269,10 +281,10 @@ a
 a
 a
 a
+a
 T
 l
 j
-a
 "}
 (3,1,1) = {"
 a
@@ -284,8 +296,8 @@ l
 W
 l
 l
-Q
-a
+l
+P
 "}
 (4,1,1) = {"
 a
@@ -295,10 +307,10 @@ J
 g
 F
 g
+g
 h
 l
-l
-a
+Q
 "}
 (5,1,1) = {"
 a
@@ -309,9 +321,9 @@ g
 g
 g
 m
+K
 o
-Q
-a
+P
 "}
 (6,1,1) = {"
 a
@@ -322,9 +334,9 @@ g
 S
 t
 r
+g
 z
-Q
-a
+P
 "}
 (7,1,1) = {"
 a
@@ -337,7 +349,7 @@ R
 w
 l
 l
-a
+Q
 "}
 (8,1,1) = {"
 a
@@ -349,8 +361,8 @@ l
 e
 l
 l
-Q
-a
+l
+P
 "}
 (9,1,1) = {"
 a
@@ -360,10 +372,10 @@ a
 a
 a
 a
+a
 y
 l
-P
-a
+b
 "}
 (10,1,1) = {"
 a

--- a/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
+++ b/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
@@ -2,15 +2,6 @@
 "a" = (
 /turf/template_noop,
 /area/template_noop)
-"b" = (
-/obj/machinery/ion_engine{
-	dir = 1
-	},
-/obj/structure/window/plastitanium{
-	dir = 4
-	},
-/turf/simulated/shuttle/plating/airless/carry,
-/area/template_noop)
 "c" = (
 /obj/machinery/computer/ship/helm{
 	req_one_access = null
@@ -35,12 +26,21 @@
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
-	dir = 6;
+	dir = 4;
 	pixel_y = 25
 	},
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/plating,
 /area/shuttle/cybershuttle)
+"f" = (
+/obj/machinery/ion_engine{
+	dir = 1
+	},
+/obj/structure/window/plastitanium{
+	dir = 4
+	},
+/turf/simulated/shuttle/plating/airless/carry,
+/area/template_noop)
 "g" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
@@ -54,16 +54,14 @@
 /obj/machinery/ion_engine{
 	dir = 1
 	},
-/obj/structure/window/plastitanium{
-	dir = 8
-	},
 /turf/simulated/shuttle/plating/airless/carry,
 /area/template_noop)
 "k" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/tank/air/full{
-	start_pressure = 10000
+/obj/machinery/atmospherics/portables_connector{
+	dir = 2
 	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
 "l" = (
@@ -180,21 +178,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
-"K" = (
-/obj/machinery/power/terminal{
-	dir = 2
-	},
-/obj/structure/cable/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/shuttle/cybershuttle)
 "P" = (
+/turf/simulated/wall/rthull,
+/area/template_noop)
+"Q" = (
 /obj/machinery/ion_engine{
 	dir = 1
 	},
+/obj/structure/window/plastitanium{
+	dir = 8
+	},
 /turf/simulated/shuttle/plating/airless/carry,
-/area/template_noop)
-"Q" = (
-/turf/simulated/wall/rthull,
 /area/template_noop)
 "R" = (
 /obj/effect/shuttle_landmark/shuttle_initializer/cybershuttle,
@@ -259,6 +253,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/cybershuttle)
+"Z" = (
+/obj/machinery/power/terminal{
+	dir = 2
+	},
+/obj/structure/cable/yellow,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/cybershuttle)
 
 (1,1,1) = {"
 a
@@ -284,7 +285,7 @@ a
 a
 T
 l
-j
+Q
 "}
 (3,1,1) = {"
 a
@@ -297,7 +298,7 @@ W
 l
 l
 l
-P
+j
 "}
 (4,1,1) = {"
 a
@@ -310,7 +311,7 @@ g
 g
 h
 l
-Q
+P
 "}
 (5,1,1) = {"
 a
@@ -321,9 +322,9 @@ g
 g
 g
 m
-K
+Z
 o
-P
+j
 "}
 (6,1,1) = {"
 a
@@ -336,7 +337,7 @@ t
 r
 g
 z
-P
+j
 "}
 (7,1,1) = {"
 a
@@ -349,7 +350,7 @@ R
 w
 l
 l
-Q
+P
 "}
 (8,1,1) = {"
 a
@@ -362,7 +363,7 @@ e
 l
 l
 l
-P
+j
 "}
 (9,1,1) = {"
 a
@@ -375,7 +376,7 @@ a
 a
 y
 l
-b
+f
 "}
 (10,1,1) = {"
 a

--- a/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
+++ b/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
@@ -13,6 +13,12 @@
 /obj/fruitspawner/watermelon,
 /obj/item/device/gps/explorer,
 /obj/item/device/gps/explorer,
+/obj/structure/closet/walllocker_double/east,
+/obj/item/weapon/gun/projectile/garand,
+/obj/item/ammo_magazine/clip/medium,
+/obj/item/ammo_magazine/clip/medium,
+/obj/item/ammo_magazine/clip/medium,
+/obj/item/weapon/storage/firstaid/regular,
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
 "e" = (
@@ -46,7 +52,7 @@
 /area/shuttle/cybershuttle)
 "h" = (
 /obj/machinery/computer/ship/engines{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
@@ -147,6 +153,20 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
+/area/shuttle/cybershuttle)
+"C" = (
+/obj/structure/table/survival_pod,
+/obj/item/glass_jar{
+	pixel_y = 13;
+	pixel_x = 6
+	},
+/obj/random/action_figure{
+	pixel_y = -4;
+	pixel_x = -9
+	},
+/obj/item/weapon/dice/d20,
+/obj/item/weapon/deck/tarot,
+/turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
 "D" = (
 /obj/structure/window/plastitanium/full,
@@ -308,7 +328,7 @@ J
 g
 F
 g
-g
+C
 h
 l
 P

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
@@ -23,7 +23,7 @@
 	icon_state = "shuttle2"
 	requires_power = 1
 
-/area/shuttle/metawhiteship/engi
+/area/shuttle/metawhiteship/eng
 	name = "\improper MetaMaterial Salvage Ship - Engineering"
 	icon_state = "shuttle2"
 	requires_power = 1
@@ -62,7 +62,13 @@
 	name = "MetaMaterial Salvage Ship" //These names must match
 	current_location = "omship_spawn_metawhiteship"
 	docking_controller_tag = "metawhiteship_docker" //This is the only thing you map in and var edit, use the map helpers to designate doors and pumps
-	shuttle_area = list(/area/shuttle/metawhiteship, /area/shuttle/metawhiteship/gen, /area/shuttle/metawhiteship/engi, /area/shuttle/metawhiteship/cargo, /area/shuttle/metawhiteship/food, /area/shuttle/metawhiteship/bridge)
+	shuttle_area = list(	/area/shuttle/metawhiteship,
+					/area/shuttle/metawhiteship/gen,
+					/area/shuttle/metawhiteship/cargo,
+					/area/shuttle/metawhiteship/food,
+					/area/shuttle/metawhiteship/bridge,
+					/area/shuttle/metawhiteship/eng
+					)
 	defer_initialisation = TRUE //We're not loaded until an admin does it
 
 // The 'ship'

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
@@ -1,0 +1,86 @@
+// Compile in the map for CI testing if we're testing compileability of all the maps
+#if MAP_TEST
+#include "metawhiteship28x19.dmm"
+#endif
+
+// Map template for spawning the shuttle
+/datum/map_template/om_ships/metawhiteship
+	name = "OM Ship - Meta White Ship"
+	desc = "A small privately-owned vessel."
+	mappath = 'metawhiteship28x19.dmm'
+	annihilate = TRUE
+
+// The shuttle's area(s)
+
+/area/shuttle/metawhiteship
+	name = "\improper MetaMaterial Salvage Ship"
+	ambience = AMBIENCE_HANGAR
+	icon_state = "shuttle2"
+	requires_power = 1
+
+/area/shuttle/metawhiteship/gen
+	name = "\improper MetaMaterial Salvage Ship - Living Quarters"
+	icon_state = "shuttle2"
+	requires_power = 1
+
+/area/shuttle/metawhiteship/engi
+	name = "\improper MetaMaterial Salvage Ship - Engineering"
+	icon_state = "shuttle2"
+	requires_power = 1
+
+/area/shuttle/metawhiteship/cargo
+	name = "\improper MetaMaterial Salvage Ship - Cargo Bay"
+	icon_state = "shuttle2"
+	requires_power = 1
+
+/area/shuttle/metawhiteship/food
+	name = "\improper MetaMaterial Salvage Ship - Recreational Lounge"
+	icon_state = "shuttle2"
+	requires_power = 1
+
+/area/shuttle/metawhiteship/bridge
+	name = "\improper MetaMaterial Salvage Ship - Bridge"
+	ambience = AMBIENCE_HIGHSEC
+	icon_state = "shuttle2"
+	requires_power = 1
+// The shuttle's 'shuttle' computer
+/obj/machinery/computer/shuttle_control/explore/metawhiteship
+	name = "short jump console"
+	shuttle_tag = "MetaMaterial Salvage Ship" //These names must match
+	req_one_access = null
+
+// A shuttle lateloader landmark
+/obj/effect/shuttle_landmark/shuttle_initializer/metawhiteship
+	name = "Origin - MetaMaterial Salvage Ship"
+	base_area = /area/space
+	base_turf = /turf/space
+	landmark_tag = "omship_spawn_metawhiteship"
+	shuttle_type = /datum/shuttle/autodock/overmap/metawhiteship
+
+// The 'shuttle'
+/datum/shuttle/autodock/overmap/metawhiteship
+	name = "MetaMaterial Salvage Ship" //These names must match
+	current_location = "omship_spawn_metawhiteship"
+	docking_controller_tag = "metawhiteship_docker" //This is the only thing you map in and var edit, use the map helpers to designate doors and pumps
+	shuttle_area = list(/area/shuttle/metawhiteship, /area/shuttle/metawhiteship/gen, /area/shuttle/metawhiteship/engi, /area/shuttle/metawhiteship/cargo, /area/shuttle/metawhiteship/food, /area/shuttle/metawhiteship/bridge)
+	defer_initialisation = TRUE //We're not loaded until an admin does it
+
+// The 'ship'
+/obj/effect/overmap/visitable/ship/landable/metawhiteship
+	name = "MetaMaterial Salvage Ship" //These names must match
+	scanner_desc = @{"[i]Registration[/i]: PRIVATE
+[i]Class[/i]: Small Shuttle
+[i]Transponder[/i]: Transmitting (CIV), non-hostile
+[b]Notice[/b]: Small private vessel"}
+	vessel_mass = 2250
+	vessel_size = SHIP_SIZE_SMALL
+	shuttle = "MetaMaterial Salvage Ship" //These names must match
+	fore_dir = EAST
+
+/datum/map_template/shelter/superpose/metawhiteship
+	shelter_id = "MetaWhiteShip"
+	mappath = 'metawhiteship28x19.dmm'
+	name = "MetaMaterial Salvage Ship"
+	description = "A medium size salvage whiteship"
+	superpose = FALSE
+	shuttle = TRUE

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
@@ -76,6 +76,7 @@
 	vessel_size = SHIP_SIZE_SMALL
 	shuttle = "MetaMaterial Salvage Ship" //These names must match
 	fore_dir = EAST
+	known = FALSE
 
 /datum/map_template/shelter/superpose/metawhiteship
 	shelter_id = "MetaWhiteShip"

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
@@ -16,33 +16,28 @@
 	name = "\improper MetaMaterial Salvage Ship"
 	ambience = AMBIENCE_HANGAR
 	icon_state = "shuttle2"
-	requires_power = 1
+	requires_power = TRUE
+	has_gravity = TRUE
 
 /area/shuttle/metawhiteship/gen
 	name = "\improper MetaMaterial Salvage Ship - Living Quarters"
 	icon_state = "shuttle2"
-	requires_power = 1
-
 /area/shuttle/metawhiteship/eng
 	name = "\improper MetaMaterial Salvage Ship - Engineering"
 	icon_state = "shuttle2"
-	requires_power = 1
 
 /area/shuttle/metawhiteship/cargo
 	name = "\improper MetaMaterial Salvage Ship - Cargo Bay"
 	icon_state = "shuttle2"
-	requires_power = 1
 
 /area/shuttle/metawhiteship/food
 	name = "\improper MetaMaterial Salvage Ship - Recreational Lounge"
 	icon_state = "shuttle2"
-	requires_power = 1
 
 /area/shuttle/metawhiteship/bridge
 	name = "\improper MetaMaterial Salvage Ship - Bridge"
 	ambience = AMBIENCE_HIGHSEC
 	icon_state = "shuttle2"
-	requires_power = 1
 // The shuttle's 'shuttle' computer
 /obj/machinery/computer/shuttle_control/explore/metawhiteship
 	name = "short jump console"

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
@@ -1,13 +1,13 @@
 // Compile in the map for CI testing if we're testing compileability of all the maps
 #if MAP_TEST
-#include "metawhiteship28x19.dmm"
+#include "metawhiteship30x21.dmm"
 #endif
 
 // Map template for spawning the shuttle
 /datum/map_template/om_ships/metawhiteship
 	name = "OM Ship - Meta White Ship"
 	desc = "A small privately-owned vessel."
-	mappath = 'metawhiteship28x19.dmm'
+	mappath = 'metawhiteship30x21.dmm'
 	annihilate = TRUE
 
 // The shuttle's area(s)
@@ -62,8 +62,7 @@
 	name = "MetaMaterial Salvage Ship" //These names must match
 	current_location = "omship_spawn_metawhiteship"
 	docking_controller_tag = "metawhiteship_docker" //This is the only thing you map in and var edit, use the map helpers to designate doors and pumps
-	shuttle_area = list(	/area/shuttle/metawhiteship,
-					/area/shuttle/metawhiteship/gen,
+	shuttle_area = list(	/area/shuttle/metawhiteship/gen,
 					/area/shuttle/metawhiteship/cargo,
 					/area/shuttle/metawhiteship/food,
 					/area/shuttle/metawhiteship/bridge,
@@ -85,7 +84,7 @@
 
 /datum/map_template/shelter/superpose/metawhiteship
 	shelter_id = "MetaWhiteShip"
-	mappath = 'metawhiteship28x19.dmm'
+	mappath = 'metawhiteship30x21.dmm'
 	name = "MetaMaterial Salvage Ship"
 	description = "A medium size salvage whiteship"
 	superpose = FALSE

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship28x19.dmm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship28x19.dmm
@@ -233,7 +233,7 @@
 /area/shuttle/metawhiteship/engi)
 "jW" = (
 /obj/machinery/embedded_controller/radio/docking_port_multi{
-	child_names_txt = "Port Airlock Control;Starboard Airlock Control";
+	child_names_txt = "Port Airlock Control;Starboard Airlock Control;Aft Airlock Control";
 	child_tags_txt = "whiteship_docking_port;whiteship_docking_star";
 	dir = 8;
 	id_tag = "metawhiteship_docker";
@@ -759,6 +759,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/engi)
+"xP" = (
+/turf/template_noop,
+/area/template_noop)
 "yd" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/table/standard,
@@ -918,10 +921,6 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
 "EC" = (
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	pixel_y = -26;
-	id_tag = "metawhiteshipaft"
-	},
 /obj/machinery/airlock_sensor{
 	pixel_y = 24
 	},
@@ -930,6 +929,13 @@
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
+	dir = 1;
+	id_tag = "whiteship_docking_aft";
+	name = "Aft Airlock Control";
+	frequency = 1380;
+	pixel_y = -23
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/engi)
 "ED" = (
@@ -1624,70 +1630,70 @@
 /area/shuttle/metawhiteship/food)
 
 (1,1,1) = {"
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
 "}
 (2,1,1) = {"
-kG
-kG
+xP
+xP
 HE
 Pp
 Pp
 HE
-kG
-kG
-kG
-kG
-kG
-kG
-kG
+xP
+xP
+xP
+xP
+xP
+xP
+xP
 HE
 Pp
 Pp
 HE
-kG
-kG
+xP
+xP
 "}
 (3,1,1) = {"
-kG
+xP
 HE
 HE
 Sa
 Sa
 HE
 HE
-kG
-kG
-kG
-kG
-kG
+xP
+xP
+xP
+xP
+xP
 HE
 HE
 Sa
 Sa
 HE
 HE
-kG
+xP
 "}
 (4,1,1) = {"
-kG
+xP
 HE
 yT
 Iu
@@ -1698,17 +1704,17 @@ OH
 HE
 qz
 HE
-kG
+xP
 HE
 qX
 Da
 Gd
 fr
 HE
-kG
+xP
 "}
 (5,1,1) = {"
-kG
+xP
 GN
 CD
 ED
@@ -1726,10 +1732,10 @@ HM
 HM
 jQ
 HE
-kG
+xP
 "}
 (6,1,1) = {"
-kG
+xP
 HE
 HE
 PE
@@ -1747,11 +1753,11 @@ HM
 MD
 HE
 HE
-kG
+xP
 "}
 (7,1,1) = {"
-kG
-kG
+xP
+xP
 HE
 dF
 lW
@@ -1767,12 +1773,12 @@ fy
 rH
 oQ
 GN
-kG
-kG
+xP
+xP
 "}
 (8,1,1) = {"
-kG
-kG
+xP
+xP
 HE
 HE
 jI
@@ -1788,11 +1794,11 @@ HE
 jI
 HE
 HE
-kG
-kG
+xP
+xP
 "}
 (9,1,1) = {"
-kG
+xP
 Tt
 Tt
 iu
@@ -1810,10 +1816,10 @@ xk
 PJ
 Tt
 Tt
-kG
+xP
 "}
 (10,1,1) = {"
-kG
+xP
 sG
 iS
 ZP
@@ -1831,10 +1837,10 @@ SB
 nd
 qN
 cQ
-kG
+xP
 "}
 (11,1,1) = {"
-kG
+xP
 sG
 WB
 WB
@@ -1852,10 +1858,10 @@ QF
 WB
 WB
 cQ
-kG
+xP
 "}
 (12,1,1) = {"
-kG
+xP
 sG
 ws
 WB
@@ -1873,10 +1879,10 @@ io
 WB
 WB
 cQ
-kG
+xP
 "}
 (13,1,1) = {"
-kG
+xP
 sG
 ws
 WB
@@ -1894,10 +1900,10 @@ QF
 WB
 kH
 cQ
-kG
+xP
 "}
 (14,1,1) = {"
-kG
+xP
 sG
 zJ
 Jj
@@ -1915,10 +1921,10 @@ QF
 lg
 Jj
 cQ
-kG
+xP
 "}
 (15,1,1) = {"
-kG
+xP
 Tt
 Tt
 Tf
@@ -1936,10 +1942,10 @@ QF
 mi
 Tt
 Tt
-kG
+xP
 "}
 (16,1,1) = {"
-kG
+xP
 kG
 Yv
 Yv
@@ -1956,11 +1962,11 @@ Yv
 NF
 Yv
 Yv
-kG
-kG
+xP
+xP
 "}
 (17,1,1) = {"
-kG
+xP
 kG
 oA
 vZ
@@ -1977,11 +1983,11 @@ ql
 Dn
 vZ
 oA
-kG
-kG
+xP
+xP
 "}
 (18,1,1) = {"
-kG
+xP
 Yv
 Yv
 Yv
@@ -1999,10 +2005,10 @@ EN
 Yv
 Yv
 Yv
-kG
+xP
 "}
 (19,1,1) = {"
-kG
+xP
 qH
 UX
 MR
@@ -2020,10 +2026,10 @@ vo
 ID
 Hf
 aS
-kG
+xP
 "}
 (20,1,1) = {"
-kG
+xP
 Lz
 Lz
 Lz
@@ -2041,10 +2047,10 @@ nG
 Yv
 Yv
 Yv
-kG
+xP
 "}
 (21,1,1) = {"
-kG
+xP
 Lz
 BD
 Lz
@@ -2062,10 +2068,10 @@ WH
 fJ
 LQ
 Yv
-kG
+xP
 "}
 (22,1,1) = {"
-kG
+xP
 HS
 Fa
 Ek
@@ -2083,10 +2089,10 @@ Wb
 Sr
 UL
 oA
-kG
+xP
 "}
 (23,1,1) = {"
-kG
+xP
 Lz
 Lz
 Lz
@@ -2104,10 +2110,10 @@ ZV
 YL
 Yv
 Yv
-kG
+xP
 "}
 (24,1,1) = {"
-kG
+xP
 HS
 uX
 Ek
@@ -2125,10 +2131,10 @@ VM
 SI
 wG
 oA
-kG
+xP
 "}
 (25,1,1) = {"
-kG
+xP
 Lz
 BD
 Lz
@@ -2146,68 +2152,68 @@ Mw
 jn
 Qn
 Yv
-kG
+xP
 "}
 (26,1,1) = {"
-kG
+xP
 Lz
 Lz
 Lz
 nh
 Lz
 Lz
-kG
-kG
-kG
-kG
-kG
+xP
+xP
+xP
+xP
+xP
 Yv
 Yv
 DM
 DM
 Yv
 Yv
-kG
+xP
 "}
 (27,1,1) = {"
-kG
-kG
+xP
+xP
 Lz
 Lz
 Lz
 Lz
-kG
-kG
-kG
-kG
-kG
-kG
-kG
+xP
+xP
+xP
+xP
+xP
+xP
+xP
 Yv
 Yv
 Yv
 Yv
-kG
-kG
+xP
+xP
 "}
 (28,1,1) = {"
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
-kG
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
 "}

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship28x19.dmm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship28x19.dmm
@@ -74,7 +74,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "et" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/belt/utility/full/multitool,
@@ -96,7 +96,7 @@
 "fr" = (
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "fy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -112,7 +112,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "fJ" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/table/standard,
@@ -200,7 +200,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "iS" = (
 /obj/effect/floor_decal/industrial/bot_outline/corner{
 	dir = 1
@@ -227,13 +227,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "jQ" = (
 /obj/structure/fuel_port/heavy{
 	pixel_y = -30
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "jW" = (
 /obj/machinery/embedded_controller/radio/docking_port_multi{
 	child_names_txt = "Port Airlock Control;Starboard Airlock Control;Aft Airlock Control";
@@ -264,7 +264,7 @@
 "kj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/thull,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "kp" = (
 /obj/effect/floor_decal/industrial/outline,
 /obj/structure/table/rack,
@@ -294,9 +294,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
-"kG" = (
-/turf/template_noop,
-/area/space)
 "kH" = (
 /obj/structure/closet/crate,
 /turf/simulated/floor/tiled/dark,
@@ -325,13 +322,13 @@
 	},
 /obj/item/stack/cable_coil/yellow,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "lf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "lg" = (
 /obj/effect/floor_decal/industrial/bot_outline/corner{
 	dir = 4
@@ -343,7 +340,7 @@
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "lM" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -366,7 +363,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "mf" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -400,7 +397,7 @@
 "nF" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "nG" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -454,7 +451,7 @@
 	req_one_access = null
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "oZ" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -503,7 +500,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "qz" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/machinery/airlock_sensor/airlock_exterior{
@@ -514,7 +511,7 @@
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "qH" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
@@ -559,7 +556,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "rf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -573,7 +570,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "rH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -589,7 +586,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "rN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -598,7 +595,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "so" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -651,7 +648,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "tI" = (
 /obj/effect/floor_decal/industrial/arrows{
 	dir = 4
@@ -704,7 +701,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "vZ" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -760,7 +757,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "yd" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/table/standard,
@@ -796,7 +793,7 @@
 	start_pressure = 10000
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "zJ" = (
 /obj/effect/floor_decal/industrial/bot_outline/corner{
 	dir = 4
@@ -809,7 +806,7 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "Az" = (
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
@@ -827,13 +824,13 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "Bo" = (
 /obj/structure/table/steel,
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/device/flashlight,
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "BD" = (
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/gen)
@@ -841,7 +838,7 @@
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "Da" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -851,7 +848,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "Dn" = (
 /obj/effect/floor_decal/industrial/warning/color{
 	dir = 10
@@ -936,13 +933,13 @@
 	pixel_y = -23
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "ED" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "EN" = (
 /obj/effect/floor_decal/industrial/warning/color,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -989,7 +986,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "Gn" = (
 /obj/machinery/airlock_sensor/airlock_interior{
 	dir = 4;
@@ -1003,12 +1000,12 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /obj/effect/map_helper/airlock/sensor/int_sensor,
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "GN" = (
 /obj/structure/grille,
 /obj/structure/window/titanium/full,
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "Hf" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	dir = 4;
@@ -1046,10 +1043,10 @@
 /area/shuttle/metawhiteship/food)
 "HE" = (
 /turf/simulated/wall/thull,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "HM" = (
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "HS" = (
 /obj/structure/grille,
 /obj/structure/window/titanium/full,
@@ -1061,7 +1058,7 @@
 	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "ID" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/effect/map_helper/airlock/door/int_door,
@@ -1094,19 +1091,19 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "KF" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/outline,
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "KR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "KZ" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
@@ -1174,7 +1171,7 @@
 	pixel_y = -26
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "MR" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/machinery/airlock_sensor{
@@ -1217,7 +1214,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "NF" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1236,20 +1233,20 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "Om" = (
 /obj/structure/table/steel,
 /obj/fiftyspawner/steel,
 /obj/fiftyspawner/glass,
 /obj/fiftyspawner/rods,
 /turf/simulated/floor/tiled/dark,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "OH" = (
 /obj/machinery/shipsensors{
 	dir = 8
 	},
 /turf/simulated/floor/plating/external,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "Pk" = (
 /obj/effect/floor_decal/industrial/outline,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1263,7 +1260,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "Pr" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1278,7 +1275,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/firecloset/full,
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "PJ" = (
 /obj/effect/floor_decal/industrial/outline,
 /obj/structure/reagent_dispensers/watertank,
@@ -1344,7 +1341,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "QF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -1369,7 +1366,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/shuttle/metawhiteship/engi)
+/area/shuttle/metawhiteship/eng)
 "Se" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -1501,13 +1498,6 @@
 /area/shuttle/metawhiteship/cargo)
 "UX" = (
 /obj/effect/shuttle_landmark/shuttle_initializer/metawhiteship,
-/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
-	dir = 4;
-	id_tag = "whiteship_docking_port";
-	name = "Port Airlock Control";
-	pixel_x = -22;
-	frequency = 1380
-	},
 /obj/machinery/airlock_sensor{
 	dir = 8;
 	pixel_x = 24;
@@ -1519,6 +1509,11 @@
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/overmap/visitable/ship/landable/metawhiteship,
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	id_tag = "metawhiteship_docker";
+	pixel_x = -24;
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/food)
 "VM" = (
@@ -1946,7 +1941,7 @@ eS
 "}
 (16,1,1) = {"
 eS
-kG
+eS
 Yv
 Yv
 lM
@@ -1967,7 +1962,7 @@ eS
 "}
 (17,1,1) = {"
 eS
-kG
+eS
 oA
 vZ
 Ut

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship28x19.dmm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship28x19.dmm
@@ -1,0 +1,2213 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aQ" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vermouth{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/obj/item/weapon/reagent_containers/food/drinks/bottle/rum{
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/drinks/bottle/wine{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"aS" = (
+/obj/machinery/door/airlock/glass_external/public,
+/obj/machinery/airlock_sensor/airlock_exterior/shuttle{
+	dir = 2;
+	pixel_x = 25;
+	pixel_y = -9
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/food)
+"ca" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/table/rack,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/mop,
+/obj/item/weapon/storage/bag/trash,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"cQ" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/blast/regular{
+	pixel_y = 0;
+	dir = 4;
+	id = "aftmetawhiteship"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/cargo)
+"cU" = (
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"dk" = (
+/obj/effect/floor_decal/corner/blue/full,
+/obj/machinery/computer/ship/sensors{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/bridge)
+"dx" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"dF" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"et" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/belt/utility/full/multitool,
+/obj/item/device/radio/off,
+/obj/item/device/radio/off{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"eQ" = (
+/obj/structure/closet/crate/freezer/rations,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"fr" = (
+/obj/structure/cable/yellow,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"fy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"fJ" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/glass/beaker/measuring_cup{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/food)
+"fZ" = (
+/obj/effect/floor_decal/industrial/warning/color{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"gb" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"gi" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/bridge)
+"gq" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/food)
+"hF" = (
+/obj/effect/floor_decal/industrial/warning/color{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"io" = (
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"iu" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"iC" = (
+/obj/machinery/space_heater,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/engi)
+"iS" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner{
+	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "foremetawhiteship";
+	pixel_y = 0;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"jn" = (
+/obj/effect/floor_decal/corner/green,
+/turf/simulated/floor/tiled/hydro,
+/area/shuttle/metawhiteship/food)
+"jI" = (
+/obj/machinery/door/airlock/glass_external/public,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"jQ" = (
+/obj/structure/fuel_port/heavy{
+	pixel_y = -30
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"jW" = (
+/obj/machinery/embedded_controller/radio/docking_port_multi{
+	child_names_txt = "Port Airlock Control;Starboard Airlock Control";
+	child_tags_txt = "whiteship_docking_port;whiteship_docking_star";
+	dir = 8;
+	id_tag = "metawhiteship_docker";
+	name = "Whiteship Master Docking Controller";
+	pixel_y = 0;
+	pixel_x = 24;
+	frequency = 1380
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"kd" = (
+/obj/machinery/door/airlock/command{
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/bridge)
+"kj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/wall/thull,
+/area/shuttle/metawhiteship/engi)
+"kp" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/table/rack,
+/obj/item/device/analyzer,
+/obj/item/clothing/mask/breath{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/item/clothing/mask/breath{
+	pixel_y = 2;
+	pixel_x = -1
+	},
+/obj/item/clothing/mask/breath{
+	pixel_y = -2;
+	pixel_x = 3
+	},
+/obj/item/weapon/tool/wrench,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"kv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"kx" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"kG" = (
+/turf/template_noop,
+/area/space)
+"kH" = (
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"kX" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"ld" = (
+/obj/structure/table/steel,
+/obj/machinery/cell_charger,
+/obj/item/weapon/cell/high{
+	pixel_y = 1;
+	pixel_x = 3
+	},
+/obj/item/weapon/cell/high{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/stack/cable_coil/yellow,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/engi)
+"lf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"lg" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"lC" = (
+/obj/structure/closet/emcloset,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/engi)
+"lM" = (
+/obj/machinery/door/airlock/glass_external/public,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"lW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"mf" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"mi" = (
+/obj/structure/dispenser/oxygen,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"na" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner{
+	dir = 1
+	},
+/obj/structure/closet/crate/internals,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"nd" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"nh" = (
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/gen)
+"nm" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"nF" = (
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"nG" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"ou" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/standard,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/weapon/reagent_containers/food/drinks/bottle/absinthe{
+	pixel_x = -7;
+	pixel_y = 1
+	},
+/obj/item/weapon/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = 17;
+	pixel_y = 13
+	},
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/item/weapon/reagent_containers/food/drinks/bottle/cognac{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"oA" = (
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/food)
+"oP" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/shuttle/metawhiteship/food)
+"oQ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/computer/ship/engines{
+	dir = 1;
+	req_one_access = null
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"oZ" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"pE" = (
+/turf/simulated/floor/tiled/old_tile,
+/area/shuttle/metawhiteship/gen)
+"pS" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/gibber{
+	emagged = 1;
+	req_access = null
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/food)
+"ql" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table/rack,
+/obj/item/clothing/head/welding,
+/obj/item/device/multitool,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"qp" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/belt/utility/full/multitool,
+/obj/item/device/radio/off,
+/obj/item/device/radio/off{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/engi)
+"qz" = (
+/obj/machinery/door/airlock/glass_external/public,
+/obj/machinery/airlock_sensor/airlock_exterior{
+	pixel_y = 25;
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"qH" = (
+/obj/machinery/door/airlock/glass_external/public,
+/obj/machinery/airlock_sensor/airlock_exterior/shuttle{
+	dir = 1;
+	pixel_x = 24;
+	pixel_y = 11
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/effect/map_helper/airlock/sensor/ext_sensor,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/food)
+"qN" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner{
+	dir = 8
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "aftmetawhiteship";
+	pixel_y = 0;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"qU" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_y = 26
+	},
+/obj/structure/table/standard,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/bridge)
+"qX" = (
+/obj/machinery/power/smes/buildable/point_of_interest,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"rf" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"rH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"rN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/engi)
+"so" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/gen)
+"sG" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/blast/regular{
+	pixel_y = 0;
+	dir = 4;
+	id = "foremetawhiteship"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/cargo)
+"sX" = (
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/bridge)
+"tw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"tx" = (
+/obj/effect/floor_decal/industrial/warning/color{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/engi)
+"tI" = (
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"uk" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"uX" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/gen)
+"vo" = (
+/obj/effect/floor_decal/industrial/warning/color{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"vE" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"vW" = (
+/obj/effect/floor_decal/industrial/warning/color/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/engi)
+"vZ" = (
+/obj/effect/floor_decal/industrial/hatch,
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"ws" = (
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"wG" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/shuttle/metawhiteship/food)
+"xk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"xA" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"xM" = (
+/obj/machinery/door/airlock/engineering{
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/engi)
+"yd" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/weapon/reagent_containers/food/drinks/cans/cola{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -9;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = -9;
+	pixel_y = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"yQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"yT" = (
+/obj/machinery/atmospherics/pipe/tank/air/full{
+	start_pressure = 10000
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"zJ" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"zX" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"Az" = (
+/obj/structure/table/steel,
+/obj/machinery/cell_charger,
+/obj/item/weapon/cell/high{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"Bo" = (
+/obj/structure/table/steel,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/flashlight,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"BD" = (
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/gen)
+"CD" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"Da" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"Dn" = (
+/obj/effect/floor_decal/industrial/warning/color{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"DF" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/table/rack,
+/obj/item/clothing/head/welding,
+/obj/item/weapon/storage/belt/utility/full/multitool,
+/obj/item/weapon/weldingtool,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"DH" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"DM" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/shuttle/metawhiteship/food)
+"DQ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/gen)
+"DZ" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"Ek" = (
+/obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/gen)
+"Eq" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"Es" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/food)
+"EC" = (
+/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+	pixel_y = -26;
+	id_tag = "metawhiteshipaft"
+	},
+/obj/machinery/airlock_sensor{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"ED" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"EN" = (
+/obj/effect/floor_decal/industrial/warning/color,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/light/small{
+	dir = 2
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"Fa" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/gen)
+"Fm" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/gen)
+"Fq" = (
+/obj/effect/floor_decal/corner/blue,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/bridge)
+"Ft" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/appliance/cooker/fryer,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/food)
+"FE" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/gen)
+"Gd" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"Gn" = (
+/obj/machinery/airlock_sensor/airlock_interior{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 25
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/obj/machinery/door/airlock/glass_external/public,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"GN" = (
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"Hf" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
+	dir = 4;
+	id_tag = "whiteship_docking_star";
+	name = "Starboard Airlock Control";
+	pixel_x = -22;
+	frequency = 1380
+	},
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 24;
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1380
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/food)
+"Hr" = (
+/obj/effect/floor_decal/corner/blue/diagonal,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	pixel_y = -26
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/gen)
+"Hz" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"HE" = (
+/turf/simulated/wall/thull,
+/area/shuttle/metawhiteship/engi)
+"HM" = (
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"HS" = (
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/gen)
+"Iu" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"ID" = (
+/obj/machinery/door/airlock/glass_external/public,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/airlock_sensor/airlock_interior{
+	dir = 1;
+	pixel_x = -26;
+	pixel_y = 9
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/food)
+"IT" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"Jj" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"JP" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"KF" = (
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/engi)
+"KR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"KZ" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/bridge)
+"Lb" = (
+/obj/structure/table/standard,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/bridge)
+"Lz" = (
+/turf/simulated/wall/thull,
+/area/shuttle/metawhiteship/gen)
+"LQ" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/table/standard,
+/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme{
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/condiment/carton/flour{
+	pixel_x = -8;
+	pixel_y = 15
+	},
+/obj/item/weapon/material/kitchen/rollingpin,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/food)
+"Ml" = (
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/cargo)
+"Mn" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/standard,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/poster/nanotrasen{
+	dir = 1
+	},
+/obj/machinery/microwave,
+/obj/random/donkpocketbox,
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"Mw" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/shuttle/metawhiteship/food)
+"MD" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	pixel_y = -26
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"MR" = (
+/obj/machinery/door/airlock/glass_external/public,
+/obj/machinery/airlock_sensor{
+	dir = 2;
+	pixel_x = 24;
+	req_one_access = null;
+	pixel_y = 0
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/food)
+"Nm" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/donut{
+	pixel_x = -10;
+	pixel_y = 0
+	},
+/obj/item/weapon/reagent_containers/food/snacks/chocolatebar{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer{
+	pixel_x = 5;
+	pixel_y = 13
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"NE" = (
+/obj/structure/table/rack,
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = 2;
+	pixel_y = 7
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/clothing/head/welding,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/engi)
+"NF" = (
+/obj/machinery/door/airlock/glass_external/public,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"NH" = (
+/obj/effect/floor_decal/industrial/warning/color/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/engi)
+"Om" = (
+/obj/structure/table/steel,
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/rods,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/engi)
+"OH" = (
+/obj/machinery/shipsensors{
+	dir = 8
+	},
+/turf/simulated/floor/plating/external,
+/area/shuttle/metawhiteship/engi)
+"Pk" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"Pp" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"Pr" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/vending/cigarette{
+	dir = 4;
+	pixel_x = 7
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"PE" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"PJ" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"PL" = (
+/obj/machinery/computer/shuttle_control/explore/metawhiteship{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/full{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/bridge)
+"PS" = (
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/standard,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 28
+	},
+/obj/item/trash/plate{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/trash/plate{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/item/trash/plate{
+	pixel_x = -5;
+	pixel_y = 0
+	},
+/obj/item/trash/plate{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/weapon/material/kitchen/utensil/fork,
+/obj/item/weapon/material/kitchen/utensil/fork{
+	pixel_x = 6
+	},
+/obj/item/weapon/material/kitchen/utensil/fork{
+	pixel_x = 2
+	},
+/obj/item/weapon/material/kitchen/utensil/fork{
+	pixel_x = 4
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"Qn" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/shuttle/metawhiteship/food)
+"Qt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"QF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"Rt" = (
+/turf/simulated/wall/thull,
+/area/shuttle/metawhiteship/bridge)
+"RN" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/food)
+"Sa" = (
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/engi)
+"Se" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"Si" = (
+/obj/structure/closet/crate/internals,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"Sr" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/food)
+"SB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"SI" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/shuttle/metawhiteship/food)
+"ST" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"SW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/gen)
+"SY" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/table/rack,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/item/weapon/storage/box/lights/bulbs,
+/obj/item/stack/cable_coil/yellow,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"Tf" = (
+/obj/effect/floor_decal/industrial/outline,
+/obj/structure/closet/firecloset/full,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"Tq" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner,
+/obj/structure/closet/crate/internals,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"Ts" = (
+/obj/structure/closet/crate/weapon,
+/obj/item/weapon/gun/energy/retro,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"Tt" = (
+/turf/simulated/wall/thull,
+/area/shuttle/metawhiteship/cargo)
+"TI" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/shuttle/metawhiteship/food)
+"TS" = (
+/obj/machinery/door/airlock,
+/turf/simulated/floor/tiled/old_tile,
+/area/shuttle/metawhiteship/gen)
+"Ut" = (
+/obj/effect/floor_decal/industrial/warning/color{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
+"UL" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/food)
+"UR" = (
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"UX" = (
+/obj/effect/shuttle_landmark/shuttle_initializer/metawhiteship,
+/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
+	dir = 4;
+	id_tag = "whiteship_docking_port";
+	name = "Port Airlock Control";
+	pixel_x = -22;
+	frequency = 1380
+	},
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 24;
+	req_one_access = null
+	},
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	frequency = 1380
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/overmap/visitable/ship/landable/metawhiteship,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/food)
+"VM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/shuttle/metawhiteship/food)
+"Wb" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/food)
+"We" = (
+/obj/structure/bed/chair/bay/comfy/green{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/bridge)
+"Wg" = (
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
+"Wn" = (
+/obj/effect/floor_decal/corner/blue{
+	dir = 9
+	},
+/obj/machinery/computer/ship/helm{
+	req_one_access = null;
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/bridge)
+"Wu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/bridge)
+"WB" = (
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"WH" = (
+/obj/effect/floor_decal/corner/grey/diagonal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/metawhiteship/food)
+"Xf" = (
+/obj/machinery/light/small{
+	dir = 2
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/shuttle/metawhiteship/gen)
+"XF" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 2
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/gen)
+"XO" = (
+/obj/structure/closet,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/regular,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"Yv" = (
+/turf/simulated/wall/thull,
+/area/shuttle/metawhiteship/food)
+"YL" = (
+/obj/machinery/smartfridge/produce,
+/turf/simulated/wall/thull,
+/area/shuttle/metawhiteship/food)
+"YS" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/bridge)
+"ZP" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"ZV" = (
+/obj/machinery/door/airlock/glass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/shuttle/metawhiteship/food)
+
+(1,1,1) = {"
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+"}
+(2,1,1) = {"
+kG
+kG
+HE
+Pp
+Pp
+HE
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+HE
+Pp
+Pp
+HE
+kG
+kG
+"}
+(3,1,1) = {"
+kG
+HE
+HE
+Sa
+Sa
+HE
+HE
+kG
+kG
+kG
+kG
+kG
+HE
+HE
+Sa
+Sa
+HE
+HE
+kG
+"}
+(4,1,1) = {"
+kG
+HE
+yT
+Iu
+Qt
+nF
+HE
+OH
+HE
+qz
+HE
+kG
+HE
+qX
+Da
+Gd
+fr
+HE
+kG
+"}
+(5,1,1) = {"
+kG
+GN
+CD
+ED
+KR
+Bo
+HE
+GN
+HE
+EC
+HE
+GN
+HE
+Az
+HM
+HM
+jQ
+HE
+kG
+"}
+(6,1,1) = {"
+kG
+HE
+HE
+PE
+lf
+zX
+HE
+KF
+kj
+Gn
+HE
+lC
+HE
+rf
+HM
+MD
+HE
+HE
+kG
+"}
+(7,1,1) = {"
+kG
+kG
+HE
+dF
+lW
+JP
+xM
+rN
+NH
+tx
+vW
+rN
+xM
+fy
+rH
+oQ
+GN
+kG
+kG
+"}
+(8,1,1) = {"
+kG
+kG
+HE
+HE
+jI
+HE
+HE
+qp
+Om
+iC
+ld
+NE
+HE
+HE
+jI
+HE
+HE
+kG
+kG
+"}
+(9,1,1) = {"
+kG
+Tt
+Tt
+iu
+xk
+DF
+Tt
+Tt
+Ml
+Ml
+Ml
+Tt
+Tt
+ca
+xk
+PJ
+Tt
+Tt
+kG
+"}
+(10,1,1) = {"
+kG
+sG
+iS
+ZP
+xk
+nd
+Si
+eQ
+ST
+UR
+na
+kX
+Se
+vE
+SB
+nd
+qN
+cQ
+kG
+"}
+(11,1,1) = {"
+kG
+sG
+WB
+WB
+xk
+zJ
+WB
+WB
+Jj
+UR
+zJ
+WB
+Ts
+Jj
+QF
+WB
+WB
+cQ
+kG
+"}
+(12,1,1) = {"
+kG
+sG
+ws
+WB
+cU
+kx
+tI
+Wg
+UR
+UR
+UR
+tI
+Wg
+gb
+io
+WB
+WB
+cQ
+kG
+"}
+(13,1,1) = {"
+kG
+sG
+ws
+WB
+xk
+nd
+WB
+WB
+ST
+UR
+nd
+WB
+WB
+ST
+QF
+WB
+kH
+cQ
+kG
+"}
+(14,1,1) = {"
+kG
+sG
+zJ
+Jj
+xk
+zJ
+Eq
+WB
+Tq
+UR
+zJ
+XO
+Eq
+Jj
+QF
+lg
+Jj
+cQ
+kG
+"}
+(15,1,1) = {"
+kG
+Tt
+Tt
+Tf
+xk
+SY
+Tt
+Tt
+Ml
+Ml
+Ml
+Tt
+Tt
+kp
+QF
+mi
+Tt
+Tt
+kG
+"}
+(16,1,1) = {"
+kG
+kG
+Yv
+Yv
+lM
+Yv
+Yv
+Mn
+nm
+yd
+DZ
+ou
+Yv
+Yv
+NF
+Yv
+Yv
+kG
+kG
+"}
+(17,1,1) = {"
+kG
+kG
+oA
+vZ
+Ut
+et
+Yv
+PS
+nm
+Nm
+DZ
+aQ
+Yv
+ql
+Dn
+vZ
+oA
+kG
+kG
+"}
+(18,1,1) = {"
+kG
+Yv
+Yv
+Yv
+fZ
+yQ
+uk
+oZ
+xA
+DH
+mf
+mf
+dx
+kv
+EN
+Yv
+Yv
+Yv
+kG
+"}
+(19,1,1) = {"
+kG
+qH
+UX
+MR
+hF
+Pk
+Yv
+RN
+IT
+tw
+jW
+Pr
+Yv
+Hz
+vo
+ID
+Hf
+aS
+kG
+"}
+(20,1,1) = {"
+kG
+Lz
+Lz
+Lz
+SW
+Lz
+Lz
+Rt
+Rt
+kd
+Rt
+Rt
+Yv
+Yv
+nG
+Yv
+Yv
+Yv
+kG
+"}
+(21,1,1) = {"
+kG
+Lz
+BD
+Lz
+so
+Lz
+Xf
+Rt
+qU
+Wu
+Lb
+Rt
+pS
+Es
+WH
+fJ
+LQ
+Yv
+kG
+"}
+(22,1,1) = {"
+kG
+HS
+Fa
+Ek
+XF
+TS
+pE
+Rt
+YS
+gi
+YS
+Rt
+Ft
+gq
+Wb
+Sr
+UL
+oA
+kG
+"}
+(23,1,1) = {"
+kG
+Lz
+Lz
+Lz
+SW
+Lz
+Lz
+Rt
+KZ
+We
+Fq
+Rt
+Yv
+Yv
+ZV
+YL
+Yv
+Yv
+kG
+"}
+(24,1,1) = {"
+kG
+HS
+uX
+Ek
+Fm
+Hr
+Lz
+sX
+PL
+Wn
+dk
+sX
+Yv
+TI
+VM
+SI
+wG
+oA
+kG
+"}
+(25,1,1) = {"
+kG
+Lz
+BD
+Lz
+DQ
+FE
+Lz
+sX
+sX
+sX
+sX
+sX
+Yv
+oP
+Mw
+jn
+Qn
+Yv
+kG
+"}
+(26,1,1) = {"
+kG
+Lz
+Lz
+Lz
+nh
+Lz
+Lz
+kG
+kG
+kG
+kG
+kG
+Yv
+Yv
+DM
+DM
+Yv
+Yv
+kG
+"}
+(27,1,1) = {"
+kG
+kG
+Lz
+Lz
+Lz
+Lz
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+Yv
+Yv
+Yv
+Yv
+kG
+kG
+"}
+(28,1,1) = {"
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+kG
+"}

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship28x19.dmm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship28x19.dmm
@@ -90,6 +90,9 @@
 /obj/structure/closet/crate/freezer/rations,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
+"eS" = (
+/turf/template_noop,
+/area/template_noop)
 "fr" = (
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating,
@@ -327,7 +330,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/engi)
 "lg" = (
@@ -759,9 +761,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/engi)
-"xP" = (
-/turf/template_noop,
-/area/template_noop)
 "yd" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/table/standard,
@@ -1060,6 +1059,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
+/obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/engi)
 "ID" = (
@@ -1630,70 +1630,70 @@
 /area/shuttle/metawhiteship/food)
 
 (1,1,1) = {"
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
 "}
 (2,1,1) = {"
-xP
-xP
+eS
+eS
 HE
 Pp
 Pp
 HE
-xP
-xP
-xP
-xP
-xP
-xP
-xP
+eS
+eS
+eS
+eS
+eS
+eS
+eS
 HE
 Pp
 Pp
 HE
-xP
-xP
+eS
+eS
 "}
 (3,1,1) = {"
-xP
+eS
 HE
 HE
 Sa
 Sa
 HE
 HE
-xP
-xP
-xP
-xP
-xP
+eS
+eS
+eS
+eS
+eS
 HE
 HE
 Sa
 Sa
 HE
 HE
-xP
+eS
 "}
 (4,1,1) = {"
-xP
+eS
 HE
 yT
 Iu
@@ -1704,17 +1704,17 @@ OH
 HE
 qz
 HE
-xP
+eS
 HE
 qX
 Da
 Gd
 fr
 HE
-xP
+eS
 "}
 (5,1,1) = {"
-xP
+eS
 GN
 CD
 ED
@@ -1732,10 +1732,10 @@ HM
 HM
 jQ
 HE
-xP
+eS
 "}
 (6,1,1) = {"
-xP
+eS
 HE
 HE
 PE
@@ -1753,11 +1753,11 @@ HM
 MD
 HE
 HE
-xP
+eS
 "}
 (7,1,1) = {"
-xP
-xP
+eS
+eS
 HE
 dF
 lW
@@ -1773,12 +1773,12 @@ fy
 rH
 oQ
 GN
-xP
-xP
+eS
+eS
 "}
 (8,1,1) = {"
-xP
-xP
+eS
+eS
 HE
 HE
 jI
@@ -1794,11 +1794,11 @@ HE
 jI
 HE
 HE
-xP
-xP
+eS
+eS
 "}
 (9,1,1) = {"
-xP
+eS
 Tt
 Tt
 iu
@@ -1816,10 +1816,10 @@ xk
 PJ
 Tt
 Tt
-xP
+eS
 "}
 (10,1,1) = {"
-xP
+eS
 sG
 iS
 ZP
@@ -1837,10 +1837,10 @@ SB
 nd
 qN
 cQ
-xP
+eS
 "}
 (11,1,1) = {"
-xP
+eS
 sG
 WB
 WB
@@ -1858,10 +1858,10 @@ QF
 WB
 WB
 cQ
-xP
+eS
 "}
 (12,1,1) = {"
-xP
+eS
 sG
 ws
 WB
@@ -1879,10 +1879,10 @@ io
 WB
 WB
 cQ
-xP
+eS
 "}
 (13,1,1) = {"
-xP
+eS
 sG
 ws
 WB
@@ -1900,10 +1900,10 @@ QF
 WB
 kH
 cQ
-xP
+eS
 "}
 (14,1,1) = {"
-xP
+eS
 sG
 zJ
 Jj
@@ -1921,10 +1921,10 @@ QF
 lg
 Jj
 cQ
-xP
+eS
 "}
 (15,1,1) = {"
-xP
+eS
 Tt
 Tt
 Tf
@@ -1942,10 +1942,10 @@ QF
 mi
 Tt
 Tt
-xP
+eS
 "}
 (16,1,1) = {"
-xP
+eS
 kG
 Yv
 Yv
@@ -1962,11 +1962,11 @@ Yv
 NF
 Yv
 Yv
-xP
-xP
+eS
+eS
 "}
 (17,1,1) = {"
-xP
+eS
 kG
 oA
 vZ
@@ -1983,11 +1983,11 @@ ql
 Dn
 vZ
 oA
-xP
-xP
+eS
+eS
 "}
 (18,1,1) = {"
-xP
+eS
 Yv
 Yv
 Yv
@@ -2005,10 +2005,10 @@ EN
 Yv
 Yv
 Yv
-xP
+eS
 "}
 (19,1,1) = {"
-xP
+eS
 qH
 UX
 MR
@@ -2026,10 +2026,10 @@ vo
 ID
 Hf
 aS
-xP
+eS
 "}
 (20,1,1) = {"
-xP
+eS
 Lz
 Lz
 Lz
@@ -2047,10 +2047,10 @@ nG
 Yv
 Yv
 Yv
-xP
+eS
 "}
 (21,1,1) = {"
-xP
+eS
 Lz
 BD
 Lz
@@ -2068,10 +2068,10 @@ WH
 fJ
 LQ
 Yv
-xP
+eS
 "}
 (22,1,1) = {"
-xP
+eS
 HS
 Fa
 Ek
@@ -2089,10 +2089,10 @@ Wb
 Sr
 UL
 oA
-xP
+eS
 "}
 (23,1,1) = {"
-xP
+eS
 Lz
 Lz
 Lz
@@ -2110,10 +2110,10 @@ ZV
 YL
 Yv
 Yv
-xP
+eS
 "}
 (24,1,1) = {"
-xP
+eS
 HS
 uX
 Ek
@@ -2131,10 +2131,10 @@ VM
 SI
 wG
 oA
-xP
+eS
 "}
 (25,1,1) = {"
-xP
+eS
 Lz
 BD
 Lz
@@ -2152,68 +2152,68 @@ Mw
 jn
 Qn
 Yv
-xP
+eS
 "}
 (26,1,1) = {"
-xP
+eS
 Lz
 Lz
 Lz
 nh
 Lz
 Lz
-xP
-xP
-xP
-xP
-xP
+eS
+eS
+eS
+eS
+eS
 Yv
 Yv
 DM
 DM
 Yv
 Yv
-xP
+eS
 "}
 (27,1,1) = {"
-xP
-xP
+eS
+eS
 Lz
 Lz
 Lz
 Lz
-xP
-xP
-xP
-xP
-xP
-xP
-xP
+eS
+eS
+eS
+eS
+eS
+eS
+eS
 Yv
 Yv
 Yv
 Yv
-xP
-xP
+eS
+eS
 "}
 (28,1,1) = {"
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
-xP
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
 "}

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship30x21.dmm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship30x21.dmm
@@ -14,6 +14,7 @@
 	pixel_x = 0;
 	pixel_y = 12
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "aS" = (
@@ -56,6 +57,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
 "dk" = (
@@ -63,11 +65,13 @@
 /obj/machinery/computer/ship/sensors{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/bridge)
 "dx" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "dF" = (
@@ -84,17 +88,29 @@
 	pixel_y = 4
 	},
 /obj/effect/floor_decal/industrial/outline,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
+"eE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/turf/simulated/wall/thull,
+/area/shuttle/metawhiteship/eng)
 "eQ" = (
 /obj/structure/closet/crate/freezer/rations,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "eS" = (
 /turf/template_noop,
 /area/template_noop)
 "fr" = (
-/obj/structure/cable/yellow,
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/phoron,
+/obj/machinery/light/small{
+	dir = 2
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "fy" = (
@@ -111,6 +127,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "fJ" = (
@@ -128,6 +145,7 @@
 	pixel_x = -9;
 	pixel_y = 0
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
 "fZ" = (
@@ -150,16 +168,23 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "gb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
 "gi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/bridge)
 "gq" = (
@@ -168,8 +193,17 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
+"gs" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
 "hF" = (
 /obj/effect/floor_decal/industrial/warning/color{
 	dir = 5
@@ -180,13 +214,26 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
+"im" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
+/turf/simulated/wall/thull,
+/area/shuttle/metawhiteship/eng)
 "io" = (
 /obj/effect/floor_decal/industrial/arrows{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
 "iu" = (
@@ -210,10 +257,12 @@
 	pixel_y = 0;
 	pixel_x = -24
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "jn" = (
 /obj/effect/floor_decal/corner/green,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/hydro,
 /area/shuttle/metawhiteship/food)
 "jI" = (
@@ -226,12 +275,26 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/eng)
+"jK" = (
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/machinery/door/blast/regular/open{
+	id = "metawhiteshiplockdown"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "jQ" = (
 /obj/structure/fuel_port/heavy{
 	pixel_y = -30
 	},
+/obj/machinery/atmospherics/portables_connector/fuel{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "jW" = (
@@ -241,9 +304,14 @@
 	dir = 8;
 	id_tag = "metawhiteship_docker";
 	name = "Whiteship Master Docking Controller";
-	pixel_y = 0;
-	pixel_x = 24;
+	pixel_y = -15;
+	pixel_x = 21;
 	frequency = 1380
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
@@ -259,10 +327,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/bridge)
 "kj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
 /turf/simulated/wall/thull,
 /area/shuttle/metawhiteship/eng)
 "kp" = (
@@ -286,16 +358,20 @@
 /area/shuttle/metawhiteship/cargo)
 "kv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "kx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
 "kH" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate/medical,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "kX" = (
@@ -307,6 +383,7 @@
 	dir = 8;
 	pixel_x = -26
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "ld" = (
@@ -327,6 +404,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "lg" = (
@@ -334,11 +412,13 @@
 	dir = 4
 	},
 /obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "lC" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/eng)
 "lM" = (
@@ -362,11 +442,13 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "mf" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "mi" = (
@@ -378,24 +460,32 @@
 	dir = 1
 	},
 /obj/structure/closet/crate/internals,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "nd" = (
 /obj/effect/floor_decal/industrial/bot_outline/corner{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "nh" = (
+/obj/structure/closet/wardrobe/black,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/gen)
 "nm" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/bed/chair,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "nF" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "nG" = (
@@ -403,8 +493,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
+"nS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/eng)
 "ou" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/table/standard,
@@ -427,16 +524,26 @@
 	pixel_x = 8;
 	pixel_y = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "oA" = (
 /obj/structure/grille,
 /obj/structure/window/titanium/full,
+/obj/machinery/door/blast/regular/open{
+	id = "metawhiteshiplockdown"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/food)
 "oP" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
+	},
+/obj/machinery/botany,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/shuttle/metawhiteship/food)
@@ -450,6 +557,7 @@
 	dir = 1;
 	req_one_access = null
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "oZ" = (
@@ -465,9 +573,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "pE" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/old_tile,
 /area/shuttle/metawhiteship/gen)
 "pS" = (
@@ -475,6 +588,12 @@
 /obj/machinery/gibber{
 	emagged = 1;
 	req_access = null
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
@@ -486,6 +605,7 @@
 /obj/structure/table/rack,
 /obj/item/clothing/head/welding,
 /obj/item/device/multitool,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "qp" = (
@@ -510,6 +630,11 @@
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "qH" = (
@@ -521,6 +646,11 @@
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/food)
 "qN" = (
@@ -532,6 +662,7 @@
 	pixel_y = 0;
 	pixel_x = -24
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "qU" = (
@@ -547,6 +678,10 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/device/camera,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/bridge)
 "qX" = (
@@ -555,6 +690,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "rf" = (
@@ -568,6 +704,12 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
@@ -585,6 +727,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "rN" = (
@@ -594,6 +737,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/eng)
 "so" = (
@@ -607,6 +751,10 @@
 	},
 /obj/machinery/light/small{
 	dir = 2
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/gen)
@@ -622,6 +770,9 @@
 "sX" = (
 /obj/structure/grille,
 /obj/structure/window/titanium/full,
+/obj/machinery/door/blast/regular/open{
+	id = "metawhiteshipbridge"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/bridge)
 "tw" = (
@@ -633,6 +784,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "tx" = (
@@ -647,12 +799,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/eng)
 "tI" = (
 /obj/effect/floor_decal/industrial/arrows{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
 "uk" = (
@@ -670,6 +830,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/brown,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/gen)
 "vo" = (
@@ -677,6 +840,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "vE" = (
@@ -688,6 +852,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "vW" = (
@@ -699,6 +864,12 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/eng)
@@ -712,6 +883,7 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "wG" = (
@@ -721,6 +893,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/botany,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/hydro,
 /area/shuttle/metawhiteship/food)
 "xk" = (
@@ -744,6 +918,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "xM" = (
@@ -756,6 +931,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/eng)
 "yd" = (
@@ -777,6 +953,7 @@
 	pixel_x = -9;
 	pixel_y = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "yQ" = (
@@ -786,17 +963,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "yT" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "zJ" = (
 /obj/effect/floor_decal/industrial/bot_outline/corner{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "zX" = (
@@ -804,6 +984,11 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = -25;
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "Az" = (
@@ -822,21 +1007,35 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "Bo" = (
 /obj/structure/table/steel,
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/device/flashlight,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "BD" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/gen)
 "CD" = (
 /obj/machinery/atmospherics/pipe/tank/air/full{
 	start_pressure = 10000
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "Da" = (
@@ -847,8 +1046,22 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
+"Db" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
 "Dn" = (
 /obj/effect/floor_decal/industrial/warning/color{
 	dir = 10
@@ -856,6 +1069,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "DF" = (
@@ -876,12 +1090,20 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "DM" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
+/obj/structure/table/standard,
+/obj/item/weapon/shovel/spade,
+/obj/item/weapon/material/minihoe,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/device/analyzer/plant_analyzer,
+/obj/item/weapon/storage/bag/plants,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/hydro,
 /area/shuttle/metawhiteship/food)
 "DQ" = (
@@ -891,6 +1113,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/gen)
 "DZ" = (
@@ -898,22 +1121,36 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "Ek" = (
 /obj/machinery/door/airlock,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/gen)
 "Eq" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 26
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
+"Er" = (
+/obj/effect/floor_decal/industrial/hatch,
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/food)
 "Es" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/structure/closet/secure_closet/freezer/fridge,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
 "EC" = (
@@ -932,12 +1169,18 @@
 	frequency = 1380;
 	pixel_y = -23
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "ED" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "EN" = (
@@ -946,13 +1189,29 @@
 /obj/machinery/light/small{
 	dir = 2
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = -25;
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
+"ER" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	color = "red";
+	icon_state = "gib2_flesh"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
 "Fa" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/brown,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/gen)
 "Fm" = (
@@ -964,26 +1223,49 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/gen)
 "Fq" = (
 /obj/effect/floor_decal/corner/blue,
+/obj/structure/bed/chair/bay/comfy/green{
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "metawhiteshiplockdown";
+	pixel_y = -25;
+	pixel_x = -9;
+	name = "ship lockdown";
+	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "metawhiteshipbridge";
+	pixel_y = -25;
+	pixel_x = 3;
+	name = "ship lockdown";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/bridge)
 "Ft" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/appliance/cooker/fryer,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
 "FE" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
+/obj/machinery/washing_machine,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/gen)
 "Gd" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable/yellow,
+/obj/item/weapon/tool/wrench,
+/obj/machinery/power/port_gen/pacman,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
@@ -999,11 +1281,20 @@
 /obj/machinery/door/airlock/glass_external/public,
 /obj/effect/map_helper/airlock/door/int_door,
 /obj/effect/map_helper/airlock/sensor/int_sensor,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "GN" = (
 /obj/structure/grille,
 /obj/structure/window/titanium/full,
+/obj/machinery/door/blast/regular/open{
+	id = "metawhiteshiplockdown"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "Hf" = (
@@ -1033,23 +1324,33 @@
 /obj/machinery/power/apc{
 	pixel_y = -26
 	},
+/obj/structure/table/standard,
+/obj/structure/bedsheetbin,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/gen)
 "Hz" = (
 /obj/effect/floor_decal/industrial/outline,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "HE" = (
 /turf/simulated/wall/thull,
 /area/shuttle/metawhiteship/eng)
 "HM" = (
+/obj/machinery/atmospherics/binary/pump/fuel{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "HS" = (
 /obj/structure/grille,
 /obj/structure/window/titanium/full,
+/obj/machinery/door/blast/regular/open{
+	id = "metawhiteshiplockdown"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/gen)
 "Iu" = (
@@ -1057,6 +1358,10 @@
 	dir = 8
 	},
 /obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "ID" = (
@@ -1071,14 +1376,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/food)
+"IL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/tiled/neutral,
+/area/shuttle/metawhiteship/gen)
 "IT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "Jj" = (
 /obj/effect/floor_decal/industrial/bot_outline/corner,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "JP" = (
@@ -1090,8 +1414,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
+"Kf" = (
+/obj/structure/table/standard,
+/obj/item/weapon/storage/toolbox,
+/obj/item/weapon/cell/high,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/bridge)
 "KF" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /obj/effect/floor_decal/industrial/outline,
@@ -1102,12 +1438,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "KZ" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 4
 	},
+/obj/structure/bed/chair/bay/comfy/green{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/bridge)
 "Lb" = (
@@ -1115,6 +1456,13 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/device/megaphone,
+/obj/item/device/radio,
+/obj/item/weapon/tool/wrench{
+	pixel_x = 11;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/bridge)
 "Lz" = (
@@ -1133,6 +1481,7 @@
 	pixel_y = 15
 	},
 /obj/item/weapon/material/kitchen/rollingpin,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
 "Ml" = (
@@ -1151,6 +1500,7 @@
 	},
 /obj/machinery/microwave,
 /obj/random/donkpocketbox,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "Mw" = (
@@ -1160,6 +1510,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/hydro,
 /area/shuttle/metawhiteship/food)
 "MD" = (
@@ -1170,8 +1521,27 @@
 /obj/machinery/power/apc{
 	pixel_y = -26
 	},
+/obj/structure/closet/crate,
+/obj/item/weapon/tank/phoron,
+/obj/item/weapon/tank/phoron,
+/obj/item/weapon/tank/phoron,
+/obj/item/stack/material/phoron{
+	amount = 25
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
+"MQ" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/machinery/vending/hydroseeds,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/hydro,
+/area/shuttle/metawhiteship/food)
 "MR" = (
 /obj/machinery/door/airlock/glass_external/public,
 /obj/machinery/airlock_sensor{
@@ -1183,8 +1553,25 @@
 /obj/effect/map_helper/airlock/door/int_door,
 /obj/effect/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/food)
+"MU" = (
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/eng)
 "Nm" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/table/standard,
@@ -1200,8 +1587,16 @@
 	pixel_x = 5;
 	pixel_y = 13
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
+"Nw" = (
+/obj/effect/floor_decal/industrial/bot_outline/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
 "NE" = (
 /obj/structure/table/rack,
 /obj/item/weapon/storage/toolbox/electrical{
@@ -1220,6 +1615,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "NH" = (
@@ -1231,6 +1627,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/eng)
@@ -1253,6 +1654,7 @@
 	dir = 1
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "Pp" = (
@@ -1269,6 +1671,7 @@
 	dir = 4;
 	pixel_x = 7
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "PE" = (
@@ -1288,6 +1691,7 @@
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/bridge)
 "PS" = (
@@ -1328,26 +1732,40 @@
 /obj/item/weapon/material/kitchen/utensil/fork{
 	pixel_x = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "Qn" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
+/obj/machinery/botany,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/hydro,
 /area/shuttle/metawhiteship/food)
 "Qt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "QF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
+"Re" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/eng)
 "Rt" = (
 /turf/simulated/wall/thull,
 /area/shuttle/metawhiteship/bridge)
@@ -1356,6 +1774,7 @@
 	dir = 4
 	},
 /obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
 "Sa" = (
@@ -1364,6 +1783,9 @@
 	},
 /obj/structure/shuttle/engine/heater{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
@@ -1376,12 +1798,23 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 0;
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "Si" = (
 /obj/structure/closet/crate/internals,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
@@ -1391,8 +1824,22 @@
 	dir = 4;
 	pixel_x = 11
 	},
+/obj/effect/decal/cleanable/flour,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
+"Sy" = (
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/shuttle/engine/heater{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/shuttle/metawhiteship/eng)
 "SB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -1402,6 +1849,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
 "SI" = (
@@ -1410,12 +1858,14 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/hydro,
 /area/shuttle/metawhiteship/food)
 "ST" = (
 /obj/effect/floor_decal/industrial/bot_outline/corner{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "SW" = (
@@ -1426,6 +1876,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/gen)
@@ -1447,15 +1901,24 @@
 /obj/structure/closet/crate/internals,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "Ts" = (
 /obj/structure/closet/crate/weapon,
 /obj/item/weapon/gun/energy/retro,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "Tt" = (
 /turf/simulated/wall/thull,
+/area/shuttle/metawhiteship/cargo)
+"TG" = (
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
 "TI" = (
 /obj/effect/floor_decal/corner/green{
@@ -1464,10 +1927,13 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/botany,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/hydro,
 /area/shuttle/metawhiteship/food)
 "TS" = (
 /obj/machinery/door/airlock,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/old_tile,
 /area/shuttle/metawhiteship/gen)
 "Ut" = (
@@ -1482,6 +1948,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "UL" = (
@@ -1491,9 +1958,11 @@
 	},
 /obj/structure/table/standard,
 /obj/machinery/microwave,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
 "UR" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
 "UX" = (
@@ -1514,29 +1983,39 @@
 	pixel_x = -24;
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/food)
 "VM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/hydro,
 /area/shuttle/metawhiteship/food)
 "Wb" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
 "We" = (
 /obj/structure/bed/chair/bay/comfy/green{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/bridge)
 "Wg" = (
 /obj/effect/floor_decal/industrial/arrows{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
 "Wn" = (
@@ -1547,6 +2026,7 @@
 	req_one_access = null;
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/bridge)
 "Wu" = (
@@ -1558,9 +2038,13 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/remains,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/bridge)
 "WB" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "WH" = (
@@ -1568,14 +2052,31 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
 "Xf" = (
 /obj/machinery/light/small{
 	dir = 2
 	},
+/obj/machinery/shower,
+/obj/structure/curtain/open/shower,
+/obj/item/weapon/soap,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/old_tile,
 /area/shuttle/metawhiteship/gen)
+"Xz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
+/area/shuttle/metawhiteship/cargo)
 "XF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 2
@@ -1585,6 +2086,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/gen)
 "XO" = (
@@ -1592,8 +2094,14 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /obj/item/weapon/storage/firstaid/fire,
-/obj/item/weapon/storage/firstaid/regular,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
+/area/shuttle/metawhiteship/cargo)
+"Yi" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/remains,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/cargo)
 "Yv" = (
 /turf/simulated/wall/thull,
@@ -1604,8 +2112,27 @@
 /area/shuttle/metawhiteship/food)
 "YS" = (
 /obj/structure/table/standard,
+/obj/item/weapon/storage/photo_album{
+	pixel_x = -16;
+	pixel_y = 0
+	},
+/obj/item/weapon/folder/blue{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/machinery/recharger,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/bridge)
+"Zz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/fuel{
+	dir = 5
+	},
+/turf/simulated/wall/thull,
+/area/shuttle/metawhiteship/eng)
 "ZP" = (
 /obj/effect/floor_decal/industrial/bot_outline/corner{
 	dir = 1
@@ -1614,6 +2141,7 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
 "ZV" = (
@@ -1621,6 +2149,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/hydro,
 /area/shuttle/metawhiteship/food)
 
@@ -1698,8 +2227,8 @@ eS
 eS
 HE
 HE
-Sa
-Sa
+MU
+MU
 HE
 HE
 eS
@@ -1710,7 +2239,7 @@ eS
 HE
 HE
 Sa
-Sa
+Sy
 HE
 HE
 eS
@@ -1724,7 +2253,7 @@ CD
 Iu
 Qt
 nF
-HE
+Zz
 OH
 HE
 qz
@@ -1747,16 +2276,16 @@ yT
 ED
 KR
 Bo
-HE
-GN
-HE
+im
+jK
+Zz
 EC
 HE
 GN
 HE
 Az
-HM
-HM
+nS
+Re
 jQ
 HE
 eS
@@ -1774,9 +2303,9 @@ HE
 KF
 kj
 Gn
-HE
+eE
 lC
-HE
+eE
 rf
 HM
 MD
@@ -1847,7 +2376,7 @@ Ml
 Tt
 Tt
 ca
-xk
+Xz
 PJ
 Tt
 Tt
@@ -1860,8 +2389,8 @@ eS
 sG
 iS
 ZP
-xk
-nd
+Xz
+Nw
 Si
 eQ
 ST
@@ -1871,7 +2400,7 @@ kX
 Se
 vE
 SB
-nd
+Nw
 qN
 cQ
 eS
@@ -1883,7 +2412,7 @@ eS
 sG
 WB
 WB
-xk
+Xz
 zJ
 WB
 WB
@@ -1908,11 +2437,11 @@ ws
 WB
 cU
 kx
-tI
+TG
 Wg
 UR
 UR
-UR
+Yi
 tI
 Wg
 gb
@@ -1929,11 +2458,11 @@ eS
 sG
 ws
 WB
-xk
-nd
+Xz
+Nw
 WB
 WB
-ST
+gs
 UR
 nd
 WB
@@ -1952,15 +2481,15 @@ eS
 sG
 zJ
 Jj
-xk
+Xz
 zJ
 Eq
 WB
 Tq
-UR
+ER
 zJ
 XO
-Eq
+Db
 Jj
 QF
 lg
@@ -2032,7 +2561,7 @@ aQ
 Yv
 ql
 Dn
-vZ
+Er
 oA
 eS
 eS
@@ -2090,7 +2619,7 @@ eS
 Lz
 Lz
 Lz
-SW
+IL
 Lz
 Lz
 Rt
@@ -2142,7 +2671,7 @@ pE
 Rt
 YS
 gi
-YS
+Kf
 Rt
 Ft
 gq
@@ -2238,7 +2767,7 @@ eS
 eS
 Yv
 Yv
-DM
+MQ
 DM
 Yv
 Yv

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship30x21.dmm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship30x21.dmm
@@ -789,9 +789,8 @@
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
 "yT" = (
-/obj/machinery/atmospherics/pipe/tank/air/full{
-	start_pressure = 10000
-	},
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "zJ" = (
@@ -835,8 +834,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/gen)
 "CD" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/pipe/tank/air/full{
+	start_pressure = 10000
+	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
 "Da" = (
@@ -1644,14 +1644,12 @@ eS
 eS
 eS
 eS
+eS
+eS
 "}
 (2,1,1) = {"
 eS
 eS
-HE
-Pp
-Pp
-HE
 eS
 eS
 eS
@@ -1659,38 +1657,70 @@ eS
 eS
 eS
 eS
-HE
-Pp
-Pp
-HE
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
 eS
 eS
 "}
 (3,1,1) = {"
 eS
+eS
+eS
 HE
-HE
-Sa
-Sa
-HE
+Pp
+Pp
 HE
 eS
 eS
 eS
 eS
 eS
+eS
+eS
 HE
+Pp
+Pp
 HE
-Sa
-Sa
-HE
-HE
+eS
+eS
 eS
 "}
 (4,1,1) = {"
 eS
+eS
 HE
-yT
+HE
+Sa
+Sa
+HE
+HE
+eS
+eS
+eS
+eS
+eS
+HE
+HE
+Sa
+Sa
+HE
+HE
+eS
+eS
+"}
+(5,1,1) = {"
+eS
+eS
+HE
+CD
 Iu
 Qt
 nF
@@ -1707,11 +1737,13 @@ Gd
 fr
 HE
 eS
+eS
 "}
-(5,1,1) = {"
+(6,1,1) = {"
+eS
 eS
 GN
-CD
+yT
 ED
 KR
 Bo
@@ -1728,8 +1760,10 @@ HM
 jQ
 HE
 eS
+eS
 "}
-(6,1,1) = {"
+(7,1,1) = {"
+eS
 eS
 HE
 HE
@@ -1749,8 +1783,10 @@ MD
 HE
 HE
 eS
+eS
 "}
-(7,1,1) = {"
+(8,1,1) = {"
+eS
 eS
 eS
 HE
@@ -1770,8 +1806,10 @@ oQ
 GN
 eS
 eS
+eS
 "}
-(8,1,1) = {"
+(9,1,1) = {"
+eS
 eS
 eS
 HE
@@ -1791,8 +1829,10 @@ HE
 HE
 eS
 eS
+eS
 "}
-(9,1,1) = {"
+(10,1,1) = {"
+eS
 eS
 Tt
 Tt
@@ -1812,8 +1852,10 @@ PJ
 Tt
 Tt
 eS
+eS
 "}
-(10,1,1) = {"
+(11,1,1) = {"
+eS
 eS
 sG
 iS
@@ -1833,8 +1875,10 @@ nd
 qN
 cQ
 eS
+eS
 "}
-(11,1,1) = {"
+(12,1,1) = {"
+eS
 eS
 sG
 WB
@@ -1854,8 +1898,10 @@ WB
 WB
 cQ
 eS
+eS
 "}
-(12,1,1) = {"
+(13,1,1) = {"
+eS
 eS
 sG
 ws
@@ -1875,8 +1921,10 @@ WB
 WB
 cQ
 eS
+eS
 "}
-(13,1,1) = {"
+(14,1,1) = {"
+eS
 eS
 sG
 ws
@@ -1896,8 +1944,10 @@ WB
 kH
 cQ
 eS
+eS
 "}
-(14,1,1) = {"
+(15,1,1) = {"
+eS
 eS
 sG
 zJ
@@ -1917,8 +1967,10 @@ lg
 Jj
 cQ
 eS
+eS
 "}
-(15,1,1) = {"
+(16,1,1) = {"
+eS
 eS
 Tt
 Tt
@@ -1938,8 +1990,10 @@ mi
 Tt
 Tt
 eS
+eS
 "}
-(16,1,1) = {"
+(17,1,1) = {"
+eS
 eS
 eS
 Yv
@@ -1959,8 +2013,10 @@ Yv
 Yv
 eS
 eS
+eS
 "}
-(17,1,1) = {"
+(18,1,1) = {"
+eS
 eS
 eS
 oA
@@ -1980,8 +2036,10 @@ vZ
 oA
 eS
 eS
+eS
 "}
-(18,1,1) = {"
+(19,1,1) = {"
+eS
 eS
 Yv
 Yv
@@ -2001,8 +2059,10 @@ Yv
 Yv
 Yv
 eS
+eS
 "}
-(19,1,1) = {"
+(20,1,1) = {"
+eS
 eS
 qH
 UX
@@ -2022,8 +2082,10 @@ ID
 Hf
 aS
 eS
+eS
 "}
-(20,1,1) = {"
+(21,1,1) = {"
+eS
 eS
 Lz
 Lz
@@ -2043,8 +2105,10 @@ Yv
 Yv
 Yv
 eS
+eS
 "}
-(21,1,1) = {"
+(22,1,1) = {"
+eS
 eS
 Lz
 BD
@@ -2064,8 +2128,10 @@ fJ
 LQ
 Yv
 eS
+eS
 "}
-(22,1,1) = {"
+(23,1,1) = {"
+eS
 eS
 HS
 Fa
@@ -2085,8 +2151,10 @@ Sr
 UL
 oA
 eS
+eS
 "}
-(23,1,1) = {"
+(24,1,1) = {"
+eS
 eS
 Lz
 Lz
@@ -2106,8 +2174,10 @@ YL
 Yv
 Yv
 eS
+eS
 "}
-(24,1,1) = {"
+(25,1,1) = {"
+eS
 eS
 HS
 uX
@@ -2127,8 +2197,10 @@ SI
 wG
 oA
 eS
+eS
 "}
-(25,1,1) = {"
+(26,1,1) = {"
+eS
 eS
 Lz
 BD
@@ -2148,8 +2220,10 @@ jn
 Qn
 Yv
 eS
+eS
 "}
-(26,1,1) = {"
+(27,1,1) = {"
+eS
 eS
 Lz
 Lz
@@ -2169,29 +2243,57 @@ DM
 Yv
 Yv
 eS
-"}
-(27,1,1) = {"
-eS
-eS
-Lz
-Lz
-Lz
-Lz
-eS
-eS
-eS
-eS
-eS
-eS
-eS
-Yv
-Yv
-Yv
-Yv
-eS
 eS
 "}
 (28,1,1) = {"
+eS
+eS
+eS
+Lz
+Lz
+Lz
+Lz
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+Yv
+Yv
+Yv
+Yv
+eS
+eS
+eS
+"}
+(29,1,1) = {"
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+eS
+"}
+(30,1,1) = {"
+eS
+eS
 eS
 eS
 eS

--- a/modular_chomp/maps/overmap/om_ships/offmap.dm
+++ b/modular_chomp/maps/overmap/om_ships/offmap.dm
@@ -13,3 +13,4 @@
 #include "cruiser.dm"
 #include "pizzashuttle.dm"
 #include "cybershuttle.dm"
+#include "metawhiteship.dm"

--- a/modular_chomp/maps/overmap/om_ships/pizzashuttle.dm
+++ b/modular_chomp/maps/overmap/om_ships/pizzashuttle.dm
@@ -48,6 +48,7 @@
 	vessel_mass = 900 //YEET
 	vessel_size = SHIP_SIZE_TINY
 	shuttle = "Pizza Gut" //These names must match
+	known = FALSE
 
 /datum/map_template/shelter/superpose/pizzashuttle
 	shelter_id = "PizzaShuttle"

--- a/modular_chomp/maps/overmap/om_ships/sdf_corvettes.dm
+++ b/modular_chomp/maps/overmap/om_ships/sdf_corvettes.dm
@@ -18,7 +18,7 @@
 	mappath = 'sdf_corvette_wreck.dmm'
 	annihilate = TRUE
 
-/datum/map_template/om_ships/sdf_corvette
+/datum/map_template/om_ships/sdf_corvette_wreck
 	name = "OM Ship - SDF Cutter (new Z)"
 	desc = "A small SDF cutter, outfitted with an ORB/OFD."
 	mappath = 'sdf_cutter.dmm'

--- a/modular_chomp/maps/overmap/om_ships/whiteship-26x33.dmm
+++ b/modular_chomp/maps/overmap/om_ships/whiteship-26x33.dmm
@@ -67,9 +67,6 @@
 "cu" = (
 /obj/item/weapon/towel/random,
 /obj/item/weapon/towel/random,
-/obj/machinery/door/airlock/glass_science{
-	id_tag = "stop_opening_this_you_idiots"
-	},
 /turf/simulated/floor/wood,
 /area/shuttle/whiteshipOM2)
 "cw" = (
@@ -87,7 +84,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/map_helper/airlock/sensor/int_sensor,
 /obj/machinery/airlock_sensor{
-	pixel_y = 25
+	pixel_y = 25;
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/whiteshipOM2)
@@ -229,7 +227,7 @@
 	pixel_y = -25
 	},
 /turf/template_noop,
-/area/shuttle/whiteshipOM2)
+/area/template_noop)
 "iQ" = (
 /obj/structure/table/wooden_reinforced,
 /obj/structure/flora/pottedplant/smallcactus{
@@ -294,7 +292,8 @@
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	id_tag = "whiteship_docker2";
-	pixel_y = 25
+	pixel_y = 25;
+	frequency = 1380
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
@@ -441,9 +440,6 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/shuttle/whiteshipOM2)
-"oX" = (
-/turf/template_noop,
 /area/shuttle/whiteshipOM2)
 "pk" = (
 /obj/machinery/atmospherics/binary/pump,
@@ -1204,7 +1200,7 @@
 	},
 /obj/effect/map_helper/airlock/sensor/ext_sensor,
 /obj/machinery/airlock_sensor/airlock_exterior/shuttle{
-	dir = 6;
+	dir = 4;
 	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
@@ -1638,7 +1634,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/power/emitter{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/whiteshipOM2)
@@ -1720,7 +1716,8 @@
 	pixel_y = 13;
 	req_access = null;
 	pixel_x = -24;
-	dir = 4
+	dir = 4;
+	specialfunctions = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/shuttle/whiteshipOM2)
@@ -1938,7 +1935,8 @@
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
-	pixel_y = -28
+	pixel_y = -28;
+	dir = 1
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
@@ -2927,15 +2925,15 @@ Eq
 (22,1,1) = {"
 Eq
 sH
-oX
-oX
-oX
-oX
-oX
-oX
-oX
-oX
-oX
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
 iv
 sH
 sH
@@ -2946,16 +2944,16 @@ sH
 WL
 sH
 sH
-oX
-oX
-oX
-oX
-oX
-oX
-oX
-oX
-oX
-oX
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
 sH
 Eq
 "}


### PR DESCRIPTION

## About The Pull Request
This PR adds a new spawnpoint for outsiders called the fuel depot. Picking the Spacefarer sub-job is highly recommended. This should allow spacefarers to more easily spawn their shuttles in space to fly instead of having to beam up to southern cross and break outside.

I also set the spawnroom up so be separate from the unfinished grid of the main fuel depot to still allow players to 'set it up' if arriving there for the first time, only a small room with basic life support to spawn in.

![StrongDMM-2024-08-28 17 52 08](https://github.com/user-attachments/assets/074fa588-9183-448b-9693-17bcdd0dc27a)

https://github.com/user-attachments/assets/45df399b-8083-4553-b295-efe8413b2d71

Also a few fixes at the existing shuttles.

## Changelog
:cl:
add: Adds a new spawnpoint for outsiders to spawn in the fuel depot. Spacefarer subjob highly recommended. 
maptweak: Fixed docking the whiteship II
maptweak: Overhauled the fuel depot and made it spawn randomly in the OM
maptweak: Fixed broken door bolts on whiteship II, removed stray door.
maptweak: Cybershuttle access fix
/:cl:
