### PR TITLE
Reverts the spacebar toggling R key

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1224,7 +1224,7 @@
 	src.in_throw_mode = 1
 	if(src.throw_icon && !issilicon(src)) // Silicon use this for something else. Do not overwrite their HUD icon
 		src.throw_icon.icon_state = "act_throw_on"
-
+/* CHOMPedit removal begin
 /mob/verb/spacebar_throw_on()
 	set name = ".throwon"
 	set hidden = TRUE
@@ -1236,7 +1236,7 @@
 	set hidden = TRUE
 	set instant = TRUE
 	throw_mode_off()
-
+ChompEdit removal end*/
 /mob/proc/isSynthetic()
 	return 0
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -792,14 +792,12 @@ macro "hotkeymode"
 	elem
 		name = "CTRL+SHIFT+SUBTRACT"
 		command = "planedown"
-/* CHOMPedit Removal Begin
-	elem
-		name = "Space"
-		command = ".throwon"
-	elem
-		name = "Space+UP"
-		command = ".throwoff"
-CHOMPedit Removal End*/
+//	elem	// CHOMPREMOVE Start
+//		name = "Space"
+//		command = ".throwon"
+//	elem
+//		name = "Space+UP"
+//		command = ".throwoff" // CHOMPREMOVE End
 macro "borgmacro"
 	elem
 		name = "TAB"

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -792,13 +792,14 @@ macro "hotkeymode"
 	elem
 		name = "CTRL+SHIFT+SUBTRACT"
 		command = "planedown"
+/* CHOMPedit Removal Begin
 	elem
 		name = "Space"
 		command = ".throwon"
 	elem
 		name = "Space+UP"
 		command = ".throwoff"
-
+CHOMPedit Removal End*/
 macro "borgmacro"
 	elem
 		name = "TAB"


### PR DESCRIPTION

## About The Pull Request
R key already toggles throw, and pressing it accidentally is something rather easy to do.
Space bar is bigger, and utilized further for typing.
Also several folks used it for Macros before.

## Changelog
:cl:
qol: spacebar no longers triggers throw
/:cl:
