### PR TITLE
Fixes Onelife trait

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
@@ -86,7 +86,7 @@
 	desc = "For whatever reason, once you dead, that is final."
 	cost = -2
 	custom_only = TRUE
-	var_changes = list("flags" = NO_SCAN, NO_DEFIB)
+	var_changes = list("flags" = NO_SCAN | NO_DEFIB)
 	excludes = list(/datum/trait/negative/nodefib, /datum/trait/negative/noresleeve)
 
 /datum/trait/negative/lightweight_light


### PR DESCRIPTION

## About The Pull Request

Many runtimes were caused by this trait, this should do.

## Changelog
:cl:
fix: Fixed onelife trait runtimes
/:cl:
