### PR TITLE
Map fixes

### DIFF
--- a/maps/southern_sun/southern_cross-1.dmm
+++ b/maps/southern_sun/southern_cross-1.dmm
@@ -43106,11 +43106,11 @@
 	name_tag = "Exploration Subgrid"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor2)
 "naS" = (

--- a/maps/southern_sun/southern_cross-1.dmm
+++ b/maps/southern_sun/southern_cross-1.dmm
@@ -269,8 +269,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Science/Xenobotany_Isolation_Chamber)
@@ -288,9 +287,7 @@
 /obj/item/seeds/glowshroom{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "abs" = (
 /turf/simulated/wall/r_wall,
@@ -503,8 +500,7 @@
 /area/SouthernCrossV2/Cargo/Mining_EVA)
 "acy" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/table/rack,
 /obj/random/cash,
@@ -1686,9 +1682,8 @@
 	pixel_y = -25
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -2131,8 +2126,7 @@
 /area/shuttle/echidna)
 "aky" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Commons/Port_1Deck_Central_Corridor_1)
@@ -2709,8 +2703,7 @@
 "anQ" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/table/rack/shelf/steel,
 /obj/random/maintenance/engineering,
@@ -3068,9 +3061,7 @@
 /area/shuttle/echidna)
 "aql" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "aqp" = (
 /obj/structure/flora/lily2,
@@ -3196,8 +3187,7 @@
 "aqN" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -3235,9 +3225,8 @@
 /area/SouthernCrossV2/Science/Xenobotany_Lab)
 "aqX" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -3394,8 +3383,7 @@
 "asm" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -3480,9 +3468,8 @@
 /area/SouthernCrossV2/Harbor/Dock3)
 "asR" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForPort_Corridor1)
@@ -3815,9 +3802,8 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -3897,8 +3883,7 @@
 "ave" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -4576,8 +4561,7 @@
 /area/SouthernCrossV2/Harbor/Fueling_Storage)
 "aAR" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
@@ -4597,8 +4581,7 @@
 /area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor1)
 "aAW" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Cargo_Corridor2)
@@ -4675,9 +4658,7 @@
 /area/SouthernCrossV2/Science/Xenobotany_Lab)
 "aBD" = (
 /obj/structure/flora/tree/sif,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "aBE" = (
 /obj/random/junk,
@@ -4843,9 +4824,8 @@
 "aCV" = (
 /obj/structure/table/bench/sifwooden/padded,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Harbor/Dock1)
@@ -4948,8 +4928,7 @@
 /area/SouthernCrossV2/Cargo/Depot2)
 "aDs" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -5201,9 +5180,8 @@
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Chamber1)
 "aFz" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -5247,9 +5225,8 @@
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
 "aGe" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -5797,8 +5774,7 @@
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -5814,8 +5790,7 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Harbor/Ship_Bay1)
@@ -5872,9 +5847,7 @@
 "aLf" = (
 /obj/structure/flora/tree/sif,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "aLh" = (
 /turf/simulated/floor/tiled/hydro,
@@ -6564,9 +6537,8 @@
 /area/shuttle/echidna)
 "aOF" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6867,9 +6839,8 @@
 /area/shuttle/cryo/station)
 "aRF" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
@@ -7381,9 +7352,7 @@
 "aVh" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "aVi" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -7931,9 +7900,8 @@
 "bap" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
@@ -8072,8 +8040,7 @@
 "bco" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/structure/bed/chair/wood/wings{
 	dir = 8
@@ -8306,8 +8273,7 @@
 "bhg" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Ship_Bay4)
@@ -8657,9 +8623,8 @@
 /area/SouthernCrossV2/Maints/ab_StripBar)
 "bmG" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -9342,9 +9307,8 @@
 /area/shuttle/needle)
 "bzk" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/white/bordercorner,
@@ -10665,9 +10629,8 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/white/border,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_1_Deck_Hall)
@@ -10893,9 +10856,8 @@
 /area/shuttle/escape_pod6/station)
 "bZz" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -10992,9 +10954,8 @@
 "caC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/item/weapon/tool/wrench,
 /obj/item/device/flashlight/color/yellow{
@@ -11583,9 +11544,8 @@
 /area/shuttle/escape_pod2/station)
 "cmh" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/table/rack,
 /obj/random/flashlight,
@@ -12178,8 +12138,7 @@
 /area/SouthernCrossV2/Commons/Stairwell_For)
 "cyc" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Maints/Market_Stall_3)
@@ -12459,9 +12418,8 @@
 	pixel_x = 6
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -12729,8 +12687,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Market_Stall_6)
@@ -13967,8 +13924,7 @@
 /area/SouthernCrossV2/Harbor/Ship_Bay2)
 "ddt" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor3)
@@ -13995,8 +13951,7 @@
 "dea" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Ship_Bay3)
@@ -14211,8 +14166,7 @@
 /area/SouthernCrossV2/Harbor/Ship_Bay1)
 "dhq" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Commons/Stairwell_For)
@@ -14577,8 +14531,7 @@
 /area/SouthernCrossV2/Cargo/Deck1_Stairwell)
 "doa" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/spacebus)
@@ -14780,9 +14733,8 @@
 /area/SouthernCrossV2/Maints/Deck1_ForPort_Corridor3)
 "dsz" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -15253,9 +15205,8 @@
 /area/SouthernCrossV2/Commons/Aft_1_Deck_Stairwell)
 "dzm" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -16134,8 +16085,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/orange/border,
@@ -16275,9 +16225,8 @@
 /area/SouthernCrossV2/Harbor/Ship_Bay1)
 "dRW" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor2)
@@ -16610,8 +16559,7 @@
 	pixel_y = 2
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
@@ -17407,9 +17355,8 @@
 /area/SouthernCrossV2/Maints/Telecomms_Substation)
 "dYf" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -17600,8 +17547,7 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -18138,9 +18084,8 @@
 /area/SouthernCrossV2/Commons/Cryostorage_Lounge)
 "eaM" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/purple/bordercorner,
@@ -20789,9 +20734,8 @@
 /area/SouthernCrossV2/Harbor/Dock4)
 "eWa" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20949,9 +20893,8 @@
 	},
 /obj/machinery/floodlight,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Corridor1)
@@ -21721,8 +21664,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -22086,9 +22028,8 @@
 /area/SouthernCrossV2/Maints/Deck1_Security_PortCorridor1)
 "ftR" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -22132,9 +22073,8 @@
 /area/SouthernCrossV2/Science/Xenobiology_Lab)
 "fvr" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
@@ -22416,8 +22356,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/SouthernCrossV2/Cargo/Supply_Ship_Bay)
@@ -22593,9 +22532,8 @@
 /area/SouthernCrossV2/Commons/Central_1_Deck_Hall)
 "fEB" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -22828,8 +22766,7 @@
 /area/SouthernCrossV2/Engineering/Telecomms_Foyer)
 "fJG" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Science_ForCorridor1)
@@ -22915,8 +22852,7 @@
 /area/SouthernCrossV2/Cargo/Mining_EVA)
 "fLI" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Corridor2)
@@ -24437,8 +24373,7 @@
 "giZ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Chamber3)
@@ -24492,8 +24427,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Distro_Central)
@@ -24702,8 +24636,7 @@
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Corridor2)
 "goA" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/table/rack/shelf,
 /obj/random/maintenance/clean,
@@ -24797,9 +24730,8 @@
 "gqM" = (
 /obj/random/organ,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/ab_Surgery)
@@ -24971,8 +24903,7 @@
 "guZ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -25242,8 +25173,7 @@
 "gzY" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor3)
@@ -25895,9 +25825,8 @@
 /area/SouthernCrossV2/Domicile/Public_Gateway)
 "gOF" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_PortChamber1)
@@ -25907,8 +25836,7 @@
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Corridor2)
 "gPj" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/random/maintenance/misc,
 /turf/simulated/floor/plating,
@@ -26029,8 +25957,7 @@
 /area/SouthernCrossV2/Harbor/Dock2)
 "gRB" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/bed/pillowpile/orange,
 /obj/item/weapon/card/id/security/detective,
@@ -26238,8 +26165,7 @@
 "gUf" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26380,9 +26306,8 @@
 /area/SouthernCrossV2/Maints/Deck1_Cargo_Corridor1)
 "gWn" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	dir = 4
@@ -26646,8 +26571,7 @@
 /area/SouthernCrossV2/Cargo/Supply_Ship_Bay)
 "hbd" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27331,9 +27255,8 @@
 /area/SouthernCrossV2/Cargo/Supply_Ship_Bay)
 "hpO" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -27358,8 +27281,7 @@
 /area/SouthernCrossV2/Commons/Cryostorage_Lounge)
 "hqi" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
@@ -27586,8 +27508,7 @@
 "huC" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -28095,9 +28016,8 @@
 	pixel_y = 2
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/steel_ridged{
@@ -28347,8 +28267,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/carpet/sblucarpet/turfpack/station,
@@ -28575,8 +28494,7 @@
 "hNA" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/random/trash_pile,
 /obj/random/junk,
@@ -28846,8 +28764,7 @@
 /area/SouthernCrossV2/Maints/ab_GeneralStore)
 "hSP" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
@@ -28879,9 +28796,8 @@
 /area/SouthernCrossV2/Harbor/Dock1)
 "hTO" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -29202,9 +29118,7 @@
 /area/SouthernCrossV2/Harbor/Ship_Bay4)
 "iau" = (
 /obj/structure/flora/sif/eyes,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "iaC" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -29409,8 +29323,7 @@
 /area/SouthernCrossV2/Maints/Deck1_Cargo_Corridor1)
 "iem" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Corridor3)
@@ -29569,9 +29482,8 @@
 /area/SouthernCrossV2/Harbor/Star_Docking_Foyer)
 "igN" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -29729,18 +29641,16 @@
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "ijT" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_PortChamber3)
 "ikq" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
@@ -29861,9 +29771,8 @@
 /area/SouthernCrossV2/Commons/Stairwell_Star)
 "ilL" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_StarChamber2)
@@ -29939,9 +29848,8 @@
 /area/shuttle/escape_pod6/station)
 "imO" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
@@ -30168,8 +30076,7 @@
 /area/SouthernCrossV2/Commons/Stairwell_Star)
 "iqJ" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Chamber1)
@@ -30202,9 +30109,8 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor2)
@@ -30731,8 +30637,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30830,9 +30735,7 @@
 	name = "Scrable";
 	faction = "nanotrasen"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "iEf" = (
 /obj/random/junk,
@@ -30882,8 +30785,7 @@
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Commons/Aft_1_Deck_Stairwell)
@@ -31109,8 +31011,7 @@
 "iMj" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -31229,9 +31130,8 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/purcarpet/turfpack/station,
 /area/SouthernCrossV2/Commons/Cryostorage_Lounge)
@@ -31760,9 +31660,8 @@
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
 "jch" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -32217,9 +32116,7 @@
 /obj/item/seeds/siflettuce{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "jkR" = (
 /obj/machinery/door/firedoor/glass,
@@ -32412,8 +32309,7 @@
 /obj/structure/table/marble,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftStar1_Corridor2)
@@ -32434,9 +32330,8 @@
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Corridor2)
 "jot" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -33316,9 +33211,8 @@
 /area/SouthernCrossV2/Engineering/Telecomms_Network)
 "jFk" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -33766,8 +33660,7 @@
 "jLl" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/structure/table/standard,
 /obj/random/maintenance/clean,
@@ -33838,8 +33731,7 @@
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
 "jMW" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -33905,8 +33797,7 @@
 /area/SouthernCrossV2/Harbor/Fueling_Storage)
 "jOw" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Chamber3)
@@ -34480,9 +34371,8 @@
 /area/SouthernCrossV2/Maints/Deck1_Cargo_Corridor1)
 "jZZ" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -34671,9 +34561,8 @@
 /area/SouthernCrossV2/Commons/Stairwell_Aft)
 "kcc" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Commons/AftStar_1_Deck_Observatory)
@@ -35379,9 +35268,8 @@
 /area/SouthernCrossV2/Cargo/Supply_Ship_Bay)
 "ksO" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -35414,8 +35302,7 @@
 /area/SouthernCrossV2/Domicile/Public_EVA)
 "ktw" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Commons/Star_1Deck_Central_Corridor_1)
@@ -35943,8 +35830,7 @@
 "kFh" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -36138,8 +36024,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -36357,9 +36242,8 @@
 "kMl" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Chamber1)
@@ -36386,8 +36270,7 @@
 /area/SouthernCrossV2/Maints/Deck1_AftStar1_Corridor3)
 "kMV" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Chamber1)
@@ -36409,8 +36292,7 @@
 "kNA" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/rust,
@@ -36492,9 +36374,7 @@
 /obj/structure/prop/statue/stump_plaque{
 	desc = "A wooden stump adorned with a little plaque. -Sif's botanical garden-"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "kPu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -36598,9 +36478,7 @@
 /area/SouthernCrossV2/Science/PA_Chamber)
 "kRH" = (
 /obj/structure/flora/rocks1,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "kSm" = (
 /obj/structure/cable{
@@ -36774,8 +36652,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -36788,8 +36665,7 @@
 "kUE" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -36826,9 +36702,8 @@
 /area/SouthernCrossV2/Domicile/Public_EVA)
 "kVR" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Cargo_Corridor2)
@@ -36962,8 +36837,7 @@
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "kXm" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Corridor1)
@@ -37268,9 +37142,8 @@
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
 "lct" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -37331,9 +37204,8 @@
 /area/SouthernCrossV2/Commons/Aft_1_Deck_Stairwell)
 "leg" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
@@ -37777,9 +37649,8 @@
 /area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor2)
 "llC" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Chamber3)
@@ -38012,9 +37883,8 @@
 /area/SouthernCrossV2/Security/Quantum_Pad_Checkpoint)
 "lol" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -38177,8 +38047,7 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Harbor/Ship_Bay2)
@@ -38188,9 +38057,8 @@
 /area/SouthernCrossV2/Maints/Market_Stall_1)
 "lsJ" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Corridor2)
@@ -38291,9 +38159,8 @@
 "lvp" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
@@ -38437,8 +38304,7 @@
 "lxJ" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/structure/loot_pile/maint/boxfort,
 /turf/simulated/floor/plating,
@@ -38462,8 +38328,7 @@
 /area/SouthernCrossV2/Engineering/Telecomms_Foyer)
 "lxO" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftStar1_Corridor2)
@@ -39193,9 +39058,8 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
@@ -39501,9 +39365,8 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Commons/Aft_1_Deck_Stairwell)
@@ -39752,8 +39615,7 @@
 /area/SouthernCrossV2/Science/Xenobiology_Lab)
 "lTF" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/table,
 /turf/simulated/floor/tiled,
@@ -39874,9 +39736,8 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Commons/ForStar_1_Deck_Observatory)
@@ -40207,9 +40068,7 @@
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
 "maQ" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "maR" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -40876,9 +40735,8 @@
 "moV" = (
 /obj/structure/table/bench/sifwooden/padded,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Harbor/Dock4)
@@ -41117,9 +40975,8 @@
 "mrC" = (
 /obj/structure/table/bench/sifwooden/padded,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Harbor/Dock2)
@@ -41817,9 +41674,8 @@
 /area/SouthernCrossV2/Commons/Stairwell_Aft)
 "mDc" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForPort_Corridor3)
@@ -42279,9 +42135,8 @@
 /area/SouthernCrossV2/Harbor/Dock1)
 "mLD" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Cargo_Chamber1)
@@ -42423,9 +42278,8 @@
 "mNh" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/dark,
@@ -42477,9 +42331,8 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_Transit_Lobby)
@@ -43412,8 +43265,7 @@
 /obj/random/trash,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Science_AftCorridor1)
@@ -43670,8 +43522,7 @@
 /area/SouthernCrossV2/Science/PA_Chamber)
 "nma" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
@@ -43898,8 +43749,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_PortCorridor2)
@@ -43912,9 +43762,7 @@
 /area/shuttle/spacebus)
 "nrb" = (
 /obj/structure/flora/sif/eyes,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "nrf" = (
 /obj/effect/decal/cleanable/flour,
@@ -44092,9 +43940,8 @@
 /area/SouthernCrossV2/Maints/ab_Medical)
 "nut" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -44338,9 +44185,7 @@
 /area/SouthernCrossV2/Maints/ab_Hydroponics)
 "nzf" = (
 /obj/structure/flora/tree/sif,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "nzv" = (
 /obj/structure/grille/rustic,
@@ -44408,8 +44253,7 @@
 /area/SouthernCrossV2/Science/Research_Ship_Bay)
 "nAO" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Chamber2)
@@ -44450,8 +44294,7 @@
 /area/SouthernCrossV2/Harbor/Dock1)
 "nBH" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
@@ -44539,8 +44382,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Commons/For_Transit_Foyer)
@@ -44794,9 +44636,8 @@
 /area/SouthernCrossV2/Science/Research_Ship_Bay)
 "nHL" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_PortChamber3)
@@ -44867,8 +44708,7 @@
 "nIY" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Corridor1)
@@ -45312,8 +45152,7 @@
 "nRi" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -45461,8 +45300,7 @@
 "nTq" = (
 /obj/structure/closet/crate/wooden,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/random/junk,
 /obj/random/junk,
@@ -46027,8 +45865,7 @@
 "obh" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -46512,8 +46349,7 @@
 /area/SouthernCrossV2/Harbor/Dock4)
 "okJ" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForPort_Corridor3)
@@ -47005,8 +46841,7 @@
 /area/SouthernCrossV2/Maints/Deck1_Cargo_Corridor2)
 "oti" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Distro_Central)
@@ -47609,9 +47444,8 @@
 /area/SouthernCrossV2/Maints/Deck1_Security_PortCorridor2)
 "oDp" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -47796,8 +47630,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_1_Deck_Hall)
@@ -48857,9 +48690,8 @@
 /area/SouthernCrossV2/Cargo/Mining_Ship_Bay)
 "oXE" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable{
@@ -49013,8 +48845,7 @@
 /area/SouthernCrossV2/Commons/AftPort_1_Deck_Observatory)
 "oZD" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
@@ -49406,8 +49237,7 @@
 "pgI" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Cargo_Chamber1)
@@ -49482,8 +49312,7 @@
 /area/SouthernCrossV2/Maints/Deck1_AftStar1_Corridor2)
 "phV" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
@@ -49979,8 +49808,7 @@
 "pnv" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -50299,9 +50127,7 @@
 /area/SouthernCrossV2/Maints/ab_Kitchen)
 "psu" = (
 /obj/structure/flora/rocks2,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "psG" = (
 /obj/structure/disposalpipe/segment{
@@ -50403,9 +50229,7 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_1_Deck_Stairwell)
 "pvi" = (
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "pvk" = (
 /obj/machinery/door/firedoor/multi_tile/glass{
@@ -50439,9 +50263,7 @@
 /area/SouthernCrossV2/Maints/Deck1_Star_Corridor)
 "pvA" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "pvG" = (
 /obj/structure/railing,
@@ -50594,9 +50416,8 @@
 /area/shuttle/spacebus)
 "pyl" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Maints/ab_Surgery)
@@ -50727,16 +50548,14 @@
 /obj/random/maintenance/medical,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Chamber2)
 "pBr" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -50760,8 +50579,7 @@
 "pBN" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Corridor2)
@@ -51398,8 +51216,7 @@
 "pOa" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Corridor2)
@@ -51631,9 +51448,8 @@
 /area/SouthernCrossV2/Maints/Market_Stall_3)
 "pPG" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Commons/AftPort_1_Deck_Observatory)
@@ -51862,9 +51678,8 @@
 /area/SouthernCrossV2/Commons/Planetside_Equipment)
 "pTF" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
@@ -51885,8 +51700,7 @@
 "pUe" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -52073,8 +51887,7 @@
 /area/SouthernCrossV2/Engineering/Telecomms_Control_Room)
 "pVV" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/table/standard,
 /obj/random/toolbox,
@@ -53007,8 +52820,7 @@
 "qoj" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54169,8 +53981,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
@@ -54401,8 +54212,7 @@
 "qPv" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -54649,9 +54459,8 @@
 /area/SouthernCrossV2/Science/PA_Chamber)
 "qSS" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/radiocarbon_spectrometer,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -55109,9 +54918,8 @@
 "qZk" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/ab_Hydroponics)
@@ -55171,9 +54979,8 @@
 /area/SouthernCrossV2/Commons/Planetside_Equipment)
 "qZK" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor1)
@@ -56105,8 +55912,7 @@
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
 "rqj" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -56665,8 +56471,7 @@
 /area/SouthernCrossV2/Science/Observation_Hall)
 "rxK" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Maints/Market_Stall_4)
@@ -56701,9 +56506,8 @@
 /area/SouthernCrossV2/Maints/Deck1_Cargo_Corridor1)
 "ryl" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -57296,8 +57100,7 @@
 /area/SouthernCrossV2/Maints/Distro_Harbor)
 "rLJ" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/table/standard,
 /obj/random/maintenance/cargo,
@@ -57365,9 +57168,8 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_1_Deck_Hall)
@@ -57509,9 +57311,8 @@
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "rRu" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/random/junk,
@@ -57694,8 +57495,7 @@
 "rWn" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_PortCorridor1)
@@ -57858,8 +57658,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58144,9 +57943,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -58403,8 +58201,7 @@
 "sfD" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForStar_Corridor3)
@@ -59368,8 +59165,7 @@
 "sAE" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Harbor_Substation)
@@ -59628,8 +59424,7 @@
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
 "sEM" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -59648,9 +59443,8 @@
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
 "sET" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Cargo_Corridor3)
@@ -59767,9 +59561,8 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Security/Quantum_Pad_Storage)
@@ -60248,9 +60041,8 @@
 /area/shuttle/expoutpost/station)
 "sND" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -60288,8 +60080,7 @@
 "sOd" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -60772,8 +60563,7 @@
 /area/SouthernCrossV2/Security/Transit_Turrets)
 "sZx" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Maints/Market_Stall_2)
@@ -60999,9 +60789,8 @@
 /area/SouthernCrossV2/Cargo/Mining_Ship_Bay)
 "tdM" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable{
@@ -61974,9 +61763,8 @@
 /area/SouthernCrossV2/Maints/ab_StripBar)
 "tvZ" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/bmarble,
 /area/SouthernCrossV2/Maints/ab_GeneralStore)
@@ -62322,9 +62110,7 @@
 /obj/item/seeds/sifbulb{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "tAZ" = (
 /obj/machinery/power/apc{
@@ -62384,9 +62170,7 @@
 /obj/item/seeds/shrinkshroom{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "tCf" = (
 /turf/simulated/wall,
@@ -62509,9 +62293,7 @@
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "tDP" = (
 /obj/structure/flora/rocks2,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "tDY" = (
 /obj/structure/reagent_dispensers/foam,
@@ -62855,8 +62637,7 @@
 /area/SouthernCrossV2/Maints/Distro_Central)
 "tLv" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled/white,
@@ -62965,9 +62746,8 @@
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/white/bordercorner,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/For_Locker_Room)
@@ -63042,8 +62822,7 @@
 "tOJ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -63475,8 +63254,7 @@
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "tYa" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/plating,
@@ -63713,8 +63491,7 @@
 /area/SouthernCrossV2/Maints/Deck1_ForPort_Chamber1)
 "ubJ" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_StarChamber2)
@@ -64099,9 +63876,8 @@
 "ujt" = (
 /obj/structure/closet/crate/wooden,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/random/junk,
 /obj/random/junk,
@@ -64189,9 +63965,8 @@
 /area/SouthernCrossV2/Science/Xenobiology_Lab)
 "ukU" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -64348,8 +64123,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -64395,9 +64169,8 @@
 /area/SouthernCrossV2/Commons/Aft_Transit_Lobby)
 "upe" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -65068,9 +64841,8 @@
 	pixel_y = -28
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Domicile/For_Restroom)
@@ -65551,9 +65323,8 @@
 	dir = 9
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Engineering/Telecomms_Control_Room)
@@ -65694,8 +65465,7 @@
 /obj/item/weapon/paper/petrification_notes,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/ab_Hydroponics)
@@ -65986,9 +65756,8 @@
 "uTe" = (
 /obj/machinery/space_heater,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Science_AftCorridor1)
@@ -66500,9 +66269,8 @@
 /area/SouthernCrossV2/Maints/Deck1_Cargo_Corridor1)
 "vdp" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/item/weapon/digestion_remains{
 	pixel_y = -4;
@@ -66678,8 +66446,7 @@
 "vfU" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/appliance/cooker/grill,
 /turf/simulated/floor/plating,
@@ -66698,8 +66465,7 @@
 /area/SouthernCrossV2/Engineering/GravGen_Room)
 "vgc" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Maints/Market_Stall_5)
@@ -67028,8 +66794,7 @@
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
 "vkh" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/item/toy/redbutton{
 	pixel_y = 5
@@ -67244,8 +67009,7 @@
 "vnN" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftStar1_Corridor3)
@@ -67721,9 +67485,8 @@
 /area/shuttle/escape_pod13/station)
 "vvQ" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -68711,9 +68474,7 @@
 /area/SouthernCrossV2/Maints/Deck1_Security_PortCorridor1)
 "vMv" = (
 /obj/structure/flora/sif/tendrils,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "vMw" = (
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
@@ -69431,9 +69192,8 @@
 /area/SouthernCrossV2/Science/PA_Chamber)
 "vZC" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -69715,8 +69475,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -69899,9 +69658,8 @@
 /area/SouthernCrossV2/Security/Quantum_Pad_Storage)
 "wgF" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_PortCorridor1)
@@ -69959,8 +69717,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Public_EVA)
@@ -70073,9 +69830,7 @@
 /area/SouthernCrossV2/Commons/Aft_1_Deck_Stairwell)
 "wjR" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "wjT" = (
 /obj/structure/cable/green{
@@ -70094,9 +69849,7 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Maints/ab_GeneralStore)
 "wjZ" = (
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "wkg" = (
 /obj/item/toy/baseball,
@@ -70237,8 +69990,7 @@
 "woh" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/structure/table/standard,
 /obj/random/maintenance/misc,
@@ -70390,8 +70142,7 @@
 "wrk" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
@@ -70714,9 +70465,8 @@
 "wxC" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -70885,15 +70635,13 @@
 /area/SouthernCrossV2/Commons/Central_1_Deck_Hall)
 "wBk" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor1)
 "wBl" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -71003,7 +70751,7 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Chamber3)
 "wEj" = (
-/obj/machinery/smartfridge/sheets/mining/persistent_lossy,
+/obj/machinery/smartfridge/sheets/persistent_lossy,
 /turf/simulated/wall,
 /area/SouthernCrossV2/Cargo/Mining_Ship_Bay)
 "wEm" = (
@@ -71195,8 +70943,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Commons/ForPort_1_Deck_Observatory)
@@ -71251,8 +70998,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -71458,9 +71204,8 @@
 /area/shuttle/echidna)
 "wNE" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Corridor1)
@@ -71681,9 +71426,8 @@
 /area/SouthernCrossV2/Commons/Aft_1_Deck_Stairwell)
 "wRb" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -71729,8 +71473,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Science_AftCorridor1)
@@ -71946,8 +71689,7 @@
 "wUg" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -71966,8 +71708,7 @@
 /area/SouthernCrossV2/Cargo/Supply_Ship_Bay)
 "wVD" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/table/rack/shelf,
 /obj/random/maintenance/clean,
@@ -72300,8 +72041,7 @@
 /area/shuttle/escape_pod7/station)
 "xbk" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForPort_Corridor2)
@@ -73148,9 +72888,8 @@
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Corridor3)
 "xpF" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -73242,9 +72981,8 @@
 /area/shuttle/expoutpost/station)
 "xrz" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_ForPort_Corridor2)
@@ -73255,8 +72993,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorblack{
@@ -73659,8 +73396,7 @@
 "xBk" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/random/tech_supply/component,
 /obj/random/tech_supply/component,
@@ -73711,8 +73447,7 @@
 /area/SouthernCrossV2/Maints/Deck1_Science_ForCorridor1)
 "xCL" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable{
@@ -74036,8 +73771,7 @@
 "xJX" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/standard,
@@ -75558,9 +75292,8 @@
 /area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor1)
 "ykL" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Harbor/Dock5)
@@ -75590,8 +75323,7 @@
 /area/SouthernCrossV2/Maints/ab_Hydroponics)
 "ymc" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Security/Quantum_Pad_Checkpoint)

--- a/maps/southern_sun/southern_cross-2.dmm
+++ b/maps/southern_sun/southern_cross-2.dmm
@@ -2087,12 +2087,12 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Aft_2_Deck_Airlock_Access)
 "aee" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Science/Toxins_Mixing_Room)
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor2)
 "aeg" = (
 /obj/machinery/papershredder,
 /obj/machinery/ai_status_display{
@@ -13386,12 +13386,16 @@
 	},
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "aNw" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor2)
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/tiled/dark,
+/area/SouthernCrossV2/Engineering/Canister_Storage)
 "aNB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18698,16 +18702,16 @@
 /turf/simulated/floor/carpet/blue,
 /area/SouthernCrossV2/Domicile/Midnight_Bar)
 "bee" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/effect/floor_decal/borderfloorblack{
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/lightorange/border{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/tiled/dark,
-/area/SouthernCrossV2/Engineering/Canister_Storage)
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck2_Engineering_PortChamber2)
 "bei" = (
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
@@ -53373,6 +53377,17 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Cargo_AftCorridor1)
+"ftQ" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck2_Security_AftPortCorridor2)
 "fub" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/border_only,
@@ -61005,16 +61020,12 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Science/Locker_Room)
 "hmv" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck2_Security_AftPortCorridor2)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "hmF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65356,13 +65367,9 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/green,
-/obj/machinery/power/sensor{
-	name = "Powernet Sensor - Engineering Subgrid";
-	name_tag = "Engineering Subgrid"
+	icon_state = "1-4"
 	},
 /obj/item/weapon/paper{
 	info = "The big blue box recently installed in here is a 'grid checker' which will shut off the power if a dangerous power spike from the engine erupts into the powernet.  Shutting everything down protects everything from electrical damage, however the outages can be disruptive to colony operations, so it is designed to restore power after a somewhat significant delay, up to ten minutes or so.  The grid checker can be manually hacked in order to end the outage sooner.  To do that, you must cut three specific wires which do not cause a red light to shine, then pulse a fourth wire.  Electrical protection is highly recommended when doing maintenance on the grid checker.";
@@ -86485,19 +86492,18 @@
 	name_tag = "Security Subgrid"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Security_Substation)
 "okt" = (
@@ -87373,16 +87379,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Star_Corridor)
-"ozh" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	color = "yellow"
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck2_Engineering_PortChamber2)
 "ozj" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4
@@ -105569,8 +105565,7 @@
 	dir = 4
 	},
 /obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
+	color = "yellow"
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Engineering_PortChamber2)
@@ -131899,9 +131894,9 @@ cHe
 cAC
 jfz
 voG
-ozh
-eXs
 tls
+eXs
+bee
 tTp
 vfn
 vfn
@@ -134193,7 +134188,7 @@ aaa
 aaa
 aaa
 dEZ
-bee
+aNw
 ctS
 bGt
 btr
@@ -146833,7 +146828,7 @@ bwW
 bBx
 bJd
 hPJ
-hmv
+ftQ
 bUo
 ame
 ctj
@@ -157623,7 +157618,7 @@ ohC
 ohC
 uli
 apY
-aNw
+aee
 brA
 brA
 acy
@@ -171865,8 +171860,8 @@ gQv
 bMW
 blw
 gYm
-aee
-aee
+hmv
+hmv
 mgI
 rmc
 nIW
@@ -173159,7 +173154,7 @@ wBK
 cDw
 xIB
 vav
-aee
+hmv
 dkb
 cxe
 rMw

--- a/maps/southern_sun/southern_cross-2.dmm
+++ b/maps/southern_sun/southern_cross-2.dmm
@@ -467,8 +467,7 @@
 "aaN" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -576,6 +575,9 @@
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
 	dir = 8
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Engineering_ForStarCorridor1)
@@ -723,8 +725,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Security/Reception)
@@ -1216,8 +1217,7 @@
 /area/SouthernCrossV2/Engineering/Engineering_EVA)
 "abV" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloor{
@@ -1361,8 +1361,7 @@
 /area/SouthernCrossV2/Security/Wardens_Office)
 "acw" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -1423,6 +1422,10 @@
 	id = "Star Lockdown";
 	desc = "A heavily reinforced gate, sector lockdown!";
 	name = "Lockdown Gate"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Science_ForPort_Chamber)
@@ -1539,9 +1542,8 @@
 "acS" = (
 /obj/structure/lattice,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_PortChamber2)
@@ -2055,9 +2057,8 @@
 	RCon_tag = "Domicile Substation Bypass"
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Domicile_Substation)
@@ -2086,8 +2087,12 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Aft_2_Deck_Airlock_Access)
 "aee" = (
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck2_Civilian_PortChamber1)
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "aeg" = (
 /obj/machinery/papershredder,
 /obj/machinery/ai_status_display{
@@ -3341,9 +3346,8 @@
 "agM" = (
 /obj/structure/table/steel,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/camera/network/security{
 	dir = 4;
@@ -3928,9 +3932,8 @@
 	pixel_x = -3
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -4046,9 +4049,8 @@
 /area/SouthernCrossV2/Science/Deck2_Corridor)
 "aiF" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Cargo_AftStarCorridor1)
@@ -4163,6 +4165,9 @@
 /obj/structure/railing/grey{
 	color = "yellow";
 	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Security_ForStar_Chamber)
@@ -4521,9 +4526,8 @@
 	pixel_y = -1
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Aft_2_Deck_Airlock_Access)
@@ -4758,6 +4762,10 @@
 "akt" = (
 /obj/structure/railing/grey{
 	color = "yellow"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Security_AftPortCorridor1)
@@ -4996,9 +5004,8 @@
 /area/SouthernCrossV2/Security/Wardens_Office)
 "alp" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -5301,6 +5308,10 @@
 	id = "Port Lockdown";
 	desc = "A heavily reinforced gate, sector lockdown!";
 	name = "Lockdown Gate"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Engineering_ForStarChamber1)
@@ -6196,8 +6207,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6475,8 +6485,7 @@
 /area/SouthernCrossV2/Security/Forensics_Office)
 "arb" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -6834,8 +6843,7 @@
 "asn" = (
 /obj/structure/closet/secure_closet/bar,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
@@ -7145,7 +7153,8 @@
 	pixel_y = -22;
 	dir = 1;
 	name = "Head of Security RC";
-	department = "Head of Security's Desk"
+	department = "Head of Security's Desk";
+	announcementConsole = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7530,9 +7539,8 @@
 	pixel_x = -7
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/SouthernCrossV2/Domicile/Star_Restroom)
@@ -7613,9 +7621,8 @@
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "auX" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Engineering_PortCorridor1)
@@ -7782,6 +7789,8 @@
 	pixel_x = 8;
 	pixel_y = 16
 	},
+/obj/item/device/lightreplacer,
+/obj/item/device/lightreplacer,
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Engineering/Engineering_Workshop)
 "avx" = (
@@ -7791,9 +7800,8 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/device/gps/engineering,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -8230,9 +8238,8 @@
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Lobby)
 "awx" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /mob/living/simple_mob/animal/passive/cockroach,
 /turf/simulated/floor/plating,
@@ -8337,8 +8344,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Shuttlebay_Corridor)
@@ -8458,8 +8464,7 @@
 	pixel_y = -2
 	},
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -8602,9 +8607,8 @@
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "aya" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
@@ -8685,9 +8689,8 @@
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "ayA" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
@@ -9047,16 +9050,13 @@
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Security/Locker_Room)
 "azG" = (
-/obj/structure/ladder{
-	pixel_y = 3
-	},
+/obj/structure/ladder/updown,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Maints/Deck2_Security_StarCorridor1)
 "azH" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
@@ -9226,8 +9226,7 @@
 	name = "1N-lighting fixture"
 	},
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -9364,9 +9363,8 @@
 /area/SouthernCrossV2/Medical/CMO_Office)
 "aAv" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
@@ -9811,9 +9809,8 @@
 "aCk" = (
 /obj/machinery/disposal,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/disposalpipe/trunk,
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -9934,8 +9931,7 @@
 "aCG" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -10198,8 +10194,7 @@
 "aDy" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -10381,9 +10376,8 @@
 	pixel_y = -4
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/item/sticky_pad/random{
 	pixel_y = 7;
@@ -10935,8 +10929,7 @@
 "aFK" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/SouthernCrossV2/Domicile/Chomp_Hydroponics)
@@ -11592,9 +11585,8 @@
 /area/SouthernCrossV2/Medical/Chemistry)
 "aHF" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/table/standard,
 /obj/random/maintenance/cargo,
@@ -11731,8 +11723,7 @@
 /area/SouthernCrossV2/Cargo/Mail_Room)
 "aIo" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -11860,8 +11851,7 @@
 "aIM" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12055,9 +12045,8 @@
 "aJi" = (
 /obj/structure/bed/chair/bay/chair/padded/red/bignest,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/SouthernCrossV2/Maints/ab_TeshDen)
@@ -12180,9 +12169,9 @@
 "aJK" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_StarChamber1)
 "aJL" = (
@@ -12913,8 +12902,7 @@
 "aLM" = (
 /obj/machinery/papershredder,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -13398,10 +13386,12 @@
 	},
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "aNw" = (
-/obj/machinery/shield_capacitor/advanced,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/SouthernCrossV2/Engineering/Storage)
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor2)
 "aNB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13427,8 +13417,7 @@
 "aNC" = (
 /obj/structure/table/steel,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/camera/network/security{
 	dir = 8;
@@ -13817,9 +13806,8 @@
 	req_access = null
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -14000,15 +13988,13 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Emergency_EVA)
 "aPf" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor1)
@@ -14396,9 +14382,8 @@
 /area/SouthernCrossV2/Cargo/QM_Office)
 "aQI" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/brown/bordercorner,
@@ -14753,9 +14738,8 @@
 /area/SouthernCrossV2/Maints/Deck2_Civilian_PortChamber1)
 "aRv" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
@@ -14917,6 +14901,10 @@
 /obj/structure/disposalpipe/down,
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Port_Corridor)
@@ -15401,6 +15389,10 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Star_Corridor)
 "aTv" = (
@@ -15900,9 +15892,8 @@
 "aUx" = (
 /obj/machinery/disposal,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -16016,8 +16007,7 @@
 "aUH" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -16748,7 +16738,8 @@
 	pixel_x = 22;
 	dir = 8;
 	name = "Research Director RC";
-	department = "Research Director's Desk"
+	department = "Research Director's Desk";
+	announcementConsole = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -17258,8 +17249,7 @@
 /area/SouthernCrossV2/Domicile/Midnight_Bar)
 "aZh" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Central_Corridor_1)
@@ -17603,6 +17593,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/up,
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Security_AftStarCorridor2)
 "bad" = (
@@ -17680,9 +17674,8 @@
 /area/SouthernCrossV2/Domicile/Chomp_Hydroponics)
 "baw" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
@@ -17861,8 +17854,7 @@
 "bbc" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
@@ -17891,8 +17883,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
@@ -18119,9 +18110,8 @@
 /area/SouthernCrossV2/Security/Restroom)
 "bcj" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -18242,9 +18232,8 @@
 /area/SouthernCrossV2/Security/Visitation_Room)
 "bcv" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18394,8 +18383,7 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/dropper,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/item/weapon/reagent_containers/glass/beaker/large{
 	pixel_y = 11;
@@ -18710,13 +18698,16 @@
 /turf/simulated/floor/carpet/blue,
 /area/SouthernCrossV2/Domicile/Midnight_Bar)
 "bee" = (
-/obj/machinery/alarm{
-	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Deck2_Civilian_AftPortCorridor1)
+/obj/effect/floor_decal/corner/lightorange/border{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/tiled/dark,
+/area/SouthernCrossV2/Engineering/Canister_Storage)
 "bei" = (
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
@@ -18766,9 +18757,8 @@
 /area/SouthernCrossV2/Security/Transit_Turrets)
 "ber" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -18863,8 +18853,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
 /obj/effect/floor_decal/borderfloorblack{
@@ -18999,7 +18988,8 @@
 	pixel_x = 22;
 	dir = 8;
 	name = "Chief Engineer RC";
-	department = "Chief Engineer's Desk"
+	department = "Chief Engineer's Desk";
+	announcementConsole = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -19103,9 +19093,8 @@
 /area/SouthernCrossV2/Science/RD_Office)
 "bfu" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19173,8 +19162,7 @@
 "bfx" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled,
@@ -19795,9 +19783,8 @@
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "bhk" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -19868,6 +19855,9 @@
 /obj/structure/disposalpipe/up{
 	dir = 4
 	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Security_AftStarCorridor2)
 "bhp" = (
@@ -19884,9 +19874,8 @@
 /area/SouthernCrossV2/Medical/Port_Medical_Post)
 "bhr" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20448,8 +20437,7 @@
 /area/SouthernCrossV2/Security/Prison_Wing)
 "bju" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -21215,9 +21203,8 @@
 /area/SouthernCrossV2/Medical/Chemistry)
 "blR" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -21295,9 +21282,8 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Emergency_EVA)
@@ -21894,8 +21880,7 @@
 "bou" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/wood/alt/parquet,
@@ -22667,8 +22652,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Security/Prison_Wing)
@@ -23003,8 +22987,7 @@
 "bsa" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -23220,9 +23203,8 @@
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "bth" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
@@ -23680,8 +23662,7 @@
 "buz" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_StarChamber1)
@@ -23753,8 +23734,7 @@
 /area/SouthernCrossV2/Medical/FirstAid_Storage)
 "buL" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -24007,6 +23987,10 @@
 	desc = "Ladder for emergency use only";
 	pixel_y = -32
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_AftPort_Corridor)
 "bvF" = (
@@ -24145,6 +24129,10 @@
 	desc = "Ladder for emergency use only";
 	pixel_y = -32
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_AftStar_Corridor)
 "bwk" = (
@@ -24245,8 +24233,7 @@
 "bwC" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/table/steel,
 /obj/effect/floor_decal/borderfloorblack{
@@ -24429,8 +24416,7 @@
 /area/SouthernCrossV2/Domicile/Office_Lounge)
 "bxe" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -25139,6 +25125,9 @@
 /obj/structure/disposalpipe/down{
 	dir = 8
 	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Security_AftStarCorridor2)
 "byN" = (
@@ -25706,8 +25695,7 @@
 "bAH" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/random/maintenance/medical,
 /obj/random/medical/pillbottle,
@@ -26298,9 +26286,8 @@
 	pixel_x = -7
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Security/Forensics_Office)
@@ -26429,8 +26416,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_AftCorridor1)
@@ -26453,6 +26439,10 @@
 "bEf" = (
 /obj/structure/railing/grey{
 	color = "yellow"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Security_AftStarCorridor2)
@@ -26642,9 +26632,8 @@
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Central_Corridor_1)
 "bFa" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26748,9 +26737,8 @@
 /area/SouthernCrossV2/Bridge/Vault_Reception)
 "bFH" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/carpet/green,
 /area/SouthernCrossV2/Cargo/Breakroom)
@@ -26920,8 +26908,7 @@
 "bGw" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -27075,8 +27062,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Medical/Treatment_Hall)
@@ -27478,9 +27464,8 @@
 	},
 /obj/item/weapon/surgical/retractor,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -27636,9 +27621,8 @@
 /area/SouthernCrossV2/Domicile/Emergency_EVA)
 "bJd" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -28069,6 +28053,9 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
 	dir = 4
 	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Science_ForPort_Corridor)
 "bLg" = (
@@ -28105,8 +28092,7 @@
 /area/SouthernCrossV2/Security/Equipment_Storage)
 "bLo" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -28150,8 +28136,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood/alt/panel/broken/turfpack/station,
 /area/SouthernCrossV2/Maints/ab_Theater)
@@ -28214,9 +28199,8 @@
 /area/SouthernCrossV2/Maints/Deck2_Science_ForCorridor1)
 "bLV" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -28432,9 +28416,8 @@
 /area/SouthernCrossV2/Maints/Deck2_Science_ForCorridor1)
 "bMt" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -28628,8 +28611,7 @@
 	dir = 9
 	},
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -28671,9 +28653,8 @@
 "bNu" = (
 /obj/structure/window/reinforced,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
@@ -28982,9 +28963,8 @@
 /area/SouthernCrossV2/Engineering/Deck2_1_Corridor)
 "bNX" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -29304,9 +29284,8 @@
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Corridor_1)
 "bPp" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -29331,8 +29310,7 @@
 /area/shuttle/escape_pod12/station)
 "bPt" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29459,9 +29437,8 @@
 	},
 /obj/structure/closet/crate/wooden,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -29722,8 +29699,7 @@
 /area/SouthernCrossV2/Harbor/Aft_2_Deck_Airlock_Access)
 "bQY" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29752,8 +29728,7 @@
 "bRa" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/green/bordercorner,
@@ -30974,9 +30949,8 @@
 /area/SouthernCrossV2/Domicile/Library)
 "bVx" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31051,16 +31025,14 @@
 /area/SouthernCrossV2/Harbor/Star_Shuttlebay)
 "bVF" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Engineering_PortChamber1)
 "bVH" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -31376,8 +31348,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -31656,9 +31627,8 @@
 /area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor1)
 "bXr" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -31918,9 +31888,8 @@
 /area/space)
 "bYi" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/white/border,
@@ -32046,6 +32015,10 @@
 	id = "Star Lockdown";
 	desc = "A heavily reinforced gate, sector lockdown!";
 	name = "Lockdown Gate"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Harbor/Star_2_Deck_Airlock_Access)
@@ -32280,6 +32253,9 @@
 	desc = "A heavily reinforced gate, sector lockdown!";
 	name = "Lockdown Gate"
 	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Cargo_AftStarChamber1)
 "bZF" = (
@@ -32319,9 +32295,8 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/railing{
 	dir = 1
@@ -32463,8 +32438,7 @@
 "caq" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32676,8 +32650,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Emergency_EVA)
@@ -32698,8 +32671,7 @@
 /area/SouthernCrossV2/Cargo/For_Tool_Storage)
 "cbk" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -32847,9 +32819,8 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/blue,
 /area/SouthernCrossV2/Domicile/Midnight_Bar)
@@ -33086,6 +33057,10 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_ForStarCorridor1)
 "ccs" = (
@@ -33287,9 +33262,8 @@
 /area/SouthernCrossV2/Maints/Deck2_Civilian_ForStarCorridor1)
 "ccX" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -33476,9 +33450,8 @@
 /obj/item/weapon/mop,
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -33557,9 +33530,8 @@
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Central_Corridor_2)
 "cdX" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/item/weapon/pen/multi{
 	pixel_x = 5
@@ -33852,8 +33824,7 @@
 "ceG" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/plating,
@@ -34701,9 +34672,8 @@
 	network = list("Engineering")
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Drone_Fab)
@@ -34831,9 +34801,8 @@
 /obj/structure/table/rack/shelf,
 /obj/item/weapon/cell/high/empty,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/SouthernCrossV2/Cargo/For_Tool_Storage)
@@ -34920,8 +34889,7 @@
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Central_Corridor_2)
 "chY" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/item/device/aicard,
 /obj/structure/table/steel,
@@ -35609,8 +35577,7 @@
 /area/SouthernCrossV2/Security/Evidence_Storage)
 "cjH" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/random/junk,
 /obj/structure/table/rack/shelf,
@@ -35824,9 +35791,8 @@
 /area/SouthernCrossV2/Domicile/Library_Office)
 "ckp" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -35943,8 +35909,7 @@
 /area/SouthernCrossV2/Domicile/Chapel_Lobby)
 "ckO" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8
@@ -36153,8 +36118,7 @@
 /area/SouthernCrossV2/Domicile/Library_Office)
 "clx" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -36432,8 +36396,7 @@
 "cmx" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -36770,8 +36733,7 @@
 "cnM" = (
 /obj/structure/table/hardwoodtable,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/item/weapon/storage/fancy/candle_box{
 	pixel_y = 8;
@@ -36924,8 +36886,7 @@
 /obj/structure/bed/chair/bay/chair/padded/red/smallnest,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -37426,9 +37387,8 @@
 /area/SouthernCrossV2/Science/Circuitry_Den)
 "cqQ" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Engineering_PortChamber2)
@@ -37481,8 +37441,7 @@
 "cqV" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled,
@@ -37510,8 +37469,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/VR)
@@ -38818,8 +38776,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -39107,7 +39064,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/techfloor,
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "cvw" = (
 /obj/machinery/atmospherics/valve{
@@ -39147,20 +39104,19 @@
 "cvJ" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/green/bordercorner,
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "cvK" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
-/area/SouthernCrossV2/Science/Toxins_Mixing_Room)
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck2_Civilian_ForStarCorridor2)
 "cvL" = (
 /obj/effect/catwalk_plated,
 /obj/item/device/radio/intercom{
@@ -39168,7 +39124,7 @@
 	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "cvM" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -39357,8 +39313,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
@@ -39444,9 +39399,8 @@
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
 "cwF" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -39659,9 +39613,8 @@
 /area/SouthernCrossV2/Commons/For_2_Deck_Central_Corridor_2)
 "cxA" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/kafel_full/red,
 /area/SouthernCrossV2/Security/Restroom)
@@ -40036,8 +39989,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/kafel_full/red/turfpack/station,
 /area/SouthernCrossV2/Security/Prison_Wing)
@@ -40250,9 +40202,8 @@
 /area/SouthernCrossV2/Domicile/Holodeck)
 "czx" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -40349,9 +40300,8 @@
 /area/SouthernCrossV2/Security/Prison_Wing)
 "cAc" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -40556,10 +40506,6 @@
 "cAO" = (
 /obj/machinery/optable{
 	name = "Robotics Operating Table"
-	},
-/obj/machinery/oxygen_pump/anesthetic{
-	dir = 4;
-	pixel_x = 28
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -40781,8 +40727,7 @@
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/monotile{
 	color = "#989898"
@@ -40791,9 +40736,8 @@
 "cBD" = (
 /obj/structure/table/steel,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/camera/network/security{
 	dir = 8;
@@ -40811,8 +40755,7 @@
 /area/SouthernCrossV2/Domicile/Gym)
 "cBK" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -40872,8 +40815,7 @@
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_2)
 "cBZ" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -41038,8 +40980,7 @@
 /area/SouthernCrossV2/Maints/Deck2_Civilian_PortChamber2)
 "cCy" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -41231,8 +41172,7 @@
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -41249,8 +41189,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/SouthernCrossV2/Domicile/Gym_Sauna)
@@ -41382,6 +41321,10 @@
 	id = "Port Lockdown";
 	desc = "A heavily reinforced gate, sector lockdown!";
 	name = "Lockdown Gate"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Cargo/Mail_Room)
@@ -41594,8 +41537,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
@@ -41759,9 +41701,8 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -41821,8 +41762,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/corner/purple/diagonal,
 /obj/effect/floor_decal/corner/purple/diagonal{
@@ -42994,8 +42934,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloor{
@@ -43594,8 +43533,7 @@
 "cWN" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/table/steel,
 /obj/effect/floor_decal/borderfloorblack{
@@ -43771,8 +43709,7 @@
 /obj/structure/closet/l3closet/medical,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -44181,8 +44118,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Emergency_EVA)
@@ -44596,7 +44532,7 @@
 /area/SouthernCrossV2/Engineering/Storage)
 "dkb" = (
 /obj/effect/catwalk_plated,
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "dkf" = (
 /obj/effect/floor_decal/borderfloor,
@@ -45930,8 +45866,7 @@
 "dDg" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Maints/ab_Pdance)
@@ -46058,8 +45993,7 @@
 /obj/structure/closet/wardrobe/science_white,
 /obj/item/weapon/storage/box/gloves,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -46493,8 +46427,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Port_Corridor)
@@ -47084,9 +47017,8 @@
 "dQR" = (
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/brown,
 /area/SouthernCrossV2/Engineering/Breakroom)
@@ -47261,8 +47193,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -47368,9 +47299,8 @@
 /area/SouthernCrossV2/Domicile/VR)
 "dUc" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -47519,7 +47449,7 @@
 	dir = 10
 	},
 /obj/effect/catwalk_plated/techfloor,
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "dWm" = (
 /obj/structure/disposalpipe/segment,
@@ -47847,9 +47777,8 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/lino,
 /area/SouthernCrossV2/Domicile/Chapel_Office)
@@ -47894,6 +47823,10 @@
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
 	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Distro_Civilian)
@@ -48214,7 +48147,7 @@
 	use_power = 0;
 	tag_south = 2
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "efo" = (
 /obj/effect/floor_decal/borderfloor{
@@ -48422,9 +48355,8 @@
 	pixel_x = -7
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_AftPort_Corridor)
@@ -48452,8 +48384,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
@@ -48496,8 +48427,7 @@
 /area/SouthernCrossV2/Security/Firing_Range)
 "ejl" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -48764,8 +48694,7 @@
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Central_Corridor_2)
 "emX" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloor{
@@ -48866,8 +48795,7 @@
 /area/SouthernCrossV2/Domicile/Library)
 "eov" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Security_AftStarCorridor1)
@@ -49088,8 +49016,7 @@
 /obj/machinery/suit_cycler/medical,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -49241,8 +49168,7 @@
 /area/SouthernCrossV2/Security/Firing_Range)
 "euB" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -49295,8 +49221,7 @@
 	pixel_y = 2
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/lino,
 /area/SouthernCrossV2/Security/Forensics_Office)
@@ -49443,8 +49368,7 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -49654,8 +49578,7 @@
 /area/SouthernCrossV2/Maints/ab_Chapel)
 "ezV" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -49811,9 +49734,8 @@
 /area/SouthernCrossV2/Commons/For_2_Deck_Central_Corridor_2)
 "eDi" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -50310,8 +50232,7 @@
 /area/SouthernCrossV2/Domicile/Gym_Sauna)
 "eIQ" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -50523,8 +50444,7 @@
 /area/SouthernCrossV2/Commons/AftPort_2_Deck_Observatory)
 "eKx" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -50822,8 +50742,7 @@
 "eNj" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/structure/fitness/punchingbag,
 /turf/simulated/floor/boxing/gym,
@@ -50958,8 +50877,7 @@
 "eNU" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -51383,8 +51301,7 @@
 "eTD" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -51392,16 +51309,14 @@
 "eTE" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Engineering_PortChamber2)
 "eTM" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -51623,9 +51538,8 @@
 /area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor3)
 "eXp" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51701,9 +51615,8 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/lightgrey/border{
@@ -52035,9 +51948,8 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -52103,8 +52015,7 @@
 /area/SouthernCrossV2/Engineering/Canister_Storage)
 "fdB" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -52742,8 +52653,7 @@
 "flB" = (
 /obj/structure/table/steel,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/camera/network/security{
 	dir = 4;
@@ -53025,6 +52935,10 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
 	dir = 4
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Medical_AftPortCorridor1)
 "foG" = (
@@ -53052,8 +52966,7 @@
 "foZ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Cargo_AftPortCorridor1)
@@ -53188,9 +53101,8 @@
 /area/SouthernCrossV2/Medical/For_Medical_Post)
 "fqy" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -53226,8 +53138,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -54314,8 +54225,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Star_Corridor)
@@ -54362,8 +54272,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -54893,8 +54802,7 @@
 /area/SouthernCrossV2/Engineering/Deck2_1_Corridor)
 "fMs" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -55056,9 +54964,8 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
@@ -55335,9 +55242,8 @@
 /area/SouthernCrossV2/Domicile/Midnight_Bar)
 "fRL" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
@@ -56347,9 +56253,8 @@
 /area/SouthernCrossV2/Security/Evidence_Storage)
 "gck" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -56429,8 +56334,7 @@
 /area/SouthernCrossV2/Commons/ForStar_2_Deck_Observatory)
 "gdd" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/random/crate,
 /turf/simulated/floor/plating,
@@ -56521,8 +56425,7 @@
 "geg" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/random/obstruction,
 /turf/simulated/floor/plating,
@@ -56537,8 +56440,7 @@
 "gex" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -56694,9 +56596,9 @@
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "ggO" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_PortChamber1)
 "ggY" = (
@@ -57287,9 +57189,8 @@
 /area/SouthernCrossV2/Maints/Cargo_Substation)
 "gnm" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Science_StarChamber1)
@@ -57626,9 +57527,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -57772,8 +57672,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/ab_TeshDen)
@@ -57956,9 +57855,8 @@
 /area/SouthernCrossV2/Medical/Port_Medical_Post)
 "gyg" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Aft_2_Deck_Airlock_Access)
@@ -58986,8 +58884,7 @@
 "gLO" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_ForPortCorridor1)
@@ -59088,6 +58985,9 @@
 	dir = 4
 	},
 /obj/structure/lattice,
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Aft_Corridor)
 "gMz" = (
@@ -59197,8 +59097,7 @@
 "gNI" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -59419,8 +59318,7 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor,
@@ -59624,9 +59522,8 @@
 /area/SouthernCrossV2/Maints/Security_Substation)
 "gTx" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -59876,9 +59773,8 @@
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
 "gWU" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/table/steel,
 /obj/random/maintenance/clean,
@@ -59942,9 +59838,8 @@
 /area/SouthernCrossV2/Cargo/Reception)
 "gXM" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -60680,8 +60575,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/floortube{
@@ -61111,8 +61005,16 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Science/Locker_Room)
 "hmv" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
 /turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck2_Civilian_StarChamber1)
+/area/SouthernCrossV2/Maints/Deck2_Security_AftPortCorridor2)
 "hmF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61171,9 +61073,8 @@
 /area/SouthernCrossV2/Maints/Deck2_Security_AftPortCorridor1)
 "hnG" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -61298,7 +61199,7 @@
 	c_tag = "D2-Sci-Toxins2";
 	network = list("Science")
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "hoK" = (
 /obj/structure/bed/chair/sofa/blue,
@@ -61446,8 +61347,7 @@
 "hqF" = (
 /obj/structure/girder/reinforced,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor2)
@@ -61466,9 +61366,8 @@
 	pixel_x = -7
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/SouthernCrossV2/Domicile/Port_Restroom)
@@ -62315,9 +62214,8 @@
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
 "hDm" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Port_Corridor)
@@ -62397,9 +62295,8 @@
 /area/SouthernCrossV2/Science/Testing_Lab)
 "hEC" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -62421,9 +62318,8 @@
 	pixel_y = 6
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Gym)
@@ -62919,8 +62815,7 @@
 /area/SouthernCrossV2/Security/Armory)
 "hOJ" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/wood/broken,
 /area/SouthernCrossV2/Maints/ab_TeshDen)
@@ -63360,9 +63255,9 @@
 "hUT" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_PortChamber1)
 "hVh" = (
@@ -63724,9 +63619,8 @@
 /area/SouthernCrossV2/Science/Research_Lab)
 "hYG" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -63869,7 +63763,8 @@
 /area/SouthernCrossV2/Medical/Deck2_Corridor)
 "iah" = (
 /obj/machinery/smartfridge/sheets{
-	density = 0
+	desc = "An industrial sized storage unit for materials. B-Shift's agreement to retain materials doesn't extend to this storage device, so you should probably only stock this with sheets you need.";
+	name = "\improper Non-Persistent Industrial Sheet Storage"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/sign/periodic{
@@ -64276,8 +64171,7 @@
 /area/SouthernCrossV2/Cargo/Aft_Tool_Storage)
 "ifO" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -64337,9 +64231,8 @@
 "iho" = (
 /obj/structure/closet/wardrobe/medic_white,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -64372,6 +64265,9 @@
 /obj/structure/sign/small/warning/emerg_only{
 	desc = "Ladder for emergency use only";
 	pixel_y = 32
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor2)
@@ -64474,8 +64370,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/lino,
 /area/SouthernCrossV2/Maints/ab_Theater)
@@ -65490,9 +65385,8 @@
 /area/SouthernCrossV2/Domicile/Gym)
 "ius" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/random/trash,
 /obj/machinery/door/blast/regular/open{
@@ -66180,9 +66074,8 @@
 	name = "1S-light fixture"
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -66391,8 +66284,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -67119,9 +67011,8 @@
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -67155,7 +67046,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "iOI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -68485,9 +68376,8 @@
 /area/SouthernCrossV2/Commons/Port_2_Deck_Corridor_2)
 "jhK" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/table/standard,
 /obj/random/maintenance/cargo,
@@ -68696,8 +68586,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor2)
@@ -69006,8 +68895,7 @@
 "jnv" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/decal/cleanable/blood/splatter{
 	name = "Liquid";
@@ -70089,8 +69977,7 @@
 "jDF" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -70161,9 +70048,8 @@
 /area/SouthernCrossV2/Maints/Deck2_For_Corridor)
 "jFB" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70859,9 +70745,8 @@
 "jPg" = (
 /obj/effect/floor_decal/milspec/box,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Engineering/Mech_Bay)
@@ -70958,9 +70843,8 @@
 	layer = 3
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -71092,8 +70976,7 @@
 "jTH" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -71471,8 +71354,7 @@
 "jYt" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -71492,9 +71374,8 @@
 /area/SouthernCrossV2/Cargo/Warehouse)
 "jYX" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71862,8 +71743,7 @@
 "kdL" = (
 /obj/structure/table/rack,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/item/weapon/gun/projectile/automatic/serdy/keltec{
 	pixel_y = 8;
@@ -72315,8 +72195,7 @@
 /area/SouthernCrossV2/Cargo/Packaging_Room)
 "kiG" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/SouthernCrossV2/Domicile/Library)
@@ -73453,9 +73332,8 @@
 /area/SouthernCrossV2/Engineering/Storage)
 "kCe" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -73852,8 +73730,7 @@
 /obj/machinery/papershredder,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74003,8 +73880,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
@@ -74132,8 +74008,7 @@
 "kKp" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -75400,6 +75275,10 @@
 	desc = "A heavily reinforced gate, sector lockdown!";
 	name = "Lockdown Gate"
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Research_Substation)
 "lbB" = (
@@ -76155,8 +76034,7 @@
 /area/SouthernCrossV2/Cargo/Packaging_Room)
 "llS" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -76532,9 +76410,8 @@
 /area/SouthernCrossV2/Medical/Patient_Ward)
 "lsf" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_ForStar_Corridor)
@@ -77598,7 +77475,7 @@
 	dir = 1;
 	name = "1N-lighting fixture"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "lHO" = (
 /obj/machinery/door/firedoor/border_only,
@@ -79089,8 +78966,7 @@
 /area/SouthernCrossV2/Domicile/Chapel_Lobby)
 "mbA" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79169,8 +79045,7 @@
 "mcI" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Lobby)
@@ -79191,8 +79066,7 @@
 /area/SouthernCrossV2/Cargo/Breakroom)
 "mdj" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	dir = 4
@@ -79400,7 +79274,7 @@
 	c_tag = "D2-Sci-Toxins1";
 	network = list("Science")
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "mgO" = (
 /obj/effect/floor_decal/industrial/arrows/blue,
@@ -79810,8 +79684,7 @@
 /obj/structure/table/bench/sifwooden,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/ab_Chapel)
@@ -81025,8 +80898,7 @@
 /area/SouthernCrossV2/Cargo/Recycling)
 "mGs" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_ForStarCorridor1)
@@ -81485,8 +81357,7 @@
 /area/SouthernCrossV2/Medical/For_Medical_Post)
 "mMU" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor1)
@@ -82022,8 +81893,7 @@
 /obj/structure/table/gamblingtable,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/blue,
 /area/SouthernCrossV2/Domicile/Rec_Lounge)
@@ -82085,9 +81955,8 @@
 /area/SouthernCrossV2/Domicile/Gym)
 "mUW" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Security_AftStarCorridor1)
@@ -82552,8 +82421,7 @@
 "nbj" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Cargo_AftCorridor2)
@@ -82676,9 +82544,8 @@
 	name = "1E-light fixture"
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -82842,8 +82709,7 @@
 "ngT" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/table/standard,
 /obj/random/maintenance/cargo,
@@ -83008,9 +82874,8 @@
 /area/SouthernCrossV2/Maints/Security_Substation)
 "niK" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
@@ -83319,8 +83184,7 @@
 /area/SouthernCrossV2/Maints/Deck2_Civilian_PortChamber1)
 "npI" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84245,9 +84109,8 @@
 "nDN" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -84267,8 +84130,7 @@
 /area/SouthernCrossV2/Commons/Star_2_Deck_Central_Corridor_1)
 "nEh" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -84629,8 +84491,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/lightgrey/border{
@@ -84642,8 +84503,7 @@
 "nKk" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -85450,8 +85310,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/carpet,
 /area/SouthernCrossV2/Bridge/HoP_Office)
@@ -85739,9 +85598,8 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/white/border,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
@@ -85825,9 +85683,8 @@
 /obj/random/maintenance/cargo,
 /obj/random/maintenance/clean,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Cargo/Warehouse)
@@ -85925,9 +85782,8 @@
 "obf" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled,
@@ -86907,6 +86763,10 @@
 	color = "yellow";
 	dir = 1
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_ForPortCorridor2)
 "oqA" = (
@@ -87117,6 +86977,10 @@
 /obj/structure/lattice,
 /obj/structure/railing/grey{
 	color = "yellow"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Cargo_AftCorridor2)
@@ -87341,9 +87205,8 @@
 	dir = 9
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 4
@@ -87446,7 +87309,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "oyk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
@@ -87510,6 +87373,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Star_Corridor)
+"ozh" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck2_Engineering_PortChamber2)
 "ozj" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4
@@ -87642,9 +87515,8 @@
 /area/SouthernCrossV2/Commons/Port_2_Deck_Corridor_1)
 "oCL" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
@@ -88160,9 +88032,8 @@
 	pixel_x = 3
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
@@ -89187,8 +89058,7 @@
 /area/SouthernCrossV2/Engineering/Deck2_2_Corridor)
 "oYl" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/atmospherics/portables_connector,
@@ -89927,8 +89797,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -91533,8 +91402,7 @@
 "pAz" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet,
@@ -91587,8 +91455,7 @@
 /area/SouthernCrossV2/Maints/Deck2_Science_StarCorridor2)
 "pBz" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -92141,9 +92008,8 @@
 "pIS" = (
 /obj/machinery/photocopier,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -92198,8 +92064,7 @@
 /area/SouthernCrossV2/Commons/Port_2_Deck_Stairwell)
 "pJu" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -92970,8 +92835,7 @@
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
 "pUi" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -93001,8 +92865,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor,
 /area/SouthernCrossV2/Cargo/Waste_Disposals)
@@ -93152,8 +93015,7 @@
 /area/SouthernCrossV2/Commons/For_2_Deck_Central_Corridor_2)
 "pWA" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -93481,9 +93343,8 @@
 /area/SouthernCrossV2/Commons/Stairwell_Star)
 "qbx" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -93758,9 +93619,9 @@
 /area/SouthernCrossV2/Maints/Deck2_Cargo_AftCorridor2)
 "qfe" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_StarChamber1)
 "qfl" = (
@@ -93800,8 +93661,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/table/rack/shelf/steel,
 /obj/effect/floor_decal/borderfloorblack{
@@ -94068,8 +93928,7 @@
 "qkk" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -95077,9 +94936,8 @@
 /area/SouthernCrossV2/Maints/Deck2_Civilian_AftCorridor1)
 "qxx" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -95114,6 +94972,10 @@
 	id = "Star Lockdown";
 	desc = "A heavily reinforced gate, sector lockdown!";
 	name = "Lockdown Gate"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Medical_AftPortChamber1)
@@ -95363,8 +95225,7 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Science/Mech_Bay)
@@ -96195,9 +96056,8 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightorange/border,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -96896,8 +96756,7 @@
 /area/SouthernCrossV2/Maints/ab_Pdance)
 "qYN" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
@@ -97063,9 +96922,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor3)
@@ -97510,9 +97368,8 @@
 	name = "Pill cabinet"
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -97927,8 +97784,7 @@
 "rlk" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Star_Corridor)
@@ -98165,8 +98021,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Cargo_Substation)
@@ -98329,9 +98184,8 @@
 /area/SouthernCrossV2/Cargo/Breakroom)
 "rrY" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -98568,9 +98422,8 @@
 /area/SouthernCrossV2/Domicile/Gallery)
 "ruc" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -100575,6 +100428,10 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_ForPortCorridor1)
 "rRK" = (
@@ -101056,9 +100913,8 @@
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
 "rYF" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/spider/stickyweb/dark,
 /turf/simulated/floor/wood/sif,
@@ -101289,8 +101145,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
@@ -101522,9 +101377,8 @@
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "sfq" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
@@ -102962,9 +102816,8 @@
 /area/SouthernCrossV2/Cargo/Breakroom)
 "syZ" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
@@ -103371,8 +103224,7 @@
 /obj/machinery/flasher/portable,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -103976,8 +103828,7 @@
 "sMa" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/decal/remains/ribcage,
 /turf/simulated/floor/wood/alt/panel,
@@ -104542,9 +104393,8 @@
 /area/SouthernCrossV2/Maints/ab_TeshDen)
 "sTb" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloor{
@@ -104568,9 +104418,8 @@
 "sTC" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -105539,9 +105388,8 @@
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/lightorange/bordercorner,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Engineering/Engineering_Workshop)
@@ -105716,13 +105564,16 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
 "tls" = (
-/obj/structure/table/bench/sifwooden,
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/ab_Chapel)
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck2_Engineering_PortChamber2)
 "tlx" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -106670,9 +106521,8 @@
 /area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "tAg" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_AftPortCorridor1)
@@ -106992,8 +106842,7 @@
 "tDS" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -108118,8 +107967,7 @@
 "tTE" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8
@@ -108178,6 +108026,10 @@
 	id = "Med Lockdown";
 	desc = "A heavily reinforced gate, sector lockdown!";
 	name = "Lockdown Gate"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Medical_AftCorridor1)
@@ -109339,8 +109191,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Science/Testing_Lab)
@@ -109415,8 +109266,7 @@
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
 "ulh" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8
@@ -109432,9 +109282,8 @@
 /area/SouthernCrossV2/Domicile/Holodeck)
 "ulR" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/smolebuilding/business,
 /turf/simulated/floor/smole,
@@ -109508,13 +109357,16 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
 	dir = 1
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Security_StarCorridor1)
 "umE" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/table/standard,
 /obj/random/maintenance/clean,
@@ -110170,6 +110022,10 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
 	dir = 8
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Cargo_AftStarCorridor1)
 "uye" = (
@@ -110369,9 +110225,8 @@
 /area/SouthernCrossV2/Maints/Research_Substation)
 "uCk" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_ForPort_Corridor)
@@ -110811,8 +110666,7 @@
 "uMr" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_AftPort_Corridor)
@@ -111012,8 +110866,7 @@
 	pixel_x = 28
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Commons/For_2_Deck_Central_Corridor_2)
@@ -111159,8 +111012,7 @@
 "uPX" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Domicile/Gym)
@@ -112080,9 +111932,8 @@
 /area/SouthernCrossV2/Maints/Security_Substation)
 "vbX" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -112158,9 +112009,8 @@
 /area/SouthernCrossV2/Maints/Deck2_Cargo_AftStarCorridor1)
 "vdV" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/computer/rdconsole/engineering{
 	dir = 8
@@ -112542,8 +112392,7 @@
 "vjZ" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -112638,9 +112487,8 @@
 "vmd" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -112695,8 +112543,7 @@
 /obj/structure/bed/chair/bay/chair/padded/red/bignest,
 /obj/item/toy/plushie/teshari,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/wood,
 /area/SouthernCrossV2/Maints/ab_TeshDen)
@@ -113345,8 +113192,7 @@
 /area/SouthernCrossV2/Maints/Research_Substation)
 "vvY" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -113574,9 +113420,8 @@
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "vyZ" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -113880,8 +113725,7 @@
 "vDJ" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_ForStarCorridor2)
@@ -113920,9 +113764,8 @@
 /area/SouthernCrossV2/Maints/Deck2_ForPort_Corridor)
 "vEF" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/floodlight,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -114286,8 +114129,7 @@
 /area/SouthernCrossV2/Maints/Deck2_Science_StarChamber1)
 "vKX" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -114412,8 +114254,7 @@
 "vMT" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_PortChamber1)
@@ -114544,8 +114385,7 @@
 /area/SouthernCrossV2/Commons/For_2_Deck_Central_Corridor_1)
 "vPP" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -115182,8 +115022,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -115295,9 +115134,8 @@
 "wao" = (
 /obj/structure/lattice,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_StarChamber2)
@@ -115416,8 +115254,7 @@
 /obj/item/clothing/suit/storage/apron/overalls,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Security/Prison_Wing)
@@ -115466,8 +115303,7 @@
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
 "wct" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -115488,8 +115324,7 @@
 "wcM" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor1)
@@ -116437,8 +116272,7 @@
 "wnv" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -116524,8 +116358,7 @@
 "woz" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/wood,
 /area/SouthernCrossV2/Maints/ab_TeshDen)
@@ -116582,8 +116415,7 @@
 "wpq" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -116591,9 +116423,8 @@
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "wpH" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -117163,8 +116994,7 @@
 "wxP" = (
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -117368,7 +117198,7 @@
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Corridor_2)
 "wBs" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/shield_gen/advanced,
+/obj/machinery/shield_gen,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Engineering/Storage)
 "wBy" = (
@@ -118342,8 +118172,7 @@
 "wNh" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -118753,9 +118582,8 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -118871,9 +118699,8 @@
 /area/SouthernCrossV2/Engineering/CE_Office)
 "wUU" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -118948,8 +118775,7 @@
 "wVM" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -119607,9 +119433,8 @@
 /area/SouthernCrossV2/Harbor/Port_Shuttlebay)
 "xff" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -120190,8 +120015,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Stairwell)
@@ -120850,9 +120674,8 @@
 /area/SouthernCrossV2/Commons/For_2_Deck_Central_Corridor_2)
 "xyn" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -121137,8 +120960,7 @@
 "xCd" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -121952,8 +121774,7 @@
 /obj/machinery/photocopier,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -122019,9 +121840,8 @@
 	pixel_x = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -122485,8 +122305,7 @@
 /area/SouthernCrossV2/Commons/ForPort_2_Deck_Observatory)
 "xXY" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -122751,8 +122570,7 @@
 "xZK" = (
 /obj/structure/bed/chair/backed_red,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8;
@@ -122773,8 +122591,7 @@
 "yaa" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -123108,9 +122925,8 @@
 "yeI" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_AftStar_Corridor)
@@ -123356,8 +123172,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -123710,8 +123525,7 @@
 "ymh" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/plating,
@@ -132085,9 +131899,9 @@ cHe
 cAC
 jfz
 voG
-vfn
+ozh
 eXs
-vfn
+tls
 tTp
 vfn
 vfn
@@ -134379,7 +134193,7 @@ aaa
 aaa
 aaa
 dEZ
-rew
+bee
 ctS
 bGt
 btr
@@ -135201,7 +135015,7 @@ oPj
 hJL
 qps
 oef
-tls
+qps
 ljC
 oBo
 cFZ
@@ -137492,7 +137306,7 @@ fCI
 fCI
 wBs
 azr
-aNw
+azr
 ahz
 ahT
 wpP
@@ -137578,36 +137392,36 @@ oht
 oht
 oht
 cCw
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
 cCw
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
 cCw
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
-vPX
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
+nCr
 oht
 hPY
 feR
@@ -137750,7 +137564,7 @@ fCI
 fCI
 cdq
 azr
-aNw
+azr
 ahz
 dck
 aWH
@@ -143512,36 +143326,36 @@ nYy
 weY
 uZc
 bFD
-aee
-aee
-aee
-aee
-aee
-aee
-aee
-aee
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
 bFD
-aee
-aee
-aee
-aee
-aee
-aee
-aee
-aee
-aee
-aee
-aee
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
 bFD
 ggO
-aee
-aee
-aee
-aee
-aee
-aee
-aee
-aee
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
 sGr
 rPT
 sjb
@@ -144028,36 +143842,36 @@ gDe
 cnt
 sCT
 bFD
-aee
-aee
-aee
-aee
-aee
-aee
-aee
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
 hUT
 bFD
-aee
-aee
-aee
-aee
-aee
-aee
-aee
-aee
-aee
-aee
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
 hUT
 bFD
-aee
-aee
-aee
-aee
-aee
-aee
-aee
-aee
-aee
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
+cfY
 ssv
 npz
 uet
@@ -146762,7 +146576,7 @@ bBx
 bHG
 gBu
 bRn
-bUo
+bRo
 ame
 ctj
 ctj
@@ -147019,7 +146833,7 @@ bwW
 bBx
 bJd
 hPJ
-bRo
+hmv
 bUo
 ame
 ctj
@@ -147131,7 +146945,7 @@ tLw
 xDR
 xDR
 qQm
-bee
+tAg
 kkc
 xDR
 wRf
@@ -157809,7 +157623,7 @@ ohC
 ohC
 uli
 apY
-apY
+aNw
 brA
 brA
 acy
@@ -159479,7 +159293,7 @@ bDi
 kzV
 bwr
 njG
-xKO
+cvK
 clv
 clv
 clv
@@ -163120,36 +162934,36 @@ evu
 vzM
 bFm
 uhD
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
 aJK
 uhD
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
 aJK
 uhD
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
 irh
 qUu
 vwX
@@ -163636,36 +163450,36 @@ evu
 mmn
 myq
 uhD
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
 uhD
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
 uhD
 qfe
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
-hmv
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
+mbj
 ycK
 ycK
 xBZ
@@ -169570,36 +169384,36 @@ sQq
 sQq
 sQq
 qcZ
-toM
-toM
-toM
-toM
-toM
-toM
-toM
-toM
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
 qcZ
-toM
-toM
-toM
-toM
-toM
-toM
-toM
-toM
-toM
-toM
-toM
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
 qcZ
-toM
-toM
-toM
-toM
-toM
-toM
-toM
-toM
-toM
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
+xTR
 sQq
 fVB
 pQm
@@ -172051,8 +171865,8 @@ gQv
 bMW
 blw
 gYm
-bjQ
-bjQ
+aee
+aee
 mgI
 rmc
 nIW
@@ -173345,7 +173159,7 @@ wBK
 cDw
 xIB
 vav
-bjQ
+aee
 dkb
 cxe
 rMw
@@ -173604,7 +173418,7 @@ rrB
 awQ
 eKB
 hoz
-cvK
+awV
 cxe
 mbY
 cBp
@@ -173862,7 +173676,7 @@ nHJ
 ccy
 rAq
 lHu
-cvK
+awV
 cxe
 gha
 tuw
@@ -174120,7 +173934,7 @@ rHy
 aAr
 lJn
 efl
-cvK
+awV
 dXa
 iIe
 uVm

--- a/maps/southern_sun/southern_cross-3.dmm
+++ b/maps/southern_sun/southern_cross-3.dmm
@@ -1181,14 +1181,8 @@
 /turf/simulated/open,
 /area/SouthernCrossV2/Domicile/Chomp_Lounge)
 "auu" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber1)
+/area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
 "auR" = (
 /obj/machinery/newscaster{
 	pixel_x = 28;
@@ -1768,17 +1762,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Port)
-"aDw" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_AftCorridor1)
 "aDE" = (
 /obj/machinery/light{
 	dir = 8;
@@ -4654,17 +4637,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Dorms_Substation)
-"bHa" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
-	},
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "bHh" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -5464,12 +5436,14 @@
 /turf/simulated/floor/carpet/blucarpet,
 /area/SouthernCrossV2/Domicile/Dormitory_01)
 "bUf" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
+/obj/effect/catwalk_plated/white,
+/obj/machinery/light_switch{
+	name = "N-light switch";
+	pixel_x = 12;
+	pixel_y = 27
 	},
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
+/turf/simulated/floor/glass/turfpack/airless,
+/area/space)
 "bUF" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "Air Mix to Connector"
@@ -6756,8 +6730,16 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_Breakroom)
 "cqo" = (
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber2)
 "cqp" = (
 /turf/simulated/wall,
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber2)
@@ -6885,15 +6867,11 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "csA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
-/obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber2)
 "csD" = (
 /obj/machinery/light{
 	dir = 8;
@@ -7131,10 +7109,14 @@
 /area/SouthernCrossV2/Medical/Virology)
 "cwY" = (
 /obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/obj/structure/railing/grey{
 	color = "yellow"
 	},
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "cxj" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -9393,6 +9375,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
+"djU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "djV" = (
 /obj/machinery/particle_accelerator/control_box,
 /obj/effect/floor_decal/techfloor/orange{
@@ -11202,6 +11198,19 @@
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Observation_Lounge)
+"dRW" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/random/junk,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "dSf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11871,10 +11880,12 @@
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Bridge/Breakroom)
 "dYS" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "dYY" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -12261,8 +12272,15 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "edc" = (
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Center_Port)
 "ede" = (
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -13082,15 +13100,23 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Star_3_Deck_Airlock_Access)
 "esF" = (
-/obj/structure/railing/grey{
-	color = "yellow";
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
 	dir = 8
 	},
-/obj/structure/railing/grey{
-	color = "yellow"
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Center_Star)
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "esI" = (
 /obj/structure/table/marble,
 /obj/item/weapon/material/kitchen/rollingpin{
@@ -13496,6 +13522,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Domicile/Observation_Lounge)
+"ezC" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor2)
 "ezD" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/durasteel,
@@ -14393,6 +14427,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Engineering/Engine1_Substation)
+"eNh" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber1)
 "eNk" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/structure/sign/poster{
@@ -14959,6 +15003,13 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Commons/Star_Breakroom)
+"eTy" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "eTA" = (
 /obj/machinery/light{
 	dir = 4;
@@ -16127,17 +16178,8 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "ffT" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "fgb" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -17070,22 +17112,13 @@
 /turf/simulated/floor/tiled/hydro,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
 "frX" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/white,
-/obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 1
+/obj/effect/catwalk_plated/techfloor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
-/obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/greengrid,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "fsh" = (
 /obj/structure/table/standard,
@@ -18530,6 +18563,20 @@
 /obj/effect/floor_decal/corner/beige/border,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Dorm_Corridor_2)
+"fNg" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber1)
 "fNB" = (
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -19793,18 +19840,12 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
 "gjw" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/SouthernCrossV2/Commons/For_3_Deck_Stairwell)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "gjA" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20594,25 +20635,16 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "gxf" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
-	},
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber2)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "gxt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/valve/digital{
+	dir = 4;
+	name = "secondary TEG valve"
 	},
-/turf/simulated/floor/tiled/milspec/raised,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "gxC" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -20686,12 +20718,14 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/SouthernCrossV2/Commons/Port_Breakroom)
 "gzl" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
+/area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber1)
 "gzB" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -21153,10 +21187,6 @@
 	},
 /obj/effect/landmark{
 	name = "tripai"
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -36;
-	name = "1S-entertainment monitor"
 	},
 /turf/simulated/floor/greengrid,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
@@ -22973,13 +23003,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber1)
-"hnY" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
-	},
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "hoi" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/deck/cards,
@@ -23096,12 +23119,14 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "hpR" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
+/turf/simulated/floor/tiled/milspec/raised,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "hqk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/effect/catwalk_plated,
@@ -23209,11 +23234,6 @@
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/SouthernCrossV2/Bridge/HoP_Office)
-"hsW" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/SouthernCrossV2/Engineering/Engine2_Canister_Storage)
 "hsZ" = (
 /obj/structure/displaycase,
 /obj/machinery/firealarm{
@@ -23898,6 +23918,16 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/SouthernCrossV2/Commons/Star_Breakroom)
+"hEy" = (
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "hEz" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
@@ -23932,19 +23962,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
-"hFd" = (
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/milspec/raised,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "hFq" = (
 /mob/living/simple_mob/animal/passive/fish/koi{
 	name = "Mupert"
@@ -24487,13 +24504,17 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "hOk" = (
-/obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/green{
-	d1 = 4;
+/obj/structure/cable/white{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/greengrid,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "hOs" = (
 /obj/machinery/light{
@@ -25557,6 +25578,17 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/SouthernCrossV2/Domicile/Dormitory_03)
+"ier" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "ieB" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/kafel_full/green,
@@ -25923,6 +25955,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Medical/Deck3_Corridor)
+"ikV" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "ilN" = (
 /obj/machinery/vending/wardrobe/atmosdrobe,
 /obj/effect/floor_decal/borderfloorblack/full,
@@ -26201,6 +26245,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Medical/Patient_4)
+"ipU" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "ipX" = (
 /turf/simulated/wall,
 /area/SouthernCrossV2/Medical/Deck3_Corridor)
@@ -28155,14 +28206,6 @@
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/SouthernCrossV2/Bridge/Captain_Office)
-"iVz" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/valve/digital{
-	dir = 4;
-	name = "secondary TEG valve"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "iVE" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
@@ -32872,14 +32915,10 @@
 "kut" = (
 /obj/structure/railing/grey{
 	color = "yellow";
-	dir = 1
+	dir = 8
 	},
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber2)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "kuy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -33684,12 +33723,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Dorm_Corridor_1)
-"kJu" = (
-/obj/structure/railing/grey{
-	color = "yellow"
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
 "kJA" = (
 /obj/machinery/camera/network/security{
 	dir = 4;
@@ -34031,13 +34064,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
-"kOP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "kOU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloor{
@@ -34642,6 +34668,15 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Bridge/Conference_Room)
+"kYk" = (
+/obj/effect/catwalk_plated/techfloor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/redgrid/animated,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "kYm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -35838,15 +35873,6 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftCorridor2)
-"ltr" = (
-/obj/effect/catwalk_plated/white,
-/obj/machinery/light_switch{
-	name = "N-light switch";
-	pixel_x = 12;
-	pixel_y = 27
-	},
-/turf/simulated/floor/glass/turfpack/airless,
-/area/space)
 "luc" = (
 /obj/structure/railing{
 	dir = 1
@@ -37447,12 +37473,30 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Bridge/Captain_Office)
 "lSj" = (
-/obj/structure/railing/grey{
-	color = "yellow";
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows/red{
 	dir = 1
 	},
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
+/obj/effect/floor_decal/industrial/arrows/red,
+/obj/machinery/flasher{
+	id = "testthis";
+	name = "Doorframe mounted flash";
+	layer = 2.5
+	},
+/obj/machinery/door/airlock/angled_bay/vault{
+	name = "AI Core";
+	req_access = list(16);
+	req_one_access = list(16);
+	dir = 8;
+	locked = 1
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "lSr" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -37541,6 +37585,17 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/SouthernCrossV2/Commons/Port_Breakroom)
+"lUf" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
 "lUl" = (
 /obj/structure/railing{
 	dir = 1
@@ -38196,15 +38251,10 @@
 /area/SouthernCrossV2/Domicile/Dormitory_06)
 "mbm" = (
 /obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
+	color = "yellow"
 	},
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "mbu" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -40972,7 +41022,7 @@
 /area/SouthernCrossV2/Medical/Patient_4)
 "mVB" = (
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "mVO" = (
 /obj/structure/cable{
@@ -41246,6 +41296,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+"nai" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
 "naj" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -41522,13 +41582,6 @@
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/SouthernCrossV2/Bridge/Captain_Office)
-"ndq" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
-	},
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "ndB" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -42781,15 +42834,6 @@
 /obj/machinery/door/airlock/angled_bay/elevator/glass,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Commons/Aft_3_Deck_Stairwell)
-"nyL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/milspec/raised,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "nza" = (
 /obj/effect/floor_decal/industrial/warning/color/corner{
 	dir = 1
@@ -44193,9 +44237,8 @@
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "nUL" = (
 /obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Primary Engine Power";
@@ -44208,6 +44251,10 @@
 	dir = 8
 	},
 /obj/effect/catwalk_plated,
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "nUX" = (
@@ -44260,6 +44307,16 @@
 /obj/effect/floor_decal/corner/lightorange/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
+"nVH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "nVI" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/effect/floor_decal/spline/plain{
@@ -47404,6 +47461,16 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber2)
+"oSc" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
 "oSB" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -48014,17 +48081,10 @@
 "pcM" = (
 /obj/structure/railing/grey{
 	color = "yellow";
-	dir = 4
+	dir = 1
 	},
-/obj/structure/railing/grey{
-	color = "yellow"
-	},
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber1)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
 "pdb" = (
 /obj/random/junk,
 /obj/structure/table/rack/steel,
@@ -48287,30 +48347,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Medical/Deck3_Corridor)
 "pgQ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows/red,
-/obj/machinery/flasher{
-	id = "testthis";
-	name = "Doorframe mounted flash";
-	layer = 2.5
-	},
-/obj/machinery/door/airlock/angled_bay/vault{
-	name = "AI Core";
-	req_access = list(16);
-	req_one_access = list(16);
-	dir = 8;
-	locked = 1
-	},
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "phb" = (
 /obj/structure/lattice,
 /obj/structure/grille/rustic{
@@ -48682,19 +48722,6 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForStarCorridor1)
-"poQ" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/random/junk,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "ppd" = (
 /obj/structure/loot_pile/maint/junk,
 /obj/random/junk,
@@ -50173,19 +50200,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Dormitory_10)
 "pMu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber2)
 "pMy" = (
 /obj/structure/sign/levels/engineering/solars{
 	dir = 4;
@@ -51588,7 +51612,7 @@
 	color = "yellow";
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "qjy" = (
 /obj/structure/sign/flag/vir/right,
@@ -52243,8 +52267,16 @@
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "qvB" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
+/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "qvE" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -52681,6 +52713,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_PortChamber1)
+"qBK" = (
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Bridge_ForStarChamber1)
 "qBN" = (
 /obj/machinery/atmospherics/unary/cryo_cell,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -52905,16 +52943,6 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Bridge/CE_Quarters)
-"qFW" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	color = "yellow"
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
 "qGo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -54247,11 +54275,11 @@
 /turf/simulated/wall,
 /area/SouthernCrossV2/Medical/Psych_Room_2)
 "rcO" = (
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/structure/railing/grey{
+	color = "yellow"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber2)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "rcT" = (
 /obj/structure/table/bench/sifwooden,
 /obj/item/device/flashlight/lamp/green{
@@ -54347,7 +54375,7 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "reO" = (
 /obj/structure/cable/green{
@@ -55687,11 +55715,14 @@
 "rxL" = (
 /obj/structure/railing/grey{
 	color = "yellow";
-	dir = 4
+	dir = 8
 	},
-/obj/structure/lattice,
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
 /turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor2)
+/area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "rxM" = (
 /obj/effect/floor_decal/industrial/warning/color{
 	dir = 9
@@ -56069,16 +56100,6 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Domicile/Dormitory_07)
-"rGp" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	color = "yellow"
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Center_Port)
 "rGv" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -56986,12 +57007,18 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForStarChamber1)
 "rXN" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "rXO" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -57127,6 +57154,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
+"rZq" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/SouthernCrossV2/Engineering/Engine2_Canister_Storage)
 "rZr" = (
 /obj/structure/table/hardwoodtable,
 /obj/item/toy/figure/captain,
@@ -57542,6 +57574,15 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
+"sgc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "sgm" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 8
@@ -58457,14 +58498,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Commons/Star_Breakroom)
-"sux" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "suB" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -59264,12 +59297,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Bridge/HoS_Quarters)
-"sIb" = (
-/obj/random/trash,
-/obj/machinery/atmospherics/binary/pump/high_power,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "sIi" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -59608,11 +59635,18 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Port)
 "sMO" = (
-/obj/structure/railing/grey{
-	color = "yellow"
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/For_3_Deck_Stairwell)
 "sMS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60207,9 +60241,8 @@
 /area/SouthernCrossV2/Bridge/AI_Upload_Hall)
 "sWi" = (
 /obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Secondary Engine Power";
@@ -60218,6 +60251,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
@@ -60376,16 +60413,6 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_PortCorridor1)
-"sZV" = (
-/obj/structure/railing/grey{
-	color = "yellow"
-	},
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "tad" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -61710,15 +61737,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/SouthernCrossV2/Domicile/Public_Garden)
-"tsU" = (
-/obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/redgrid/animated,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "ttn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -62030,9 +62048,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
 "tAE" = (
-/obj/effect/catwalk_plated/techmaint,
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortCorridor1)
+/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "tAO" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 8
@@ -63229,15 +63250,11 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Domicile/Dormitory_05)
 "tWL" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
-	},
-/obj/structure/railing/grey{
-	color = "yellow"
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
+/obj/random/trash,
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "tWS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -64274,6 +64291,15 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
+"umX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "uni" = (
 /obj/structure/sign/department/atmos{
 	layer = 3.5;
@@ -65287,12 +65313,6 @@
 "uCu" = (
 /turf/simulated/wall,
 /area/SouthernCrossV2/Domicile/Dormitory_10)
-"uCH" = (
-/obj/structure/railing/grey{
-	color = "yellow"
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Bridge_ForStarChamber1)
 "uDd" = (
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor/plating,
@@ -65583,16 +65603,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber3)
-"uGc" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
-	},
-/obj/structure/railing/grey{
-	color = "yellow"
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber1)
 "uGj" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -66189,6 +66199,12 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
+"uRh" = (
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
 "uRl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -66618,18 +66634,16 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Star_3_Deck_Airlock_Access)
 "uWK" = (
-/obj/structure/cable/white{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
 	},
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
 	},
-/turf/simulated/floor/tiled/milspec/raised,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_AftCorridor1)
 "uWM" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -68130,13 +68144,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Engineering/Deck3_1_Corridor)
-"vtL" = (
-/obj/structure/railing/grey{
-	color = "yellow"
-	},
-/obj/structure/lattice,
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "vum" = (
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/white,
@@ -69267,7 +69274,8 @@
 	charge = 2e+006;
 	input_attempt = 1;
 	input_level = 100000;
-	output_level = 200000
+	output_level = 200000;
+	output_attempt = 0
 	},
 /obj/structure/cable/cyan{
 	d2 = 4;
@@ -70037,16 +70045,9 @@
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Domicile/Dormitory_05)
 "vXz" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
-	},
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Center_Star)
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortCorridor1)
 "vXB" = (
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Chamber1)
@@ -70668,15 +70669,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
-"wgT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/milspec/raised,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "whj" = (
 /obj/machinery/camera/network/security{
 	c_tag = "D3-Eng-Atmos1";
@@ -73485,10 +73477,6 @@
 	color = "yellow";
 	dir = 1
 	},
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
-	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "wZe" = (
@@ -74622,7 +74610,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "xoy" = (
 /obj/machinery/cell_charger{
@@ -90043,15 +90031,15 @@ mzY
 eHd
 xFr
 dLl
-csA
+nVH
 qIw
 ehe
 ehe
 mml
-dYS
-dYS
-dYS
-dYS
+pgQ
+pgQ
+pgQ
+pgQ
 ayO
 fHn
 jtv
@@ -90300,7 +90288,7 @@ jqa
 hpy
 vmW
 fCr
-kOP
+eTy
 uqb
 ary
 ary
@@ -90558,7 +90546,7 @@ xvN
 hZk
 gwJ
 pfq
-rXN
+ipU
 kde
 mFO
 vly
@@ -91321,7 +91309,7 @@ vxq
 fey
 oOx
 gmz
-hsW
+rZq
 moy
 dNq
 oOx
@@ -92367,7 +92355,7 @@ xRB
 twp
 msq
 pbI
-sIb
+tWL
 ghY
 vTu
 xDk
@@ -92610,7 +92598,7 @@ cHp
 uDZ
 ufa
 eaY
-sZV
+hEy
 aPD
 joW
 sOE
@@ -92624,7 +92612,7 @@ puR
 puR
 puR
 puR
-iVz
+gxt
 puR
 puR
 puR
@@ -95430,9 +95418,9 @@ jux
 sFC
 hDD
 gDe
-vtL
+reN
 tZh
-sux
+qjx
 qTm
 cDs
 pko
@@ -96462,9 +96450,9 @@ jux
 xhg
 sjC
 clf
-vtL
+reN
 tZh
-sux
+qjx
 qTm
 jdR
 pko
@@ -96774,7 +96762,7 @@ uHI
 udu
 muz
 qRA
-poQ
+dRW
 liY
 oKg
 xyE
@@ -97770,7 +97758,7 @@ qTm
 qTm
 tNr
 qCG
-rxL
+ezC
 tcw
 eUk
 bBZ
@@ -98017,7 +98005,7 @@ clf
 wFS
 aWE
 aWE
-ndq
+wYU
 oAF
 uNr
 nAa
@@ -98275,7 +98263,7 @@ cni
 pbh
 orE
 mjG
-bHa
+qvB
 oAF
 rbQ
 kmO
@@ -98791,7 +98779,7 @@ hwu
 gam
 aWE
 jCc
-wYU
+ier
 oAF
 hJs
 aVT
@@ -99049,7 +99037,7 @@ qWl
 bnW
 aWE
 jCc
-ndq
+wYU
 oAF
 gTT
 lGS
@@ -103423,7 +103411,7 @@ aoa
 apc
 hbN
 hbN
-rGp
+edc
 jGw
 mqp
 yjc
@@ -105585,7 +105573,7 @@ xso
 tja
 kWj
 ihy
-aDw
+uWK
 uBy
 xWY
 dHa
@@ -105671,7 +105659,7 @@ aqj
 kqq
 hjD
 hjD
-ltr
+bUf
 mJP
 oaL
 oaL
@@ -105936,7 +105924,7 @@ hag
 cNm
 cNm
 cNm
-frX
+esF
 tTr
 qGo
 gGw
@@ -106210,7 +106198,7 @@ rMD
 kLs
 pVE
 aKr
-gjw
+sMO
 gSX
 xXn
 sdA
@@ -106218,7 +106206,7 @@ sdA
 sdA
 sdA
 rjS
-gjw
+sMO
 vni
 sdA
 qIf
@@ -106706,11 +106694,11 @@ hjD
 oaL
 rZz
 uLN
-uWK
+hOk
 tSp
 irl
-nyL
-gxt
+hpR
+umX
 cKn
 cKn
 cSs
@@ -107485,7 +107473,7 @@ tTr
 ifx
 tTr
 tTr
-hOk
+frX
 wvZ
 wvZ
 mGv
@@ -108001,7 +107989,7 @@ tTr
 nTn
 tTr
 tTr
-hOk
+frX
 wvZ
 wvZ
 rTI
@@ -108256,7 +108244,7 @@ bqN
 cLD
 xGf
 ezD
-pgQ
+lSj
 ezD
 ihn
 tbb
@@ -108517,10 +108505,10 @@ xGf
 yhJ
 xGf
 xEA
-tsU
+kYk
 pLe
 oHc
-pMu
+djU
 pQQ
 oZK
 eiK
@@ -108774,7 +108762,7 @@ lBH
 nPP
 iVn
 rvL
-wgT
+sgc
 ouO
 laf
 ktl
@@ -109030,7 +109018,7 @@ qED
 vmy
 jRl
 dhi
-hFd
+rXN
 uLN
 pQl
 blt
@@ -109548,7 +109536,7 @@ vfq
 cNm
 cNm
 cNm
-frX
+esF
 tTr
 qGo
 gGw
@@ -111873,7 +111861,7 @@ dHa
 dHa
 dHa
 gEV
-uCH
+qBK
 bHz
 gTB
 gTB
@@ -112227,7 +112215,7 @@ rFD
 rFD
 xGM
 mtz
-vXz
+rxL
 eXY
 eXY
 apc
@@ -112479,7 +112467,7 @@ hxM
 eXY
 iwG
 iwG
-esF
+cwY
 bNg
 ntp
 umB
@@ -112507,7 +112495,7 @@ lmX
 sOH
 xmc
 iAN
-tWL
+oSc
 lkh
 uDF
 tYA
@@ -112765,7 +112753,7 @@ lmX
 sOH
 xmc
 aVj
-kJu
+uRh
 vll
 sVX
 tYA
@@ -113023,9 +113011,9 @@ lmX
 lmX
 xmc
 xIE
-qFW
+nai
 lkh
-mbm
+lUf
 tYA
 uwA
 jga
@@ -113565,7 +113553,7 @@ uYL
 qMf
 msL
 tZq
-uGc
+eNh
 gwf
 gbc
 fbj
@@ -113824,7 +113812,7 @@ qMf
 phH
 mmM
 xtq
-pcM
+fNg
 gbc
 gms
 uER
@@ -116610,8 +116598,8 @@ feh
 oSW
 tMD
 bXe
-gzl
-gzl
+dYS
+dYS
 dpB
 mwU
 iue
@@ -116864,12 +116852,12 @@ mDu
 kAF
 nHT
 gSg
-edc
-cwY
+gxf
+mbm
 tKz
 wPn
-bUf
-bUf
+tAE
+tAE
 dpB
 tbD
 tbD
@@ -117096,7 +117084,7 @@ rPo
 kcG
 kcG
 keO
-hpR
+kut
 pZA
 cXq
 kcG
@@ -117122,8 +117110,8 @@ fnZ
 kAF
 wMD
 gSg
-edc
-cwY
+gxf
+mbm
 gaI
 eaJ
 eaJ
@@ -117354,9 +117342,9 @@ kfL
 kcG
 mfp
 toW
-qvB
+ffT
 pZA
-hpR
+kut
 nNW
 kcG
 vwH
@@ -117374,18 +117362,18 @@ sYA
 sYA
 sYA
 qII
-auu
-auu
-auu
+gzl
+gzl
+gzl
 cAA
 wZN
 gSg
-edc
-cwY
+gxf
+mbm
 tMD
 bXe
-gzl
-gzl
+dYS
+dYS
 dpB
 eDW
 rPp
@@ -117612,10 +117600,10 @@ jhv
 kcG
 tcM
 toW
-qvB
+ffT
 pZA
-qvB
-sMO
+ffT
+rcO
 kcG
 vwH
 pZA
@@ -117638,12 +117626,12 @@ hgu
 hgu
 hgu
 gSg
-edc
-cwY
+gxf
+mbm
 tMD
 faj
-edc
-edc
+gxf
+gxf
 dpB
 xgV
 tbD
@@ -117870,9 +117858,9 @@ kfL
 kcG
 kcG
 aEE
-hnY
+gjw
 pZA
-hnY
+gjw
 tbM
 kcG
 hZh
@@ -117896,12 +117884,12 @@ gWK
 gWK
 gWK
 gSg
-edc
-cwY
+gxf
+mbm
 tMD
 oeW
-edc
-edc
+gxf
+gxf
 dpB
 kUH
 fgI
@@ -118386,7 +118374,7 @@ kcG
 kcG
 clj
 dkH
-hpR
+kut
 pZA
 hHO
 kcG
@@ -118670,9 +118658,9 @@ blM
 ixY
 iMd
 hIh
-tAE
-tAE
-tAE
+vXz
+vXz
+vXz
 hsc
 fdT
 pEj
@@ -118876,7 +118864,7 @@ dHa
 dbu
 fCm
 wam
-ffT
+ikV
 bDN
 wrm
 whP
@@ -118928,8 +118916,8 @@ rvp
 juv
 wLU
 hIh
-tAE
-tAE
+vXz
+vXz
 uKF
 hsc
 fCX
@@ -119186,9 +119174,9 @@ aIV
 wfT
 qXC
 hIh
-tAE
+vXz
 bCC
-tAE
+vXz
 hsc
 rRF
 rRF
@@ -119444,8 +119432,8 @@ aIV
 wfT
 pML
 hIh
-tAE
-tAE
+vXz
+vXz
 dyt
 hsc
 hsc
@@ -119703,8 +119691,8 @@ wfT
 jfX
 hIh
 uKF
-tAE
-tAE
+vXz
+vXz
 hsc
 bCU
 bCU
@@ -119960,9 +119948,9 @@ aIV
 wfT
 oSC
 hIh
-tAE
-tAE
-tAE
+vXz
+vXz
+vXz
 hsc
 qaj
 pEj
@@ -120218,9 +120206,9 @@ aIV
 wfT
 kge
 hIh
-tAE
+vXz
 bCC
-tAE
+vXz
 hsc
 lwr
 gDl
@@ -122283,8 +122271,8 @@ pAE
 fhI
 hBX
 nTH
-lSj
-cqo
+pcM
+auu
 hHB
 sPW
 xPH
@@ -122541,8 +122529,8 @@ pAE
 kzp
 hBX
 nTH
-lSj
-cqo
+pcM
+auu
 hHB
 ufx
 fVy
@@ -123556,7 +123544,7 @@ xgk
 xRu
 xVM
 cbr
-kut
+pMu
 lOH
 gnf
 moL
@@ -128188,7 +128176,7 @@ dHa
 boE
 boE
 boE
-rcO
+csA
 dEw
 toJ
 wBn
@@ -128449,7 +128437,7 @@ boE
 jah
 boE
 pjr
-gxf
+cqo
 xFd
 isJ
 wLV
@@ -128710,7 +128698,7 @@ boE
 boE
 boE
 isJ
-rcO
+csA
 wBn
 nJi
 xyc

--- a/maps/southern_sun/southern_cross-3.dmm
+++ b/maps/southern_sun/southern_cross-3.dmm
@@ -151,8 +151,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
@@ -359,8 +358,7 @@
 "adI" = (
 /obj/structure/transit_tube/station,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -971,9 +969,8 @@
 /area/SouthernCrossV2/Bridge/Leisure_Room)
 "apA" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
@@ -1053,8 +1050,7 @@
 /obj/item/weapon/bedsheet/mimedouble,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/purcarpet,
@@ -1185,9 +1181,14 @@
 /turf/simulated/open,
 /area/SouthernCrossV2/Domicile/Chomp_Lounge)
 "auu" = (
-/obj/structure/lattice,
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber1)
 "auR" = (
 /obj/machinery/newscaster{
 	pixel_x = 28;
@@ -1430,14 +1431,10 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_AftStarCorridor1)
 "ayO" = (
-/obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/redgrid/animated,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+/obj/machinery/atmospherics/pipe/manifold/visible/green,
+/obj/effect/catwalk_plated,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "ayQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1455,8 +1452,7 @@
 /area/SouthernCrossV2/Medical/Aft_Medical_Post)
 "azb" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -1772,6 +1768,17 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Port)
+"aDw" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_AftCorridor1)
 "aDE" = (
 /obj/machinery/light{
 	dir = 8;
@@ -1847,7 +1854,7 @@
 	color = "yellow";
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "aES" = (
 /obj/structure/cable/green{
@@ -1902,14 +1909,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "aFT" = (
 /obj/machinery/iv_drip,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/camera/network/research{
 	c_tag = "D3-Med-Patient2";
@@ -2048,17 +2059,19 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/arrows/red,
-/obj/machinery/door/airlock/angled_bay/secure{
-	dir = 4;
+/obj/machinery/door/airlock/hatch{
+	icon_state = "door_locked";
 	id_tag = "SC-engine_access_hatch";
-	name = "Airtight Hatch";
 	locked = 1;
-	req_access = list(11);
-	req_one_access = list(12)
+	req_access = list(11)
 	},
-/obj/machinery/door/blast/radproof/open{
+/obj/machinery/door/blast/regular{
 	id = "SC-GCemitterview";
-	layer = 3.5
+	layer = 3.3;
+	name = "Reactor Blast Door";
+	icon_state = "pdoor0";
+	density = 0;
+	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -2187,10 +2200,12 @@
 /area/SouthernCrossV2/Maints/Deck3_Bridge_AftStarCorridor1)
 "aLj" = (
 /obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/greengrid,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
@@ -2538,8 +2553,7 @@
 /obj/structure/bed/chair/sofa/left/yellow,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Domicile/Chomp_Lounge)
@@ -2569,8 +2583,7 @@
 /area/SouthernCrossV2/Harbor/Aft_3_Deck_Airlock_Access)
 "aTK" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -2779,7 +2792,7 @@
 /area/SouthernCrossV2/Medical/Psych_Room_2)
 "aWE" = (
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "aWW" = (
 /obj/structure/cable/green{
@@ -2834,9 +2847,8 @@
 "aXC" = (
 /obj/structure/girder/reinforced,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForStarCorridor2)
@@ -2876,9 +2888,8 @@
 	pixel_x = -7
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/SouthernCrossV2/Bridge/HoP_Office)
@@ -3001,10 +3012,11 @@
 /obj/structure/window/phoronreinforced{
 	dir = 4
 	},
-/obj/machinery/door/blast/radproof{
-	dir = 4;
+/obj/machinery/door/blast/regular{
+	dir = 8;
 	id = "SC-GCreactor";
-	layer = 3.5
+	layer = 3.3;
+	name = "Reactor Blast Door"
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
@@ -3388,8 +3400,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "biX" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3451,9 +3462,8 @@
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "bjF" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -3465,8 +3475,7 @@
 "bjX" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber2)
@@ -3579,11 +3588,6 @@
 	dir = 4;
 	name = "1E-light fixture"
 	},
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "blw" = (
@@ -3591,8 +3595,7 @@
 /area/space)
 "blD" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
@@ -4224,12 +4227,7 @@
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Atmos Substation Bypass"
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForCorridor1)
 "bzr" = (
@@ -4321,8 +4319,7 @@
 /obj/structure/table/standard,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Medical/Virology)
@@ -4402,7 +4399,7 @@
 "bCC" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/random/trash,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortCorridor1)
 "bCG" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
@@ -4491,8 +4488,7 @@
 /obj/structure/table/steel,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4658,6 +4654,17 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Dorms_Substation)
+"bHa" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "bHh" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -4775,8 +4782,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForPort_Corridor2)
 "bJK" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Port)
@@ -4798,7 +4804,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "bJT" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -4939,7 +4945,8 @@
 	RCon_tag = "Solar - AftStar";
 	input_attempt = 1;
 	input_level = 150000;
-	output_level = 100000
+	output_level = 100000;
+	cur_coils = 2
 	},
 /obj/structure/cable,
 /obj/structure/sign/warning/high_voltage{
@@ -5061,9 +5068,8 @@
 /area/SouthernCrossV2/Medical/Aft_Medical_Post)
 "bNg" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
@@ -5074,9 +5080,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -5175,16 +5180,16 @@
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Autoresleeving)
 "bPl" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
@@ -5231,6 +5236,10 @@
 	color = "yellow"
 	},
 /obj/structure/disposalpipe/down,
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_AftStarCorridor1)
 "bQP" = (
@@ -5282,8 +5291,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Waste_Handling)
@@ -5448,8 +5456,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
@@ -5461,8 +5468,7 @@
 	color = "yellow";
 	dir = 4
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "bUF" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -5591,7 +5597,7 @@
 	color = "yellow";
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "bXz" = (
 /obj/structure/cable/green{
@@ -5771,8 +5777,7 @@
 "bZQ" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
@@ -5798,8 +5803,7 @@
 /area/SouthernCrossV2/Domicile/Public_Garden)
 "caz" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Domicile/Dormitory_12)
@@ -5915,7 +5919,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Dorms_StarCorridor1)
 "ccv" = (
 /obj/effect/catwalk_plated/white,
-/turf/simulated/floor/glass,
+/turf/simulated/floor/plating/turfpack/airless,
 /area/space)
 "ccx" = (
 /obj/machinery/door/firedoor/glass,
@@ -6165,6 +6169,11 @@
 /area/SouthernCrossV2/Bridge/HoP_Office)
 "chr" = (
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "cih" = (
@@ -6270,8 +6279,7 @@
 /area/SouthernCrossV2/Domicile/Dorm_Corridor_3)
 "cji" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber3)
@@ -6440,8 +6448,7 @@
 "clj" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
@@ -6502,8 +6509,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -6750,7 +6756,7 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_Breakroom)
 "cqo" = (
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
 "cqp" = (
 /turf/simulated/wall,
@@ -6879,12 +6885,15 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "csA" = (
-/obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
 	},
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber2)
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "csD" = (
 /obj/machinery/light{
 	dir = 8;
@@ -7124,8 +7133,7 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "cxj" = (
 /obj/structure/cable/cyan{
@@ -7341,7 +7349,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber1)
 "cBg" = (
 /obj/structure/cable/green{
@@ -7498,9 +7506,8 @@
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "cDM" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated/techmaint,
@@ -7536,9 +7543,8 @@
 /area/SouthernCrossV2/Domicile/Dormitory_12)
 "cEp" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -7846,8 +7852,7 @@
 "cHG" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -7883,8 +7888,7 @@
 /area/SouthernCrossV2/Harbor/Aft_3_Deck_Airlock_Access)
 "cIT" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -8249,7 +8253,7 @@
 	color = "yellow";
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "cOH" = (
 /obj/machinery/light_construct,
@@ -8646,8 +8650,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
@@ -8733,8 +8736,7 @@
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
 "cXq" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
@@ -8775,8 +8777,7 @@
 "cXW" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/table/bench/marble,
 /obj/structure/flora/pottedplant/bamboo,
@@ -8784,7 +8785,7 @@
 /area/SouthernCrossV2/Domicile/Dormitory_02)
 "cYb" = (
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "cYU" = (
 /obj/machinery/light{
@@ -8896,6 +8897,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "cZW" = (
@@ -8974,8 +8980,7 @@
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "dbm" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -9424,7 +9429,7 @@
 	color = "yellow";
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "dkU" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -9462,8 +9467,7 @@
 "dlA" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9518,24 +9522,23 @@
 /area/SouthernCrossV2/Domicile/Dormitory_03)
 "dmt" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/table/standard,
 /obj/random/maintenance/morestuff,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftCorridor2)
 "dmx" = (
-/obj/structure/cable/pink{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	color = "#989898";
@@ -9610,14 +9613,13 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Engineering/Deck3_1_Corridor)
 "doG" = (
-/obj/item/modular_computer/console/preset/sysadmin{
+/obj/item/modular_computer/console/preset/security{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -9678,7 +9680,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber2)
 "dpO" = (
 /turf/simulated/floor/tiled/kafel_full/white,
@@ -9813,8 +9815,7 @@
 "dtC" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Aft_3_Deck_Airlock_Access)
@@ -9897,8 +9898,7 @@
 /obj/structure/undies_wardrobe,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/item/device/threadneedle{
 	pixel_y = 11;
@@ -10016,7 +10016,7 @@
 "dyt" = (
 /obj/machinery/light/small,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortCorridor1)
 "dyy" = (
 /obj/structure/ladder{
@@ -10028,17 +10028,15 @@
 "dyJ" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber1)
 "dyU" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/bluegrid,
@@ -10123,8 +10121,7 @@
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "dzC" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber2)
@@ -10408,9 +10405,8 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/SouthernCrossV2/Medical/Autoresleeving)
@@ -10857,6 +10853,9 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "dLu" = (
@@ -11032,7 +11031,7 @@
 "dOz" = (
 /obj/random/trash,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "dOD" = (
 /obj/machinery/door/firedoor/border_only,
@@ -11126,6 +11125,10 @@
 /area/SouthernCrossV2/Bridge/Conference_Room)
 "dQv" = (
 /obj/machinery/power/smes/batteryrack/mapped,
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "dRb" = (
@@ -11376,8 +11379,7 @@
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "dTD" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -11460,8 +11462,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -11583,8 +11584,7 @@
 "dVO" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -11615,6 +11615,11 @@
 /area/SouthernCrossV2/Bridge/Control_Atrium)
 "dWa" = (
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "dWg" = (
@@ -11644,15 +11649,14 @@
 /obj/structure/cable/yellow,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "dWD" = (
 /obj/random/junk,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "dWR" = (
 /obj/structure/cable/green{
@@ -11682,8 +11686,7 @@
 /obj/structure/undies_wardrobe,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/item/device/threadneedle{
 	pixel_y = 11;
@@ -11868,12 +11871,10 @@
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Bridge/Breakroom)
 "dYS" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "dYY" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -12260,8 +12261,7 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "edc" = (
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "ede" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -12317,8 +12317,7 @@
 /area/SouthernCrossV2/Medical/Restrooms)
 "edU" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_AftPortCorridor1)
@@ -12372,9 +12371,8 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -12413,6 +12411,10 @@
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
 	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
@@ -12487,6 +12489,7 @@
 "ehe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "ehj" = (
@@ -12917,8 +12920,7 @@
 "eog" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -13080,10 +13082,15 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Star_3_Deck_Airlock_Access)
 "esF" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/SouthernCrossV2/Engineering/Engine2_Canister_Storage)
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "esI" = (
 /obj/structure/table/marble,
 /obj/item/weapon/material/kitchen/rollingpin{
@@ -13460,8 +13467,7 @@
 /area/SouthernCrossV2/Commons/Port_Breakroom)
 "ezA" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/loot_pile/maint/technical,
 /obj/random/trash,
@@ -13545,11 +13551,11 @@
 "eAz" = (
 /obj/structure/table/marble,
 /obj/item/toy/chewtoy,
-/obj/machinery/door/blast/shutters{
-	dir = 4;
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
 	layer = 3.3;
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
@@ -14054,6 +14060,9 @@
 /obj/structure/disposalpipe/down{
 	dir = 8
 	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "eIE" = (
@@ -14273,9 +14282,8 @@
 "eMl" = (
 /obj/machinery/vending/wardrobe/hydrobe,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -14343,8 +14351,7 @@
 "eMQ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14379,7 +14386,7 @@
 	req_access = list(11);
 	req_one_access = list(10)
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -14445,8 +14452,7 @@
 "eNQ" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber1)
@@ -14507,8 +14513,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for the engine radiator viewport shutters.";
@@ -14759,8 +14764,7 @@
 "eRh" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/item/frame,
 /turf/simulated/floor/plating,
@@ -15149,9 +15153,8 @@
 /area/SouthernCrossV2/Bridge/Deck3_Corridor)
 "eUM" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -15345,8 +15348,7 @@
 "eWG" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -15474,9 +15476,8 @@
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
 "eYV" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/shield_capacitor{
 	dir = 4
@@ -15570,8 +15571,7 @@
 	color = "yellow";
 	dir = 1
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "fal" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15666,9 +15666,8 @@
 /area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber1)
 "fbn" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -15719,7 +15718,7 @@
 	color = "yellow";
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
 "fbT" = (
 /obj/structure/cable/yellow{
@@ -15853,13 +15852,18 @@
 	name = "Christmas Spirit"
 	},
 /obj/structure/table/bench/glass,
-/obj/structure/cable/cyan{
+/obj/structure/cable/white{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/super{
 	pixel_y = 24;
 	dir = 1
+	},
+/obj/machinery/light_switch{
+	name = "N-light switch";
+	pixel_x = 12;
+	pixel_y = 27
 	},
 /turf/simulated/floor/greengrid,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
@@ -15928,6 +15932,10 @@
 	color = "yellow";
 	dir = 4
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForStarChamber1)
 "fdN" = (
@@ -15954,7 +15962,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "fey" = (
 /obj/machinery/light{
@@ -16119,14 +16127,17 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "ffT" = (
-/obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/catwalk_plated/techmaint,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/turf/simulated/floor/redgrid/animated,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "fgb" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -16288,8 +16299,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
@@ -16705,7 +16715,7 @@
 	dir = 1
 	},
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "fnn" = (
 /obj/structure/sign/flag/sol/left,
@@ -16776,8 +16786,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber1)
 "fod" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
@@ -16978,9 +16987,8 @@
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
 "frh" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightorange/border,
@@ -17062,19 +17070,23 @@
 /turf/simulated/floor/tiled/hydro,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
 "frX" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/window/titanium{
+	dir = 8
 	},
-/obj/effect/catwalk_plated/techmaint,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "fsh" = (
 /obj/structure/table/standard,
 /obj/random/maintenance/misc,
@@ -17220,13 +17232,12 @@
 	dir = 1
 	},
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "fvh" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17257,6 +17268,10 @@
 /obj/structure/railing/grey{
 	color = "yellow";
 	dir = 8
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Medical_StarCorridor1)
@@ -17469,9 +17484,8 @@
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "fzy" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Medical/Stairwell)
@@ -17944,8 +17958,7 @@
 "fGa" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18060,15 +18073,13 @@
 	pixel_y = -1
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber2)
 "fHm" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -18192,9 +18203,8 @@
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
 "fIG" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -18362,8 +18372,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/item/device/threadneedle{
 	pixel_y = 11;
@@ -18461,8 +18470,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
@@ -18516,8 +18524,7 @@
 "fNe" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/beige/border,
@@ -18590,11 +18597,11 @@
 /area/SouthernCrossV2/Medical/Autoresleeving)
 "fPf" = (
 /obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 8;
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
 	layer = 3.3;
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
@@ -18718,8 +18725,7 @@
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
 "fRd" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/girder/reinforced{
 	default_material = "lead"
@@ -18876,7 +18882,7 @@
 /area/SouthernCrossV2/Medical/Restrooms)
 "fTK" = (
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
 "fTX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18892,8 +18898,7 @@
 "fUa" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Commons/Aft_3_Deck_Stairwell)
@@ -18955,6 +18960,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/wood/alt/panel,
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
 "fUN" = (
@@ -19373,7 +19379,7 @@
 	},
 /area/SouthernCrossV2/Bridge/Firstaid_Post)
 "gci" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -19440,8 +19446,7 @@
 "gcY" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -19603,8 +19608,7 @@
 /area/SouthernCrossV2/Engineering/Engine_Tech_Storage)
 "gfN" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -19729,9 +19733,8 @@
 /area/SouthernCrossV2/Bridge/CE_Quarters)
 "gir" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -19753,8 +19756,7 @@
 /obj/machinery/clonepod/transhuman/full,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -19793,8 +19795,7 @@
 "gjw" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -19843,8 +19844,7 @@
 /obj/structure/undies_wardrobe,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle/wataur{
 	pixel_y = 18;
@@ -19995,7 +19995,7 @@
 	dir = 1;
 	name = "1N-lighting fixture"
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Engineering/Engine2_Canister_Storage)
 "gmD" = (
@@ -20260,9 +20260,8 @@
 /area/SouthernCrossV2/Bridge/AI_Upload_Hall)
 "gqf" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/random/crate,
 /turf/simulated/floor/plating,
@@ -20311,8 +20310,7 @@
 /area/SouthernCrossV2/Bridge/Control_Atrium)
 "gqI" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/open,
@@ -20342,6 +20340,9 @@
 /obj/structure/sign/small/warning/emerg_only{
 	desc = "Ladder for emergency use only";
 	pixel_y = 32
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_AftStarCorridor1)
@@ -20470,7 +20471,7 @@
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Medical/Stairwell)
 "gun" = (
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "guM" = (
 /obj/structure/cable/green{
@@ -20593,21 +20594,25 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "gxf" = (
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
-"gxt" = (
-/obj/effect/floor_decal/industrial/loading/blue{
+/obj/structure/railing/grey{
+	color = "yellow";
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/cut_corners/blue,
-/obj/structure/sign/department/conference_room{
-	name = "DOMICILE Department";
-	desc = "A sign indicating the location for Domicile department. Use the nearby chute for quick access."
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile{
-	color = "#989898"
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber2)
+"gxt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/area/SouthernCrossV2/Bridge/Deck3_Corridor)
+/turf/simulated/floor/tiled/milspec/raised,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "gxC" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -20685,8 +20690,7 @@
 	color = "yellow";
 	dir = 8
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "gzB" = (
 /obj/structure/railing/grey{
@@ -21096,7 +21100,7 @@
 /obj/structure/window/titanium{
 	dir = 8
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -21443,10 +21447,10 @@
 	pixel_y = -24
 	},
 /obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/cyan{
+/obj/structure/cable/white{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/greengrid,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
@@ -21527,8 +21531,7 @@
 "gLQ" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -21762,8 +21765,7 @@
 "gPw" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftPortChamber1)
@@ -22144,8 +22146,7 @@
 /turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Array_AftPort)
 "gWK" = (
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber1)
 "gWO" = (
 /obj/machinery/light{
@@ -22319,8 +22320,7 @@
 /obj/structure/undies_wardrobe,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/item/device/threadneedle{
 	pixel_y = 11;
@@ -22471,11 +22471,11 @@
 	nutriment_desc = list("sweet    bread" = 3, "tamarind" = 2, "gummy" = 1);
 	pixel_y = 10
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 8;
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
 	layer = 3.3;
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
@@ -22545,8 +22545,7 @@
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "hfj" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Commons/Star_3_Deck_Stairwell)
@@ -22585,12 +22584,11 @@
 /turf/simulated/floor/carpet/blue2,
 /area/SouthernCrossV2/Domicile/Dormitory_06)
 "hgu" = (
-/obj/structure/lattice,
 /obj/structure/railing/grey{
 	color = "yellow";
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber1)
 "hgw" = (
 /obj/structure/bed/chair/sofa/left/blue,
@@ -22626,7 +22624,7 @@
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "hgE" = (
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber1)
 "hgN" = (
 /turf/simulated/wall,
@@ -22916,9 +22914,8 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/tealcarpet,
 /area/SouthernCrossV2/Bridge/Secretary_Quarters)
@@ -22976,6 +22973,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber1)
+"hnY" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "hoi" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/deck/cards,
@@ -23092,13 +23096,12 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "hpR" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
 	},
-/turf/simulated/floor/greengrid,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "hqk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/effect/catwalk_plated,
@@ -23206,6 +23209,11 @@
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/SouthernCrossV2/Bridge/HoP_Office)
+"hsW" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/phoron,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/SouthernCrossV2/Engineering/Engine2_Canister_Storage)
 "hsZ" = (
 /obj/structure/displaycase,
 /obj/machinery/firealarm{
@@ -23642,8 +23650,7 @@
 "hAK" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Commons/Aft_3_Deck_Central_Corridor_1)
@@ -23680,8 +23687,7 @@
 /area/space)
 "hBG" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -23790,8 +23796,7 @@
 	name = "1E-emergency suit storage"
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/item/weapon/storage/box/admints,
 /obj/effect/floor_decal/techfloor/orange{
@@ -23927,6 +23932,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
+"hFd" = (
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "hFq" = (
 /mob/living/simple_mob/animal/passive/fish/koi{
 	name = "Mupert"
@@ -23958,9 +23976,8 @@
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "hGg" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24104,8 +24121,7 @@
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
 "hJs" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/landmark/event_spawn/morphspawn,
 /turf/simulated/floor/plating,
@@ -24301,8 +24317,7 @@
 /area/SouthernCrossV2/Engineering/Engine3_Control_Room)
 "hLS" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_StarCorridor1)
@@ -24472,10 +24487,14 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "hOk" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
+/obj/effect/catwalk_plated/techfloor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/greengrid,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "hOs" = (
 /obj/machinery/light{
 	name = "1S-light fixture"
@@ -24499,9 +24518,8 @@
 /area/SouthernCrossV2/Medical/Virology)
 "hOT" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -24615,9 +24633,8 @@
 /obj/machinery/vending/wardrobe/genedrobe,
 /obj/effect/floor_decal/borderfloorblack/full,
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Commons/Star_Breakroom)
@@ -24893,9 +24910,8 @@
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "hVq" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24918,8 +24934,7 @@
 /obj/structure/table/marble,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/item/weapon/storage/box/donut{
 	pixel_x = 4;
@@ -24948,8 +24963,7 @@
 "hVL" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/beige/bordercorner,
@@ -25171,6 +25185,10 @@
 	desc = "Ladder for emergency use only";
 	pixel_x = -32
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftCorridor2)
 "hZZ" = (
@@ -25217,7 +25235,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "iaG" = (
 /obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_alc{
+/obj/machinery/chemical_dispenser/bar_alc/full{
 	dir = 1;
 	pixel_y = -10
 	},
@@ -25577,8 +25595,7 @@
 "ifa" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -25590,11 +25607,6 @@
 /area/SouthernCrossV2/Bridge/Leisure_Room)
 "ifx" = (
 /obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/item/toy/mistletoe{
 	pixel_y = 17
 	},
@@ -25683,7 +25695,7 @@
 	input_level = 200000;
 	output_level = 200000
 	},
-/obj/structure/cable/green{
+/obj/structure/cable/white{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -25765,6 +25777,10 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
 	dir = 1
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForCorridor1)
 "iiF" = (
@@ -25819,8 +25835,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber1)
 "ijR" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
@@ -25857,8 +25872,7 @@
 "ikG" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -26066,9 +26080,8 @@
 /area/SouthernCrossV2/Commons/For_3_Deck_Stairwell)
 "inY" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Chamber1)
@@ -26087,8 +26100,7 @@
 "ios" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/machinery/field_generator{
 	anchored = 1;
@@ -26224,6 +26236,11 @@
 "irl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/ai_slipper,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "irr" = (
@@ -26232,9 +26249,8 @@
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber1)
 "irZ" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26458,13 +26474,15 @@
 	color = "yellow";
 	dir = 4
 	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "ivH" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Commons/Aft_3_Deck_Central_Corridor_1)
@@ -26811,9 +26829,8 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/SouthernCrossV2/Bridge/Captain_Quarters)
@@ -27019,13 +27036,16 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
 "iDQ" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/light/small,
 /obj/structure/girder/reinforced{
@@ -28091,6 +28111,11 @@
 "iVn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/ai_slipper,
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "iVs" = (
@@ -28130,6 +28155,14 @@
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/SouthernCrossV2/Bridge/Captain_Office)
+"iVz" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/valve/digital{
+	dir = 4;
+	name = "secondary TEG valve"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "iVE" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
@@ -28321,6 +28354,9 @@
 	desc = "Ladder for emergency use only";
 	pixel_y = 32
 	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Engineering/Atmospherics_Substation)
 "iYf" = (
@@ -28396,9 +28432,8 @@
 /area/SouthernCrossV2/Commons/Stairwell_For)
 "iZX" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Star_3_Deck_Airlock_Access)
@@ -29039,7 +29074,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "jjY" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -29087,9 +29122,8 @@
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
 "jkP" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -29125,8 +29159,7 @@
 /area/SouthernCrossV2/Bridge/Captain_Quarters)
 "jlt" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -29441,7 +29474,7 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Domicile/Dormitory_10)
 "jra" = (
-/obj/item/modular_computer/console/preset/security{
+/obj/item/modular_computer/console/preset/sysadmin{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
@@ -29885,9 +29918,8 @@
 /area/SouthernCrossV2/Domicile/Dormitory_08)
 "jyH" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber2)
@@ -30053,16 +30085,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "jCo" = (
 /obj/structure/bed/chair/sofa/corner/black{
 	dir = 1
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/carpet,
 /area/SouthernCrossV2/Bridge/HoS_Quarters)
@@ -30080,9 +30111,8 @@
 	pixel_x = 6
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -30206,11 +30236,11 @@
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "jET" = (
 /obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 4;
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
 	layer = 3.3;
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
@@ -30282,9 +30312,8 @@
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "jFL" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -30355,9 +30384,8 @@
 /area/SouthernCrossV2/Engineering/Atmospherics_Substation)
 "jGo" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForStarCorridor2)
@@ -30431,7 +30459,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Maints/Deck3_Center_Port)
 "jGz" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -30621,9 +30649,9 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Stairwell_Port)
 "jIY" = (
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -30903,6 +30931,11 @@
 	icon_state = "1-8"
 	},
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "jOy" = (
@@ -31194,8 +31227,7 @@
 "jUZ" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -31313,8 +31345,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -31614,8 +31645,7 @@
 /obj/structure/bed/chair/sofa/right/yellow,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Domicile/Chomp_Lounge)
@@ -31771,7 +31801,7 @@
 	color = "yellow";
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "keW" = (
 /obj/machinery/door/firedoor/glass,
@@ -31925,9 +31955,8 @@
 /area/SouthernCrossV2/Engineering/Engine2_Canister_Storage)
 "kgr" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -32282,8 +32311,7 @@
 "knU" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber1)
@@ -32581,8 +32609,7 @@
 	pixel_x = -4
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Construction_Area)
@@ -32645,14 +32672,13 @@
 "krb" = (
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -32678,6 +32704,7 @@
 "krr" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/random/trash,
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "krt" = (
@@ -32776,15 +32803,15 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_PortCorridor1)
 "ktl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "ktn" = (
@@ -32843,11 +32870,16 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/For_3_Deck_Airlock_Access_2)
 "kut" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 10
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber2)
 "kuy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -33021,8 +33053,7 @@
 /area/SouthernCrossV2/Medical/Autoresleeving)
 "kyx" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -33628,9 +33659,8 @@
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "kIW" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Substation)
@@ -33654,6 +33684,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Dorm_Corridor_1)
+"kJu" = (
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
 "kJA" = (
 /obj/machinery/camera/network/security{
 	dir = 4;
@@ -33995,6 +34031,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
+"kOP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "kOU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloor{
@@ -34223,9 +34266,8 @@
 /area/SouthernCrossV2/Commons/Stairwell_For)
 "kSR" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -34235,11 +34277,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
 	},
 /obj/random/junk,
 /obj/effect/catwalk_plated/techmaint,
@@ -34331,8 +34368,7 @@
 /area/SouthernCrossV2/Domicile/Public_Garden)
 "kUj" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -34535,7 +34571,7 @@
 	color = "yellow";
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "kXf" = (
 /obj/structure/railing/grey{
@@ -34551,9 +34587,8 @@
 /area/SouthernCrossV2/Bridge/Deck3_Corridor)
 "kXz" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Medical/Stairwell)
@@ -34658,12 +34693,12 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/SouthernCrossV2/Medical/Autoresleeving)
 "laf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "laj" = (
@@ -34772,7 +34807,7 @@
 /obj/structure/table/steel,
 /obj/random/soap,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "lby" = (
 /obj/machinery/door/firedoor/border_only,
@@ -34811,7 +34846,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -35803,6 +35838,15 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftCorridor2)
+"ltr" = (
+/obj/effect/catwalk_plated/white,
+/obj/machinery/light_switch{
+	name = "N-light switch";
+	pixel_x = 12;
+	pixel_y = 27
+	},
+/turf/simulated/floor/glass/turfpack/airless,
+/area/space)
 "luc" = (
 /obj/structure/railing{
 	dir = 1
@@ -35924,6 +35968,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "lwD" = (
@@ -36009,20 +36058,17 @@
 /area/SouthernCrossV2/Domicile/Chomp_Lounge)
 "lxJ" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "lxK" = (
-/obj/effect/floor_decal/industrial/stand_clear/blue{
+/obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile{
-	color = "#989898"
-	},
+/turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Bridge/Deck3_Corridor)
 "lxL" = (
 /obj/structure/bed/chair/office/dark{
@@ -36411,9 +36457,8 @@
 	pixel_x = 2
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -36501,9 +36546,8 @@
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForCorridor1)
 "lEX" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -36766,8 +36810,7 @@
 /obj/structure/undies_wardrobe,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/item/device/threadneedle{
 	pixel_y = 11;
@@ -36851,6 +36894,9 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "lKg" = (
@@ -36915,8 +36961,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftPortChamber1)
 "lLm" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36992,7 +37037,7 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "lMi" = (
 /obj/machinery/portable_atmospherics/canister/air/airlock,
@@ -37298,9 +37343,8 @@
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "lQu" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -37407,7 +37451,7 @@
 	color = "yellow";
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
 "lSr" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
@@ -38002,8 +38046,7 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
@@ -38067,8 +38110,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -38154,10 +38196,15 @@
 /area/SouthernCrossV2/Domicile/Dormitory_06)
 "mbm" = (
 /obj/structure/railing/grey{
-	color = "yellow"
+	color = "yellow";
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
 	},
 /turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
 "mbu" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -38207,8 +38254,7 @@
 /area/SouthernCrossV2/Domicile/Dormitory_10)
 "mbS" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
@@ -38367,13 +38413,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber2)
 "meA" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -38427,8 +38472,7 @@
 "mgv" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
@@ -38513,8 +38557,7 @@
 /obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
@@ -38558,7 +38601,7 @@
 /turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
 "mhK" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -38637,8 +38680,7 @@
 /obj/structure/undies_wardrobe,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/item/weapon/reagent_containers/food/drinks/cans/waterbottle/wataur{
 	pixel_y = 18;
@@ -38691,8 +38733,7 @@
 "mji" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -38711,8 +38752,7 @@
 	name = "1E-emergency suit storage"
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/item/weapon/storage/box/admints,
 /obj/effect/floor_decal/techfloor/orange{
@@ -38731,9 +38771,8 @@
 /area/SouthernCrossV2/Bridge/Secretary_Quarters)
 "mjz" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_PortCorridor1)
@@ -38762,7 +38801,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "mjJ" = (
 /obj/structure/table/steel,
@@ -39011,7 +39050,7 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "mmh" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -39026,6 +39065,7 @@
 	dir = 9
 	},
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "mmp" = (
@@ -39055,9 +39095,8 @@
 /area/SouthernCrossV2/Engineering/Construction_Area)
 "mmK" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/icecream_vat,
 /turf/simulated/floor/plating,
@@ -39231,6 +39270,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber3)
 "moT" = (
@@ -39532,6 +39572,10 @@
 	color = "yellow";
 	dir = 4
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Center_Port)
 "mtz" = (
@@ -39656,8 +39700,7 @@
 "mwU" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
@@ -39940,8 +39983,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/SouthernCrossV2/Domicile/Dormitory_06)
@@ -40040,8 +40082,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber3)
 "mDu" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber1)
@@ -40122,6 +40163,10 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
 	dir = 8
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_StarChamber1)
 "mEC" = (
@@ -40141,6 +40186,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/down,
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Engineering/Atmospherics_Substation)
 "mFn" = (
@@ -40430,8 +40479,7 @@
 /area/SouthernCrossV2/Bridge/CE_Quarters)
 "mKx" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
@@ -40918,8 +40966,7 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Medical/Patient_4)
@@ -40934,8 +40981,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
@@ -41476,6 +41522,13 @@
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/SouthernCrossV2/Bridge/Captain_Office)
+"ndq" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "ndB" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -41809,7 +41862,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber1)
 "niI" = (
 /obj/machinery/vending/foodveggie,
@@ -42105,9 +42158,8 @@
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "nnf" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Domicile/Dormitory_11)
@@ -42213,15 +42265,19 @@
 /obj/structure/disposalpipe/down{
 	dir = 1
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber1)
 "nqE" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
@@ -42253,9 +42309,8 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Bridge/Embassy)
@@ -42433,8 +42488,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "nts" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -42623,15 +42677,14 @@
 /area/SouthernCrossV2/Bridge/Control_Atrium)
 "nxS" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "nxY" = (
 /obj/structure/cable/yellow{
@@ -42728,6 +42781,15 @@
 /obj/machinery/door/airlock/angled_bay/elevator/glass,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Commons/Aft_3_Deck_Stairwell)
+"nyL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "nza" = (
 /obj/effect/floor_decal/industrial/warning/color/corner{
 	dir = 1
@@ -43757,7 +43819,7 @@
 	color = "yellow";
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "nOi" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -44222,9 +44284,9 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "nVM" = (
-/obj/structure/cable/yellow{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -44723,7 +44785,7 @@
 	color = "yellow";
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "odR" = (
 /obj/machinery/suit_storage_unit/engineering,
@@ -44806,7 +44868,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "oeX" = (
 /obj/structure/cable/cyan{
@@ -45134,9 +45196,8 @@
 /area/SouthernCrossV2/Maints/Deck3_Center_Port)
 "ojz" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
@@ -45148,8 +45209,7 @@
 /area/SouthernCrossV2/Domicile/Observation_Lounge)
 "ojN" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/loot_pile/maint/trash,
 /obj/random/trash,
@@ -45164,8 +45224,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/item/device/geiger/wall/south,
 /obj/effect/floor_decal/borderfloorblack,
@@ -45620,9 +45679,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated/techmaint,
@@ -45687,7 +45745,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "orM" = (
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -45791,9 +45849,8 @@
 "osR" = (
 /obj/structure/table/sifwoodentable,
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Bridge/RD_Quarters)
@@ -45827,7 +45884,10 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "otX" = (
-/obj/structure/cable/yellow,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/random/trash,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -46112,7 +46172,7 @@
 	dir = 8
 	},
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "oxk" = (
 /obj/machinery/light{
@@ -46273,8 +46333,7 @@
 "ozX" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/white{
 	d1 = 4;
@@ -46368,6 +46427,10 @@
 /obj/structure/railing/grey{
 	color = "yellow";
 	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Engineering/Construction_Area)
@@ -46697,8 +46760,7 @@
 "oIQ" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -46752,8 +46814,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "oJs" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
 /turf/simulated/floor/plating,
@@ -46891,8 +46952,7 @@
 /obj/structure/bed/chair/comfy/orange,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
@@ -47166,7 +47226,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -47210,9 +47270,8 @@
 /area/SouthernCrossV2/Harbor/For_3_Deck_Airlock_Access_2)
 "oPl" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
@@ -47255,8 +47314,7 @@
 "oPW" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -47380,7 +47438,7 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "oTc" = (
 /obj/machinery/power/apc{
@@ -47437,6 +47495,11 @@
 /area/SouthernCrossV2/Maints/Deck3_Medical_StarCorridor1)
 "oTP" = (
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "oUd" = (
@@ -47444,7 +47507,7 @@
 	color = "yellow";
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "oUk" = (
 /obj/machinery/atmospherics/pipe/tank/air{
@@ -47951,11 +48014,17 @@
 "pcM" = (
 /obj/structure/railing/grey{
 	color = "yellow";
-	dir = 1
+	dir = 4
 	},
-/obj/structure/lattice,
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
 /turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
+/area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber1)
 "pdb" = (
 /obj/random/junk,
 /obj/structure/table/rack/steel,
@@ -48133,8 +48202,7 @@
 	name = "Hot Loop Waste Gas pump"
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Waste_Handling)
@@ -48180,7 +48248,8 @@
 	RCon_tag = "Solar - ForStar";
 	input_attempt = 1;
 	input_level = 150000;
-	output_level = 100000
+	output_level = 100000;
+	cur_coils = 2
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -48218,19 +48287,30 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Medical/Deck3_Corridor)
 "pgQ" = (
-/obj/structure/cable/yellow{
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows/red{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/arrows/red,
+/obj/machinery/flasher{
+	id = "testthis";
+	name = "Doorframe mounted flash";
+	layer = 2.5
+	},
+/obj/machinery/door/airlock/angled_bay/vault{
+	name = "AI Core";
+	req_access = list(16);
+	req_one_access = list(16);
+	dir = 8;
+	locked = 1
+	},
+/obj/structure/cable/white{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
+/turf/simulated/floor/tiled/techmaint,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "phb" = (
 /obj/structure/lattice,
 /obj/structure/grille/rustic{
@@ -48424,15 +48504,13 @@
 /area/SouthernCrossV2/Bridge/RD_Quarters)
 "pld" = (
 /obj/structure/table/steel,
-/obj/item/stack/cable_coil/pink,
-/obj/item/stack/cable_coil/pink{
-	pixel_y = 4;
-	pixel_x = -2
+/obj/item/stack/cable_coil/yellow{
+	pixel_x = -7
 	},
-/obj/item/stack/cable_coil/pink{
-	pixel_y = 8;
-	pixel_x = -5
+/obj/item/stack/cable_coil/yellow{
+	pixel_y = 4
 	},
+/obj/item/stack/cable_coil/yellow,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "plL" = (
@@ -48604,6 +48682,19 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForStarCorridor1)
+"poQ" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/random/junk,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "ppd" = (
 /obj/structure/loot_pile/maint/junk,
 /obj/random/junk,
@@ -49038,6 +49129,10 @@
 	desc = "A heavily reinforced gate, sector lockdown!";
 	name = "Lockdown Gate"
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
 "pwP" = (
@@ -49127,7 +49222,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable/white{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -49442,7 +49537,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Engineering/Engine1_Control_Room)
 "pAU" = (
-/obj/item/modular_computer/console/preset/civilian,
+/obj/item/modular_computer/console/preset/research,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -25;
@@ -49901,8 +49996,7 @@
 "pJf" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/light{
 	name = "1S-light fixture"
@@ -50079,12 +50173,19 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Dormitory_10)
 "pMu" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "pMy" = (
 /obj/structure/sign/levels/engineering/solars{
 	dir = 4;
@@ -50104,7 +50205,7 @@
 /turf/simulated/wall,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "pMH" = (
-/obj/item/modular_computer/console/preset/ert,
+/obj/item/modular_computer/console/preset/engineering,
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
 	},
@@ -50178,7 +50279,10 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "pOt" = (
-/obj/structure/cable/yellow,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -50410,7 +50514,7 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Airlock_Access)
 "pSa" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -50653,9 +50757,8 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -51558,8 +51661,7 @@
 "qkC" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -51640,8 +51742,7 @@
 "qlY" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -51954,8 +52055,7 @@
 "qrz" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/table/glass,
 /obj/item/roller{
@@ -52057,8 +52157,7 @@
 "qtS" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/plating,
@@ -52066,6 +52165,10 @@
 "qtU" = (
 /obj/structure/railing/grey{
 	color = "yellow"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Center_Port)
@@ -52140,13 +52243,8 @@
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "qvB" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 4
-	},
-/obj/effect/engine_setup/pump_max,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "qvE" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -52299,8 +52397,7 @@
 "qys" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -52527,7 +52624,7 @@
 	},
 /area/SouthernCrossV2/Medical/Genetics_Lab)
 "qAk" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
@@ -52575,9 +52672,8 @@
 /area/SouthernCrossV2/Commons/Star_Breakroom)
 "qBq" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/light/small{
@@ -52791,9 +52887,8 @@
 /area/SouthernCrossV2/Engineering/Engine2_Waste_Handling)
 "qFG" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -52810,6 +52905,16 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Bridge/CE_Quarters)
+"qFW" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
 "qGo" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -52858,8 +52963,7 @@
 /area/SouthernCrossV2/Bridge/CMO_Quarters)
 "qHV" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -52977,6 +53081,7 @@
 	dir = 9
 	},
 /obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "qIy" = (
@@ -53039,6 +53144,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor2)
 "qJs" = (
@@ -53341,7 +53447,7 @@
 "qMF" = (
 /obj/random/trash,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "qMP" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -53575,8 +53681,7 @@
 "qTc" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_PortChamber1)
@@ -53674,9 +53779,8 @@
 /area/SouthernCrossV2/Engineering/Deck3_2_Corridor)
 "qUs" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -53798,8 +53902,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftCorridor2)
 "qXt" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -53836,9 +53939,13 @@
 /obj/structure/window/phoronreinforced{
 	dir = 4
 	},
-/obj/machinery/door/blast/radproof/open{
+/obj/machinery/door/blast/regular{
 	id = "SC-GCemitterview";
-	layer = 3.5
+	layer = 3.3;
+	name = "Reactor Blast Door";
+	icon_state = "pdoor0";
+	density = 0;
+	opacity = 0
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
@@ -54141,8 +54248,7 @@
 /area/SouthernCrossV2/Medical/Psych_Room_2)
 "rcO" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber2)
@@ -54208,7 +54314,7 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "rem" = (
 /obj/structure/cable{
@@ -54217,6 +54323,11 @@
 	icon_state = "2-4"
 	},
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "reI" = (
@@ -54344,8 +54455,7 @@
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "rfX" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -55153,8 +55263,7 @@
 	name = "1E-emergency suit storage"
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/item/weapon/storage/box/admints,
 /obj/effect/floor_decal/techfloor/orange{
@@ -55167,7 +55276,7 @@
 	color = "yellow";
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "rrK" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -55178,8 +55287,7 @@
 /area/SouthernCrossV2/Domicile/Public_Garden)
 "rsx" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -55213,6 +55321,11 @@
 	icon_state = "1-4"
 	},
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "rtM" = (
@@ -55382,9 +55495,8 @@
 	id = "sc-WTmental01"
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -55402,8 +55514,7 @@
 "rvv" = (
 /obj/structure/bed/chair/sofa/left/sif_ora,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -55574,19 +55685,13 @@
 	},
 /area/SouthernCrossV2/Medical/Genetics_Lab)
 "rxL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
 	},
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/milspec/raised,
-/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor2)
 "rxM" = (
 /obj/effect/floor_decal/industrial/warning/color{
 	dir = 9
@@ -55609,8 +55714,9 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/SouthernCrossV2/Domicile/Dormitory_02)
 "rys" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -55711,11 +55817,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 8;
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
 	layer = 3.3;
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
@@ -55727,8 +55833,7 @@
 "rzD" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/structure/table/standard,
 /obj/random/maintenance/misc,
@@ -55817,8 +55922,7 @@
 /area/SouthernCrossV2/Medical/Aft_Medical_Post)
 "rCN" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
@@ -55965,6 +56069,16 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Domicile/Dormitory_07)
+"rGp" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Center_Port)
 "rGv" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -56020,8 +56134,7 @@
 "rHD" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/SouthernCrossV2/Domicile/Dormitory_03)
@@ -56307,8 +56420,7 @@
 "rMh" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/beige/border,
@@ -56441,8 +56553,7 @@
 "rNS" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Domicile/Dormitory_11)
@@ -56533,7 +56644,7 @@
 /obj/structure/table/steel,
 /obj/random/coin/sometimes,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "rQW" = (
 /obj/structure/table/rack/steel,
@@ -56583,9 +56694,8 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 4
@@ -56869,18 +56979,17 @@
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "rXM" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForStarChamber1)
 "rXN" = (
-/obj/machinery/atmospherics/binary/pump/high_power{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "rXO" = (
@@ -56935,6 +57044,7 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Bridge/RD_Quarters)
 "rYu" = (
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber3)
 "rYI" = (
@@ -57085,8 +57195,7 @@
 "saw" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Bridge/Control_Atrium)
@@ -57101,7 +57210,7 @@
 /obj/random/trash,
 /obj/structure/table/steel,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "sbr" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -57550,9 +57659,8 @@
 /area/SouthernCrossV2/Maints/Deck3_Bridge_AftStarCorridor1)
 "siU" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
@@ -58349,6 +58457,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Commons/Star_Breakroom)
+"sux" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "suB" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -58361,7 +58477,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber1)
 "suJ" = (
 /obj/effect/floor_decal/industrial/arrows/blue,
@@ -58517,8 +58633,7 @@
 "sxg" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/beige/bordercorner,
@@ -58583,9 +58698,8 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -58673,6 +58787,11 @@
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber3)
 "szK" = (
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "sAc" = (
@@ -59145,11 +59264,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Bridge/HoS_Quarters)
+"sIb" = (
+/obj/random/trash,
+/obj/machinery/atmospherics/binary/pump/high_power,
+/obj/effect/floor_decal/industrial/outline/blue,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "sIi" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -59264,9 +59388,8 @@
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
 "sJb" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -59485,19 +59608,11 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Port)
 "sMO" = (
-/obj/machinery/alarm{
-	name = "W-alarm";
-	dir = 4;
-	pixel_x = -25
+/obj/structure/railing/grey{
+	color = "yellow"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/SouthernCrossV2/Commons/For_3_Deck_Stairwell)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "sMS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59765,8 +59880,7 @@
 /area/SouthernCrossV2/Medical/Surgery_Storage)
 "sQc" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -60262,6 +60376,16 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_PortCorridor1)
+"sZV" = (
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
 "tad" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -60367,13 +60491,13 @@
 	dir = 1
 	},
 /obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/cyan{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/white{
+/obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/greengrid,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
@@ -60419,6 +60543,11 @@
 	icon_state = "2-8"
 	},
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "tbC" = (
@@ -60440,7 +60569,7 @@
 	color = "yellow";
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "tbQ" = (
 /obj/effect/floor_decal/industrial/hatch,
@@ -60882,6 +61011,7 @@
 	color = "yellow";
 	dir = 1
 	},
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber3)
 "thx" = (
@@ -60890,8 +61020,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -61131,11 +61260,11 @@
 	pixel_x = 32;
 	pixel_y = -4
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 4;
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
 	layer = 3.3;
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -61234,9 +61363,8 @@
 /area/SouthernCrossV2/Harbor/For_3_Deck_Airlock_Access_2)
 "tln" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
@@ -61418,8 +61546,7 @@
 	color = "yellow";
 	dir = 1
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "toX" = (
 /obj/structure/railing/grey{
@@ -61431,6 +61558,10 @@
 	icon_state = "32-1"
 	},
 /obj/structure/lattice,
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "toY" = (
@@ -61579,6 +61710,15 @@
 	},
 /turf/simulated/floor/grass,
 /area/SouthernCrossV2/Domicile/Public_Garden)
+"tsU" = (
+/obj/effect/catwalk_plated/techfloor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/redgrid/animated,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "ttn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61600,8 +61740,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -61891,12 +62030,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
 "tAE" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
-	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortCorridor1)
 "tAO" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 8
@@ -62013,8 +62149,7 @@
 /area/SouthernCrossV2/Domicile/Dorm_Corridor_2)
 "tCO" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Port_3_Deck_Airlock_Access)
@@ -62023,9 +62158,8 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -62063,7 +62197,7 @@
 	color = "yellow";
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
 "tDY" = (
 /obj/machinery/door/firedoor/border_only,
@@ -62097,9 +62231,8 @@
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "tEM" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftPortChamber1)
@@ -62648,8 +62781,7 @@
 /obj/structure/undies_wardrobe,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/item/device/threadneedle{
 	pixel_y = 11;
@@ -62680,8 +62812,7 @@
 "tOx" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -62883,6 +63014,11 @@
 "tSp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
@@ -63093,9 +63229,15 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Domicile/Dormitory_05)
 "tWL" = (
-/obj/effect/catwalk_plated/techmaint,
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber2)
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
 "tWS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -63291,6 +63433,7 @@
 /area/SouthernCrossV2/Harbor/Aft_3_Deck_Airlock_Access)
 "tZh" = (
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "tZj" = (
@@ -63373,8 +63516,7 @@
 /area/SouthernCrossV2/Engineering/Construction_Area)
 "ubW" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
@@ -63636,11 +63778,11 @@
 /obj/machinery/cash_register/civilian{
 	dir = 8
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 8;
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
 	layer = 3.3;
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
@@ -63914,8 +64056,7 @@
 "uiX" = (
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -64375,6 +64516,10 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftStarChamber1)
 "urv" = (
@@ -64444,8 +64589,7 @@
 /area/space)
 "use" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -64528,9 +64672,8 @@
 /area/SouthernCrossV2/Bridge/AI_Upload_Hall)
 "ute" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated/techmaint,
@@ -64622,9 +64765,8 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -64633,8 +64775,7 @@
 "uuD" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/table/glass,
 /obj/item/roller{
@@ -64922,8 +65063,7 @@
 /area/SouthernCrossV2/Bridge/CMO_Quarters)
 "uzx" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -65147,6 +65287,12 @@
 "uCu" = (
 /turf/simulated/wall,
 /area/SouthernCrossV2/Domicile/Dormitory_10)
+"uCH" = (
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Bridge_ForStarChamber1)
 "uDd" = (
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor/plating,
@@ -65233,6 +65379,10 @@
 	dir = 8
 	},
 /obj/machinery/light/small,
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber2)
 "uDO" = (
@@ -65257,8 +65407,7 @@
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "uDZ" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -65359,9 +65508,8 @@
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber1)
 "uFm" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -65435,6 +65583,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber3)
+"uGc" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber1)
 "uGj" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -65562,7 +65720,7 @@
 "uKF" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/random/junk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortCorridor1)
 "uKX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -65673,9 +65831,8 @@
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "uMh" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Stairwell)
@@ -65746,8 +65903,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/item/device/threadneedle{
 	pixel_y = 11;
@@ -65945,8 +66101,7 @@
 /obj/structure/table/bench/marble,
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Domicile/Dormitory_10)
@@ -66278,6 +66433,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 10
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "uUN" = (
@@ -66458,29 +66618,17 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Star_3_Deck_Airlock_Access)
 "uWK" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows/red{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows/red,
-/obj/machinery/flasher{
-	id = "testthis";
-	name = "Doorframe mounted flash";
-	layer = 2.5
-	},
-/obj/machinery/door/airlock/angled_bay/vault{
-	name = "AI Core";
-	req_access = list(16);
-	req_one_access = list(16);
-	dir = 8;
-	locked = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
+/obj/structure/cable/white{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "uWM" = (
 /obj/structure/cable/green{
@@ -67013,8 +67161,7 @@
 /area/SouthernCrossV2/Medical/Deck3_Corridor)
 "veg" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -67117,8 +67264,7 @@
 /area/SouthernCrossV2/Domicile/Dorm_Corridor_1)
 "vfS" = (
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber1)
@@ -67238,9 +67384,8 @@
 /area/SouthernCrossV2/Bridge/Deck3_Corridor)
 "vht" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/kafel_full/white,
@@ -67462,16 +67607,14 @@
 "vlA" = (
 /obj/item/weapon/tool/wirecutters/brass,
 /obj/structure/table/steel,
-/obj/item/stack/cable_coil/white{
-	pixel_x = 4
-	},
-/obj/item/stack/cable_coil/white{
-	pixel_y = 5;
+/obj/item/stack/cable_coil/cyan,
+/obj/item/stack/cable_coil/cyan{
+	pixel_y = 10;
 	pixel_x = 1
 	},
-/obj/item/stack/cable_coil/white{
-	pixel_y = 9;
-	pixel_x = -1
+/obj/item/stack/cable_coil/cyan{
+	pixel_y = 4;
+	pixel_x = -6
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
@@ -67934,8 +68077,7 @@
 /area/SouthernCrossV2/Domicile/Dormitory_05)
 "vtd" = (
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
@@ -67988,6 +68130,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Engineering/Deck3_1_Corridor)
+"vtL" = (
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "vum" = (
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/tiled/white,
@@ -68186,11 +68335,7 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Bridge/Deck3_Corridor)
 "vxI" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
-	},
-/turf/simulated/open,
+/turf/simulated/wall,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftStarChamber1)
 "vxP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -68625,9 +68770,8 @@
 /area/SouthernCrossV2/Bridge/Deck3_Corridor)
 "vDz" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/SouthernCrossV2/Bridge/Captain_Office)
@@ -68699,9 +68843,8 @@
 /area/SouthernCrossV2/Bridge/Breakroom)
 "vEw" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForPort_Chamber1)
@@ -68870,7 +69013,7 @@
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Domicile/Chomp_Lounge)
 "vHp" = (
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -69138,8 +69281,7 @@
 "vJZ" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Medical/Patient_1)
@@ -69352,17 +69494,19 @@
 /obj/effect/floor_decal/industrial/arrows/red{
 	dir = 1
 	},
-/obj/machinery/door/airlock/angled_bay/secure{
-	dir = 4;
+/obj/machinery/door/airlock/hatch{
+	icon_state = "door_locked";
 	id_tag = "SC-engine_access_hatch";
-	name = "Airtight Hatch";
 	locked = 1;
-	req_access = list(11);
-	req_one_access = list(12)
+	req_access = list(11)
 	},
-/obj/machinery/door/blast/radproof/open{
+/obj/machinery/door/blast/regular{
 	id = "SC-GCemitterview";
-	layer = 3.5
+	layer = 3.3;
+	name = "Reactor Blast Door";
+	icon_state = "pdoor0";
+	density = 0;
+	opacity = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -69824,8 +69968,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
@@ -69894,18 +70037,16 @@
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Domicile/Dormitory_05)
 "vXz" = (
-/obj/effect/floor_decal/industrial/loading/blue{
-	dir = 4
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/cut_corners/blue,
-/obj/structure/sign/department/dock{
-	name = "HARBOR department";
-	desc = "A sign indicating the location for Harbor department. Use the nearby chute for quick access."
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile{
-	color = "#989898"
-	},
-/area/SouthernCrossV2/Commons/For_3_Deck_Stairwell)
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "vXB" = (
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Chamber1)
@@ -69970,7 +70111,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber1)
 "vYr" = (
 /obj/structure/cable{
@@ -70527,6 +70668,15 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
+"wgT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "whj" = (
 /obj/machinery/camera/network/security{
 	c_tag = "D3-Eng-Atmos1";
@@ -70610,8 +70760,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/machinery/button/windowtint{
 	name = "S-window tint control";
@@ -70722,8 +70871,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/SouthernCrossV2/Domicile/Dormitory_04)
@@ -70744,8 +70892,7 @@
 "wlX" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -70761,9 +70908,8 @@
 /area/SouthernCrossV2/Domicile/Dormitory_05)
 "wma" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -71481,6 +71627,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "wxE" = (
@@ -71692,11 +71843,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
@@ -71803,8 +71949,7 @@
 /obj/structure/dispenser/phoron,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightorange/border,
@@ -72590,7 +72735,7 @@
 	color = "yellow";
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "wPv" = (
 /obj/structure/fitness/weightlifter,
@@ -72921,8 +73066,7 @@
 "wTa" = (
 /obj/structure/table/marble,
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /obj/item/weapon/packageWrap{
 	pixel_x = 3;
@@ -73341,7 +73485,11 @@
 	color = "yellow";
 	dir = 1
 	},
-/turf/simulated/open,
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "wZe" = (
 /obj/structure/cable/green{
@@ -73405,7 +73553,7 @@
 /area/SouthernCrossV2/Medical/Virology)
 "wZN" = (
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber1)
 "xab" = (
 /obj/structure/railing/grey{
@@ -73641,11 +73789,11 @@
 /area/SouthernCrossV2/Domicile/Dorm_Corridor_4)
 "xcP" = (
 /obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 8;
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
 	layer = 3.3;
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73845,7 +73993,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "xfg" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -73995,8 +74143,7 @@
 	dir = 6
 	},
 /obj/machinery/alarm{
-	name = "N-alarm";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
@@ -74024,8 +74171,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
@@ -74112,7 +74258,7 @@
 /turf/simulated/wall,
 /area/SouthernCrossV2/Bridge/CE_Quarters)
 "xjG" = (
-/obj/item/modular_computer/console/preset/research,
+/obj/item/modular_computer/console/preset/civilian,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
@@ -74284,8 +74430,7 @@
 /obj/structure/undies_wardrobe,
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/item/device/threadneedle{
 	pixel_y = 11;
@@ -74780,9 +74925,8 @@
 /area/SouthernCrossV2/Bridge/Leisure_Room)
 "xsF" = (
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -74817,9 +74961,8 @@
 /area/SouthernCrossV2/Domicile/Dorm_Foyer)
 "xsY" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber2)
@@ -74906,9 +75049,8 @@
 "xvg" = (
 /obj/structure/table/glass,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -75020,7 +75162,7 @@
 /area/SouthernCrossV2/Bridge/RD_Quarters)
 "xwQ" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+/obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -75368,8 +75510,7 @@
 /obj/structure/cable/yellow,
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
@@ -75453,11 +75594,11 @@
 /obj/machinery/cash_register/civilian{
 	dir = 4
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 4;
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
 	layer = 3.3;
-	name = "Kitchen Shutters"
+	name = "Kitchen Shutters";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
@@ -75510,7 +75651,7 @@
 /turf/simulated/open,
 /area/SouthernCrossV2/Domicile/Public_Garden)
 "xEA" = (
-/obj/structure/cable/green{
+/obj/structure/cable/white{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -75593,8 +75734,7 @@
 "xFU" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -75773,8 +75913,7 @@
 "xIq" = (
 /obj/machinery/alarm{
 	dir = 4;
-	name = "W-alarm";
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -75924,9 +76063,8 @@
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
 "xJH" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/SouthernCrossV2/Bridge/Captain_Office)
@@ -76047,8 +76185,7 @@
 "xLu" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 22
 	},
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Bridge/Breakroom)
@@ -76459,9 +76596,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber1)
@@ -76472,8 +76608,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	name = "E-alarm";
-	pixel_x = 25
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -76576,9 +76711,8 @@
 	dir = 1
 	},
 /obj/machinery/alarm{
-	pixel_y = -25;
-	name = "S-alarm";
-	dir = 1
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor/bluegrid,
 /area/SouthernCrossV2/Bridge/Cyborg_Station)
@@ -76732,7 +76866,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/pink{
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -77046,9 +77180,8 @@
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_2)
 "yaw" = (
 /obj/machinery/alarm{
-	name = "E-alarm";
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForPort_Corridor2)
@@ -77062,6 +77195,9 @@
 /obj/structure/railing/grey{
 	color = "yellow";
 	dir = 8
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Engineering/Construction_Area)
@@ -77234,9 +77370,8 @@
 	dir = 8
 	},
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 8
@@ -77612,9 +77747,8 @@
 /area/SouthernCrossV2/Medical/Virology)
 "yjc" = (
 /obj/machinery/alarm{
-	name = "W-alarm";
 	dir = 4;
-	pixel_x = -25
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Port)
@@ -77742,6 +77876,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "ykl" = (
@@ -77770,8 +77909,7 @@
 "ykt" = (
 /obj/machinery/alarm{
 	dir = 1;
-	name = "S-alarm";
-	pixel_y = -25
+	pixel_y = -22
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber3)
@@ -77875,7 +78013,7 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "ylV" = (
-/obj/item/modular_computer/console/preset/engineering,
+/obj/item/modular_computer/console/preset/ert,
 /obj/machinery/light{
 	dir = 1;
 	name = "1N-lighting fixture"
@@ -84185,7 +84323,7 @@ hjD
 ava
 dXG
 ava
-ava
+gci
 ava
 ccv
 ccv
@@ -89905,16 +90043,16 @@ mzY
 eHd
 xFr
 dLl
-xpL
+csA
 qIw
 ehe
 ehe
 mml
-jXK
-jXK
-jXK
-jXK
-gjd
+dYS
+dYS
+dYS
+dYS
+ayO
 fHn
 jtv
 dHa
@@ -90162,7 +90300,7 @@ jqa
 hpy
 vmW
 fCr
-ary
+kOP
 uqb
 ary
 ary
@@ -90420,7 +90558,7 @@ xvN
 hZk
 gwJ
 pfq
-gwJ
+rXN
 kde
 mFO
 vly
@@ -90678,7 +90816,7 @@ dAz
 hZk
 ija
 njj
-puR
+dFh
 puR
 ocL
 gnG
@@ -90924,8 +91062,8 @@ sZu
 eHp
 kgk
 oOx
-esF
-esF
+oQZ
+oQZ
 wHS
 kXZ
 oOx
@@ -90936,15 +91074,15 @@ wPJ
 mwZ
 nlI
 nhg
-puR
+dFh
 puR
 oFF
 wPJ
-pbI
-hOk
-csy
-twp
-tZQ
+puR
+gtE
+nhg
+puR
+dFh
 puR
 gjd
 tfI
@@ -91183,7 +91321,7 @@ vxq
 fey
 oOx
 gmz
-oQZ
+hsW
 moy
 dNq
 oOx
@@ -91194,11 +91332,11 @@ wPJ
 uAL
 cnv
 odf
-twp
+ghY
 sKt
 ciH
 cwb
-eQJ
+pbI
 vTu
 wuj
 twp
@@ -91456,11 +91594,11 @@ twp
 epU
 xBe
 wPJ
-pMu
+dFh
 puR
 nhg
 puR
-rXN
+dFh
 puR
 gjd
 uBR
@@ -92227,14 +92365,14 @@ eQJ
 cnv
 xRB
 twp
-tZQ
-puR
-ocL
-eQJ
+msq
+pbI
+sIb
+ghY
 vTu
 xDk
 twp
-tZQ
+msq
 puR
 gjd
 fHn
@@ -92472,7 +92610,7 @@ cHp
 uDZ
 ufa
 eaY
-jqn
+sZV
 aPD
 joW
 sOE
@@ -92485,14 +92623,14 @@ lkB
 puR
 puR
 puR
-qvB
+puR
+iVz
 puR
 puR
-kut
-twp
-twp
-twp
-msq
+puR
+puR
+puR
+puR
 puR
 vSq
 eQx
@@ -92743,8 +92881,8 @@ lzN
 twp
 twp
 twp
-ghY
 twp
+ghY
 pXp
 twp
 twp
@@ -95292,9 +95430,9 @@ jux
 sFC
 hDD
 gDe
-reN
+vtL
 tZh
-qjx
+sux
 qTm
 cDs
 pko
@@ -96291,7 +96429,7 @@ apc
 dHa
 elu
 lLJ
-frX
+cik
 pOt
 clB
 clB
@@ -96324,9 +96462,9 @@ jux
 xhg
 sjC
 clf
-reN
+vtL
 tZh
-qjx
+sux
 qTm
 jdR
 pko
@@ -96379,7 +96517,7 @@ qRA
 qRA
 qRA
 nVM
-pgQ
+heQ
 qBZ
 xyE
 dHa
@@ -96636,7 +96774,7 @@ uHI
 udu
 muz
 qRA
-fxW
+poQ
 liY
 oKg
 xyE
@@ -97632,7 +97770,7 @@ qTm
 qTm
 tNr
 qCG
-qCG
+rxL
 tcw
 eUk
 bBZ
@@ -97879,7 +98017,7 @@ clf
 wFS
 aWE
 aWE
-wYU
+ndq
 oAF
 uNr
 nAa
@@ -98137,7 +98275,7 @@ cni
 pbh
 orE
 mjG
-wYU
+bHa
 oAF
 rbQ
 kmO
@@ -98911,7 +99049,7 @@ qWl
 bnW
 aWE
 jCc
-wYU
+ndq
 oAF
 gTT
 lGS
@@ -98919,7 +99057,7 @@ gbu
 xKv
 pKJ
 wOf
-gbu
+lGS
 oAF
 cji
 szC
@@ -103285,7 +103423,7 @@ aoa
 apc
 hbN
 hbN
-mtj
+rGp
 jGw
 mqp
 yjc
@@ -104556,7 +104694,7 @@ idA
 pAl
 ylV
 iIX
-oDR
+avO
 dad
 pWH
 rvz
@@ -104814,7 +104952,7 @@ tWG
 bXW
 pMH
 erg
-avO
+oDR
 hIz
 blQ
 hcQ
@@ -105190,7 +105328,7 @@ xvd
 fke
 uXD
 xNK
-uBy
+iSZ
 xWY
 dHa
 dHa
@@ -105447,7 +105585,7 @@ xso
 tja
 kWj
 ihy
-iSZ
+aDw
 uBy
 xWY
 dHa
@@ -105533,7 +105671,7 @@ aqj
 kqq
 hjD
 hjD
-hjD
+ltr
 mJP
 oaL
 oaL
@@ -105798,7 +105936,7 @@ hag
 cNm
 cNm
 cNm
-cNm
+frX
 tTr
 qGo
 gGw
@@ -106072,7 +106210,7 @@ rMD
 kLs
 pVE
 aKr
-sMO
+gjw
 gSX
 xXn
 sdA
@@ -106084,9 +106222,9 @@ gjw
 vni
 sdA
 qIf
-vXz
+sdA
 lxK
-gxt
+aaM
 pdW
 wUP
 wUP
@@ -106568,11 +106706,11 @@ hjD
 oaL
 rZz
 uLN
-pQl
+uWK
 tSp
 irl
-cKn
-cKn
+nyL
+gxt
 cKn
 cKn
 cSs
@@ -106828,10 +106966,10 @@ bqN
 iUS
 xGf
 xGf
-ayO
-hpR
-hpR
-ffT
+euR
+xGf
+xEA
+euR
 pLe
 oHc
 mZV
@@ -107086,7 +107224,7 @@ bqN
 cLD
 xGf
 ezD
-uWK
+sHc
 ezD
 dQv
 aLj
@@ -107347,7 +107485,7 @@ tTr
 ifx
 tTr
 tTr
-aLj
+hOk
 wvZ
 wvZ
 mGv
@@ -107860,10 +107998,10 @@ eOx
 cLD
 tTr
 tTr
-cLD
-tTr
-tTr
 nTn
+tTr
+tTr
+hOk
 wvZ
 wvZ
 rTI
@@ -108118,7 +108256,7 @@ bqN
 cLD
 xGf
 ezD
-sHc
+pgQ
 ezD
 ihn
 tbb
@@ -108376,13 +108514,13 @@ bqN
 iUS
 xGf
 xGf
-euR
+yhJ
 xGf
 xEA
-yhJ
+tsU
 pLe
 oHc
-rTI
+pMu
 pQQ
 oZK
 eiK
@@ -108636,8 +108774,8 @@ lBH
 nPP
 iVn
 rvL
+wgT
 ouO
-rxL
 laf
 ktl
 bPl
@@ -108892,9 +109030,9 @@ qED
 vmy
 jRl
 dhi
+hFd
 uLN
-uLN
-uLN
+pQl
 blt
 lBH
 kYN
@@ -109410,7 +109548,7 @@ vfq
 cNm
 cNm
 cNm
-cNm
+frX
 tTr
 qGo
 gGw
@@ -110092,7 +110230,7 @@ mnR
 lsX
 nUd
 aPi
-gRp
+det
 hKY
 dHa
 dHa
@@ -111735,7 +111873,7 @@ dHa
 dHa
 dHa
 gEV
-evx
+uCH
 bHz
 gTB
 gTB
@@ -112089,7 +112227,7 @@ rFD
 rFD
 xGM
 mtz
-iwG
+vXz
 eXY
 eXY
 apc
@@ -112341,7 +112479,7 @@ hxM
 eXY
 iwG
 iwG
-iwG
+esF
 bNg
 ntp
 umB
@@ -112369,7 +112507,7 @@ lmX
 sOH
 xmc
 iAN
-iAN
+tWL
 lkh
 uDF
 tYA
@@ -112627,9 +112765,9 @@ lmX
 sOH
 xmc
 aVj
-aVj
+kJu
 vll
-aVj
+sVX
 tYA
 fGE
 oMy
@@ -112885,9 +113023,9 @@ lmX
 lmX
 xmc
 xIE
-xIE
+qFW
 lkh
-xIE
+mbm
 tYA
 uwA
 jga
@@ -113427,7 +113565,7 @@ uYL
 qMf
 msL
 tZq
-fbj
+uGc
 gwf
 gbc
 fbj
@@ -113686,7 +113824,7 @@ qMf
 phH
 mmM
 xtq
-qSC
+pcM
 gbc
 gms
 uER
@@ -116473,7 +116611,7 @@ oSW
 tMD
 bXe
 gzl
-dYS
+gzl
 dpB
 mwU
 iue
@@ -116709,10 +116847,10 @@ kcG
 pZA
 hsw
 axl
-tWL
-tWL
-tWL
-tWL
+ayA
+ayA
+ayA
+ayA
 rFQ
 wro
 gvN
@@ -116726,12 +116864,12 @@ mDu
 kAF
 nHT
 gSg
-gxf
-mbm
+edc
+cwY
 tKz
 wPn
 bUf
-tAE
+bUf
 dpB
 tbD
 tbD
@@ -116958,7 +117096,7 @@ rPo
 kcG
 kcG
 keO
-pei
+hpR
 pZA
 cXq
 kcG
@@ -116967,10 +117105,10 @@ vwH
 ulO
 ayA
 ayA
-tWL
-tWL
-tWL
-tWL
+ayA
+ayA
+ayA
+ayA
 rFQ
 rFQ
 maN
@@ -117216,38 +117354,38 @@ kfL
 kcG
 mfp
 toW
-uNb
+qvB
 pZA
-pei
+hpR
 nNW
 kcG
 vwH
 pZA
 aWm
 aWm
-tWL
-tWL
-tWL
-tWL
-tWL
+ayA
+ayA
+ayA
+ayA
+ayA
 rFQ
 jiV
 sYA
 sYA
 sYA
 qII
-sYA
-sYA
-sYA
+auu
+auu
+auu
 cAA
 wZN
 gSg
-gxf
-mbm
+edc
+cwY
 tMD
 bXe
-dYS
-dYS
+gzl
+gzl
 dpB
 eDW
 rPp
@@ -117474,34 +117612,34 @@ jhv
 kcG
 tcM
 toW
-uNb
+qvB
 pZA
-uNb
-kfL
+qvB
+sMO
 kcG
 vwH
 pZA
 aWm
 aWm
-tWL
-tWL
-tWL
-tWL
-tWL
+ayA
+ayA
+ayA
+ayA
+ayA
 rFQ
 qHV
 qht
 gYn
 xlY
 rFQ
-gYn
-gYn
 hgu
-gYn
-gYn
+hgu
+hgu
+hgu
+hgu
 gSg
-gxf
-mbm
+edc
+cwY
 tMD
 faj
 edc
@@ -117732,38 +117870,38 @@ kfL
 kcG
 kcG
 aEE
-fiE
+hnY
 pZA
-fiE
+hnY
 tbM
 kcG
 hZh
 pZA
 dzC
 hum
-tWL
-tWL
-tWL
-tWL
-tWL
+ayA
+ayA
+ayA
+ayA
+ayA
 rFQ
 kxl
 xSt
 iTY
 iTY
 rFQ
-iTY
-iTY
 gWK
-iTY
-iTY
+gWK
+gWK
+gWK
+gWK
 gSg
 edc
 cwY
 tMD
 oeW
-gxf
-gxf
+edc
+edc
 dpB
 kUH
 fgI
@@ -118248,7 +118386,7 @@ kcG
 kcG
 clj
 dkH
-pei
+hpR
 pZA
 hHO
 kcG
@@ -118532,9 +118670,9 @@ blM
 ixY
 iMd
 hIh
-qsY
-qsY
-qsY
+tAE
+tAE
+tAE
 hsc
 fdT
 pEj
@@ -118738,7 +118876,7 @@ dHa
 dbu
 fCm
 wam
-kfl
+ffT
 bDN
 wrm
 whP
@@ -118790,8 +118928,8 @@ rvp
 juv
 wLU
 hIh
-qsY
-qsY
+tAE
+tAE
 uKF
 hsc
 fCX
@@ -119048,9 +119186,9 @@ aIV
 wfT
 qXC
 hIh
-qsY
+tAE
 bCC
-qsY
+tAE
 hsc
 rRF
 rRF
@@ -119306,8 +119444,8 @@ aIV
 wfT
 pML
 hIh
-qsY
-qsY
+tAE
+tAE
 dyt
 hsc
 hsc
@@ -119565,8 +119703,8 @@ wfT
 jfX
 hIh
 uKF
-qsY
-qsY
+tAE
+tAE
 hsc
 bCU
 bCU
@@ -119822,9 +119960,9 @@ aIV
 wfT
 oSC
 hIh
-qsY
-qsY
-qsY
+tAE
+tAE
+tAE
 hsc
 qaj
 pEj
@@ -120080,9 +120218,9 @@ aIV
 wfT
 kge
 hIh
-qsY
+tAE
 bCC
-qsY
+tAE
 hsc
 lwr
 gDl
@@ -122145,8 +122283,8 @@ pAE
 fhI
 hBX
 nTH
-pcM
-auu
+lSj
+cqo
 hHB
 sPW
 xPH
@@ -123418,7 +123556,7 @@ xgk
 xRu
 xVM
 cbr
-dBo
+kut
 lOH
 gnf
 moL
@@ -128311,7 +128449,7 @@ boE
 jah
 boE
 pjr
-xFd
+gxf
 xFd
 isJ
 wLV
@@ -128572,7 +128710,7 @@ boE
 boE
 boE
 isJ
-csA
+rcO
 wBn
 nJi
 xyc

--- a/maps/southern_sun/southern_cross-4.dmm
+++ b/maps/southern_sun/southern_cross-4.dmm
@@ -10672,6 +10672,14 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/light/small,
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Outpost Reactor Power Input";
+	name_tag = "Outpost Reactor Input"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/storage)
 "tG" = (
@@ -25139,8 +25147,8 @@
 /area/surface/outside/plains/normal)
 "UQ" = (
 /obj/machinery/power/sensor{
-	name = "Powernet Sensor - Outpost Reactor Power";
-	name_tag = "Outpost Reactor Power"
+	name = "Powernet Sensor - Outpost Reactor Power Output";
+	name_tag = "Outpost Reactor Power Output"
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;


### PR DESCRIPTION
## About The Pull Request

<Here's the quick and easy stuff for the map. Got a lot more things that need doing but this should improve a lot of issues people are having currently.

## Changelog
:cl:
add: Added railings to many areas in maintenance which were missing them causing easy fall risk, especially around ladders. Maints is now 90% more Space OSHA approved!
add: Added lattices above the dock areas where maints trash exists. Hopefully this should keep the mice and raccoons safe.
add: Gave the AI a light switch so they don't have to live in a dark basement
del: Deleted the signs on deck 3 for a transit tube that did not exist, and filled in the missing emergency shutter
del: Deleted the APC in the abandoned chapel. Area doesn't need power anyway and if someone wants to power it they can build their own APC. It wasn't wired up anyway.
del: Removed the AI entertainment monitors. AI doesn't like TV anyway and they were blocking intercoms
del: Removed the nitrous anaesthetic from Robotics
qol: The command office request consoles are now allowed to make station announcements
qol: Gave the kitchen their booze back
qol: Gives engineering a light replacer tool
qol: Added plating under the catwalks on the tesla platform so borgs can go for a space walk
fix: Fixed a couple of bypass breakers with wires underneath still, bypassing the bypass.
fix: Fixed a disposals bin above the botanical kitchen that wasn't connected to the network
fix: Added a missing connector for the airlock tanks on the secondary engine airlock
fix: Replaced airless plating in toxins lab with some breathable air.
fix: Fixed the air alarm naming conventions
fix: Hopefully fixed persistent storages (though can't test this). Locations of storages are up for debate but given the location of the qpad, I think cargo could benefit from a transit tube in future updates
fix: Fixed the terrain below medical that was having shields generated on it (lost the Sif look for now)
fix; Fixed the AI chamber wiring being back to front and causing the AI to die at round start
fix: Fixed some powernet sensors that weren't connected to the subgrids properly and added a distinction for outpost R-UST Input and Output grids. Deleted a doubled up engineering sensor.
maptweak: Remapped the supermatter cold loop to be a bit more beginner-friendly for modifications as well as making it flow better normally. Feel free to play with the setup in-round though!
maptweak: Replaced two Nitrogen canisters with phoron canisters in the supermatter gas storage (4 nitrogen 4 phoron to 2 nitrogen 6 phoron). Nitrogen gets used a lot more rarely and surprisingly few phoron canisters about. This should be a better QoL change for SM engines.
maptweak: Replaced engineering's advanced shield equipment with basic ones, so cargo still had one more reason to exist.
maptweak: Recoloured the secondary engine output wires from pink to yellow to differentiate it from the primary engine. This will be particularly useful later with plans I have for shield gens at some point-. Also recoloured the coils left for setup to cyan and yellow to match the wires in use in that area.
maptweak: Closed off a few drop vore spots that allowed too easy access to restricted areas with glass. You can still see and break in to eat people but no easy dropping in and printing whatever you want off the protolathe. Some less secure spots are left unprotected and have some lattices to allow escape, and I did the same with the public area spots as well.
maptweak: Rewired the solar APCs to run off mains so they don't shut down the airlocks when solars aren't working. Added an extra coil to the Eastern SMES to allow them to cope with the additional load from the extra arrays.
maptweak: Gave the bar pretty see-through shutters so it looks less industrial while closed
maptweak: Replaced the SM doors and blast doors with ones that shouldn't melt so easy this time. Also the doors should be obvious that they're bolted now.
maptweak: Set the secondary engine power supply SMES output to off at round start so it doesn't drain all it's power before the second engine can be set up.
/:cl:
