### PR TITLE
Various map fixes

### DIFF
--- a/maps/southern_sun/southern_cross-1.dmm
+++ b/maps/southern_sun/southern_cross-1.dmm
@@ -3689,7 +3689,8 @@
 	name = "S-window tint control";
 	pixel_x = -12;
 	pixel_y = -26;
-	id = "sc-WTcustodian"
+	id = "sc-WTcustodian";
+	range = 10
 	},
 /obj/structure/cable/green,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -9354,6 +9355,11 @@
 /area/SouthernCrossV2/Engineering/Telecomms_Control_Room)
 "bzS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Science/PA_Chamber)
 "bzT" = (
@@ -12456,7 +12462,8 @@
 	id = "sc-GCxenoflora";
 	name = "Reception Shutters Control";
 	pixel_y = -24;
-	req_access = list(28)
+	req_access = list(55);
+	req_one_access = list(47)
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -13293,6 +13300,11 @@
 /obj/effect/floor_decal/techfloor/orange,
 /obj/effect/floor_decal/techfloor/hole/right,
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Science/PA_Chamber)
 "cSV" = (
@@ -15842,6 +15854,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Security/Exploration_Ship_Bay)
+"dLd" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall,
+/area/SouthernCrossV2/Commons/For_Transit_Foyer)
 "dLu" = (
 /obj/machinery/firealarm{
 	pixel_y = 25;
@@ -15995,7 +16011,6 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftPort_Chamber3)
 "dMY" = (
-/obj/structure/grille/rustic,
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
 "dNp" = (
@@ -20237,6 +20252,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Market_Stall_5)
+"eNj" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Commons/Central_1_Deck_Hall)
 "eNk" = (
 /obj/machinery/ai_status_display{
 	name = "1E-AI display";
@@ -24799,6 +24818,11 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4;
 	color = "#989898"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Science/PA_Chamber)
@@ -30311,6 +30335,11 @@
 /obj/effect/floor_decal/techfloor/orange,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Science/PA_Chamber)
@@ -37662,6 +37691,11 @@
 	dir = 4;
 	color = "#989898"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Science/PA_Chamber)
 "llQ" = (
@@ -41803,6 +41837,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Science/PA_Chamber)
 "mEB" = (
@@ -44188,7 +44227,6 @@
 /turf/simulated/floor/grass,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "nzv" = (
-/obj/structure/grille/rustic,
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "nzy" = (
@@ -45814,6 +45852,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Maints/Deck1_AftStar1_Corridor1)
+"oaQ" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
 "oaR" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/arrows/blue{
@@ -51345,10 +51387,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 6
 	},
-/obj/structure/table/steel{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/table/steel,
 /obj/item/device/lightreplacer,
 /obj/item/device/lightreplacer,
 /turf/simulated/floor/tiled/dark,
@@ -54679,7 +54718,6 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_StarChamber2)
 "qVj" = (
-/obj/structure/grille/rustic,
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Commons/For_Transit_Foyer)
 "qVn" = (
@@ -57028,8 +57066,10 @@
 	dir = 5
 	},
 /obj/machinery/power/emitter/antique{
-	dir = 4
+	dir = 4;
+	anchored = 1
 	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Science/PA_Chamber)
 "rKl" = (
@@ -61500,6 +61540,11 @@
 "trg" = (
 /obj/effect/floor_decal/techfloor/orange,
 /obj/machinery/atmospherics/pipe/simple/hidden/purple,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Science/PA_Chamber)
 "tri" = (
@@ -64216,6 +64261,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Science/PA_Chamber)
 "uqm" = (
@@ -65201,7 +65251,6 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/ab_SportsField)
 "uIl" = (
-/obj/structure/grille/rustic,
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Commons/Central_1_Deck_Hall)
 "uIn" = (
@@ -67597,6 +67646,14 @@
 /obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Engineering/Telecomms_Foyer)
+"vxE" = (
+/obj/machinery/door/airlock/angled_bay/standard/color/security{
+	dir = 4;
+	req_one_access = list(19,1);
+	req_access = null
+	},
+/turf/simulated/wall,
+/area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor2)
 "vxR" = (
 /obj/machinery/telecomms/server/presets/medical,
 /obj/effect/catwalk_plated/dark,
@@ -71871,6 +71928,11 @@
 /obj/effect/floor_decal/corner/purple/bordercorner{
 	dir = 8
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Science/PA_Chamber)
 "wZg" = (
@@ -72491,6 +72553,10 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Science/Research_Ship_Bay)
+"xiB" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Commons/Star_1Deck_Atrium)
 "xiM" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
@@ -91184,7 +91250,7 @@ vjR
 jbI
 arO
 ezl
-aaM
+oaQ
 dMY
 pYC
 lOW
@@ -103308,7 +103374,7 @@ jYA
 mNn
 fgr
 jYA
-jYP
+eNj
 jYP
 oJV
 abF
@@ -106607,7 +106673,7 @@ rjC
 rjC
 rjC
 rjC
-rjC
+vxE
 vIN
 amq
 vBS
@@ -106869,7 +106935,7 @@ iAD
 emE
 saS
 emE
-cnK
+dLd
 qVj
 jfT
 tFa
@@ -119048,7 +119114,7 @@ lxD
 nse
 uBF
 qFn
-qFn
+xiB
 nzv
 wax
 sHO

--- a/maps/southern_sun/southern_cross-2.dmm
+++ b/maps/southern_sun/southern_cross-2.dmm
@@ -3559,7 +3559,8 @@
 	id = "sc-GCsecurityreception";
 	name = "Reception Shutters Control";
 	pixel_x = -24;
-	req_access = list(28)
+	req_access = list(28);
+	pixel_y = 5
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -3569,6 +3570,15 @@
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
+	},
+/obj/machinery/button/remote/airlock{
+	desc = "A remote control switch for the brig foyer.";
+	id = "SC-ODsecurityfoyer";
+	name = "Brig Foyer Doors";
+	req_access = list(63);
+	dir = 4;
+	pixel_y = -5;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Security/Reception)
@@ -3945,11 +3955,6 @@
 /area/SouthernCrossV2/Security/HoS_Office)
 "aiz" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
@@ -3960,7 +3965,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "aiA" = (
@@ -4861,6 +4865,11 @@
 "akI" = (
 /obj/random/junk,
 /obj/structure/table/steel,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_StarCorridor1)
 "akJ" = (
@@ -5223,11 +5232,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "alU" = (
-/obj/machinery/smartfridge/drinks/showcase,
-/obj/machinery/firealarm{
-	pixel_y = -25;
-	name = "S-fire alarm";
-	dir = 1
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	dir = 1;
+	pixel_y = -13
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
@@ -6851,6 +6859,11 @@
 /obj/structure/table/steel,
 /obj/random/maintenance/cargo,
 /obj/random/maintenance/engineering,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_StarCorridor1)
 "ass" = (
@@ -9472,6 +9485,11 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/SouthernCrossV2/Domicile/Aft_Restroom)
 "aAZ" = (
@@ -10192,10 +10210,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Security/Prison_Wing)
 "aDy" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -10205,6 +10219,11 @@
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
+	},
+/obj/machinery/computer/guestpass{
+	dir = 4;
+	pixel_x = -19;
+	name = "1W-guest pass terminal"
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
@@ -12119,10 +12138,8 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Storage)
 "aJt" = (
-/obj/machinery/shield_capacitor{
-	dir = 8
-	},
-/obj/structure/cable/green{
+/obj/machinery/shield_capacitor,
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
@@ -15659,6 +15676,11 @@
 /obj/machinery/light{
 	dir = 1;
 	name = "1N-lighting fixture"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
@@ -19223,11 +19245,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Medical/Treatment_Hall)
 "bfF" = (
-/obj/structure/cable/green{
+/obj/machinery/shield_gen/external,
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/shield_gen/external,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "bfG" = (
@@ -19831,26 +19853,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Emergency_EVA)
 "bhm" = (
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control switch for the brig foyer.";
-	id = "SC-ODsecurityfoyer";
-	name = "Brig Foyer Doors";
-	req_access = list(63);
-	dir = 1;
-	pixel_y = -31;
-	pixel_x = -4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/button/remote/airlock{
-	desc = "A remote control switch for the brig foyer.";
-	id = "BrigFoyer";
-	name = "Brig Foyer Doors";
-	req_access = list(63);
-	dir = 1;
-	pixel_y = -31;
-	pixel_x = 5
-	},
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Security/Reception)
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck2_Civilian_StarCorridor1)
 "bho" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -21738,7 +21747,6 @@
 /turf/simulated/floor/carpet,
 /area/SouthernCrossV2/Cargo/QM_Office)
 "bnP" = (
-/obj/structure/grille/rustic,
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
 "bnQ" = (
@@ -21867,8 +21875,8 @@
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/button/remote/driver{
 	id = "SC-MSdisposals";
-	name = "Chapel Mass Driver";
-	pixel_x = -24
+	pixel_x = -24;
+	name = "trash mass driver button"
 	},
 /turf/simulated/floor,
 /area/SouthernCrossV2/Cargo/Waste_Disposals)
@@ -27862,8 +27870,7 @@
 /area/SouthernCrossV2/Medical/FirstAid_Storage)
 "bKm" = (
 /obj/machinery/sleep_console{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29934,6 +29941,11 @@
 /obj/machinery/door/airlock/maintenance/int{
 	name = "Gym Access"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Gym)
 "bRA" = (
@@ -30631,7 +30643,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Security/Armory)
 "bUn" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
@@ -30983,9 +30995,8 @@
 	},
 /obj/machinery/door/airlock/angled_bay/double/glass/command{
 	dir = 8;
-	req_one_access = list(18);
 	req_access = null;
-	name = "E.V.A."
+	name = "Vault Lobby"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31557,6 +31568,11 @@
 	name = "Chapel Access"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_ForStarCorridor2)
 "bWZ" = (
@@ -32081,7 +32097,6 @@
 /turf/simulated/wall,
 /area/SouthernCrossV2/Cargo/For_Tool_Storage)
 "bYV" = (
-/obj/machinery/vending/foodmeat,
 /obj/machinery/light{
 	dir = 4;
 	name = "1E-light fixture"
@@ -34068,21 +34083,41 @@
 /turf/simulated/floor/carpet/oracarpet,
 /area/SouthernCrossV2/Domicile/Library)
 "cfo" = (
+/obj/structure/table/rack/shelf,
+/obj/item/weapon/storage/box/donkpockets{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/item/weapon/storage/box/donkpockets/berry{
+	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/weapon/storage/box/donkpockets/gondola{
+	pixel_x = -9;
+	pixel_y = -7
+	},
+/obj/item/weapon/storage/box/donkpockets/honk{
+	pixel_x = -9;
+	pixel_y = -3
+	},
+/obj/item/weapon/storage/box/donkpockets/pizza{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/weapon/storage/box/donkpockets/spicy{
+	pixel_x = -9;
+	pixel_y = 1
+	},
+/obj/item/weapon/storage/box/donkpockets/teriyaki{
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/box/donkpockets/teriyaki{
+	pixel_y = 5
+	},
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
 	pixel_y = -27;
 	name = "1S-extinguisher cabinet"
-	},
-/obj/machinery/chemical_dispenser/bar_soft/full{
-	dir = 8;
-	pixel_x = 13
-	},
-/obj/structure/table/marble,
-/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
-	pixel_x = 3
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
@@ -35303,31 +35338,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Security/Armory)
 "ciN" = (
-/obj/structure/table/marble,
-/obj/item/weapon/reagent_containers/glass/rag,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
-/obj/item/weapon/flame/lighter/zippo/skull{
-	pixel_y = 2;
-	pixel_x = -7
-	},
-/obj/item/clothing/head/that{
-	pixel_x = -8;
-	pixel_y = 11
-	},
-/obj/item/weapon/book/codex/chef_recipes{
-	pixel_y = 4;
-	pixel_x = 9
-	},
-/obj/item/weapon/reagent_containers/food/drinks/flask/vacuumflask{
-	pixel_y = 5;
-	pixel_x = 3
-	},
-/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
-	pixel_y = -2;
-	pixel_x = 6
-	},
+/obj/machinery/smartfridge/drinks/showcase,
 /turf/simulated/floor/wood/alt/tile,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
 "ciO" = (
@@ -35345,6 +35356,11 @@
 	},
 /obj/effect/floor_decal/corner/white/bordercorner2{
 	dir = 9
+	},
+/obj/machinery/computer/guestpass{
+	dir = 8;
+	pixel_x = 19;
+	name = "1E-guest pass terminal"
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
@@ -35729,7 +35745,6 @@
 /turf/simulated/floor/tiled/kafel_full,
 /area/SouthernCrossV2/Domicile/Aft_Restroom)
 "ckg" = (
-/obj/structure/grille/rustic,
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Lobby)
 "ckj" = (
@@ -36458,6 +36473,11 @@
 	icon_state = "restroom";
 	desc = "A warning sign which reads 'Restroom'."
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Domicile/Aft_Restroom)
 "cmF" = (
@@ -36884,6 +36904,11 @@
 /obj/structure/curtain/black{
 	name = "privacy curtain"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
 "cou" = (
@@ -37255,11 +37280,6 @@
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
 "cqs" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -37271,7 +37291,6 @@
 	dir = 4
 	},
 /obj/random/trash,
-/obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "cqt" = (
@@ -38625,6 +38644,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
+"cul" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Domicile/Aft_Restroom)
 "cum" = (
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor2)
@@ -38683,28 +38710,23 @@
 /turf/simulated/floor/tiled/airless,
 /area/SouthernCrossV2/Science/Testing_Chamber)
 "cuq" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Domicile_Substation)
 "cur" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Domicile_Substation)
 "cus" = (
 /obj/machinery/shield_capacitor{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
@@ -39390,10 +39412,6 @@
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Science/Server_Room)
 "cwE" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/item/weapon/storage/box/mixedglasses{
-	pixel_y = 14
-	},
 /obj/machinery/camera/network/security{
 	dir = 4;
 	c_tag = "D2-Dmc-Midnight Bar3";
@@ -40387,6 +40405,11 @@
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/green/bordercorner,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Lobby)
 "cAu" = (
@@ -41481,67 +41504,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Engineering/Engineering_Workshop)
 "cDS" = (
-/obj/structure/table/rack/shelf,
-/obj/item/weapon/storage/box/donkpockets{
-	pixel_x = 7;
-	pixel_y = -7
-	},
-/obj/item/weapon/storage/box/donkpockets/berry{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/weapon/storage/box/donkpockets/gondola{
-	pixel_x = -9;
-	pixel_y = -7
-	},
-/obj/item/weapon/storage/box/donkpockets/honk{
-	pixel_x = -9;
-	pixel_y = -3
-	},
-/obj/item/weapon/storage/box/donkpockets/pizza{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/weapon/storage/box/donkpockets/spicy{
-	pixel_x = -9;
-	pixel_y = 1
-	},
-/obj/item/weapon/storage/box/donkpockets/teriyaki{
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/box/donkpockets/teriyaki{
-	pixel_y = 5
-	},
-/obj/item/weapon/storage/box/donkpockets{
-	pixel_x = 7;
-	pixel_y = -7
-	},
-/obj/item/weapon/storage/box/donkpockets/gondola{
-	pixel_x = -9;
-	pixel_y = -7
-	},
-/obj/item/weapon/storage/box/donkpockets/berry{
-	pixel_x = 7;
-	pixel_y = -3
-	},
-/obj/item/weapon/storage/box/donkpockets/honk{
-	pixel_x = -9;
-	pixel_y = -3
-	},
-/obj/item/weapon/storage/box/donkpockets/pizza{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/weapon/storage/box/donkpockets/spicy{
-	pixel_x = -9;
-	pixel_y = 1
-	},
-/obj/item/weapon/storage/box/donkpockets/teriyaki{
-	pixel_y = 5
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 22
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/item/weapon/storage/box/mixedglasses{
+	pixel_y = 14
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
@@ -42550,6 +42519,11 @@
 	pixel_y = -30;
 	name = "1S-newscaster"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/SouthernCrossV2/Domicile/Aft_Restroom)
 "cGL" = (
@@ -43510,6 +43484,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Medical/Locker_Room)
+"cWa" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall,
+/area/SouthernCrossV2/Maints/Deck2_Cargo_AftCorridor2)
 "cWj" = (
 /obj/structure/sign/painting/public{
 	pixel_y = 32
@@ -45975,6 +45953,11 @@
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
 "dEh" = (
@@ -46403,14 +46386,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Maints/ab_Theater)
 "dIT" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/binary/passive_gate{
 	regulate_mode = 0;
 	unlocked = 1
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Medical_Substation)
@@ -47036,6 +47019,10 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Science_StarCorridor1)
+"dRp" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "dRD" = (
 /obj/structure/reagent_dispensers/fueltank/high,
 /turf/simulated/floor/plating,
@@ -48767,6 +48754,25 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/For_2_Deck_Corridor_1)
+"enP" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "enQ" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -50077,6 +50083,11 @@
 "eHz" = (
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/black/bordercorner,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
 "eHK" = (
@@ -51210,10 +51221,10 @@
 /area/SouthernCrossV2/Medical/Surgery_Viewing)
 "eSw" = (
 /obj/machinery/shield_capacitor{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green,
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Medical_Substation)
 "eSB" = (
@@ -51685,6 +51696,11 @@
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Gym)
@@ -53546,10 +53562,6 @@
 /area/SouthernCrossV2/Security/Boardroom)
 "fva" = (
 /obj/structure/table/standard,
-/obj/item/device/t_scanner/advanced{
-	pixel_y = 3;
-	pixel_x = 10
-	},
 /obj/item/device/measuring_tape{
 	pixel_y = 6;
 	pixel_x = -4
@@ -53571,6 +53583,10 @@
 /obj/structure/cable/green,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
+/obj/item/device/t_scanner{
+	pixel_y = 4;
+	pixel_x = 9
+	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Science/Locker_Room)
 "fvk" = (
@@ -54982,6 +54998,11 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
 "fOY" = (
@@ -56192,16 +56213,6 @@
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Security/Brig)
 "gbG" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Domicile_Substation)
 "gbH" = (
@@ -57102,15 +57113,15 @@
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "glE" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/light{
 	dir = 4;
 	name = "1E-light fixture"
 	},
 /obj/machinery/shield_gen/external,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Domicile_Substation)
 "glF" = (
@@ -58495,6 +58506,19 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_2)
+"gFa" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Domicile_Substation)
 "gFB" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 4
@@ -59651,10 +59675,6 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Stairwell)
 "gVl" = (
-/obj/structure/fireaxecabinet{
-	name = "1S-fire axe cabinet";
-	pixel_y = -29
-	},
 /obj/machinery/camera/network/security{
 	c_tag = "D2-Com-Aft Stairwell1";
 	network = list("Commons");
@@ -61305,7 +61325,6 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/For_2_Deck_Stairwell)
 "hqA" = (
-/obj/structure/grille/rustic,
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Security/Lobby)
 "hqB" = (
@@ -61971,20 +61990,15 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Science/Toxins_Storage)
 "hzO" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
+/obj/structure/cable{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Medical_Substation)
@@ -64792,8 +64806,8 @@
 /area/SouthernCrossV2/Science/Testing_Lab)
 "ilR" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green,
 /obj/machinery/shield_gen/external,
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Medical_Substation)
 "ilT" = (
@@ -64821,6 +64835,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Security_AftStarCorridor2)
+"imz" = (
+/obj/machinery/vending/boozeomat,
+/turf/simulated/wall,
+/area/SouthernCrossV2/Domicile/Midnight_Kitchen)
 "imD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -65066,7 +65084,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "ipx" = (
-/obj/structure/grille/rustic,
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "ipA" = (
@@ -66073,9 +66090,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/SouthernCrossV2/Security/Firing_Range)
 "iCs" = (
-/obj/machinery/vending/foodveggie,
-/turf/simulated/floor/wood/alt,
-/area/SouthernCrossV2/Domicile/Chomp_Dinner_2)
+/obj/structure/grille/rustic,
+/turf/simulated/wall,
+/area/SouthernCrossV2/Maints/Deck2_Medical_AftCorridor1)
 "iCL" = (
 /obj/machinery/light{
 	name = "1S-light fixture"
@@ -66952,6 +66969,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Aft_Corridor)
+"iMU" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck2_Civilian_StarCorridor1)
 "iNa" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -67112,6 +67138,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Medical/Patient_Ward)
+"iPo" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
 "iPq" = (
 /obj/machinery/light{
 	name = "1S-light fixture"
@@ -67977,6 +68007,11 @@
 /area/SouthernCrossV2/Security/Forensics_Office)
 "jbg" = (
 /obj/machinery/light/small,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_ForStarCorridor2)
 "jbo" = (
@@ -70722,6 +70757,14 @@
 /obj/machinery/light/small/neon/nif2,
 /turf/space,
 /area/SouthernCrossV2/Harbor/Port_Shuttlebay)
+"jPa" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/SouthernCrossV2/Domicile/Gym)
 "jPf" = (
 /obj/structure/table/standard,
 /obj/item/stack/cable_coil/random{
@@ -72441,6 +72484,11 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Lobby)
 "kmz" = (
@@ -73461,27 +73509,6 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 5
 	},
-/obj/machinery/turretid/stun{
-	pixel_y = 26;
-	req_access = list(29);
-	check_access = 0;
-	check_down = 0;
-	check_weapons = 1;
-	lethal_is_configurable = 0;
-	name = "transit turret control panel";
-	check_anomalies = 0;
-	check_arrest = 0;
-	check_records = 0
-	},
-/obj/machinery/power/apc/hyper{
-	name = "east bump";
-	pixel_x = 24;
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/For_2_Deck_Stairwell)
 "kDd" = (
@@ -73668,6 +73695,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/SouthernCrossV2/Domicile/Aft_Restroom)
 "kFL" = (
@@ -73755,6 +73787,11 @@
 "kHj" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
@@ -74588,6 +74625,11 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 10
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Gym)
 "kRC" = (
@@ -74875,6 +74917,18 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/SouthernCrossV2/Security/Boardroom)
+"kUY" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck2_Cargo_AftCorridor1)
 "kVa" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -74907,10 +74961,19 @@
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "kVy" = (
 /obj/structure/table/marble,
-/obj/machinery/chemical_dispenser/bar_alc/full{
-	pixel_x = -13;
-	pixel_y = 1;
-	dir = 4
+/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
+	pixel_y = 16;
+	pixel_x = 6
+	},
+/obj/item/weapon/book/codex/chef_recipes{
+	pixel_y = 10;
+	pixel_x = -7
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/small/peppermill{
+	pixel_x = 3
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
@@ -75116,7 +75179,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Security/Lobby)
 "kYA" = (
-/obj/structure/grille/rustic,
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "kYN" = (
@@ -76501,10 +76563,15 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Shuttlebay_Corridor)
 "lte" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
@@ -76871,6 +76938,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1;
 	icon_state = "pipe-j2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Lobby)
@@ -77828,6 +77900,14 @@
 	name = "yoga mat"
 	},
 /area/SouthernCrossV2/Domicile/Gym)
+"lNg" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/SouthernCrossV2/Domicile/Chapel_Morgue)
 "lNq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -78148,6 +78228,10 @@
 	id = "sc-GCmidnightbar";
 	layer = 3.1;
 	name = "Bar Shutters"
+	},
+/obj/machinery/light{
+	dir = 8;
+	name = "1E-light fixture"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
@@ -78538,7 +78622,7 @@
 	req_one_access = list(50)
 	},
 /turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Cargo/Breakroom)
+/area/SouthernCrossV2/Maints/Deck2_Cargo_AftCorridor1)
 "lVM" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -78893,6 +78977,13 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_ForStarCorridor1)
+"maA" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/SouthernCrossV2/Domicile/Gym)
 "maC" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows,
@@ -79079,6 +79170,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
+"mdu" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall,
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
 "mdY" = (
 /obj/structure/cable/green{
@@ -79646,6 +79741,15 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Medical_AftPortCorridor1)
+"mnn" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Medical_Substation)
 "mno" = (
 /obj/effect/decal/remains/tajaran,
 /obj/effect/decal/cleanable/greenglow,
@@ -83437,16 +83541,18 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_2_Deck_Corridor_2)
 "nsS" = (
-/obj/machinery/shield_capacitor,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/shield_capacitor{
+	dir = 8
 	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/camera/network/security{
 	dir = 8;
 	c_tag = "D2-Eng-Substation Domicile1";
 	network = list("engineering")
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Domicile_Substation)
@@ -83712,6 +83818,11 @@
 	pixel_y = 11;
 	pixel_x = -7
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Domicile/Aft_Restroom)
 "nws" = (
@@ -83759,6 +83870,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Cargo/Warehouse)
+"nxz" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall,
+/area/SouthernCrossV2/Security/Forensics_Office)
 "nxC" = (
 /turf/simulated/wall,
 /area/SouthernCrossV2/Bridge/HoP_Office)
@@ -84575,6 +84690,11 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Lobby)
@@ -85546,6 +85666,11 @@
 	icon_state = "1-4"
 	},
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Domicile_Substation)
 "nYH" = (
@@ -87228,6 +87353,15 @@
 	},
 /turf/simulated/wall,
 /area/SouthernCrossV2/Maints/Deck2_Cargo_StarChamber1)
+"oxz" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck2_Civilian_StarCorridor1)
 "oxE" = (
 /obj/machinery/disposal/wall/cleaner{
 	name = "1W-Resleeving lost & found bin";
@@ -88706,11 +88840,6 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/For_2_Deck_Stairwell)
 "oTP" = (
@@ -89592,6 +89721,11 @@
 /obj/machinery/door/airlock/maintenance/int{
 	name = "Chapel Access"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
 "pes" = (
@@ -89697,6 +89831,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Engineering/Locker_Room)
+"pfb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "pft" = (
 /obj/effect/floor_decal/industrial/arrows/red{
 	dir = 1
@@ -91537,6 +91679,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Cargo_AftCorridor2)
+"pCj" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Domicile_Substation)
 "pCJ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -91699,6 +91854,10 @@
 /obj/item/weapon/stool/baystool/padded,
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Domicile/Midnight_Bar)
+"pFk" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall,
+/area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "pFy" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -92358,6 +92517,11 @@
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Gym)
@@ -93060,8 +93224,8 @@
 "pWZ" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Medical_Substation)
@@ -93472,6 +93636,11 @@
 /obj/effect/floor_decal/shuttle/blue{
 	pixel_x = -1;
 	pixel_y = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
@@ -95784,11 +95953,11 @@
 /area/SouthernCrossV2/Maints/ab_TeshDen)
 "qKX" = (
 /obj/machinery/shield_capacitor{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green,
 /obj/machinery/light,
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Medical_Substation)
 "qLg" = (
@@ -95864,7 +96033,6 @@
 /turf/simulated/floor/tiled/airless,
 /area/SouthernCrossV2/Science/Testing_Chamber)
 "qLD" = (
-/obj/structure/grille/rustic,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -96004,6 +96172,20 @@
 	},
 /turf/simulated/wall,
 /area/SouthernCrossV2/Commons/Stairwell_Star)
+"qNd" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck2_Cargo_AftCorridor1)
 "qNz" = (
 /obj/item/stack/material/cardboard{
 	amount = 25
@@ -96159,6 +96341,11 @@
 	icon_state = "0-8"
 	},
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Medical_Substation)
 "qPt" = (
@@ -96717,6 +96904,11 @@
 	dir = 1;
 	pixel_y = -28
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Domicile/Aft_Restroom)
 "qYs" = (
@@ -96846,6 +97038,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/SouthernCrossV2/Security/Firing_Range)
 "rae" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
 "raf" = (
@@ -98228,11 +98425,6 @@
 "rsu" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
@@ -98628,6 +98820,11 @@
 	pixel_x = 25;
 	name = "E-fire alarm"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Domicile/Aft_Restroom)
 "rxm" = (
@@ -98664,6 +98861,16 @@
 /area/SouthernCrossV2/Engineering/Storage)
 "rxH" = (
 /obj/random/junk,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Medical_Substation)
 "rxI" = (
@@ -99655,6 +99862,11 @@
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Lobby)
 "rHb" = (
@@ -99986,6 +100198,14 @@
 	},
 /turf/simulated/wall,
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
+"rLh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/SouthernCrossV2/Domicile/Chapel_Lobby)
 "rLy" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -101132,16 +101352,14 @@
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Domicile/Midnight_Bar)
 "sbL" = (
-/obj/machinery/shield_capacitor{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
+/obj/machinery/shield_capacitor,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
@@ -101321,6 +101539,19 @@
 /obj/effect/decal/cleanable/filth,
 /turf/simulated/floor/wood/alt/panel,
 /area/SouthernCrossV2/Maints/ab_Theater)
+"sed" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "sex" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -103135,7 +103366,6 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_AftPortCorridor1)
 "sCt" = (
-/obj/structure/grille/rustic,
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
 "sCB" = (
@@ -103717,6 +103947,11 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 6
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
 "sJF" = (
@@ -104000,6 +104235,25 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/SouthernCrossV2/Domicile/Library)
+"sNK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Domicile/Gym)
 "sNL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -105513,6 +105767,11 @@
 "tkC" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Lobby)
 "tkH" = (
@@ -106483,6 +106742,11 @@
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "tzj" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
 "tzm" = (
@@ -109017,7 +109281,19 @@
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Security/Armory)
 "uhF" = (
-/obj/machinery/vending/boozeomat,
+/obj/structure/table/marble,
+/obj/machinery/chemical_dispenser/bar_alc/full{
+	pixel_y = -13;
+	dir = 1
+	},
+/obj/item/weapon/flame/lighter/zippo/skull{
+	pixel_y = 2;
+	pixel_x = -7
+	},
+/obj/item/clothing/head/that{
+	pixel_x = -8;
+	pixel_y = 11
+	},
 /turf/simulated/floor/wood/alt/tile,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
 "uhK" = (
@@ -109867,6 +110143,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Science/RD_Office)
+"usM" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall,
+/area/SouthernCrossV2/Maints/Research_Substation)
 "usY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -112583,6 +112863,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/SouthernCrossV2/Science/Testing_Lab)
+"vnH" = (
+/obj/structure/grille/rustic,
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Domicile/Aft_Restroom)
 "vnP" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable{
@@ -113336,17 +113620,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
 "vyg" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/random/trash,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Medical_Substation)
 "vyn" = (
@@ -113798,6 +114082,14 @@
 	},
 /turf/simulated/floor/carpet,
 /area/SouthernCrossV2/Domicile/Library_Office)
+"vES" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck2_Civilian_StarCorridor1)
 "vET" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -115013,6 +115305,19 @@
 "vZc" = (
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod3/station)
+"vZp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "vZs" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -117826,6 +118131,20 @@
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Central_Corridor_2)
+"wJo" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck2_Civilian_StarCorridor1)
 "wJt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -120041,6 +120360,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Morgue)
 "xoK" = (
@@ -121453,6 +121777,16 @@
 /obj/effect/floor_decal/corner/white/border,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
+"xJI" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck2_Civilian_ForStarCorridor2)
 "xJK" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -123377,6 +123711,10 @@
 	name = "\improper RAD SAFE";
 	desc = "A warning sign which reads 'RADIATION SHIELDING IN THIS AREA'.";
 	pixel_x = -32
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flask/vacuumflask{
+	pixel_y = 5;
+	pixel_x = 3
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
@@ -136272,7 +136610,7 @@ sBS
 kCb
 ahz
 sbL
-lte
+pfb
 aiz
 dbv
 lUc
@@ -136571,8 +136909,8 @@ wCI
 cSJ
 uZD
 alH
-bQr
-twl
+kUY
+qNd
 tXg
 bug
 aaa
@@ -136788,9 +137126,9 @@ fCI
 bmk
 ahz
 aJt
-lte
-dZD
-bSc
+vZp
+enP
+sed
 bSc
 bSc
 ahz
@@ -137600,13 +137938,13 @@ jhR
 wsk
 evp
 wCI
-snR
-snR
+wCI
+wCI
 lVA
-snR
-snR
-snR
-iOV
+wCI
+wCI
+wCI
+bug
 aaa
 aaa
 aaa
@@ -138598,7 +138936,7 @@ gDr
 ayB
 jnX
 ahz
-ahz
+dRp
 cQN
 mNU
 iiA
@@ -138612,7 +138950,7 @@ tAt
 okh
 vVx
 wAv
-wAv
+cWa
 aEG
 bnM
 bkO
@@ -151310,9 +151648,9 @@ xvF
 jeH
 uiW
 nYE
-cur
-cur
-cur
+gFa
+pCj
+pCj
 cur
 mga
 qfA
@@ -151462,7 +151800,7 @@ aAw
 aJg
 vNX
 aQG
-aTm
+nxz
 hqA
 bdj
 biV
@@ -151502,16 +151840,16 @@ pgb
 atZ
 end
 oma
-tkH
+pFk
 ilk
 chj
 bjJ
-tkH
+pFk
 aOO
 nDR
 xCF
 oWb
-apO
+mdu
 apO
 fpT
 nZi
@@ -152540,7 +152878,7 @@ aej
 aej
 fZP
 qQk
-sMt
+iPo
 bbp
 wbB
 vTN
@@ -153263,7 +153601,7 @@ aeQ
 iSG
 aeQ
 aeQ
-bhm
+aeQ
 ahl
 clq
 aJm
@@ -153390,7 +153728,7 @@ aMR
 aMR
 bMw
 nQK
-aGz
+imz
 atA
 gPC
 gPC
@@ -153913,7 +154251,7 @@ baY
 gPC
 gPC
 yjo
-gPC
+aGz
 gPC
 wct
 vdc
@@ -155108,7 +155446,7 @@ vxj
 vxj
 vxj
 xPc
-iCs
+vxj
 jAh
 cvf
 hYU
@@ -155164,7 +155502,7 @@ jWR
 sCC
 iLA
 ckg
-bOk
+vnH
 ckQ
 blg
 nVW
@@ -156975,7 +157313,7 @@ cmH
 hPt
 bOk
 vRq
-bOk
+cul
 bOk
 uCD
 wdf
@@ -157491,7 +157829,7 @@ cmH
 nrK
 xde
 uNL
-xde
+xJI
 bWY
 nMi
 lzt
@@ -157752,7 +158090,7 @@ rvV
 hPt
 gNy
 cnL
-rir
+rLh
 nDn
 bVT
 rir
@@ -158010,7 +158348,7 @@ rvV
 eff
 gNy
 cnM
-rir
+rLh
 ozj
 hwH
 dJS
@@ -160084,10 +160422,10 @@ xGd
 xGd
 xGd
 ieU
-uQd
+oxz
 bRz
 kRv
-pOX
+sNK
 pOX
 pOX
 pOX
@@ -160342,15 +160680,15 @@ uhC
 cnP
 tIV
 ieU
-rfR
+bhm
 qPt
 kWB
-acD
+jPa
 acD
 ydd
 ydd
 acD
-acD
+jPa
 acD
 xXo
 kxM
@@ -160603,12 +160941,12 @@ ieU
 aso
 qPt
 cvg
-acD
+maA
 byp
 ydd
 ydd
 acD
-acD
+maA
 cdv
 xXo
 uqj
@@ -161106,7 +161444,7 @@ cpH
 wHC
 cnP
 ggu
-rae
+lNg
 eHz
 dEa
 kHj
@@ -161114,9 +161452,9 @@ fOV
 kHj
 sJp
 pdX
-uQd
-ieU
-rfR
+iMU
+wJo
+vES
 gWZ
 gWZ
 gWZ
@@ -168010,7 +168348,7 @@ cgs
 xCE
 rkm
 jeI
-jeI
+usM
 jeI
 tdm
 hku
@@ -168024,7 +168362,7 @@ ukV
 sBX
 nYU
 uPY
-qLx
+iCs
 kXd
 ufJ
 cwr
@@ -169832,7 +170170,7 @@ eBL
 hPZ
 lWU
 gME
-rPP
+mnn
 dIT
 ybs
 qiY

--- a/maps/southern_sun/southern_cross-3.dmm
+++ b/maps/southern_sun/southern_cross-3.dmm
@@ -586,11 +586,17 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "ahv" = (
-/obj/structure/cable/yellow,
-/obj/machinery/power/terminal{
-	dir = 4
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Solar - AftPort";
+	input_attempt = 1;
+	input_level = 150000;
+	output_level = 100000
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable,
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = -32
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "ahK" = (
 /obj/structure/cable/green{
@@ -732,26 +738,6 @@
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Observation_Atrium)
-"akm" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/machinery/atmospheric_field_generator/perma/underdoors{
-	color = "Yellow"
-	},
-/obj/machinery/access_button{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/effect/map_helper/airlock/button/ext_button{
-	pixel_y = -14
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "aku" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -1331,16 +1317,6 @@
 /obj/effect/floor_decal/corner/lightorange/border,
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Commons/Port_Breakroom)
-"awS" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "axl" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -1889,15 +1865,11 @@
 /area/space)
 "aFL" = (
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
+/obj/machinery/light{
+	dir = 8;
+	name = "1E-light fixture"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "aFT" = (
 /obj/machinery/iv_drip,
@@ -2791,20 +2763,21 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Medical/Deck3_Corridor)
 "aXd" = (
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1381;
-	id_tag = "SC-ForStarSolar";
-	pixel_x = -24;
-	dir = 4
+/obj/machinery/power/apc/hyper{
+	pixel_y = -24;
+	name = "south bump"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "S-light switch";
+	pixel_x = 11;
+	pixel_y = -27
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/yellow,
+/obj/random/trash,
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "aXg" = (
 /obj/structure/sign/hydro{
 	layer = 3.5
@@ -3133,15 +3106,6 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_AftStarCorridor1)
-"bdA" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "bdC" = (
 /obj/item/weapon/stool/baystool/padded{
 	dir = 4
@@ -3955,9 +3919,12 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Dorm_Corridor_4)
 "btA" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/arrows,
+/obj/machinery/door/airlock/angled_bay/external/glass/red,
+/turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "btH" = (
 /turf/simulated/open,
@@ -3973,19 +3940,9 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Bridge/Control_Atrium)
 "buv" = (
-/obj/machinery/airlock_sensor{
-	pixel_x = -24;
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "buC" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -4062,10 +4019,22 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "bwg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = -2;
+	pixel_y = 11
 	},
-/obj/effect/catwalk_plated/techmaint,
+/obj/structure/table/steel,
+/obj/item/taperoll/engineering{
+	pixel_y = -1;
+	pixel_x = 9
+	},
+/obj/item/taperoll/engineering{
+	pixel_y = 1;
+	pixel_x = 7
+	},
+/obj/item/taperoll/atmos{
+	pixel_x = 3
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "bwo" = (
@@ -4913,19 +4882,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Dormitory_12)
 "bLC" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Solar - AftStar";
-	input_attempt = 1;
-	input_level = 150000;
-	output_level = 100000;
-	cur_coils = 2
-	},
-/obj/structure/cable,
-/obj/structure/sign/warning/high_voltage{
-	pixel_y = -32
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "bLD" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -6060,16 +6019,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Bridge/Captain_Office)
-"cfB" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "cgc" = (
 /obj/structure/sign/department/medbay{
 	layer = 3.5;
@@ -6143,26 +6092,27 @@
 /area/SouthernCrossV2/Bridge/HoP_Office)
 "chr" = (
 /obj/effect/catwalk_plated/techmaint,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
+/obj/random/trash,
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "cih" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Resleeving)
 "cik" = (
+/obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "cim" = (
 /obj/machinery/pipedispenser/disposal,
@@ -6588,35 +6538,11 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Engineering/Atmospherics_Control_Room)
 "coA" = (
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/lights/mixed{
-	pixel_x = 8;
-	pixel_y = 9
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/obj/item/device/radio{
-	pixel_x = -8;
-	pixel_y = -1
-	},
-/obj/item/device/radio{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/device/radio{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/device/radio{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/stack/cable_coil/yellow{
-	pixel_y = -1;
-	pixel_x = 16
-	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "coG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7014,14 +6940,9 @@
 /area/SouthernCrossV2/Bridge/Control_Atrium)
 "cvZ" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Array_AftStar)
@@ -8241,24 +8162,6 @@
 /obj/machinery/light_construct,
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Domicile/Dormitory_12)
-"cOJ" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/machinery/access_button{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/effect/map_helper/airlock/button/int_button{
-	pixel_y = -14
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "cOS" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -8412,6 +8315,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Bridge/Control_Atrium)
 "cRp" = (
@@ -8457,14 +8365,9 @@
 /area/SouthernCrossV2/Bridge/Leisure_Room)
 "cRB" = (
 /obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Array_ForStar)
@@ -8520,9 +8423,12 @@
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "cTi" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/arrows,
+/obj/machinery/door/airlock/angled_bay/external/glass/red,
+/turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "cTj" = (
 /obj/structure/railing,
@@ -8631,10 +8537,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "cVl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -8875,16 +8778,12 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "cZV" = (
+/obj/machinery/light{
+	dir = 4;
+	name = "1E-light fixture"
+	},
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "cZW" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -8943,20 +8842,15 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForPort_Corridor1)
 "dbf" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
@@ -9070,16 +8964,12 @@
 /turf/simulated/open,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_2)
 "dds" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/machinery/light{
+	dir = 4;
+	name = "1E-light fixture"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "ddt" = (
 /turf/simulated/floor/plating,
@@ -9821,17 +9711,22 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4;
 	regulate_mode = 0;
 	unlocked = 1
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "dvf" = (
@@ -9862,13 +9757,14 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Chamber1)
 "dvZ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/random/junk,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "dwb" = (
 /obj/machinery/status_display{
@@ -10907,10 +10803,22 @@
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_2)
 "dMC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = -2;
+	pixel_y = 11
 	},
-/obj/effect/catwalk_plated/techmaint,
+/obj/structure/table/steel,
+/obj/item/taperoll/engineering{
+	pixel_y = -1;
+	pixel_x = 9
+	},
+/obj/item/taperoll/engineering{
+	pixel_y = 1;
+	pixel_x = 7
+	},
+/obj/item/taperoll/atmos{
+	pixel_x = 3
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "dMY" = (
@@ -11200,16 +11108,13 @@
 /area/SouthernCrossV2/Domicile/Observation_Lounge)
 "dRW" = (
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/random/junk,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "dSf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11622,15 +11527,6 @@
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Bridge/Control_Atrium)
-"dWa" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "dWg" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -11656,11 +11552,7 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "dWD" = (
 /obj/random/junk,
@@ -11980,11 +11872,9 @@
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Bridge/Control_Atrium)
 "eap" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/atmospherics/pipe/tank/air/full,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "eau" = (
 /obj/structure/transit_tube/station{
 	dir = 1
@@ -12970,11 +12860,11 @@
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForCorridor1)
 "epg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "eps" = (
 /obj/structure/sign/directions/command{
@@ -13165,22 +13055,12 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "etz" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
+/obj/structure/fireaxecabinet{
+	name = "1E-fire axe cabinet";
+	pixel_x = 32
 	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/machinery/access_button{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/effect/map_helper/airlock/button/ext_button{
-	pixel_y = -14
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/Stairwell_Aft)
 "etB" = (
 /obj/structure/transit_tube{
 	icon_state = "D-SW"
@@ -13671,20 +13551,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
-"eBI" = (
-/obj/machinery/airlock_sensor{
-	pixel_x = 24;
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/catwalk_plated,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "eBJ" = (
 /obj/item/device/radio/intercom/department/medbay{
 	pixel_y = -22;
@@ -13821,10 +13687,20 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/SouthernCrossV2/Domicile/Dormitory_06)
 "eDT" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+/obj/machinery/cell_charger{
+	pixel_y = 11
 	},
-/obj/effect/catwalk_plated/techmaint,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "eDW" = (
@@ -14353,9 +14229,9 @@
 /turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Array_AftPort)
 "eMz" = (
-/obj/structure/cable/green,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/shield_gen/external,
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "eMJ" = (
@@ -15108,19 +14984,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Commons/Star_3_Deck_Stairwell)
-"eUg" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/machinery/atmospheric_field_generator/perma/underdoors{
-	color = "Yellow"
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "eUk" = (
 /obj/random/trash,
 /obj/effect/catwalk_plated/techmaint,
@@ -15241,12 +15104,14 @@
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Genetics_Lab)
 "eUU" = (
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
+/obj/structure/sign/directions/engineering/solars{
+	pixel_y = 9
 	},
-/turf/simulated/floor/plating,
+/obj/structure/sign/levels/engineering/solars{
+	dir = 8;
+	pixel_y = -9
+	},
+/turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "eUW" = (
 /obj/structure/disposalpipe/segment{
@@ -15531,13 +15396,13 @@
 	pixel_y = -22
 	},
 /obj/machinery/shield_capacitor{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/cable/green,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	name = "1S-light fixture"
 	},
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "eZc" = (
@@ -16041,23 +15906,6 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Engineering/Engine1_Control_Room)
-"feL" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/machinery/access_button{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/effect/map_helper/airlock/button/ext_button{
-	pixel_y = -14
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "feO" = (
 /obj/machinery/shower{
 	pixel_y = 16
@@ -16800,15 +16648,20 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/SouthernCrossV2/Domicile/Observation_Lounge)
 "fnF" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/cell_charger{
+	pixel_y = 11
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 6;
+	pixel_y = -3
 	},
-/obj/effect/catwalk_plated/techmaint,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "fnJ" = (
@@ -17369,13 +17222,13 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "fwW" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "fxe" = (
 /obj/machinery/hologram/holopad,
@@ -17440,14 +17293,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood/alt/tile,
 /area/SouthernCrossV2/Domicile/Observation_Lounge)
-"fxW" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/random/junk,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "fya" = (
 /turf/simulated/wall,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_AftPortCorridor1)
@@ -17746,36 +17591,14 @@
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Virology)
 "fCm" = (
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/lights/mixed{
-	pixel_x = 8;
-	pixel_y = 9
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/obj/item/device/radio{
-	pixel_x = -8;
-	pixel_y = -1
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/item/device/radio{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/device/radio{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/device/radio{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/stack/cable_coil/yellow{
-	pixel_y = -1;
-	pixel_x = 16
-	},
-/obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "fCn" = (
 /turf/simulated/open,
@@ -18162,14 +17985,21 @@
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Virology)
 "fHB" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Solar - ForStar";
+	input_attempt = 1;
+	input_level = 150000;
+	output_level = 100000;
+	cur_coils = 2
 	},
-/obj/structure/cable/yellow{
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = 32
+	},
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "fHI" = (
 /obj/machinery/door/firedoor/border_only,
@@ -19017,12 +18847,6 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Domicile/Dorm_Foyer)
-"fUQ" = (
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "fVy" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -19436,10 +19260,7 @@
 "gck" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/random/trash,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "gct" = (
 /obj/machinery/firealarm{
@@ -20040,6 +19861,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Engineering/Engine2_Canister_Storage)
 "gmD" = (
+/obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
@@ -20050,8 +19872,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "gnf" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -20485,16 +20306,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Star_3_Deck_Airlock_Access)
-"gtK" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "gud" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/techfloor/corner{
@@ -21537,19 +21348,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
-"gLt" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/machinery/atmospheric_field_generator/perma/underdoors{
-	color = "Yellow"
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "gLF" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/floor_decal/corner/white{
@@ -21815,11 +21613,11 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Medical/Lounge)
 "gQy" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "gQA" = (
 /turf/simulated/floor/carpet/blue2,
@@ -22432,6 +22230,11 @@
 "haC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "haI" = (
@@ -22524,13 +22327,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Dorm_Foyer)
 "heQ" = (
+/obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "hfg" = (
 /obj/structure/cable/green{
@@ -22640,16 +22443,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/valve/shutoff{
 	name = "Bridge automatic shutoff valve";
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "hgE" = (
@@ -23213,20 +23021,6 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Bridge/Conference_Room)
-"hsK" = (
-/obj/machinery/airlock_sensor{
-	pixel_x = -24;
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "hsN" = (
 /obj/structure/table/sifwoodentable,
 /obj/item/device/flashlight/lamp/green{
@@ -23276,8 +23070,17 @@
 /obj/effect/floor_decal/corner/blue/bordercorner{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled,
-/area/SouthernCrossV2/Bridge/Control_Atrium)
+/area/SouthernCrossV2/Security/Transit_Turrets)
 "hum" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -24011,6 +23814,11 @@
 	dir = 5
 	},
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "hGT" = (
@@ -24195,9 +24003,22 @@
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber3)
 "hKn" = (
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
+/obj/machinery/power/apc/hyper{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = 27;
+	name = "N-light switch"
+	},
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "hKr" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -24441,36 +24262,14 @@
 /turf/simulated/floor/grass,
 /area/SouthernCrossV2/Domicile/Public_Garden)
 "hNx" = (
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/lights/mixed{
-	pixel_x = 8;
-	pixel_y = 9
+/obj/machinery/power/terminal{
+	dir = 4
 	},
-/obj/item/device/radio{
-	pixel_x = -8;
-	pixel_y = -1
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/item/device/radio{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/device/radio{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/device/radio{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/stack/cable_coil/yellow{
-	pixel_y = -1;
-	pixel_x = 16
-	},
-/obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "hNz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -24494,14 +24293,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
 "hOa" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/random/trash,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "hOk" = (
 /obj/structure/cable/white{
@@ -24688,10 +24491,22 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "hQR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = -2;
+	pixel_y = 11
 	},
-/obj/effect/catwalk_plated/techmaint,
+/obj/structure/table/steel,
+/obj/item/taperoll/engineering{
+	pixel_y = -1;
+	pixel_x = 9
+	},
+/obj/item/taperoll/engineering{
+	pixel_y = 1;
+	pixel_x = 7
+	},
+/obj/item/taperoll/atmos{
+	pixel_x = 3
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "hRf" = (
@@ -25957,15 +25772,13 @@
 /area/SouthernCrossV2/Medical/Deck3_Corridor)
 "ikV" = (
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
+/obj/random/trash,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "ilN" = (
 /obj/machinery/vending/wardrobe/atmosdrobe,
@@ -25996,16 +25809,21 @@
 /turf/simulated/floor/carpet/blue2,
 /area/SouthernCrossV2/Domicile/Dormitory_06)
 "imB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
@@ -26996,6 +26814,11 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "iCy" = (
@@ -27177,27 +27000,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/For_3_Deck_Stairwell)
-"iEZ" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/machinery/atmospheric_field_generator/perma/underdoors{
-	color = "Yellow"
-	},
-/obj/machinery/access_button{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/effect/map_helper/airlock/button/int_button{
-	pixel_y = -14
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "iFp" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/clothing/head/greenbandana,
@@ -27260,7 +27062,7 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftPortChamber1)
 "iGW" = (
-/obj/machinery/vending/foodmeat,
+/obj/structure/table/woodentable,
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
 "iHm" = (
@@ -27615,12 +27417,6 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/SouthernCrossV2/Domicile/Botanical_Shop)
-"iMq" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/turf/simulated/floor/airless,
-/area/space)
 "iMv" = (
 /obj/machinery/light{
 	name = "1S-light fixture"
@@ -28072,28 +27868,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Bridge/Breakroom)
-"iUF" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/hatch,
-/obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "iUN" = (
 /obj/structure/dancepole{
 	pixel_x = 1
@@ -28451,9 +28225,13 @@
 /turf/simulated/floor/carpet/blue2,
 /area/SouthernCrossV2/Bridge/Captain_Quarters)
 "iYO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "iYR" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
@@ -28536,13 +28314,13 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Dorm_Corridor_4)
 "jaM" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "jbe" = (
 /obj/structure/bed/chair/sofa/right/orange{
@@ -30338,18 +30116,13 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
 "jFq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
@@ -30648,6 +30421,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "jIk" = (
@@ -30692,25 +30470,8 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Stairwell_Port)
 "jIY" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
-	},
-/obj/machinery/power/apc/hyper{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "jJp" = (
 /obj/structure/table/standard,
@@ -30967,20 +30728,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Medical/Virology)
-"jOu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "jOy" = (
 /turf/simulated/floor/grass,
 /area/SouthernCrossV2/Domicile/Public_Garden)
@@ -31534,14 +31281,6 @@
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/SouthernCrossV2/Domicile/Public_Garden)
-"jYN" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/random/trash,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "jYT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -31717,12 +31456,6 @@
 /obj/effect/floor_decal/corner/lightorange/border,
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Engineering/Engine2_Substation)
-"kct" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "kcG" = (
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
@@ -31867,10 +31600,7 @@
 /area/SouthernCrossV2/Medical/Patient_4)
 "kfl" = (
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "kfn" = (
 /obj/machinery/power/apc{
@@ -31885,11 +31615,12 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor2)
 "kfu" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/machinery/light{
+	dir = 8;
+	name = "1E-light fixture"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "kfG" = (
 /obj/machinery/door/firedoor/border_only,
@@ -32025,21 +31756,14 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/For_3_Deck_Stairwell)
 "kgC" = (
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = -2;
-	pixel_y = 11
-	},
 /obj/structure/table/steel,
-/obj/item/taperoll/engineering{
-	pixel_y = -1;
-	pixel_x = 9
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 1
 	},
-/obj/item/taperoll/engineering{
-	pixel_y = 1;
-	pixel_x = 7
-	},
-/obj/item/taperoll/atmos{
-	pixel_x = 3
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 1
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "D3-Eng-Solars AftStar1";
@@ -32117,13 +31841,13 @@
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Dorms_Substation)
 "kig" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Bridge/Firstaid_Post)
 "kiv" = (
 /obj/structure/sign/directions/roomnum{
 	pixel_y = 8;
@@ -32663,12 +32387,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
-"kqz" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/atmospherics/pipe/tank/air/full,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "kqE" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -33880,23 +33598,6 @@
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Observation_Lounge)
-"kMz" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/machinery/access_button{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/effect/map_helper/airlock/button/ext_button{
-	pixel_y = -14
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "kMO" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/red{
@@ -34299,14 +34000,14 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Port)
 "kSX" = (
+/obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/random/junk,
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "kTm" = (
 /obj/machinery/computer/arcade{
@@ -35054,16 +34755,6 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Bridge/Embassy)
-"lfl" = (
-/obj/structure/sign/levels/engineering/solars{
-	dir = 8;
-	pixel_y = -9
-	},
-/obj/structure/sign/directions/engineering/solars{
-	pixel_y = 9
-	},
-/turf/simulated/wall/r_wall,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "lfv" = (
 /obj/machinery/vending/wallmed1{
 	pixel_y = 26;
@@ -35255,14 +34946,18 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Airlock_Access)
 "liY" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/random/trash,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "ljg" = (
 /obj/structure/bed/chair/office/light{
@@ -35991,15 +35686,13 @@
 /area/SouthernCrossV2/Bridge/Leisure_Room)
 "lwv" = (
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
+/obj/random/trash,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "lwD" = (
 /obj/structure/table/rack,
@@ -37020,21 +36713,14 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_PortChamber1)
 "lLJ" = (
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = -2;
-	pixel_y = 11
-	},
 /obj/structure/table/steel,
-/obj/item/taperoll/engineering{
-	pixel_y = -1;
-	pixel_x = 9
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 1
 	},
-/obj/item/taperoll/engineering{
-	pixel_y = 1;
-	pixel_x = 7
-	},
-/obj/item/taperoll/atmos{
-	pixel_x = 3
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 1
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "D3-Eng-Solars ForPort1";
@@ -37065,14 +36751,6 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
-"lMi" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "lMs" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
@@ -38176,27 +37854,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Bridge/Control_Atrium)
 "maJ" = (
-/obj/machinery/cell_charger{
-	pixel_y = 11
-	},
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = -2
-	},
 /obj/structure/table/steel,
-/turf/simulated/floor/plating,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/cable_coil/yellow{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "maM" = (
 /obj/structure/bookcase,
@@ -38664,24 +38328,31 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber3)
 "mhP" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Array_ForStar)
+"mhS" = (
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Solar - AftPort";
+	RCon_tag = "Solar - AftStar";
 	input_attempt = 1;
 	input_level = 150000;
-	output_level = 100000
+	output_level = 100000;
+	cur_coils = 2
 	},
 /obj/structure/cable,
 /obj/structure/sign/warning/high_voltage{
 	pixel_y = -32
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
-"mhS" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable/yellow,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "mhT" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -39558,15 +39229,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Dorm_Foyer)
 "mrZ" = (
-/obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/atmospherics/portables_connector{
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/tank/air/full{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 25;
+	name = "E-fire alarm"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
+/turf/simulated/open,
+/area/SouthernCrossV2/Commons/Stairwell_Aft)
 "mse" = (
 /obj/machinery/disposal,
 /obj/structure/window/reinforced,
@@ -39678,15 +39350,6 @@
 "muw" = (
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftPortChamber1)
-"muz" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "muA" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -40977,15 +40640,20 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/SouthernCrossV2/Domicile/Dormitory_09)
 "mUl" = (
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/cell_charger{
+	pixel_y = 11
 	},
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 6;
+	pixel_y = -3
 	},
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "mUo" = (
@@ -41098,10 +40766,20 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Domicile/Dormitory_09)
 "mXj" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+/obj/machinery/cell_charger{
+	pixel_y = 11
 	},
-/obj/effect/catwalk_plated/techmaint,
+/obj/item/weapon/cell/high{
+	charge = 100;
+	maxcharge = 15000;
+	pixel_x = 6;
+	pixel_y = -3
+	},
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "mXp" = (
@@ -41458,23 +41136,9 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "nbz" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/machinery/access_button{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/effect/map_helper/airlock/button/int_button{
-	pixel_y = -14
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "nbA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/catwalk_plated,
@@ -41918,11 +41582,11 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber1)
 "niI" = (
-/obj/machinery/vending/foodveggie,
 /obj/machinery/light{
 	dir = 4;
 	layer = 3
 	},
+/obj/structure/table/woodentable,
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
 "niM" = (
@@ -41950,11 +41614,12 @@
 /turf/simulated/floor/carpet/blue2,
 /area/SouthernCrossV2/Domicile/Dormitory_06)
 "njd" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
+/obj/machinery/light{
+	dir = 8;
+	name = "1E-light fixture"
 	},
-/turf/simulated/floor/plating,
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "njj" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
@@ -43511,27 +43176,13 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Center_Star)
 "nIj" = (
-/obj/machinery/cell_charger{
-	pixel_y = 11
-	},
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = -2
-	},
 /obj/structure/table/steel,
-/turf/simulated/floor/plating,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/cable_coil/yellow{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "nIp" = (
 /obj/effect/floor_decal/techfloor{
@@ -44341,25 +43992,8 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "nVM" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
-	},
-/obj/machinery/power/apc/hyper{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "nVQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -44787,14 +44421,18 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "ocO" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/random/trash,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "oda" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -45941,27 +45579,23 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "otX" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/effect/catwalk_plated/techmaint,
-/obj/random/trash,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/machinery/power/apc/hyper{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	dir = 1;
-	name = "S-light switch";
-	pixel_x = 11;
-	pixel_y = -27
+	pixel_x = 12;
+	pixel_y = 27;
+	name = "N-light switch"
 	},
-/obj/machinery/power/apc/hyper{
-	pixel_y = -24;
-	name = "south bump"
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "oug" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -46203,6 +45837,11 @@
 /area/SouthernCrossV2/Commons/Stairwell_Aft)
 "owV" = (
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "owX" = (
@@ -46943,35 +46582,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor1)
 "oKg" = (
-/obj/structure/table/steel,
-/obj/item/weapon/storage/box/lights/mixed{
-	pixel_x = 8;
-	pixel_y = 9
+/obj/machinery/power/terminal{
+	dir = 4
 	},
-/obj/item/device/radio{
-	pixel_x = -8;
-	pixel_y = -1
-	},
-/obj/item/device/radio{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/device/radio{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/device/radio{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/stack/cable_coil/yellow{
-	pixel_y = -1;
-	pixel_x = 16
-	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "oKh" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -47208,14 +46823,14 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
 "oML" = (
+/obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/random/junk,
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "oNd" = (
 /obj/effect/catwalk_plated/white,
@@ -47560,15 +47175,6 @@
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_StarCorridor1)
-"oTP" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "oUd" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -47663,13 +47269,6 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Bridge/Embassy)
-"oVx" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "oVy" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/porta_turret/ai_defense{
@@ -48303,23 +47902,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Waste_Handling)
-"pgc" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Solar - ForStar";
-	input_attempt = 1;
-	input_level = 150000;
-	output_level = 100000;
-	cur_coils = 2
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/sign/warning/high_voltage{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "pgC" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/atmospheric_field_generator/perma/underdoors{
@@ -49893,6 +49475,7 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Construction_Area)
 "pGS" = (
+/obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -49903,8 +49486,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "pGV" = (
 /obj/structure/cable/yellow{
@@ -50303,25 +49885,8 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "pOt" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	name = "S-light switch";
-	pixel_x = 11;
-	pixel_y = -27
-	},
-/obj/machinery/power/apc/hyper{
-	pixel_y = -24;
-	name = "south bump"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "pOU" = (
 /turf/simulated/wall/r_wall,
@@ -52411,19 +51976,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Commons/Aft_3_Deck_Central_Corridor_1)
-"qyb" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "qyr" = (
 /obj/machinery/shield_capacitor{
-	dir = 8
+	dir = 1
 	},
-/obj/structure/cable/green,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "qys" = (
@@ -52738,21 +52296,14 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Waste_Handling)
 "qBZ" = (
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = -2;
-	pixel_y = 11
-	},
 /obj/structure/table/steel,
-/obj/item/taperoll/engineering{
-	pixel_y = -1;
-	pixel_x = 9
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 1
 	},
-/obj/item/taperoll/engineering{
-	pixel_y = 1;
-	pixel_x = 7
-	},
-/obj/item/taperoll/atmos{
-	pixel_x = 3
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 1
 	},
 /obj/machinery/camera/network/security{
 	c_tag = "D3-Eng-Solars AftPort1";
@@ -54303,9 +53854,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Medical/Morgue)
 "rdk" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/arrows,
+/obj/machinery/door/airlock/angled_bay/external/glass/red,
+/turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "rdp" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -54345,16 +53899,29 @@
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber2)
 "rem" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium/full,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/obj/effect/catwalk_plated/techmaint,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
@@ -54531,16 +54098,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Autoresleeving)
-"rgz" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/effect/map_helper/airlock/door/ext_door,
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "rgB" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -55342,20 +54899,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Commons/Star_Breakroom)
-"rtw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "rtM" = (
 /obj/machinery/iv_drip,
 /obj/item/weapon/reagent_containers/blood/prelabeled/OMinus{
@@ -55607,20 +55150,10 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/SouthernCrossV2/Bridge/HoP_Office)
 "rwO" = (
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1381;
-	id_tag = "SC-ForPortSolar";
-	pixel_x = 24;
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/catwalk_plated,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
+/obj/effect/catwalk_plated/techmaint,
+/obj/random/junk,
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "rwU" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/alt/panel,
@@ -56020,21 +55553,20 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftPortChamber2)
 "rEC" = (
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Solar - ForPort";
-	input_attempt = 1;
-	input_level = 150000;
-	output_level = 100000
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/yellow,
+/obj/machinery/power/apc/hyper{
+	pixel_y = -24;
+	name = "south bump"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/light_switch{
+	dir = 1;
+	name = "S-light switch";
+	pixel_x = 11;
+	pixel_y = -27
 	},
-/obj/structure/sign/warning/high_voltage{
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "rEL" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -56360,27 +55892,13 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/SouthernCrossV2/Medical/Psych_Room_2)
 "rKO" = (
-/obj/machinery/cell_charger{
-	pixel_y = 11
-	},
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = -2
-	},
 /obj/structure/table/steel,
-/turf/simulated/floor/plating,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/cable_coil/yellow{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "rKQ" = (
 /obj/structure/cable/green{
@@ -56994,9 +56512,12 @@
 /turf/simulated/floor/tiled/kafel_full,
 /area/SouthernCrossV2/Medical/Aft_Medical_Post)
 "rXr" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/arrows,
+/obj/machinery/door/airlock/angled_bay/external/glass/red,
+/turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "rXM" = (
 /obj/machinery/alarm{
@@ -58818,15 +58339,6 @@
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarChamber3)
-"szK" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "sAc" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -58870,9 +58382,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Bridge/AI_Upload_Hall)
 "sBY" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
-/obj/effect/catwalk_plated,
-/turf/simulated/floor/plating,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "sCc" = (
 /turf/simulated/open,
@@ -60563,20 +60079,6 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Substation)
-"tbB" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "tbC" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -61647,8 +61149,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "tpQ" = (
@@ -62375,16 +61882,6 @@
 	},
 /turf/simulated/floor/glass,
 /area/SouthernCrossV2/Commons/Star_3_Deck_Stairwell)
-"tGt" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "tGH" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -62486,22 +61983,21 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
-"tJm" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "tJr" = (
-/obj/structure/cable/yellow{
+/obj/machinery/power/smes/buildable{
+	RCon_tag = "Solar - ForPort";
+	input_attempt = 1;
+	input_level = 150000;
+	output_level = 100000
+	},
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = 32
+	},
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "tJw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -63305,13 +62801,13 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Bridge/CMO_Quarters)
 "tXb" = (
+/obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "tXd" = (
 /obj/machinery/door/firedoor/multi_tile/glass,
@@ -63538,18 +63034,18 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Domicile/Chomp_Kitchen)
 "ucc" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "ucr" = (
 /obj/structure/table/hardwoodtable,
@@ -63632,14 +63128,6 @@
 	color = "#8bbbd5"
 	},
 /area/SouthernCrossV2/Medical/Virology)
-"udu" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "udw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -64148,16 +63636,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
-"ukp" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "uks" = (
 /turf/simulated/wall,
 /area/SouthernCrossV2/Medical/Patient_4)
@@ -64838,6 +64316,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
@@ -65478,18 +64961,18 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Bridge/AI_Upload_Hall)
 "uEQ" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "uER" = (
 /obj/structure/lattice,
@@ -65703,12 +65186,6 @@
 	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/SouthernCrossV2/Bridge/CE_Quarters)
-"uJS" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/hatch/blue,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "uJV" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -65733,10 +65210,22 @@
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortCorridor1)
 "uKX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
+/obj/item/weapon/storage/toolbox/electrical{
+	pixel_x = -2;
+	pixel_y = 11
 	},
-/obj/effect/catwalk_plated/techmaint,
+/obj/structure/table/steel,
+/obj/item/taperoll/engineering{
+	pixel_y = -1;
+	pixel_x = 9
+	},
+/obj/item/taperoll/engineering{
+	pixel_y = 1;
+	pixel_x = 7
+	},
+/obj/item/taperoll/atmos{
+	pixel_x = 3
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "uLn" = (
@@ -66445,31 +65934,13 @@
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Genetics_Lab)
 "uUo" = (
+/obj/machinery/light{
+	dir = 4;
+	name = "1E-light fixture"
+	},
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
-"uUN" = (
-/obj/machinery/airlock_sensor{
-	pixel_x = 24;
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/catwalk_plated,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "uUU" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -67696,13 +67167,13 @@
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
 "vmA" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "vmB" = (
 /obj/structure/bed/chair/sofa/black{
@@ -68588,17 +68059,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Virology)
-"vAO" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "vAY" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -68656,11 +68116,9 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Domicile/Central_Restroom)
 "vBV" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
+/obj/effect/catwalk_plated/techmaint,
+/obj/random/junk,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "vCb" = (
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -68730,11 +68188,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Domicile/Dormitory_06)
-"vDm" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "vDn" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -68999,21 +68452,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
-"vHc" = (
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1381;
-	id_tag = "SC-AftStarSolar";
-	pixel_x = -24;
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/catwalk_plated,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "vHd" = (
 /obj/structure/table/woodentable,
 /obj/item/device/paicard,
@@ -69655,16 +69093,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Medical/Resleeving)
-"vQn" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "vQT" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
@@ -69975,10 +69403,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "vWd" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -70221,14 +69646,18 @@
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Virology)
 "wam" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/random/trash,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "wap" = (
 /obj/structure/bed/double/padded,
@@ -70714,14 +70143,6 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Domicile/Dormitory_01)
-"whP" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "wik" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
@@ -71061,25 +70482,18 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "wpa" = (
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = -2;
-	pixel_y = 11
-	},
 /obj/structure/table/steel,
-/obj/item/taperoll/engineering{
-	pixel_y = -1;
-	pixel_x = 9
-	},
-/obj/item/taperoll/engineering{
-	pixel_y = 1;
-	pixel_x = 7
-	},
-/obj/item/taperoll/atmos{
-	pixel_x = 3
-	},
 /obj/machinery/camera/network/security{
 	c_tag = "D3-Eng-Solars ForStar1";
 	network = list("engineering")
+	},
+/obj/item/device/radio{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/item/device/radio{
+	pixel_x = 5;
+	pixel_y = 1
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
@@ -71229,17 +70643,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Central_Restroom)
-"wrm" = (
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "wro" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -71615,16 +71018,12 @@
 /area/SouthernCrossV2/Commons/Stairwell_Star)
 "wxB" = (
 /obj/effect/catwalk_plated/techmaint,
-/obj/random/junk,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "wxE" = (
 /obj/structure/dispenser/oxygen,
@@ -71830,13 +71229,13 @@
 /turf/simulated/floor/tiled/kafel_full,
 /area/SouthernCrossV2/Domicile/Dormitory_05)
 "wBF" = (
+/obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "wBQ" = (
 /obj/effect/catwalk_plated,
@@ -73684,16 +73083,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber2)
-"xbH" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "xbI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -73749,21 +73138,6 @@
 "xco" = (
 /turf/simulated/wall,
 /area/SouthernCrossV2/Domicile/Dormitory_05)
-"xcw" = (
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
-	frequency = 1381;
-	id_tag = "SC-AftPortSolar";
-	pixel_x = 24;
-	dir = 8
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/catwalk_plated,
-/obj/effect/floor_decal/industrial/outline/blue,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "xcG" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -74144,16 +73518,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Medical/Lounge)
-"xhW" = (
-/obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/tank/air/full{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "xiD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -74613,27 +73977,13 @@
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "xoy" = (
-/obj/machinery/cell_charger{
-	pixel_y = 11
-	},
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 6;
-	pixel_y = -3
-	},
-/obj/item/weapon/cell/high{
-	charge = 100;
-	maxcharge = 15000;
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = -2
-	},
 /obj/structure/table/steel,
-/turf/simulated/floor/plating,
+/obj/item/stack/cable_coil/yellow,
+/obj/item/stack/cable_coil/yellow{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
 "xoK" = (
 /obj/effect/floor_decal/techfloor/orange,
@@ -75496,11 +74846,7 @@
 	dir = 1
 	},
 /obj/structure/cable/yellow,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftPort)
 "xCv" = (
 /obj/structure/table/bench/wooden,
@@ -76178,23 +75524,18 @@
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Bridge/Breakroom)
 "xLA" = (
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/industrial/arrows,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/machinery/access_button{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/effect/map_helper/airlock/button/int_button{
-	pixel_y = -14
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor/tiled/techmaint,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForStar)
+/turf/simulated/floor/airless,
+/area/SouthernCrossV2/Engineering/Solar_Array_AftStar)
 "xLJ" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -77812,11 +77153,6 @@
 "yjU" = (
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
@@ -77861,15 +77197,11 @@
 /area/SouthernCrossV2/Domicile/Dorm_Foyer)
 "ykf" = (
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
+/obj/machinery/light{
+	dir = 8;
+	name = "1E-light fixture"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "ykl" = (
 /obj/machinery/light{
@@ -77915,16 +77247,13 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForPort_Corridor2)
 "ykJ" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 9
+/obj/machinery/light{
+	dir = 4;
+	name = "1E-light fixture"
 	},
-/turf/simulated/floor/plating,
+/obj/random/trash,
+/turf/simulated/floor/airless,
 /area/SouthernCrossV2/Engineering/Solar_Control_AftStar)
 "ykL" = (
 /turf/simulated/wall/r_wall,
@@ -77992,14 +77321,6 @@
 /obj/structure/bed/chair/bay/chair/padded/red/smallnest,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Domicile/Dormitory_11)
-"ylR" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Solar_Control_ForPort)
 "ylV" = (
 /obj/item/modular_computer/console/preset/ert,
 /obj/machinery/light{
@@ -95391,7 +94712,7 @@ blw
 blw
 blw
 blw
-blw
+apc
 apc
 apc
 apc
@@ -95467,7 +94788,7 @@ apc
 apc
 apc
 apc
-blw
+apc
 blw
 blw
 blw
@@ -95646,10 +94967,10 @@ clB
 hRf
 elu
 elu
-elu
 clB
 clB
-blw
+dHa
+apc
 rUK
 rUK
 rUK
@@ -95725,10 +95046,10 @@ apc
 apc
 apc
 apc
-blw
+apc
+dHa
 qRA
 qRA
-xyE
 xyE
 xyE
 bsD
@@ -95903,11 +95224,11 @@ clB
 cVa
 pGS
 njd
-hKn
+pOt
 eDT
-ylR
 clB
-blw
+dHa
+apc
 rUK
 vTY
 avi
@@ -95983,11 +95304,11 @@ apc
 apc
 apc
 apc
-blw
+apc
+dHa
 qRA
-uJS
 mXj
-vDm
+nVM
 kfu
 gmD
 xCo
@@ -96161,11 +95482,11 @@ elu
 nIj
 cik
 gck
-oVx
+pOt
 dMC
-xhW
 clB
-blw
+dHa
+apc
 rUK
 wqb
 eTW
@@ -96241,12 +95562,12 @@ apc
 apc
 apc
 apc
-blw
+apc
+dHa
 qRA
-eap
 uKX
 vBV
-fxW
+nVM
 heQ
 rKO
 xyE
@@ -96419,11 +95740,11 @@ elu
 lLJ
 cik
 pOt
+pOt
+bLC
 clB
-clB
-clB
-clB
-blw
+dHa
+apc
 rUK
 rUK
 rUK
@@ -96499,13 +95820,13 @@ apc
 apc
 apc
 apc
-blw
+apc
+dHa
 qRA
-qRA
-qRA
-qRA
+buv
 nVM
-heQ
+nVM
+chr
 qBZ
 xyE
 dHa
@@ -96677,11 +95998,11 @@ elu
 hNx
 ocO
 wxB
+aXd
 clB
-vAO
-kig
 xgI
-iMq
+pmn
+jub
 jub
 jub
 jub
@@ -96757,11 +96078,11 @@ jub
 jub
 jub
 jub
-blw
+jub
+pmn
 uHI
-udu
-muz
 qRA
+otX
 dRW
 liY
 oKg
@@ -96931,14 +96252,14 @@ apc
 apc
 apc
 dHa
-elu
+clB
 tJr
 dvZ
 uUo
-nbz
+pOt
 rXr
 sBY
-kMz
+kaL
 kaL
 kaL
 kaL
@@ -97015,15 +96336,15 @@ kaL
 kaL
 kaL
 kaL
-dHa
-etz
+kaL
+kaL
 gQy
 cTi
-cOJ
+nVM
 cZV
 jaM
 ahv
-xyE
+qRA
 dHa
 apc
 apc
@@ -97190,13 +96511,13 @@ apc
 apc
 dHa
 clB
-rEC
-rtw
-dWa
-awS
-rwO
-eBI
-cfB
+clB
+mcs
+elu
+elu
+clB
+cpE
+dHa
 dHa
 dHa
 dHa
@@ -97274,13 +96595,13 @@ dHa
 dHa
 dHa
 dHa
-gtK
-uUN
-xcw
-vQn
-oTP
+dHa
+aMV
+qRA
+xyE
+xyE
 rem
-mhP
+qRA
 qRA
 dHa
 apc
@@ -97447,14 +96768,14 @@ apc
 apc
 apc
 dHa
-clB
-clB
-mcs
-elu
-clB
-clB
-clB
-cpE
+dHa
+dHa
+ggn
+dHa
+oRH
+dHa
+dHa
+dHa
 dHa
 dHa
 dHa
@@ -97532,14 +96853,14 @@ dHa
 dHa
 dHa
 dHa
-aMV
-qRA
-qRA
-qRA
-xyE
-iUF
-qRA
-qRA
+dHa
+dHa
+dHa
+nbo
+dHa
+ggn
+dHa
+dHa
 dHa
 apc
 apc
@@ -108396,9 +107717,9 @@ lrZ
 mEG
 fCn
 qKL
-jgM
+etz
 mWW
-kMU
+mrZ
 mEG
 qKM
 uob
@@ -108549,7 +107870,7 @@ tiC
 xml
 sjb
 hiF
-sOg
+kig
 htL
 eup
 eup
@@ -117833,7 +117154,7 @@ dHa
 lvr
 ggn
 dHa
-dHa
+oRH
 dHa
 dHa
 dHa
@@ -118087,14 +117408,14 @@ apc
 apc
 apc
 dHa
-bDN
-bDN
-ndB
-dbu
-bDN
-bDN
-bDN
-uVF
+dHa
+dHa
+ggn
+dHa
+oRH
+dHa
+dHa
+dHa
 dHa
 dHa
 dHa
@@ -118172,14 +117493,14 @@ dHa
 dHa
 dHa
 dHa
-fYV
-nQB
-nQB
-nQB
-aAy
-bUQ
-nQB
-nQB
+dHa
+dHa
+dHa
+nbo
+dHa
+ggn
+dHa
+dHa
 dHa
 apc
 apc
@@ -118346,13 +117667,13 @@ apc
 apc
 dHa
 bDN
-pgc
-jOu
-chr
-tGt
-aXd
-hsK
-rgz
+bDN
+ndB
+dbu
+dbu
+bDN
+uVF
+dHa
 dHa
 dHa
 dHa
@@ -118430,13 +117751,13 @@ dHa
 dHa
 dHa
 dHa
-gLt
-buv
-vHc
-eUg
-szK
-tbB
-bLC
+dHa
+fYV
+nQB
+aAy
+aAy
+bUQ
+nQB
 nQB
 dHa
 apc
@@ -118603,14 +117924,14 @@ apc
 apc
 apc
 dHa
-dbu
+bDN
 fHB
 vmA
 aFL
-xLA
+kfl
 btA
 iYO
-feL
+sra
 sra
 sra
 sra
@@ -118688,14 +118009,14 @@ sra
 sra
 sra
 sra
-akm
+sra
 epg
 rdk
-iEZ
+jIY
 ykf
 fwW
 mhS
-aAy
+nQB
 dHa
 apc
 apc
@@ -118865,11 +118186,11 @@ dbu
 fCm
 wam
 ikV
+rEC
 bDN
-wrm
-whP
 uRK
-fUQ
+ttG
+nhz
 nhz
 nhz
 nhz
@@ -118945,11 +118266,11 @@ wqn
 nhz
 nhz
 nhz
-fUQ
-lfl
+nhz
+ttG
 eUU
-bdA
 nQB
+hKn
 lwv
 hOa
 coA
@@ -119122,12 +118443,12 @@ dHa
 dbu
 wpa
 wBF
-otX
+kfl
+rwO
+nbz
 bDN
-bDN
-bDN
-bDN
-blw
+dHa
+apc
 apc
 apc
 apc
@@ -119203,11 +118524,11 @@ hXb
 apc
 apc
 apc
-blw
+apc
+dHa
 nQB
-nQB
-nQB
-nQB
+eap
+jIY
 jIY
 kSX
 kgC
@@ -119381,11 +118702,11 @@ dbu
 xoy
 oML
 kfl
-tJm
+kfl
 bwg
-mrZ
-dbu
-blw
+bDN
+dHa
+apc
 apc
 apc
 apc
@@ -119461,12 +118782,12 @@ hXb
 apc
 apc
 apc
-blw
-aAy
-kqz
+apc
+dHa
+nQB
 hQR
-qyb
-jYN
+jIY
+jIY
 tXb
 maJ
 aAy
@@ -119639,11 +118960,11 @@ bDN
 vWb
 uEQ
 dds
-ukp
+kfl
 fnF
-lMi
-dbu
-blw
+bDN
+dHa
+apc
 apc
 apc
 apc
@@ -119719,11 +119040,11 @@ hXb
 apc
 apc
 apc
-blw
-aAy
-kct
+apc
+dHa
+nQB
 mUl
-xbH
+jIY
 ykJ
 ucc
 dWz
@@ -119895,13 +119216,13 @@ apc
 dHa
 bDN
 bDN
-dbu
-dbu
-dbu
 cbe
+dbu
+dbu
 bDN
 bDN
-blw
+dHa
+apc
 apc
 apc
 apc
@@ -119977,13 +119298,13 @@ hXb
 apc
 apc
 apc
-blw
+apc
+dHa
 nQB
 nQB
+aAy
+aAy
 rGW
-aAy
-aAy
-aAy
 nQB
 nQB
 dHa
@@ -120153,13 +119474,13 @@ uFR
 uFR
 uFR
 uFR
-uFR
+mhP
 uFR
 uFR
 cRB
 blw
 blw
-blw
+apc
 apc
 apc
 apc
@@ -120235,13 +119556,13 @@ hXb
 apc
 apc
 apc
-blw
+apc
 blw
 blw
 cvZ
 fNU
 fNU
-fNU
+xLA
 fNU
 fNU
 fNU


### PR DESCRIPTION

-Transit turret control panel was moved to the bridge. -Janitors window tint range increase.
-Midnight bar now has drink dispensers at front.
-Vault lobby door access fixed and renamed.
-Gym hamster wheels are wired to main. (red wire)
-Science: PA room: Emitter is wired.
-Solars are now airless, removed airlock cycling.
-Science: Replace Advance T-ray to a normal one.
-Cargo: Mass drive button renamed.
-All shield gens have been moved from green wire to red wire. Security: Moved reception buttons.
-Added missing APC in cargo maints.
-Transit chutes entry points are a tad larger, crew can now wait and insta-nom near them. -Science: Xenobotany: Fixed shutter button access. -Reduced the amount of food vendors in the Chomp Dinner. -Moved Aft side stairwell fireaxe to the third deck.
