### PR TITLE
Lifts hard-access lock on cargo vendor, puts public non-persistant ore storage in cargo window

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -48427,6 +48427,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/hallway/secondary/entry/docking_lounge)
+"fjx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/smartfridge/sheets{
+	desc = "An industrial sized storage unit for materials. B-Shift's agreement to retain materials doesn't extend to this storage device, so you should probably only stock this with sheets you need.";
+	name = "\improper Non-Persistent Industrial Sheet Storage"
+	},
+/obj/structure/fans/tiny,
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	health = null
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "fjy" = (
 /obj/structure/ladder/updown,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -57765,8 +57782,7 @@
 "kar" = (
 /obj/machinery/smartfridge/sheets/persistent_lossy{
 	desc = "An industrial sized storage unit for materials. Following company policy with B-Shift, this particular storage unit will retain a percentage of its material in-between crew transfers.";
-	name = "\improper Persistent Industrial Sheet Storage";
-	req_one_access = list(31,48)
+	name = "\improper Persistent Industrial Sheet Storage"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/warehouse)
@@ -104247,7 +104263,7 @@ bYD
 bRG
 bqo
 bqn
-bsn
+fjx
 bug
 bCU
 bEJ


### PR DESCRIPTION

## About The Pull Request
Thanks to departmental lathes, and lower pop, I decided to lift the cargo access lock for now, I also added a non persistent public fridge so cargo players can 'set and forget' and control what materials go out. They shouldn't put ALL materials there because at that point its non persistant and you'll lose out.
## Changelog
:cl:
maptweak: removed access lock in cargo ore silo, adds public fridge thats non-persistant.
/:cl:
