### PR TITLE
only check either access

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -193,6 +193,7 @@
 	containertype = /obj/structure/closet/crate/secure/einstein
 	containername = "Particle Accelerator crate"
 	access = list(access_ce, access_research) // CHOMPEdit
+	one_access = TRUE //CHOMPAdd
 
 /datum/supply_pack/eng/shield_gen
 	contains = list(/obj/item/weapon/circuitboard/shield_gen)


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:
fix: PA crates will only check for either CE or science access
/:cl:
