### PR TITLE
Southern Sun Map fixes! 1.4

### DIFF
--- a/maps/southern_sun/southern_cross-1.dmm
+++ b/maps/southern_sun/southern_cross-1.dmm
@@ -1074,15 +1074,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Commons/Central_1_Deck_Hall)
 "afY" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -1097,8 +1088,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/Central_1_Deck_Hall)
 "aga" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -1205,12 +1196,12 @@
 "agy" = (
 /obj/machinery/turretid/lethal{
 	ailock = 1;
-	check_synth = 1;
 	control_area = "\improper GravGen Room";
 	desc = "A firewall prevents AIs from interacting with this device.";
 	name = "GravityGen lethal turret control";
 	pixel_y = 29;
-	req_access = null;
+	req_access = list(17,11,24);
+	check_records = 0;
 	req_one_access = list(17,11,24)
 	},
 /obj/structure/cable/green{
@@ -6124,17 +6115,16 @@
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Science/Xenobiology_Lab)
 "aMv" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Harbor/Dock2)
 "aMD" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -11498,10 +11488,6 @@
 	pixel_y = 9;
 	pixel_x = -7
 	},
-/obj/item/device/t_scanner/advanced{
-	pixel_y = 4;
-	pixel_x = 1
-	},
 /obj/item/clothing/mask/gas{
 	pixel_y = -5;
 	pixel_x = 6
@@ -11530,6 +11516,10 @@
 	},
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 4
+	},
+/obj/item/device/t_scanner{
+	pixel_y = 5;
+	pixel_x = 2
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Harbor/Fueling_Storage)
@@ -29204,17 +29194,10 @@
 /turf/simulated/floor/airless,
 /area/shuttle/escape_pod8/station)
 "icV" = (
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
-/obj/effect/catwalk_plated/techmaint,
+/obj/random/trash,
+/obj/random/junk,
 /turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/area/SouthernCrossV2/Maints/Deck1_AftStar1_Corridor1)
 "idc" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 28;
@@ -38558,17 +38541,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Security/Exploration_Sling_Shuttle)
 "lBJ" = (
 /obj/structure/railing/grey,
 /obj/random/junk,
@@ -44199,7 +44173,7 @@
 	control_area = "\improper Telecomms Foyer";
 	name = "Telecomms Teleporter turret control";
 	pixel_x = 28;
-	req_access = null;
+	req_access = list(17,11,24);
 	req_one_access = list(17,11,24)
 	},
 /obj/machinery/camera/network/security{
@@ -50488,21 +50462,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass2,
 /area/SouthernCrossV2/Commons/Port_1Deck_Atrium)
-"pzH" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
 "pzK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -50839,6 +50798,7 @@
 /area/SouthernCrossV2/Maints/ab_StripBar)
 "pFA" = (
 /obj/structure/loot_pile/maint/technical,
+/obj/random/trash,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_AftStar1_Corridor1)
 "pFH" = (
@@ -52403,17 +52363,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Harbor/Dock3)
 "qfl" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -59653,17 +59604,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Harbor/Dock5)
 "sHO" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposalpipe/segment{
@@ -60576,31 +60518,10 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Harbor/Dock5)
 "sZu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
+/obj/random/trash_pile,
+/obj/random/trash,
 /turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/area/SouthernCrossV2/Maints/Deck1_AftStar1_Corridor1)
 "sZx" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -66671,10 +66592,10 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck1_Security_StarCorridor1)
 "vig" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Distro_Harbor)
@@ -67684,10 +67605,6 @@
 	pixel_y = 9;
 	pixel_x = -7
 	},
-/obj/item/device/t_scanner/advanced{
-	pixel_y = 4;
-	pixel_x = 1
-	},
 /obj/item/clothing/mask/gas{
 	pixel_y = -5;
 	pixel_x = 6
@@ -67707,6 +67624,10 @@
 /obj/item/taperoll/atmos{
 	pixel_y = 14;
 	pixel_x = 6
+	},
+/obj/item/device/t_scanner{
+	pixel_y = 5;
+	pixel_x = 2
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Distro_Harbor)
@@ -74310,7 +74231,7 @@
 	},
 /area/SouthernCrossV2/Science/Observation_Hall)
 "xTt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/plating,
@@ -91763,7 +91684,7 @@ dFh
 pfi
 bCu
 trr
-pzH
+fxn
 trr
 fxn
 oZp
@@ -92862,7 +92783,7 @@ cfp
 tXo
 eJf
 tZf
-icV
+azD
 gkN
 azD
 jEl
@@ -96734,7 +96655,7 @@ vGQ
 dDr
 akk
 vDr
-qfh
+aMv
 lQq
 act
 aaa
@@ -103184,7 +103105,7 @@ hbs
 dZJ
 kOh
 aMb
-aMv
+aMb
 aMb
 aMb
 qoL
@@ -103595,7 +103516,7 @@ fMw
 fHV
 mwb
 nIQ
-icV
+xVH
 qsy
 eZh
 lok
@@ -103832,7 +103753,7 @@ bhd
 tqg
 mFe
 aQY
-aMv
+aQY
 aQY
 qSB
 tpj
@@ -105220,7 +105141,7 @@ uHz
 qyi
 dYv
 aTh
-sZu
+aVg
 frW
 xes
 rnA
@@ -107312,7 +107233,7 @@ pTA
 iEc
 aNe
 qOv
-aMv
+qOv
 qOv
 qOv
 qgY
@@ -115258,11 +115179,11 @@ wHn
 ayY
 azQ
 oIK
-pgz
-oIK
+icV
+icV
 dem
-oIK
-oIK
+dem
+icV
 pgz
 mkY
 oIK
@@ -115515,10 +115436,10 @@ xQV
 tBL
 dqQ
 mkY
-oIK
-oIK
+sZu
+sZu
 pFA
-pgz
+icV
 kNJ
 fXm
 hNA
@@ -117630,7 +117551,7 @@ wOk
 aVp
 nME
 wPB
-icV
+eKQ
 gAk
 eKQ
 bCX
@@ -118595,7 +118516,7 @@ lKt
 kSY
 kZc
 wya
-pzH
+kZc
 fTv
 kZc
 lAG

--- a/maps/southern_sun/southern_cross-2.dmm
+++ b/maps/southern_sun/southern_cross-2.dmm
@@ -4078,6 +4078,10 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
+/obj/item/device/flash,
+/obj/item/device/radio/headset/headset_sci{
+	pixel_x = -3
+	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Science/Locker_Room)
 "aiL" = (
@@ -6492,8 +6496,19 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Security/Forensics_Office)
 "arb" = (
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = 27;
+	name = "N-light switch"
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -9074,7 +9089,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
 	},
-/turf/simulated/floor/glass,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_2_Deck_Central_Corridor_1)
 "azJ" = (
 /obj/structure/bed/padded,
@@ -11363,15 +11378,15 @@
 	pixel_x = 8;
 	pixel_y = -1
 	},
-/obj/item/device/t_scanner/advanced{
-	pixel_y = 3;
-	pixel_x = -6
-	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lightorange/bordercorner{
 	dir = 8
+	},
+/obj/item/device/t_scanner{
+	pixel_y = 2;
+	pixel_x = -6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Engineering/Engineering_Workshop)
@@ -13373,26 +13388,15 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Central_Corridor_1)
 "aNt" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
-	},
-/obj/machinery/light_switch{
-	dir = 4;
-	name = "W-light switch";
-	pixel_x = -27;
-	pixel_y = 12
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 10
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Port_Medical_Post)
@@ -18755,15 +18759,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chapel_Lobby)
 "beq" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -18779,8 +18774,8 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/Port_2_Deck_Central_Corridor_1)
 "ber" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -21846,14 +21841,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Emergency_EVA)
 "bof" = (
-/obj/structure/ladder{
-	pixel_y = 3
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/small/warning/emerg_only{
 	desc = "Ladder for emergency use only";
 	pixel_y = -32
 	},
+/obj/structure/ladder/up,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_AftPortCorridor1)
 "bog" = (
@@ -23258,7 +23251,8 @@
 "btk" = (
 /obj/machinery/button/windowtint{
 	id = "sc-WTsauna";
-	pixel_x = 27
+	pixel_x = 27;
+	range = 11
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Gym_Sauna)
@@ -24636,25 +24630,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Security/Visitation_Room)
 "bxv" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/white/border,
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/Star_2_Deck_Central_Corridor_1)
 "bxD" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -30305,23 +30284,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Security/Locker_Room)
 "bSR" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Bridge/Vault_Reception)
 "bSS" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -31519,7 +31489,13 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/turf/simulated/floor/glass,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Central_Corridor_1)
 "bWO" = (
 /obj/item/weapon/stool/padded{
@@ -31637,7 +31613,7 @@
 	desc = "A warning sign which reads 'RADIATION SHIELDING IN THIS AREA'.";
 	pixel_x = -32
 	},
-/turf/simulated/floor/glass,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "bXq" = (
 /obj/structure/table/steel,
@@ -36923,23 +36899,14 @@
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Security/Prison_Wing)
 "cow" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/tiled/dark,
+/area/SouthernCrossV2/Security/Equipment_Storage)
 "cox" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -42227,15 +42194,6 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/ForPort_2_Deck_Observatory)
 "cFV" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -42252,8 +42210,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/For_2_Deck_Stairwell)
 "cFW" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -43285,7 +43243,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	dir = 8
 	},
-/turf/simulated/floor/glass,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_Transit_Foyer)
 "cTL" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
@@ -48049,7 +48007,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	dir = 4
 	},
-/turf/simulated/floor/glass,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
 "eej" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
@@ -48097,22 +48055,13 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/ForPort_2_Deck_Observatory)
 "eeQ" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
 /obj/effect/landmark/start,
 /obj/effect/landmark{
 	name = "Observer-Start";
 	pixel_y = 5
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/tiled/techmaint,
+/area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
 "efb" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1443;
@@ -48252,6 +48201,12 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Maints/Deck2_Medical_AftStarChamber1)
+"ehe" = (
+/obj/structure/loot_pile/maint/trash,
+/obj/random/trash,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck2_Science_StarChamber1)
 "ehg" = (
 /obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/carpet/green,
@@ -52358,7 +52313,13 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/simulated/floor/glass,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Central_Corridor_1)
 "fhs" = (
 /obj/effect/catwalk_plated/white,
@@ -52610,6 +52571,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Science/Toxins_Mixing_Room)
+"fjD" = (
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck2_Civilian_AftPortCorridor1)
+"fjG" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/Port_2_Deck_Central_Corridor_1)
 "fjI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -53359,6 +53333,10 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
+/obj/item/device/flash,
+/obj/item/device/radio/headset/headset_sci{
+	pixel_x = -3
+	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Science/Locker_Room)
 "ftC" = (
@@ -54141,6 +54119,29 @@
 /area/SouthernCrossV2/Medical/Deck2_Corridor)
 "fCA" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/weapon/reagent_containers/chem_disp_cartridge/berry{
+	pixel_y = -4;
+	pixel_x = 8
+	},
+/obj/item/weapon/reagent_containers/chem_disp_cartridge/hot_coco{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/weapon/reagent_containers/chem_disp_cartridge/milk{
+	pixel_x = 8
+	},
+/obj/item/weapon/reagent_containers/chem_disp_cartridge/mint{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/weapon/reagent_containers/chem_disp_cartridge/tea{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/item/weapon/reagent_containers/chem_disp_cartridge/coffee{
+	pixel_y = 6;
+	pixel_x = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Domicile/Midnight_Kitchen)
 "fCI" = (
@@ -54974,11 +54975,6 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Technical_Storage)
 "fOE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -55281,7 +55277,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/glass,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
 "fRM" = (
 /obj/item/weapon/pen/red{
@@ -56684,11 +56680,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Maints/Deck2_Port_Corridor)
 "ghq" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
-/turf/simulated/floor/glass,
-/area/SouthernCrossV2/Commons/Star_2_Deck_Central_Corridor_1)
+/obj/random/trash_pile,
+/obj/random/junk,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck2_Civilian_AftPortCorridor1)
 "ghx" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -62003,11 +61999,6 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Medical_Substation)
 "hzQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
@@ -62017,7 +62008,7 @@
 /obj/structure/sign/poster/custom{
 	dir = 4
 	},
-/turf/simulated/floor/glass,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_2_Deck_Central_Corridor_1)
 "hzX" = (
 /obj/machinery/button/remote/airlock{
@@ -62888,11 +62879,6 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
 "hON" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -65393,6 +65379,7 @@
 	name = "grid checker info"
 	},
 /obj/structure/table/steel,
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "iuj" = (
@@ -70189,15 +70176,6 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Aft_2_Deck_Airlock_Access)
 "jGK" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -70213,8 +70191,8 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/Star_2_Deck_Central_Corridor_1)
 "jHa" = (
 /obj/structure/undies_wardrobe,
 /obj/item/weapon/towel/random{
@@ -74294,13 +74272,13 @@
 /turf/simulated/wall,
 /area/SouthernCrossV2/Maints/Deck2_Security_PortCorridor1)
 "kMO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/meter,
 /obj/machinery/camera/network/security{
 	dir = 8;
 	c_tag = "D2-Eng-Distro Domicile1";
 	network = list("engineering")
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Distro_Civilian)
 "kMX" = (
@@ -74807,17 +74785,15 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Security_ForCorridor1)
 "kTt" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
+/obj/machinery/light/small{
+	dir = 4
 	},
+/obj/random/trash_pile,
+/obj/random/junk,
+/obj/random/trash,
+/obj/random/trash,
 /turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/area/SouthernCrossV2/Maints/Deck2_Civilian_AftPortCorridor1)
 "kTR" = (
 /obj/structure/table/glass,
 /obj/machinery/power/apc{
@@ -86684,6 +86660,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Maints/Deck2_Medical_AftPortCorridor1)
+"okL" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/Star_2_Deck_Central_Corridor_1)
 "okO" = (
 /obj/structure/urinal{
 	dir = 8;
@@ -87651,7 +87636,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
 	},
-/turf/simulated/floor/glass,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_2_Deck_Central_Corridor_1)
 "oCR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -89224,10 +89209,6 @@
 	pixel_y = 9;
 	pixel_x = -7
 	},
-/obj/item/device/t_scanner/advanced{
-	pixel_y = 4;
-	pixel_x = 1
-	},
 /obj/item/clothing/mask/gas{
 	pixel_y = -5;
 	pixel_x = 6
@@ -89247,6 +89228,9 @@
 /obj/item/taperoll/atmos{
 	pixel_y = 14;
 	pixel_x = 6
+	},
+/obj/item/device/t_scanner{
+	pixel_y = 6
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Distro_Civilian)
@@ -90609,11 +90593,6 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
 "ppy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -92798,11 +92777,6 @@
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/For_Medical_Post)
 "pRp" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -92820,6 +92794,11 @@
 	},
 /obj/effect/floor_decal/corner/white/bordercorner2{
 	dir = 6
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Port_Medical_Post)
@@ -96593,6 +96572,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Security/Deck2_1_Corridor)
+"qSG" = (
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/atmospherics/pipe/cap/visible{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Distro_Civilian)
 "qSL" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -97413,7 +97399,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
 	},
-/turf/simulated/floor/glass,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Central_Corridor_1)
 "req" = (
 /obj/machinery/door/firedoor/glass,
@@ -97952,11 +97938,6 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_2_Deck_Hall)
 "rla" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -100774,7 +100755,8 @@
 /obj/machinery/button/remote/airlock{
 	id = "sc-DBSstall4";
 	name = "1N-Bolt control";
-	pixel_y = 24
+	pixel_y = 24;
+	specialfunctions = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -103404,7 +103386,7 @@
 	pixel_x = 28;
 	name = "1E-newscaster"
 	},
-/turf/simulated/floor/glass,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
 "sCG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -108231,7 +108213,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8
 	},
-/turf/simulated/floor/glass,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Central_Corridor_1)
 "tTO" = (
 /obj/structure/table/rack/shelf,
@@ -109542,7 +109524,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8
 	},
-/turf/simulated/floor/glass,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Central_Corridor_1)
 "uli" = (
 /turf/simulated/wall,
@@ -110864,7 +110846,13 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/turf/simulated/floor/glass,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_2_Deck_Central_Corridor_1)
 "uKL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -114845,7 +114833,9 @@
 	dir = 1;
 	pixel_y = -32
 	},
-/turf/simulated/floor/glass,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_2_Deck_Central_Corridor_1)
 "vTN" = (
 /obj/structure/disposalpipe/sortjunction/wildcard{
@@ -116095,6 +116085,7 @@
 /area/SouthernCrossV2/Maints/Deck2_Security_AftPortCorridor1)
 "wim" = (
 /obj/structure/loot_pile/maint/trash,
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Science_StarChamber1)
 "wix" = (
@@ -122002,10 +121993,6 @@
 	pixel_y = 9;
 	pixel_x = -7
 	},
-/obj/item/device/t_scanner/advanced{
-	pixel_y = 4;
-	pixel_x = 1
-	},
 /obj/item/clothing/mask/gas{
 	pixel_y = -5;
 	pixel_x = 6
@@ -122025,6 +122012,9 @@
 /obj/item/taperoll/atmos{
 	pixel_y = 14;
 	pixel_x = 6
+	},
+/obj/item/device/t_scanner{
+	pixel_y = 6
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Security_Substation)
@@ -122724,18 +122714,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Medical/Surgery_Room_2)
 "xYt" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random/trash_pile,
+/obj/random/trash,
+/obj/random/junk,
 /turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/area/SouthernCrossV2/Maints/Deck2_Science_StarChamber1)
 "xYy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -140489,11 +140472,11 @@ eRx
 urA
 vaX
 bhL
-bei
-bei
+aUV
+aUV
 flL
-bei
-bei
+aUV
+aUV
 bhL
 teP
 nOA
@@ -142811,11 +142794,11 @@ mCA
 iAT
 iAT
 bse
-bei
-bei
+aUV
+aUV
 flL
-bei
-bei
+aUV
+aUV
 bse
 oOS
 oOS
@@ -146164,13 +146147,13 @@ aIm
 aJL
 aLD
 noZ
-aSh
+jrb
 czR
 sdq
 asa
 sdq
 czR
-aSh
+vAi
 bbe
 wKN
 bPN
@@ -146422,13 +146405,13 @@ kDj
 ltX
 aLF
 vAi
-aSh
+oJc
 czR
 aVn
 wcN
 aVn
 czR
-aSh
+fjG
 jrb
 wKN
 aCh
@@ -146901,7 +146884,7 @@ fYw
 brD
 xxw
 xUd
-xYt
+xUd
 qlh
 hRt
 fJP
@@ -147455,11 +147438,11 @@ ctj
 iis
 aOP
 rek
-aSh
+vcv
 pTu
 lYw
 nXE
-aSh
+vcv
 rek
 bbc
 wKN
@@ -148038,7 +148021,7 @@ aKA
 aKA
 aKA
 aKA
-xDR
+fjD
 bof
 mga
 fcX
@@ -148948,7 +148931,7 @@ oLK
 oLK
 imD
 mNZ
-cow
+mNZ
 mNZ
 vqQ
 pul
@@ -149347,7 +149330,7 @@ fcX
 cGL
 mga
 dzd
-xDR
+ghq
 kkc
 aGf
 wZn
@@ -149605,7 +149588,7 @@ fcX
 bEM
 kWG
 bTU
-xDR
+ghq
 kkc
 dpC
 wZn
@@ -150637,8 +150620,8 @@ fcX
 vjy
 ulI
 ybp
-qQm
-xDR
+kTt
+ghq
 wRf
 kWt
 wZn
@@ -152044,7 +152027,7 @@ xun
 cBx
 mlw
 rYQ
-kTt
+rYQ
 rYQ
 fTL
 saC
@@ -153463,7 +153446,7 @@ mnK
 kRq
 mnK
 nnG
-aMR
+nnG
 aMR
 aMR
 aMR
@@ -153616,7 +153599,7 @@ agt
 bye
 bye
 xcl
-kTt
+aTk
 tdn
 rXE
 aoE
@@ -153690,7 +153673,7 @@ eaM
 fhn
 cDX
 fLQ
-kTt
+cgk
 aBw
 cin
 vPP
@@ -153721,7 +153704,7 @@ bXA
 yic
 pKB
 nnG
-aMR
+nnG
 tRq
 aMR
 aMR
@@ -153936,7 +153919,7 @@ mLM
 ezo
 lDC
 nJD
-ezo
+qSG
 kMO
 wYZ
 qDw
@@ -153979,7 +153962,7 @@ cjy
 fyL
 nNA
 nnG
-aMR
+nnG
 aMR
 aMR
 aMR
@@ -154882,7 +154865,7 @@ cUk
 bmu
 lIm
 pZI
-bxv
+bmu
 slC
 bmu
 bmu
@@ -159003,7 +158986,7 @@ btt
 bfK
 czc
 bCi
-kTt
+bCi
 gZm
 bCi
 wlZ
@@ -160096,13 +160079,13 @@ asV
 jKu
 asV
 nFa
-ghq
+nFa
 hzV
 deB
 rNz
 qfC
 hzV
-ghq
+nFa
 nFa
 bsU
 bsU
@@ -161128,13 +161111,13 @@ bEx
 rEq
 asV
 nDH
-aZE
+bxv
 wKg
 soe
 cDx
 lAk
 lXn
-aZE
+okL
 voE
 aut
 wDm
@@ -164229,7 +164212,7 @@ bXk
 cTF
 cuE
 cTF
-sXo
+mXo
 oJo
 aWc
 aWc
@@ -164483,11 +164466,11 @@ kjc
 kTT
 kTT
 kTh
-sXo
-sXo
+mXo
+mXo
 rAK
-sXo
-sXo
+mXo
+mXo
 kTh
 tUc
 tUc
@@ -166805,11 +166788,11 @@ oeI
 hRL
 mlJ
 oJo
-sXo
-sXo
+mXo
+mXo
 rAK
-sXo
-sXo
+mXo
+mXo
 oJo
 uNQ
 aWc
@@ -175573,8 +175556,8 @@ aLK
 dvL
 kCW
 gNu
-bTV
-bTV
+xYt
+xYt
 gNC
 xuB
 xuB
@@ -176087,8 +176070,8 @@ eib
 gNC
 aLK
 bTV
-bTV
-wim
+xYt
+ehe
 bTV
 wim
 gNC

--- a/maps/southern_sun/southern_cross-3.dmm
+++ b/maps/southern_sun/southern_cross-3.dmm
@@ -2746,7 +2746,9 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/SouthernCrossV2/Medical/Psych_Room_2)
 "aWE" = (
-/obj/effect/catwalk_plated/techmaint,
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "aWW" = (
@@ -4349,8 +4351,10 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Bridge/RD_Quarters)
 "bCC" = (
-/obj/effect/catwalk_plated/techmaint,
 /obj/random/trash,
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortCorridor1)
 "bCG" = (
@@ -8315,11 +8319,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Bridge/Control_Atrium)
 "cRp" = (
@@ -9306,6 +9305,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Medical/Surgery_Storage)
+"dkv" = (
+/obj/structure/sign/levels/engineering/solars{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/structure/sign/levels/engineering/solars{
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/engineering/solars{
+	dir = 10
+	},
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Maints/Deck3_Bridge_AftStarCorridor1)
 "dkH" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -9694,6 +9706,13 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_2)
+"dsH" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
 "dsP" = (
 /obj/structure/railing,
 /turf/simulated/open,
@@ -11915,7 +11934,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber2)
 "eaN" = (
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -14161,6 +14180,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
+"eLF" = (
+/obj/random/trash,
+/obj/random/junk,
+/obj/random/trash_pile,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Chamber1)
 "eLN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -14374,6 +14400,10 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/random/trash_pile,
+/obj/random/trash,
+/obj/random/trash,
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber1)
 "eNS" = (
@@ -18758,7 +18788,6 @@
 /turf/simulated/wall,
 /area/SouthernCrossV2/Medical/Restrooms)
 "fTK" = (
-/obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
 "fTX" = (
@@ -22461,8 +22490,7 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "hgE" = (
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber1)
 "hgN" = (
 /turf/simulated/wall,
@@ -22935,6 +22963,16 @@
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+"hqb" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
 "hqk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/effect/catwalk_plated,
@@ -23070,17 +23108,8 @@
 /obj/effect/floor_decal/corner/blue/bordercorner{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/area/SouthernCrossV2/Bridge/Control_Atrium)
 "hum" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -26917,21 +26946,12 @@
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
 "iDQ" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
 	},
-/obj/machinery/light/small,
-/obj/structure/girder/reinforced{
-	default_material = "lead"
-	},
-/obj/machinery/door/blast/radproof/open{
-	dir = 4;
-	id = "SC-GCengineroom";
-	layer = 3.5
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Construction_Area)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForChamber1)
 "iEb" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -29022,17 +29042,11 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Domicile/Dormitory_12)
 "jlQ" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
+/obj/structure/railing/grey{
+	color = "yellow"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortCorridor1)
 "jme" = (
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -31374,6 +31388,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "kat" = (
@@ -32375,9 +32392,6 @@
 	pixel_y = 6;
 	pixel_x = -4
 	},
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Construction_Area)
 "kqx" = (
@@ -32463,11 +32477,8 @@
 /turf/simulated/floor/reinforced/airless,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "krr" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/random/trash,
-/obj/structure/lattice,
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber2)
 "krt" = (
 /obj/structure/table/standard,
 /obj/random/coin/sometimes,
@@ -33506,6 +33517,11 @@
 	},
 /turf/space,
 /area/space)
+"kLn" = (
+/obj/random/trash_pile,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "kLr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34519,6 +34535,13 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor2)
+"laT" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/random/trash_pile,
+/obj/random/junk,
+/obj/random/junk,
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber2)
 "laU" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -36604,6 +36627,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/SouthernCrossV2/Medical/Restrooms)
+"lJz" = (
+/obj/structure/sign/directions/engineering/solars,
+/obj/structure/sign/levels/engineering/solars{
+	dir = 8;
+	pixel_y = -9
+	},
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForPortChamber1)
 "lJN" = (
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Medical/Resleeving)
@@ -36612,9 +36643,9 @@
 	name = "1S-light fixture"
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/machinery/atmospherics/pipe/tank{
+	dir = 1;
+	start_pressure = 0
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
@@ -37417,15 +37448,15 @@
 	pixel_y = 9;
 	pixel_x = 7
 	},
-/obj/item/device/t_scanner/advanced{
-	pixel_y = 5;
-	pixel_x = -13
-	},
 /obj/item/weapon/storage/belt/utility/atmostech{
 	pixel_y = -3;
 	pixel_x = -2
 	},
 /obj/item/weapon/storage/belt/utility/atmostech,
+/obj/item/device/t_scanner/upgraded{
+	pixel_y = 5;
+	pixel_x = -12
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "lVx" = (
@@ -38181,7 +38212,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/For_3_Deck_Airlock_Access_2)
 "mgf" = (
-/turf/simulated/floor/glass/reinforced,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
 "mgv" = (
 /obj/machinery/alarm{
@@ -38516,12 +38547,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "mjJ" = (
@@ -40606,10 +40637,10 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/SouthernCrossV2/Bridge/Captain_Office)
 "mTB" = (
-/obj/machinery/atmospherics/binary/pump{
+/obj/effect/engine_setup/pump_max,
+/obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 4
 	},
-/obj/effect/engine_setup/pump_max,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Waste_Handling)
 "mTF" = (
@@ -40689,9 +40720,16 @@
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Medical/Patient_4)
 "mVB" = (
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_AftPortChamber1)
 "mVO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -45434,12 +45472,12 @@
 "orE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "orM" = (
@@ -48153,6 +48191,13 @@
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_ForStarCorridor2)
+"plP" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "plR" = (
 /obj/effect/floor_decal/spline/fancy{
 	dir = 5
@@ -48270,6 +48315,17 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Central_3_Deck_Hall)
+"pnr" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
 "pnQ" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -50193,6 +50249,16 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"pTP" = (
+/obj/structure/sign/directions/engineering/solars{
+	dir = 4
+	},
+/obj/structure/sign/levels/engineering/solars{
+	dir = 8;
+	pixel_y = -9
+	},
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "pTW" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled,
@@ -50705,17 +50771,12 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/SouthernCrossV2/Domicile/Dormitory_08)
 "qdr" = (
-/obj/machinery/light/small,
-/obj/structure/girder/reinforced{
-	default_material = "lead"
-	},
-/obj/machinery/door/blast/radproof/open{
-	dir = 4;
-	id = "SC-GCengineroom";
-	layer = 3.5
-	},
+/obj/effect/graffitispawner,
+/obj/random/trash_pile,
+/obj/random/junk,
+/obj/random/junk,
 /turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Construction_Area)
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Chamber1)
 "qdY" = (
 /obj/machinery/light/small,
 /obj/random/junk,
@@ -51177,7 +51238,7 @@
 	color = "yellow";
 	dir = 1
 	},
-/turf/simulated/floor/glass/reinforced,
+/turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "qjy" = (
 /obj/structure/sign/flag/vir/right,
@@ -53025,7 +53086,13 @@
 /area/SouthernCrossV2/Harbor/For_3_Deck_Airlock_Access_2)
 "qMF" = (
 /obj/random/trash,
-/obj/effect/catwalk_plated/techmaint,
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "qMP" = (
@@ -53040,18 +53107,15 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
 "qMY" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/For_3_Deck_Stairwell)
 "qNj" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/green,
@@ -53296,6 +53360,17 @@
 	},
 /turf/space,
 /area/space)
+"qTG" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 1
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber2)
 "qTR" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
@@ -53602,6 +53677,12 @@
 /obj/effect/floor_decal/corner/beige/bordercorner,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Dorm_Corridor_4)
+"rab" = (
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
 "rae" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -53942,7 +54023,7 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
-/turf/simulated/floor/glass/reinforced,
+/turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "reO" = (
 /obj/structure/cable/green{
@@ -54157,6 +54238,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Engineering/Engine2_Access_Hall)
+"rhn" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Construction_Area)
 "rhw" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/random/junk,
@@ -54831,6 +54919,12 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Bridge/Control_Atrium)
+"rqC" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/random/trash_pile,
+/obj/random/junk,
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber2)
 "rqF" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -55169,11 +55263,9 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "rwZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine1_Chamber)
+/obj/random/junk,
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortCorridor1)
 "rxc" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -55202,6 +55294,20 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Dorm_Corridor_4)
+"rxi" = (
+/obj/structure/sign/levels/engineering/solars{
+	dir = 4;
+	pixel_y = 9
+	},
+/obj/structure/sign/levels/engineering/solars{
+	dir = 8;
+	pixel_y = -9
+	},
+/obj/structure/sign/directions/engineering/solars{
+	dir = 6
+	},
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Maints/Deck3_Bridge_AftPortCorridor1)
 "rxk" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 3
@@ -57393,15 +57499,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Dormitory_08)
 "slG" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/porta_turret/crescent{
-	check_down = 0;
-	check_access = 0;
-	req_one_access = list(19);
-	desc = "A light weight energy turret design to be non-lethal, a deterrence against rowdy crew and deadly targets";
-	name = "Disabler turret";
-	faction = "nanotrasen"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -57418,8 +57515,8 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/tiled,
+/area/SouthernCrossV2/Commons/For_3_Deck_Stairwell)
 "sma" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -57788,6 +57885,13 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_AftPortChamber1)
+"sqh" = (
+/obj/structure/ladder{
+	pixel_y = 3
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftPortChamber1)
 "sqk" = (
 /obj/machinery/atmospherics/unary/heat_exchanger{
@@ -58513,16 +58617,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Engineering/Engine_Tech_Storage)
 "sEa" = (
-/obj/structure/girder/reinforced{
-	default_material = "lead"
-	},
-/obj/machinery/door/blast/radproof/open{
-	dir = 4;
-	id = "SC-GCengineroom";
-	layer = 3.5
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Construction_Area)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_AftPortCorridor1)
 "sEc" = (
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/SouthernCrossV2/Domicile/Dormitory_09)
@@ -60895,6 +60991,11 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "tls" = (
@@ -61281,6 +61382,12 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"ttH" = (
+/obj/random/trash,
+/obj/random/trash_pile,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Chamber1)
 "ttJ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central5,
 /obj/structure/noticeboard{
@@ -61862,11 +61969,12 @@
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_1)
 "tFZ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
 	},
 /turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Domicile/Public_Hydroponics)
+/area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber2)
 "tGp" = (
 /obj/structure/railing{
 	dir = 4
@@ -62895,6 +63003,7 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 1
 	},
+/obj/item/device/t_scanner/advanced,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Engineering/Deck3_1_Corridor)
 "tYA" = (
@@ -62946,7 +63055,6 @@
 /area/SouthernCrossV2/Harbor/Aft_3_Deck_Airlock_Access)
 "tZh" = (
 /obj/effect/catwalk_plated/techmaint,
-/obj/structure/lattice,
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "tZj" = (
@@ -63057,26 +63165,12 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/SouthernCrossV2/Bridge/Captain_Office)
 "uct" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/structure/railing/grey{
+	color = "yellow";
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/obj/machinery/turretid/stun{
-	pixel_y = 26;
-	req_access = list(29);
-	check_access = 0;
-	check_down = 0;
-	check_weapons = 1;
-	lethal_is_configurable = 0;
-	name = "transit turret control panel";
-	check_anomalies = 0;
-	check_arrest = 0;
-	check_records = 0
-	},
-/turf/simulated/floor/tiled,
-/area/SouthernCrossV2/Security/Transit_Turrets)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_PortChamber2)
 "ucy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -63778,6 +63872,15 @@
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+"und" = (
+/obj/structure/sign/directions/engineering/solars{
+	dir = 8
+	},
+/obj/structure/sign/levels/engineering/solars{
+	pixel_y = -9
+	},
+/turf/simulated/wall/r_wall,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Chamber1)
 "uni" = (
 /obj/structure/sign/department/atmos{
 	layer = 3.5;
@@ -65204,6 +65307,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_3_Deck_Central_Corridor_1)
+"uKE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "uKF" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/random/junk,
@@ -66350,15 +66460,15 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/SouthernCrossV2/Bridge/CE_Quarters)
 "uZK" = (
-/obj/machinery/portable_atmospherics/canister/air/airlock,
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/camera/network/security{
 	c_tag = "D3-Eng-1st Engine2";
 	network = list("engineering","Engine");
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/tank{
+	dir = 1;
+	start_pressure = 0
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
@@ -67256,6 +67366,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Construction_Area)
+"vnT" = (
+/obj/random/trash_pile,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Chamber1)
 "vnV" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -68495,12 +68610,19 @@
 /area/SouthernCrossV2/Domicile/Chomp_Lounge)
 "vHG" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
-/turf/simulated/floor/glass/reinforced,
+/turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
 "vIb" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Bridge/Conference_Room)
+"vIf" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 8
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
 "vIr" = (
 /obj/structure/table/bench/marble,
 /obj/effect/floor_decal/spline/plain{
@@ -70611,6 +70733,9 @@
 	id = "Eng Lockdown";
 	name = "Lockdown Gate";
 	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/obj/structure/sign/warning/airlock{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Engineering/Airlock_Access)
@@ -73974,7 +74099,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/glass/reinforced,
+/turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "xoy" = (
 /obj/structure/table/steel,
@@ -74906,6 +75031,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Atmospherics_Chamber)
+"xDu" = (
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber2)
 "xDw" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -75601,6 +75729,11 @@
 /obj/structure/bed/chair/bay/chair/padded/red/bignest,
 /turf/simulated/floor/carpet/gaycarpet,
 /area/SouthernCrossV2/Domicile/Dormitory_05)
+"xMi" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/random/trash,
+/turf/simulated/open,
+/area/SouthernCrossV2/Maints/Deck3_Engineering_ForStarChamber1)
 "xMl" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -85468,7 +85601,7 @@ aGi
 gmg
 aGi
 aGi
-sEa
+jcJ
 vTE
 dHa
 dHa
@@ -85726,7 +85859,7 @@ jcJ
 jcJ
 aGi
 lsT
-sEa
+jcJ
 tgj
 tgj
 wzt
@@ -85965,7 +86098,7 @@ xtj
 xJY
 sOU
 rae
-rwZ
+vLY
 uZK
 mCr
 urH
@@ -85984,7 +86117,7 @@ sWn
 sWn
 wjD
 ubE
-sEa
+jcJ
 bng
 eeV
 sqK
@@ -86242,7 +86375,7 @@ jcJ
 jcJ
 ulX
 aGi
-iDQ
+eLm
 tgj
 qcT
 lDH
@@ -86500,7 +86633,7 @@ jcJ
 jcJ
 aGi
 aGi
-sEa
+jcJ
 tgj
 xei
 pkC
@@ -86758,7 +86891,7 @@ jcJ
 jcJ
 aGi
 aGi
-sEa
+jcJ
 tgj
 vLz
 iRi
@@ -87016,7 +87149,7 @@ jcJ
 jcJ
 aGi
 aGi
-sEa
+jcJ
 kaJ
 gvZ
 hAo
@@ -87274,7 +87407,7 @@ jcJ
 jcJ
 aGi
 aGi
-sEa
+jcJ
 tXO
 tXO
 tXO
@@ -87532,7 +87665,7 @@ jcJ
 jcJ
 aGi
 aGi
-sEa
+jcJ
 tXO
 czb
 roY
@@ -87790,7 +87923,7 @@ pRO
 pRO
 aGi
 aGi
-qdr
+eLm
 tXO
 dzT
 dQn
@@ -88048,7 +88181,7 @@ jWT
 jWT
 kVy
 vCq
-sEa
+jcJ
 tXO
 dVb
 jQQ
@@ -88306,7 +88439,7 @@ jcJ
 jcJ
 aGi
 xYg
-sEa
+jcJ
 tXO
 rmf
 bOR
@@ -88560,11 +88693,11 @@ xDE
 jcJ
 jcJ
 jcJ
-jcJ
+rhn
 yjL
 aGi
 aGi
-sEa
+jcJ
 tXO
 jqU
 mag
@@ -92696,9 +92829,9 @@ ffp
 ocD
 sOE
 joW
-mVB
-mVB
-mVB
+cOG
+gun
+gun
 mqI
 jFf
 mTB
@@ -92954,9 +93087,9 @@ eaY
 cIT
 hUU
 joW
-mVB
-mVB
-mVB
+kWZ
+gun
+gun
 mqI
 pfQ
 oGN
@@ -93212,9 +93345,9 @@ eaY
 xiQ
 gZd
 joW
-mVB
-mVB
-mVB
+kWZ
+gun
+gun
 mqI
 nse
 piW
@@ -95256,7 +95389,7 @@ vpl
 spK
 clf
 reN
-krr
+tZh
 xom
 qTm
 syI
@@ -95514,7 +95647,7 @@ vBg
 sjC
 clf
 reN
-tZh
+xMi
 qjx
 qTm
 syI
@@ -97066,8 +97199,8 @@ dOf
 oUk
 clf
 nhu
-aWE
-aWE
+xDu
+xDu
 qTm
 qTm
 qTm
@@ -97324,9 +97457,9 @@ bBk
 imS
 clf
 wFS
-aWE
-aWE
-wYU
+plP
+plP
+xDu
 oAF
 uNr
 nAa
@@ -98099,7 +98232,7 @@ dFr
 hwu
 gam
 aWE
-jCc
+uKE
 ier
 oAF
 hJs
@@ -100754,7 +100887,7 @@ hWG
 ycV
 nRP
 muw
-muw
+wVX
 lPX
 lPX
 lPX
@@ -101013,7 +101146,7 @@ muw
 voL
 muw
 muw
-muw
+wVX
 jTu
 lPX
 gCl
@@ -101163,7 +101296,7 @@ odv
 pIA
 fWL
 hKP
-fWL
+rxi
 dHa
 dHa
 dHa
@@ -101497,7 +101630,7 @@ pvp
 oQM
 pvp
 wtj
-wtj
+ttH
 wtj
 jZH
 aTK
@@ -101523,8 +101656,8 @@ uOc
 jTu
 viP
 hrB
-wVX
-wVX
+mVB
+sqh
 hgZ
 gPw
 drl
@@ -101754,8 +101887,8 @@ dHa
 pvp
 wtj
 onR
-vXB
-tNl
+wRG
+eLF
 qkf
 jZH
 mYV
@@ -102008,12 +102141,12 @@ dHa
 dHa
 dHa
 dHa
-pvp
+und
 pvp
 tNl
 tNl
-vXB
-vXB
+wRG
+vnT
 wzO
 jZH
 gxS
@@ -102529,7 +102662,7 @@ tNl
 wRG
 wtj
 vXB
-dvU
+qdr
 naq
 jZH
 gqj
@@ -102786,7 +102919,7 @@ tNl
 vXB
 biB
 omi
-vXB
+wRG
 jVP
 oXo
 juo
@@ -103814,11 +103947,11 @@ pfx
 reP
 hLn
 ede
-fTK
-fTK
-fTK
-fTK
-fTK
+pnr
+vIf
+vIf
+vIf
+hqb
 pfx
 wvD
 jZH
@@ -104072,11 +104205,11 @@ ori
 iKS
 bge
 sJb
+dsH
 fTK
 fTK
 fTK
-fTK
-fTK
+rab
 pfx
 pKv
 jZH
@@ -105810,9 +105943,9 @@ stg
 iSF
 eup
 eup
-eup
+iSF
 uMP
-jlQ
+bYz
 bYz
 fJj
 cNZ
@@ -106068,7 +106201,7 @@ bXW
 qsN
 eup
 eup
-eup
+iSF
 iSE
 tvL
 gop
@@ -106326,7 +106459,7 @@ bXW
 cvU
 eup
 eup
-eup
+iSF
 jVA
 cHl
 fHW
@@ -106377,7 +106510,7 @@ mgf
 mgf
 mgf
 mgf
-tFZ
+qTV
 eSH
 nrR
 rfG
@@ -106584,7 +106717,7 @@ mpp
 jWS
 eup
 eup
-eup
+iSF
 inK
 moT
 xGI
@@ -107086,7 +107219,7 @@ jjK
 ylA
 wVH
 tPH
-jlQ
+aaM
 aaM
 rqw
 nkF
@@ -107613,10 +107746,10 @@ tat
 tat
 qIj
 ofh
-uct
+cvU
 eup
 eup
-eup
+iSF
 bOD
 cIk
 bHJ
@@ -107874,7 +108007,7 @@ kig
 htL
 eup
 eup
-eup
+iSF
 jVA
 bfP
 fHW
@@ -107925,7 +108058,7 @@ mgf
 mgf
 mgf
 mgf
-tFZ
+qTV
 mEk
 nrR
 rfG
@@ -108132,7 +108265,7 @@ rnN
 cRl
 eup
 eup
-eup
+iSF
 weg
 tpU
 qIs
@@ -108390,9 +108523,9 @@ sOg
 kIy
 eup
 eup
-eup
+iSF
 jVj
-jlQ
+bYz
 bYz
 fwN
 vFh
@@ -110453,7 +110586,7 @@ ncV
 jcH
 fmR
 wbH
-jlQ
+pMP
 yjo
 fVU
 ipJ
@@ -112328,7 +112461,7 @@ dHa
 dHa
 dHa
 dHa
-lmX
+pTP
 lmX
 xmc
 xIE
@@ -112626,7 +112759,7 @@ ueV
 kxT
 fcD
 gZV
-wtq
+rqC
 uTy
 beO
 ppd
@@ -112884,7 +113017,7 @@ eSM
 fcD
 fcD
 wtq
-wtq
+laT
 uTy
 eRh
 aEV
@@ -113031,7 +113164,7 @@ dTD
 uaG
 rul
 cwa
-rul
+dkv
 dHa
 dHa
 dHa
@@ -115625,7 +115758,7 @@ dHa
 dHa
 dHa
 dHa
-aan
+lJz
 aan
 bMd
 bMd
@@ -116142,7 +116275,7 @@ dHa
 dHa
 dHa
 eaE
-kcG
+pyK
 kcG
 vxz
 vXD
@@ -116156,10 +116289,10 @@ kcG
 pZA
 hsw
 axl
-ayA
-ayA
-ayA
-ayA
+qTG
+tFZ
+tFZ
+tFZ
 rFQ
 wro
 gvN
@@ -116414,10 +116547,10 @@ vwH
 ulO
 ayA
 ayA
-ayA
-ayA
-ayA
-ayA
+uct
+krr
+krr
+krr
 rFQ
 rFQ
 maN
@@ -116660,7 +116793,7 @@ dHa
 eaE
 uNb
 kfL
-kcG
+pyK
 mfp
 toW
 ffT
@@ -116672,11 +116805,11 @@ vwH
 pZA
 aWm
 aWm
-ayA
-ayA
-ayA
-ayA
-ayA
+uct
+krr
+krr
+krr
+krr
 rFQ
 jiV
 sYA
@@ -116918,7 +117051,7 @@ dHa
 aan
 sCc
 jhv
-kcG
+pyK
 tcM
 toW
 ffT
@@ -116930,11 +117063,11 @@ vwH
 pZA
 aWm
 aWm
-ayA
-ayA
-ayA
-ayA
-ayA
+uct
+krr
+krr
+krr
+krr
 rFQ
 qHV
 qht
@@ -117176,7 +117309,7 @@ aan
 aan
 uNb
 kfL
-kcG
+kLn
 kcG
 aEE
 gjw
@@ -117188,11 +117321,11 @@ hZh
 pZA
 dzC
 hum
-ayA
-ayA
-ayA
-ayA
-ayA
+uct
+krr
+krr
+krr
+krr
 rFQ
 kxl
 xSt
@@ -117979,8 +118112,8 @@ blM
 ixY
 iMd
 hIh
-vXz
-vXz
+sEa
+jlQ
 vXz
 hsc
 fdT
@@ -118217,7 +118350,7 @@ yaW
 iAh
 knU
 niE
-hgE
+iDQ
 hgE
 hgE
 hIh
@@ -118237,8 +118370,8 @@ rvp
 juv
 wLU
 hIh
-vXz
-vXz
+sEa
+jlQ
 uKF
 hsc
 fCX
@@ -118475,7 +118608,7 @@ yaW
 iPa
 ctH
 niE
-hgE
+iDQ
 hgE
 hgE
 hIh
@@ -118495,7 +118628,7 @@ aIV
 wfT
 qXC
 hIh
-vXz
+sEa
 bCC
 vXz
 hsc
@@ -118733,7 +118866,7 @@ npz
 tIc
 tIc
 suB
-hgE
+iDQ
 hgE
 hgE
 hIh
@@ -118753,8 +118886,8 @@ aIV
 wfT
 pML
 hIh
-vXz
-vXz
+sEa
+jlQ
 dyt
 hsc
 hsc
@@ -118991,7 +119124,7 @@ yaW
 hnW
 ctH
 niE
-hgE
+iDQ
 hgE
 hgE
 hIh
@@ -119011,8 +119144,8 @@ aIV
 wfT
 jfX
 hIh
-uKF
-vXz
+rwZ
+jlQ
 vXz
 hsc
 bCU
@@ -119249,7 +119382,7 @@ yaW
 xfg
 ctH
 niE
-hgE
+iDQ
 hgE
 hgE
 hIh
@@ -119269,8 +119402,8 @@ aIV
 wfT
 oSC
 hIh
-vXz
-vXz
+sEa
+jlQ
 vXz
 hsc
 qaj
@@ -119507,7 +119640,7 @@ wDV
 wmx
 ddi
 vYj
-hgE
+iDQ
 hgE
 hgE
 hIh
@@ -119527,7 +119660,7 @@ aIV
 wfT
 kge
 hIh
-vXz
+sEa
 bCC
 vXz
 hsc
@@ -125428,8 +125561,8 @@ dHa
 dHa
 dgt
 dgt
-vkF
-vkF
+cej
+cej
 vkF
 nxp
 dVi


### PR DESCRIPTION

-Removes all disabler turrets.
-Fix various third deck catwalk decals.
-Added catridge dispensers for Midnightbar.
-Gym Sauna. Increase range of the window tint.
-Gym bathroom can lock its door.
-Added more trash piles in maints. 
-Fixed access on turrets inside Gravgen and T'coms (Hopefully stop shooting engies)
-Fixed ladder behind holodeck.
-Engineering: engine room: Replaced black pipe pump to high powered.
-Engineering: Added missing wire knot in engineering substation.
-Replaced all advance T-ray scanners to normal ones. Placed 1 upgraded T-ray scanner. 
-Engineering: Removed one layer of rad shielding. (On my test server, radiation is 10 times stronger.)
-Harbor Distro pipes are fixed.
-Reduced and shrank a lot of glass floors in various rooms.
-Disconnected dorms from the main atmos distroy, hopefully prevent mobs spawns. (Dorms still has an emergency distro)
-Moved a number of APC's near doors, lightswitch access!
-Engineering: Fixed third deck airlock, hopefully be faster.
-Added 2 flashers in the roboticist wardrobe.

