### PR TITLE
Spacefarer patches

### DIFF
--- a/maps/southern_cross/overmap/space/fueldepot.dmm
+++ b/maps/southern_cross/overmap/space/fueldepot.dmm
@@ -1185,6 +1185,21 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
+"da" = (
+/obj/structure/cryofeed,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	health = 1e+006;
+	req_access = list(5)
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/sc_away/fueldepotspawn)
 "ec" = (
 /obj/effect/floor_decal/industrial/warning/dust/corner{
 	dir = 8
@@ -1262,7 +1277,9 @@
 /turf/space,
 /area/sc_away/fueldepot)
 "iF" = (
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/sc_away/fueldepotspawn)
 "ja" = (
@@ -1453,6 +1470,10 @@
 /obj/effect/landmark{
 	name = "JoinLateFuelDepot"
 	},
+/obj/machinery/computer/cryopod{
+	pixel_x = 32;
+	pixel_y = 0
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/sc_away/fueldepotspawn)
 "AT" = (
@@ -1490,15 +1511,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/sc_away/fueldepotspawn)
 "BI" = (
-/obj/structure/bed/padded,
-/obj/effect/landmark{
-	name = "JoinLateFuelDepot"
+/obj/machinery/cryopod{
+	quiet = 1
 	},
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_y = 0
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/milspec/raised,
 /area/sc_away/fueldepotspawn)
 "DC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -1666,7 +1690,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/sc_away/fueldepotspawn)
 "LN" = (
-/obj/machinery/gear_dispenser/suit/autolok,
+/obj/machinery/gear_dispenser/suit_fancy/autolok,
 /turf/simulated/floor/tiled/techmaint,
 /area/sc_away/fueldepotspawn)
 "MO" = (
@@ -1704,6 +1728,9 @@
 "QT" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/effect/landmark{
+	name = "JoinLateFuelDepot"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/sc_away/fueldepotspawn)
@@ -12972,7 +12999,7 @@ rV
 Ho
 rV
 rV
-rV
+da
 rV
 aa
 ay

--- a/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
+++ b/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
@@ -185,9 +185,10 @@
 	set name = "Reset Active Pod"
 	set desc = "Resets the pod back to factory settings."
 	set category = "Object"
-	template_id = null
-	template = null // Important to reset both, otherwise the template cannot be reset once the pod has been deployed.
-	to_chat(usr, span_notice("The pod settings have been reset."))
+	if(!used)
+		template_id = null
+		template = null // Important to reset both, otherwise the template cannot be reset once the pod has been deployed.
+		to_chat(usr, span_notice("You reset the pod's selection."))
 
 /obj/item/device/survivalcapsule/superpose/shuttle
 	name = "superposed surfluid shuttle capsule"
@@ -208,12 +209,4 @@
 			template_id = answer
 			unique_id = answer
 			return
-	..()
-
-/obj/item/device/survivalcapsule/superpose/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/weapon/pen) && !used)
-		template_id = null
-		unique_id = null
-		template = null
-		to_chat(user, SPAN_NOTICE("You reset the pod's selection."))
 	..()

--- a/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
+++ b/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
@@ -188,6 +188,7 @@
 	if(!used)
 		template_id = null
 		template = null // Important to reset both, otherwise the template cannot be reset once the pod has been deployed.
+		unique_id = null
 		to_chat(usr, span_notice("You reset the pod's selection."))
 
 /obj/item/device/survivalcapsule/superpose/shuttle

--- a/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
+++ b/modular_chomp/code/modules/mining/shelter_atoms_ch.dm
@@ -147,7 +147,7 @@
 
 /obj/item/device/survivalcapsule/superpose
 	name = "superposed surfluid shelter capsule"
-	desc = "A proprietary hyperstructure of many three-dimensional spaces superposed around a supermatter nano crystal; use a pen to reach the reset button. There's a license for use printed on the bottom."
+	desc = "A proprietary hyperstructure of many three-dimensional spaces superposed around a supermatter nano crystal; right-click to reset the pod. There's a license for use printed on the bottom."
 	description_info = "The capsule contains pockets of compressed space in a super position stabilized by a miniscule supermatter crystal. \
 	NanoTrasen stresses the safety of this model over previous prototypes but assumes no liability for sub-kiloton explosions."
 	template_id = null
@@ -181,12 +181,13 @@
 	..()
 
 // Allows resetting the capsule if the wrong template is chosen.
-/obj/item/device/survivalcapsule/superpose/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/weapon/pen) && !used)
-		template_id = null
-		template = null // Important to reset both, otherwise the template cannot be reset once the pod has been deployed.
-		to_chat(user, "<span class='notice'>You reset the pod's selection.</span>")
-	..()
+/obj/item/device/survivalcapsule/superpose/verb/resetpod()
+	set name = "Reset Active Pod"
+	set desc = "Resets the pod back to factory settings."
+	set category = "Object"
+	template_id = null
+	template = null // Important to reset both, otherwise the template cannot be reset once the pod has been deployed.
+	to_chat(usr, span_notice("The pod settings have been reset."))
 
 /obj/item/device/survivalcapsule/superpose/shuttle
 	name = "superposed surfluid shuttle capsule"

--- a/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
+++ b/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
@@ -150,7 +150,8 @@
 	},
 /obj/machinery/power/apc/alarms_hidden{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	locked = 0
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/cybershuttle)

--- a/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
+++ b/modular_chomp/maps/overmap/om_ships/cybershuttle-10x11.dmm
@@ -206,6 +206,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/cybershuttle)
+"M" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "CyberShuttle"
+	},
+/obj/structure/table/survival_pod,
+/turf/simulated/floor/tiled/techfloor,
+/area/shuttle/cybershuttle)
 "Q" = (
 /obj/machinery/ion_engine{
 	dir = 1
@@ -368,7 +375,7 @@ j
 a
 D
 d
-g
+M
 k
 V
 R

--- a/modular_chomp/maps/overmap/om_ships/cybershuttle.dm
+++ b/modular_chomp/maps/overmap/om_ships/cybershuttle.dm
@@ -49,6 +49,7 @@
 	burn_delay = 0.25 SECONDS //Fast as fuck
 	vessel_size = SHIP_SIZE_TINY
 	shuttle = "Cyber Shuttle" //These names must match
+	known = FALSE
 
 /datum/map_template/shelter/superpose/cybershuttle
 	shelter_id = "CyberShuttle"

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship.dm
@@ -64,6 +64,7 @@
 					/area/shuttle/metawhiteship/eng
 					)
 	defer_initialisation = TRUE //We're not loaded until an admin does it
+	fuel_consumption = 1.5
 
 // The 'ship'
 /obj/effect/overmap/visitable/ship/landable/metawhiteship

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship30x21.dmm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship30x21.dmm
@@ -682,6 +682,9 @@
 /obj/item/weapon/pen,
 /obj/item/device/camera,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/photocopier/faxmachine{
+	department = "Metamaterial White Ship"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/bridge)
 "qX" = (
@@ -1263,7 +1266,7 @@
 "Gd" = (
 /obj/structure/cable/yellow,
 /obj/item/weapon/tool/wrench,
-/obj/machinery/power/port_gen/pacman,
+/obj/machinery/power/port_gen/pacman/super,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
@@ -1531,6 +1534,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
+	},
+/obj/item/stack/material/uranium{
+	amount = 25
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)

--- a/modular_chomp/maps/overmap/om_ships/metawhiteship30x21.dmm
+++ b/modular_chomp/maps/overmap/om_ships/metawhiteship30x21.dmm
@@ -170,7 +170,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 22;
+	locked = 0
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
@@ -381,7 +382,8 @@
 	},
 /obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -26
+	pixel_x = -26;
+	locked = 0
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
@@ -543,7 +545,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 26
+	pixel_x = 26;
+	locked = 0
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/shuttle/metawhiteship/food)
@@ -593,7 +596,8 @@
 /obj/machinery/alarm{
 	pixel_y = 0;
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -24;
+	locked = 0
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/metawhiteship/food)
@@ -672,7 +676,8 @@
 	},
 /obj/machinery/power/apc{
 	dir = 1;
-	pixel_y = 26
+	pixel_y = 26;
+	locked = 0
 	},
 /obj/structure/table/standard,
 /obj/machinery/light/small{
@@ -709,7 +714,8 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 22;
+	locked = 0
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 4
@@ -872,7 +878,8 @@
 /obj/machinery/alarm{
 	pixel_y = 0;
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -24;
+	locked = 0
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/eng)
@@ -990,7 +997,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	pixel_y = -25;
-	dir = 1
+	dir = 1;
+	locked = 0
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/metawhiteship/eng)
@@ -1140,7 +1148,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 26
+	pixel_x = 26;
+	locked = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
@@ -1195,7 +1204,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	pixel_y = -25;
-	dir = 1
+	dir = 1;
+	locked = 0
 	},
 /turf/simulated/floor/tiled,
 /area/shuttle/metawhiteship/food)
@@ -1325,7 +1335,8 @@
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/cable,
 /obj/machinery/power/apc{
-	pixel_y = -26
+	pixel_y = -26;
+	locked = 0
 	},
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
@@ -1399,7 +1410,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 26
+	pixel_x = 26;
+	locked = 0
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/food)
@@ -1522,7 +1534,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	pixel_y = -26
+	pixel_y = -26;
+	locked = 0
 	},
 /obj/structure/closet/crate,
 /obj/item/weapon/tank/phoron,
@@ -1710,7 +1723,8 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_y = 28
+	pixel_y = 28;
+	locked = 0
 	},
 /obj/item/trash/plate{
 	pixel_x = -5;
@@ -1808,7 +1822,8 @@
 /obj/machinery/alarm{
 	pixel_y = 0;
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -24;
+	locked = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/cargo)
@@ -1885,7 +1900,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 22;
+	locked = 0
 	},
 /turf/simulated/floor/tiled/neutral,
 /area/shuttle/metawhiteship/gen)
@@ -2129,7 +2145,8 @@
 /obj/machinery/recharger,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
-	pixel_y = 22
+	pixel_y = 22;
+	locked = 0
 	},
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/metawhiteship/bridge)

--- a/modular_chomp/maps/overmap/om_ships/pizzashuttle-11x13.dmm
+++ b/modular_chomp/maps/overmap/om_ships/pizzashuttle-11x13.dmm
@@ -337,7 +337,8 @@
 /obj/effect/floor_decal/corner/yellow/diagonal,
 /obj/machinery/power/apc/super{
 	dir = 4;
-	pixel_x = 26
+	pixel_x = 26;
+	locked = 0
 	},
 /obj/structure/cable/blue,
 /turf/simulated/floor/tiled/old_tile/red,

--- a/modular_chomp/maps/overmap/om_ships/pizzashuttle.dm
+++ b/modular_chomp/maps/overmap/om_ships/pizzashuttle.dm
@@ -37,6 +37,7 @@
 	docking_controller_tag = "pizza_shuttle_docker" //This is the only thing you map in and var edit, use the map helpers to designate doors and pumps
 	shuttle_area = list(/area/shuttle/pizza_shuttle)
 	defer_initialisation = TRUE //We're not loaded until an admin does it
+	fuel_consumption = 1
 
 // The 'ship'
 /obj/effect/overmap/visitable/ship/landable/pizza_shuttle

--- a/modular_chomp/maps/overmap/om_ships/whiteship-26x33.dmm
+++ b/modular_chomp/maps/overmap/om_ships/whiteship-26x33.dmm
@@ -1774,10 +1774,6 @@
 /area/shuttle/whiteshipOM2)
 "RV" = (
 /obj/structure/table/steel_reinforced,
-/obj/machinery/power/apc/alarms_hidden{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/structure/cable/green,
 /obj/random/maintenance,
 /obj/random/maintenance,
@@ -1791,6 +1787,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green,
+/obj/machinery/power/apc/hyper{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = 26;
+	locked = 0
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/shuttle/whiteshipOM2)
 "St" = (

--- a/modular_chomp/maps/overmap/om_ships/whiteship-26x33.dmm
+++ b/modular_chomp/maps/overmap/om_ships/whiteship-26x33.dmm
@@ -602,6 +602,8 @@
 	dir = 8
 	},
 /obj/item/weapon/material/knife/machete/hatchet,
+/obj/item/device/xenoarch_multi_tool,
+/obj/item/weapon/pickaxe/excavationdrill,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/whiteshipOM2)
 "tb" = (
@@ -1290,6 +1292,9 @@
 /obj/machinery/chem_master{
 	pixel_x = -7
 	},
+/obj/machinery/photocopier/faxmachine{
+	department = "CyberShuttle"
+	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/whiteshipOM2)
 "Ij" = (
@@ -1335,6 +1340,9 @@
 /obj/item/weapon/pen{
 	pixel_x = 4;
 	pixel_y = 4
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "White Ship Mk II"
 	},
 /turf/simulated/shuttle/floor/purple,
 /area/shuttle/whiteshipOM2)
@@ -1671,7 +1679,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
 	},
-/obj/machinery/suspension_gen,
+/obj/machinery/suspension_gen{
+	req_access = null
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/whiteshipOM2)
 "QC" = (

--- a/modular_chomp/maps/overmap/om_ships/whiteship.dm
+++ b/modular_chomp/maps/overmap/om_ships/whiteship.dm
@@ -55,6 +55,7 @@
 	docking_controller_tag = "whiteship_docker" //This is the only thing you map in and var edit, use the map helpers to designate doors and pumps
 	shuttle_area = list(/area/shuttle/whiteshipOM)
 	defer_initialisation = TRUE //We're not loaded until an admin does it
+	fuel_consumption = 2.5
 
 /datum/shuttle/autodock/overmap/whiteship2
 	name = "White Ship II" //These names must match
@@ -62,6 +63,7 @@
 	docking_controller_tag = "whiteship_docker2" //This is the only thing you map in and var edit, use the map helpers to designate doors and pumps
 	shuttle_area = list(/area/shuttle/whiteshipOM2)
 	defer_initialisation = TRUE //We're not loaded until an admin does it
+	fuel_consumption = 2.5
 
 // The 'ship'
 /obj/effect/overmap/visitable/ship/landable/whiteship
@@ -74,6 +76,7 @@
 	vessel_size = SHIP_SIZE_LARGE
 	shuttle = "White Ship" //These names must match
 	fore_dir = WEST
+	known = FALSE
 
 /obj/effect/overmap/visitable/ship/landable/whiteship2
 	name = "White Ship II" //These names must match
@@ -85,12 +88,13 @@
 	vessel_size = SHIP_SIZE_LARGE
 	shuttle = "White Ship II" //These names must match
 	fore_dir = WEST
+	known = FALSE
 
 //Player accessable superposed pod
 /datum/map_template/shelter/superpose/whiteship2
 	shelter_id = "WhiteShipII"
 	mappath = 'whiteship-26x33.dmm'
-	name = "White Ship Mk 22"
+	name = "White Ship Mk II"
 	description = "A large titanium ship."
 	superpose = FALSE
 	shuttle = TRUE


### PR DESCRIPTION

## About The Pull Request
Added a variable to two outsider ships to be 'unknown' to NT

Buffed the metawhiteship's generator to be a superpacman

Fixed a wiring issue in the fuel depot

Added a fuel cost to the white ship's short jump

Superposed pods can be rightclicked to be reset now instead of needing a pen
## Changelog
:cl:
qol: Superposed pods can be rightclicked to be reset now instead of needing a pen
balance: Buffed the metawhiteship's generator to be a superpacman
balance: Added a fuel cost to the superposed ship's short jumps
maptweak: Fixed a wiring issue in the fuel depot
/:cl:
