### PR TITLE
More fixes

### DIFF
--- a/maps/southern_sun/southern_cross-1.dmm
+++ b/maps/southern_sun/southern_cross-1.dmm
@@ -561,6 +561,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock2)
 "acK" = (
@@ -1975,6 +1976,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock4)
 "ajD" = (
@@ -7209,8 +7211,7 @@
 /obj/machinery/door/blast/regular{
 	dir = 4;
 	id = "SC-BDxenobiodivider1";
-	name = "Containment Divider Doors";
-	opacity = 0
+	name = "Containment Divider Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/SouthernCrossV2/Science/Xenobiology_Lab)
@@ -8701,6 +8702,7 @@
 	},
 /obj/machinery/door/airlock/angled_bay/external/glass/red,
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock5)
 "boC" = (
@@ -10145,6 +10147,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock3)
 "bMw" = (
@@ -10167,8 +10170,7 @@
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/blast/regular{
 	id = "SC-BDxenobiovent3";
-	name = "Containment Vent Doors";
-	opacity = 0
+	name = "Containment Vent Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/SouthernCrossV2/Science/Xenobiology_Lab)
@@ -11716,6 +11718,7 @@
 	dir = 1
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock1)
 "cop" = (
@@ -17691,6 +17694,7 @@
 /obj/machinery/door/airlock/angled_bay/external/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock4)
 "dZl" = (
@@ -18346,8 +18350,7 @@
 /obj/machinery/door/blast/regular{
 	dir = 4;
 	id = "SC-BDxenobiodivider2";
-	name = "Containment Divider Doors";
-	opacity = 0
+	name = "Containment Divider Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/SouthernCrossV2/Science/Xenobiology_Lab)
@@ -18425,6 +18428,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock1)
 "edU" = (
@@ -20430,6 +20434,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock4)
 "eQS" = (
@@ -21538,8 +21543,7 @@
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/blast/regular{
 	id = "SC-BDxenobiovent4";
-	name = "Containment Vent Doors";
-	opacity = 0
+	name = "Containment Vent Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/SouthernCrossV2/Science/Xenobiology_Lab)
@@ -23377,6 +23381,7 @@
 	},
 /obj/machinery/door/airlock/angled_bay/external/glass/red,
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock4)
 "fUe" = (
@@ -25009,6 +25014,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock1)
 "gwX" = (
@@ -27851,6 +27857,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock4)
 "hAv" = (
@@ -30817,6 +30824,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Commons/Aft_1_Deck_Stairwell)
+"iFw" = (
+/obj/structure/lattice,
+/obj/machinery/shield_diffuser,
+/turf/space,
+/area/space)
 "iFL" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable{
@@ -33133,6 +33145,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock5)
 "jEl" = (
@@ -35586,6 +35599,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock2)
 "kyc" = (
@@ -37122,6 +37136,7 @@
 	dir = 4
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock2)
 "lbQ" = (
@@ -40614,6 +40629,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock5)
 "mma" = (
@@ -42535,6 +42551,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock5)
 "mPC" = (
@@ -43031,8 +43048,7 @@
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/blast/regular{
 	id = "SC-BDxenobiovent2";
-	name = "Containment Vent Doors";
-	opacity = 0
+	name = "Containment Vent Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/SouthernCrossV2/Science/Xenobiology_Lab)
@@ -43271,6 +43287,7 @@
 	},
 /obj/machinery/door/airlock/angled_bay/external/glass/red,
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock3)
 "neh" = (
@@ -44327,6 +44344,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock1)
 "nBH" = (
@@ -44464,6 +44482,7 @@
 	pixel_y = -14
 	},
 /obj/machinery/door/airlock/angled_bay/external/glass,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock2)
 "nDP" = (
@@ -49230,6 +49249,7 @@
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/machinery/door/airlock/angled_bay/external/glass,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock2)
 "pgb" = (
@@ -52694,6 +52714,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock3)
 "qlf" = (
@@ -60768,6 +60789,7 @@
 	dir = 4
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock4)
 "tdK" = (
@@ -62759,6 +62781,7 @@
 	dir = 4
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock3)
 "tOb" = (
@@ -63203,6 +63226,7 @@
 	dir = 4
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock1)
 "tXo" = (
@@ -66902,6 +66926,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock4)
 "vlb" = (
@@ -66996,6 +67021,7 @@
 /obj/effect/map_helper/airlock/button/ext_button{
 	pixel_y = -14
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock3)
 "vnD" = (
@@ -70170,8 +70196,7 @@
 /obj/machinery/door/blast/regular{
 	dir = 4;
 	id = "SC-BDxenobiodivider3";
-	name = "Containment Divider Doors";
-	opacity = 0
+	name = "Containment Divider Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/SouthernCrossV2/Science/Xenobiology_Lab)
@@ -70795,8 +70820,7 @@
 /obj/machinery/shield_diffuser,
 /obj/machinery/door/blast/regular{
 	id = "SC-BDxenobiovent1";
-	name = "Containment Vent Doors";
-	opacity = 0
+	name = "Containment Vent Doors"
 	},
 /turf/simulated/floor/reinforced,
 /area/SouthernCrossV2/Science/Xenobiology_Lab)
@@ -71809,6 +71833,7 @@
 	dir = 4
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Harbor/Dock5)
 "wXu" = (
@@ -84265,7 +84290,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -84524,7 +84549,7 @@ aaa
 aaa
 svz
 cVn
-aaf
+iFw
 aaa
 aaa
 aaa
@@ -85234,7 +85259,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -85491,7 +85516,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+iFw
 aCB
 otU
 aaa
@@ -87911,7 +87936,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aBe
 gwU
@@ -87950,7 +87975,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -88168,7 +88193,7 @@ aaa
 vuJ
 aaa
 aaa
-aaf
+iFw
 cmI
 aaf
 aBe
@@ -88207,9 +88232,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+iFw
 cmI
-aaf
+iFw
 aaa
 aaa
 aaa
@@ -94142,7 +94167,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -94399,9 +94424,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+iFw
 cmI
-aaf
+iFw
 aaa
 aaa
 aaa
@@ -96463,9 +96488,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+iFw
 htS
-aaf
+iFw
 aaa
 aaa
 aaa
@@ -96722,7 +96747,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -102720,7 +102745,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -102977,7 +103002,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+iFw
 aCB
 eLm
 dKC
@@ -103236,7 +103261,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aHq
 adN
@@ -103948,7 +103973,7 @@ jLb
 wHM
 agL
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -104207,7 +104232,7 @@ xiM
 agL
 jlA
 fZW
-aaf
+iFw
 aaa
 aaa
 aaa
@@ -106271,7 +106296,7 @@ xiM
 agL
 jlA
 deu
-aaf
+iFw
 aaa
 aaa
 aaa
@@ -106528,7 +106553,7 @@ viE
 oSV
 agL
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -106848,7 +106873,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aHq
 adN
@@ -107105,7 +107130,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+iFw
 aCB
 eLm
 dKC
@@ -107364,7 +107389,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -113750,7 +113775,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -114007,9 +114032,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+iFw
 cmI
-aaf
+iFw
 aaa
 aaa
 aaa
@@ -116071,9 +116096,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+iFw
 htS
-aaf
+iFw
 aaa
 aaa
 aaa
@@ -116330,7 +116355,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -121419,7 +121444,7 @@ kkp
 aaa
 qrA
 jhX
-aaf
+iFw
 aaa
 aaa
 aaa
@@ -121676,7 +121701,7 @@ dWT
 lXX
 aaa
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa
@@ -122224,7 +122249,7 @@ aaa
 vuJ
 aaa
 aaa
-aaf
+iFw
 htS
 aaf
 oAw
@@ -122263,9 +122288,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+iFw
 din
-aaf
+iFw
 aaa
 aaa
 aaa
@@ -122483,7 +122508,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 cNg
 oAw
 vkS
@@ -122522,7 +122547,7 @@ aaa
 aaa
 aaa
 aaf
-aaf
+iFw
 aaf
 aaa
 aaa

--- a/maps/southern_sun/southern_cross-1.dmm
+++ b/maps/southern_sun/southern_cross-1.dmm
@@ -5456,15 +5456,6 @@
 	},
 /turf/space,
 /area/space)
-"aIz" = (
-/obj/machinery/pda_multicaster/prebuilt,
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating{
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/SouthernCrossV2/Engineering/Telecomms_Network)
 "aIA" = (
 /turf/simulated/wall/rthull,
 /area/shuttle/escape_pod4/station)
@@ -20260,7 +20251,7 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Market_Stall_5)
 "eNj" = (
-/obj/structure/grille/rustic,
+/obj/structure/inflatable,
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Commons/Central_1_Deck_Hall)
 "eNk" = (
@@ -105142,7 +105133,7 @@ aNq
 jYM
 qkX
 aTF
-aIz
+aTF
 iuI
 cjG
 cjG

--- a/maps/southern_sun/southern_cross-2.dmm
+++ b/maps/southern_sun/southern_cross-2.dmm
@@ -8055,22 +8055,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Security/Reception)
-"avZ" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/terminal,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Engineering_Substation)
 "awb" = (
 /obj/structure/cryofeed,
 /obj/structure/window/reinforced{
@@ -25836,12 +25820,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Security/Visitation_Room)
-"bBo" = (
-/obj/structure/sign/department/shield{
-	desc = "Sign of some important station compartment."
-	},
-/turf/simulated/wall,
-/area/SouthernCrossV2/Maints/Deck2_Medical_AftCorridor1)
 "bBq" = (
 /obj/effect/wingrille_spawn/reinforced_phoron,
 /obj/machinery/door/firedoor/glass,
@@ -26173,6 +26151,12 @@
 /obj/item/weapon/storage/box/snappops,
 /turf/simulated/floor/carpet/bcarpet,
 /area/SouthernCrossV2/Security/Boardroom)
+"bCT" = (
+/obj/structure/sign/department/shield{
+	desc = "Sign of some important station compartment."
+	},
+/turf/simulated/wall,
+/area/SouthernCrossV2/Maints/Deck2_Medical_AftCorridor1)
 "bCU" = (
 /obj/structure/girder,
 /turf/simulated/floor/plating,
@@ -59667,6 +59651,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/SouthernCrossV2/Science/Robotics_Lab)
+"gWp" = (
+/obj/machinery/shield_diffuser,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "gWq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -66845,19 +66834,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Corridor_2)
-"iLW" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/power/smes/batteryrack,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Engineering_Substation)
 "iMs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -68361,6 +68337,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_Transit_Foyer)
+"jib" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "jil" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -69597,11 +69581,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Engineering/Engineering_Workshop)
-"jzm" = (
-/obj/machinery/shield_diffuser,
-/obj/structure/lattice,
-/turf/space,
-/area/space)
 "jzq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -75426,19 +75405,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Corridor_1)
-"lcZ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "ldd" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/lights/bulbs{
@@ -76455,10 +76421,17 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Shuttlebay_Corridor)
 "lte" = (
-/obj/structure/sign/department/shield{
-	desc = "Sign of some important station compartment."
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/wall,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/smes/batteryrack,
+/turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "ltH" = (
 /turf/simulated/floor/carpet,
@@ -79778,6 +79751,19 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/SouthernCrossV2/Domicile/Library_Cafe)
+"mpf" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/batteryrack,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "mpo" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -82809,18 +82795,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Science_StarCorridor1)
-"nir" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Engineering_Substation)
 "niD" = (
 /obj/item/weapon/storage/box/lights/mixed{
 	pixel_x = 8;
@@ -86539,14 +86513,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Maints/Deck2_Medical_AftPortCorridor1)
-"okK" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "okO" = (
 /obj/structure/urinal{
 	dir = 8;
@@ -86649,6 +86615,11 @@
 	},
 /turf/simulated/floor/lino,
 /area/SouthernCrossV2/Domicile/Chapel_Office)
+"onO" = (
+/obj/structure/lattice,
+/obj/machinery/shield_diffuser,
+/turf/space,
+/area/space)
 "oos" = (
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
@@ -86738,6 +86709,19 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Central_Engineering_Post)
+"opB" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/smes/batteryrack,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "opU" = (
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
@@ -88080,19 +88064,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_2)
-"oIS" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes/batteryrack,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Engineering_Substation)
 "oIX" = (
 /obj/item/weapon/paper_bin{
 	pixel_x = 5
@@ -91109,6 +91080,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Domicile/Holodeck)
+"pyb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "pym" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -92823,10 +92802,21 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Star_2_Deck_Airlock_Access)
 "pUM" = (
-/obj/structure/lattice,
-/obj/machinery/shield_diffuser,
-/turf/space,
-/area/space)
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "pUX" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
@@ -96609,16 +96599,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_2_Deck_Corridor_2)
-"qXo" = (
-/obj/structure/disposalpipe/tagger{
-	dir = 4;
-	sort_tag = "transit_crew"
-	},
-/obj/structure/sign/department/shield{
-	desc = "Sign of some important station compartment."
-	},
-/turf/simulated/wall,
-/area/SouthernCrossV2/Domicile/Chomp_Hydroponics)
 "qXt" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -100910,14 +100890,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Security/Deck2_1_Corridor)
-"rZl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "rZn" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -105466,6 +105438,16 @@
 	},
 /turf/simulated/floor/lino,
 /area/SouthernCrossV2/Domicile/Chapel_Office)
+"tiC" = (
+/obj/structure/disposalpipe/tagger{
+	dir = 4;
+	sort_tag = "transit_crew"
+	},
+/obj/structure/sign/department/shield{
+	desc = "Sign of some important station compartment."
+	},
+/turf/simulated/wall,
+/area/SouthernCrossV2/Domicile/Chomp_Hydroponics)
 "tiT" = (
 /obj/structure/closet/toolcloset,
 /obj/item/weapon/storage/box/lights/mixed,
@@ -108110,6 +108092,14 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_2_Deck_Corridor_1)
+"tWn" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "tWA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -111142,18 +111132,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
 /area/SouthernCrossV2/Domicile/Chomp_Hydroponics)
-"uSD" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/power/terminal,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Engineering_Substation)
 "uSG" = (
 /obj/structure/table/woodentable,
 /obj/item/device/starcaster_news,
@@ -115743,6 +115721,12 @@
 /obj/item/weapon/storage/bag/chemistry,
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Chemistry)
+"why" = (
+/obj/structure/sign/department/shield{
+	desc = "Sign of some important station compartment."
+	},
+/turf/simulated/wall,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "whH" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -118071,19 +118055,6 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Domicile/Midnight_Bar)
-"wLY" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/power/smes/batteryrack,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Engineering_Substation)
 "wLZ" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -118692,7 +118663,7 @@
 	},
 /obj/item/weapon/storage/backpack/holding{
 	pixel_y = -4;
-	name = "EMERGECNY bag of holding"
+	name = "EMERGENCY bag of holding"
 	},
 /obj/machinery/button/remote/blast_door{
 	desc = "A remote control-switch for engine core.";
@@ -119524,6 +119495,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Civilian_StarChamber2)
+"xgF" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "xgL" = (
 /turf/simulated/wall,
 /area/SouthernCrossV2/Domicile/VR)
@@ -120035,6 +120018,18 @@
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor/tiled/kafel_full,
 /area/SouthernCrossV2/Domicile/Gym)
+"xnW" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "xof" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28;
@@ -121862,6 +121857,11 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "xQQ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -136798,7 +136798,7 @@ aJt
 vZp
 enP
 sed
-uSD
+xgF
 bSc
 ahz
 tnm
@@ -137313,9 +137313,9 @@ ahz
 ahT
 wpP
 qBn
-wLY
+lte
 aYy
-iLW
+opB
 ahz
 tnm
 oFM
@@ -137571,10 +137571,10 @@ ahz
 dck
 aWH
 ycd
-oIS
-avZ
-oIS
-lte
+mpf
+pUM
+mpf
+why
 pJt
 pMS
 ayV
@@ -138083,7 +138083,7 @@ vvp
 cfS
 fCI
 dUK
-lte
+why
 fyJ
 xQF
 iUU
@@ -138316,7 +138316,7 @@ aaa
 aaa
 aaa
 aaa
-pUM
+onO
 aaf
 aaf
 mcs
@@ -138346,7 +138346,7 @@ ajO
 ekT
 weu
 fDG
-nir
+xnW
 fDG
 ahz
 cdH
@@ -138832,7 +138832,7 @@ aaa
 aaa
 aaa
 aaa
-pUM
+onO
 aaf
 aaf
 myY
@@ -139635,7 +139635,7 @@ ahz
 ahz
 ahq
 sXf
-lte
+why
 mCN
 tYN
 alt
@@ -144087,9 +144087,9 @@ aaa
 mLP
 aaa
 aaa
-pUM
+onO
 bTv
-pUM
+onO
 aaa
 aaa
 vbD
@@ -153056,7 +153056,7 @@ end
 end
 chy
 end
-qXo
+tiC
 vIQ
 aTa
 aTa
@@ -153313,7 +153313,7 @@ bpF
 jAh
 ckd
 rIv
-okK
+tWn
 aoL
 gVv
 aTa
@@ -153571,7 +153571,7 @@ pDo
 jAh
 alI
 rIv
-xQQ
+pyb
 aoM
 apJ
 aTa
@@ -153829,7 +153829,7 @@ aQW
 lOz
 aQw
 rIv
-lcZ
+xQQ
 aoO
 apJ
 aTa
@@ -154087,7 +154087,7 @@ aHe
 jAh
 tAa
 rIv
-xQQ
+pyb
 mCd
 fra
 pZR
@@ -154345,7 +154345,7 @@ svX
 jAh
 aIE
 cvo
-xQQ
+pyb
 aXj
 oSv
 aVG
@@ -154603,7 +154603,7 @@ vaL
 jAh
 alK
 rft
-rZl
+jib
 nqK
 oSv
 aUJ
@@ -162548,9 +162548,9 @@ aaa
 aow
 aaa
 aaa
-jzm
+gWp
 dTE
-jzm
+gWp
 aaa
 aaa
 aow
@@ -167730,7 +167730,7 @@ aaa
 aaa
 aaa
 aaa
-pUM
+onO
 aaf
 aaf
 pxs
@@ -168246,7 +168246,7 @@ aaa
 aaa
 aaa
 aaa
-pUM
+onO
 aaf
 aaf
 nZm
@@ -168810,7 +168810,7 @@ fmG
 tAn
 qxx
 lZV
-bBo
+bCT
 pGQ
 cNu
 wML

--- a/maps/southern_sun/southern_cross-2.dmm
+++ b/maps/southern_sun/southern_cross-2.dmm
@@ -5867,12 +5867,11 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green,
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "aoM" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -5883,7 +5882,7 @@
 /area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "aoO" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green,
+/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -8056,6 +8055,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Security/Reception)
+"avZ" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "awb" = (
 /obj/structure/cryofeed,
 /obj/structure/window/reinforced{
@@ -17095,8 +17110,11 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/power/smes/batteryrack,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "aYA" = (
@@ -19232,10 +19250,6 @@
 /area/SouthernCrossV2/Medical/Treatment_Hall)
 "bfF" = (
 /obj/machinery/shield_gen/external,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "bfG" = (
@@ -25822,6 +25836,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Security/Visitation_Room)
+"bBo" = (
+/obj/structure/sign/department/shield{
+	desc = "Sign of some important station compartment."
+	},
+/turf/simulated/wall,
+/area/SouthernCrossV2/Maints/Deck2_Medical_AftCorridor1)
 "bBq" = (
 /obj/effect/wingrille_spawn/reinforced_phoron,
 /obj/machinery/door/firedoor/glass,
@@ -30006,6 +30026,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/smes/batteryrack,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "bSd" = (
@@ -47714,9 +47735,6 @@
 	color = "yellow";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
 	dir = 1
 	},
@@ -56504,6 +56522,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Mains Grid";
+	name_tag = "Mains Grid"
+	},
+/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "ggO" = (
@@ -57004,10 +57027,6 @@
 	name = "1E-light fixture"
 	},
 /obj/machinery/shield_gen/external,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Domicile_Substation)
 "glF" = (
@@ -61877,11 +61896,6 @@
 /area/SouthernCrossV2/Science/Toxins_Storage)
 "hzO" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -64683,7 +64697,6 @@
 "ilR" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/shield_gen/external,
-/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Medical_Substation)
 "ilT" = (
@@ -66832,6 +66845,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Corridor_2)
+"iLW" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/smes/batteryrack,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "iMs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69571,6 +69597,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Engineering/Engineering_Workshop)
+"jzm" = (
+/obj/machinery/shield_diffuser,
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "jzq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -75395,6 +75426,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Port_2_Deck_Corridor_1)
+"lcZ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "ldd" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/lights/bulbs{
@@ -76411,17 +76455,10 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_2_Deck_Shuttlebay_Corridor)
 "lte" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/sign/department/shield{
+	desc = "Sign of some important station compartment."
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "ltH" = (
 /turf/simulated/floor/carpet,
@@ -82772,6 +82809,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck2_Science_StarCorridor1)
+"nir" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "niD" = (
 /obj/item/weapon/storage/box/lights/mixed{
 	pixel_x = 8;
@@ -86490,6 +86539,14 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Maints/Deck2_Medical_AftPortCorridor1)
+"okK" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "okO" = (
 /obj/structure/urinal{
 	dir = 8;
@@ -88023,6 +88080,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Chomp_Dinner_2)
+"oIS" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/batteryrack,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "oIX" = (
 /obj/item/weapon/paper_bin{
 	pixel_x = 5
@@ -92753,25 +92823,10 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Harbor/Star_2_Deck_Airlock_Access)
 "pUM" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Central_Engineering_Post)
+/obj/structure/lattice,
+/obj/machinery/shield_diffuser,
+/turf/space,
+/area/space)
 "pUX" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
@@ -96291,9 +96346,7 @@
 /area/SouthernCrossV2/Security/Deck2_1_Corridor)
 "qSG" = (
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/machinery/atmospherics/pipe/cap/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Distro_Civilian)
 "qSL" = (
@@ -96556,6 +96609,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Star_2_Deck_Corridor_2)
+"qXo" = (
+/obj/structure/disposalpipe/tagger{
+	dir = 4;
+	sort_tag = "transit_crew"
+	},
+/obj/structure/sign/department/shield{
+	desc = "Sign of some important station compartment."
+	},
+/turf/simulated/wall,
+/area/SouthernCrossV2/Domicile/Chomp_Hydroponics)
 "qXt" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -97218,6 +97281,11 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "rfQ" = (
@@ -100842,6 +100910,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Security/Deck2_1_Corridor)
+"rZl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Central_Engineering_Post)
 "rZn" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -101241,6 +101317,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/power/smes/batteryrack,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "sex" = (
@@ -103421,8 +103498,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -111065,6 +111142,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
 /area/SouthernCrossV2/Domicile/Chomp_Hydroponics)
+"uSD" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/terminal,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "uSG" = (
 /obj/structure/table/woodentable,
 /obj/item/device/starcaster_news,
@@ -117982,6 +118071,19 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/wood/sif,
 /area/SouthernCrossV2/Domicile/Midnight_Bar)
+"wLY" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/power/smes/batteryrack,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Engineering_Substation)
 "wLZ" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -121760,10 +121862,10 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Engineering_Substation)
 "xQQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Central_Engineering_Post)
@@ -136435,7 +136537,7 @@ bmk
 bmk
 ahz
 bfF
-lte
+rMJ
 cqs
 aWH
 aWH
@@ -136696,7 +136798,7 @@ aJt
 vZp
 enP
 sed
-bSc
+uSD
 bSc
 ahz
 tnm
@@ -137211,9 +137313,9 @@ ahz
 ahT
 wpP
 qBn
+wLY
 aYy
-aYy
-aYy
+iLW
 ahz
 tnm
 oFM
@@ -137469,10 +137571,10 @@ ahz
 dck
 aWH
 ycd
-aYy
-aYy
-aYy
-ahz
+oIS
+avZ
+oIS
+lte
 pJt
 pMS
 ayV
@@ -137981,7 +138083,7 @@ vvp
 cfS
 fCI
 dUK
-ahz
+lte
 fyJ
 xQF
 iUU
@@ -138214,9 +138316,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+pUM
+aaf
+aaf
 mcs
 bEg
 luv
@@ -138244,7 +138346,7 @@ ajO
 ekT
 weu
 fDG
-fDG
+nir
 fDG
 ahz
 cdH
@@ -138730,9 +138832,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+pUM
+aaf
+aaf
 myY
 bEg
 luv
@@ -139533,7 +139635,7 @@ ahz
 ahz
 ahq
 sXf
-ahz
+lte
 mCN
 tYN
 alt
@@ -143985,9 +144087,9 @@ aaa
 mLP
 aaa
 aaa
-aaa
+pUM
 bTv
-aaa
+pUM
 aaa
 aaa
 vbD
@@ -144243,9 +144345,9 @@ aaa
 bFW
 aaa
 aaa
-aaa
+aaf
 nkv
-aaa
+aaf
 aaa
 aaa
 bFW
@@ -144501,9 +144603,9 @@ aaa
 bFW
 aaa
 aaa
-aaa
+aaf
 xud
-aaa
+aaf
 aaa
 aaa
 bFW
@@ -150695,7 +150797,7 @@ jsn
 iRP
 eIB
 dNa
-xvF
+dFK
 rtk
 pIK
 jDg
@@ -151217,7 +151319,7 @@ uiW
 nYE
 gFa
 pCj
-pCj
+uMS
 cur
 mga
 qfA
@@ -151727,9 +151829,9 @@ wql
 cFm
 nxW
 jIY
+xvF
+xvF
 dFK
-xvF
-xvF
 dZA
 xvF
 tur
@@ -152954,7 +153056,7 @@ end
 end
 chy
 end
-wPD
+qXo
 vIQ
 aTa
 aTa
@@ -153210,8 +153312,8 @@ bNv
 bpF
 jAh
 ckd
-pUM
-xQQ
+rIv
+okK
 aoL
 gVv
 aTa
@@ -153468,7 +153570,7 @@ lVM
 pDo
 jAh
 alI
-pUM
+rIv
 xQQ
 aoM
 apJ
@@ -153726,8 +153828,8 @@ lVM
 aQW
 lOz
 aQw
-pUM
-xQQ
+rIv
+lcZ
 aoO
 apJ
 aTa
@@ -153985,7 +154087,7 @@ aHe
 jAh
 tAa
 rIv
-aQw
+xQQ
 mCd
 fra
 pZR
@@ -154243,7 +154345,7 @@ svX
 jAh
 aIE
 cvo
-aQw
+xQQ
 aXj
 oSv
 aVG
@@ -154501,7 +154603,7 @@ vaL
 jAh
 alK
 rft
-aQw
+rZl
 nqK
 oSv
 aUJ
@@ -161930,9 +162032,9 @@ aaa
 bHR
 aaa
 aaa
-aaa
+aaf
 xhM
-aaa
+aaf
 aaa
 aaa
 bHR
@@ -162188,9 +162290,9 @@ cFG
 bHR
 aaa
 aaa
-aaa
+aaf
 opk
-aaa
+aaf
 aaa
 aaa
 bHR
@@ -162446,9 +162548,9 @@ aaa
 aow
 aaa
 aaa
-aaa
+jzm
 dTE
-aaa
+jzm
 aaa
 aaa
 aow
@@ -167628,9 +167730,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+pUM
+aaf
+aaf
 pxs
 slm
 pxs
@@ -168144,9 +168246,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+pUM
+aaf
+aaf
 nZm
 slm
 pxs
@@ -168708,7 +168810,7 @@ fmG
 tAn
 qxx
 lZV
-qLx
+bBo
 pGQ
 cNu
 wML
@@ -169218,7 +169320,7 @@ aJx
 aJx
 uOd
 tHA
-hPZ
+vRU
 ccg
 tSf
 gjl
@@ -169485,7 +169587,7 @@ rPP
 rts
 wQe
 dLR
-hPZ
+vRU
 puV
 xua
 ikJ

--- a/maps/southern_sun/southern_cross-2.dmm
+++ b/maps/southern_sun/southern_cross-2.dmm
@@ -13837,7 +13837,7 @@
 /obj/machinery/light{
 	name = "1S-light fixture"
 	},
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightorange/border,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -85601,6 +85601,7 @@
 	icon_state = "open";
 	id = "sc-GCeastshuttlebay"
 	},
+/obj/machinery/shield_diffuser,
 /turf/space,
 /area/SouthernCrossV2/Harbor/Star_Shuttlebay)
 "nZr" = (
@@ -121907,6 +121908,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Security_Substation)
+"xRY" = (
+/obj/structure/lattice,
+/obj/effect/catwalk_plated/white,
+/obj/machinery/shield_diffuser,
+/turf/space,
+/area/SouthernCrossV2/Harbor/Star_Shuttlebay)
 "xSl" = (
 /obj/machinery/door/firedoor/multi_tile/glass{
 	dir = 1
@@ -167475,7 +167482,7 @@ aaa
 aaa
 aaa
 aaa
-pxs
+xRY
 slm
 pxs
 vqB
@@ -167733,7 +167740,7 @@ aaa
 onO
 aaf
 aaf
-pxs
+xRY
 slm
 pxs
 bOa
@@ -168507,7 +168514,7 @@ aaa
 aaa
 aaa
 aaa
-pxs
+xRY
 slm
 pxs
 hmH

--- a/maps/southern_sun/southern_cross-3.dmm
+++ b/maps/southern_sun/southern_cross-3.dmm
@@ -371,13 +371,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Chomp_Lounge)
-"adJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "adS" = (
 /obj/machinery/light{
 	dir = 8;
@@ -990,13 +983,6 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Medical/Lounge)
-"aqd" = (
-/obj/machinery/atmospherics/binary/pump/on{
-	target_pressure = 200;
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "aqj" = (
 /obj/structure/lattice,
 /turf/space,
@@ -5257,17 +5243,6 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_AftStarCorridor1)
-"bRy" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "bRF" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -7372,12 +7347,10 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/SouthernCrossV2/Domicile/Observation_Atrium)
 "cDl" = (
-/obj/effect/catwalk_plated/techmaint,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
+/obj/structure/lattice,
+/obj/machinery/shield_diffuser,
+/turf/space,
+/area/space)
 "cDq" = (
 /obj/machinery/vending/donksoft,
 /turf/simulated/floor/tiled/dark,
@@ -10621,6 +10594,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftCorridor2)
+"dHZ" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1;
+	start_pressure = 4559.63
+	},
+/obj/effect/floor_decal/industrial/hatch/blue,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "dIm" = (
 /obj/machinery/light{
 	dir = 8;
@@ -12832,12 +12813,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Bridge/RD_Quarters)
 "enk" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/meter,
+/obj/random/junk,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
 /turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "enm" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13452,14 +13431,6 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/durasteel,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
-"ezJ" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Airlock_Access)
 "ezK" = (
 /obj/machinery/newscaster{
 	pixel_x = -28;
@@ -14001,8 +13972,11 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Engineering/Engine1_Control_Room)
 "eIx" = (
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "eIA" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -18609,6 +18583,17 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Medical_StarCorridor1)
+"fQk" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "fQm" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -20244,6 +20229,14 @@
 /obj/structure/bed/chair/sofa/yellow,
 /turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Domicile/Chomp_Lounge)
+"gqX" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Airlock_Access)
 "grh" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -20509,6 +20502,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
+"gxz" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Airlock_Access)
 "gxC" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -21063,6 +21064,13 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /area/SouthernCrossV2/Domicile/Public_Garden)
+"gHy" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Airlock_Access)
 "gHI" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/door/blast/angled{
@@ -22125,11 +22133,11 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/SouthernCrossV2/Bridge/Captain_Office)
 "gXM" = (
-/obj/structure/railing/grey{
-	color = "yellow"
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
 	},
-/turf/simulated/floor/glass/reinforced,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "gXS" = (
 /obj/effect/floor_decal/industrial/warning/color/corner{
 	dir = 8
@@ -22252,13 +22260,6 @@
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber2)
-"haa" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "hag" = (
 /obj/structure/cable/white{
 	d1 = 2;
@@ -23596,12 +23597,6 @@
 /obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Bridge/Embassy)
-"hBT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "hBX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -26630,6 +26625,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Medical/Morgue)
+"izE" = (
+/obj/random/trash,
+/obj/machinery/atmospherics/valve/shutoff{
+	name = "Dorms level automatic shutoff valve";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "izF" = (
 /obj/machinery/light{
 	dir = 8;
@@ -29122,13 +29125,6 @@
 "jnO" = (
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Commons/Stairwell_Port)
-"jof" = (
-/obj/random/trash,
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "jol" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -29185,13 +29181,6 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
-"jph" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Airlock_Access)
 "jpj" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -29227,14 +29216,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Bridge/Firstaid_Post)
-"jpP" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
+"jpB" = (
+/obj/random/trash,
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 4;
+	unlocked = 1
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Airlock_Access)
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "jqa" = (
 /obj/structure/cable/pink{
 	d1 = 1;
@@ -30213,11 +30202,11 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Bridge/Deck3_Corridor)
 "jFO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5
+/obj/structure/railing/grey{
+	color = "yellow"
 	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
 "jFT" = (
 /obj/machinery/airlock_sensor{
 	pixel_y = 24
@@ -32207,6 +32196,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForPort_Corridor1)
+"koQ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "kpk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/newscaster{
@@ -39101,6 +39097,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Commons/Aft_3_Deck_Stairwell)
+"mpw" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "mpD" = (
 /mob/living/simple_mob/animal/passive/dog/corgi/puppy/wiggle,
 /obj/structure/dogbed{
@@ -39353,7 +39356,7 @@
 /area/SouthernCrossV2/Engineering/Deck3_2_Corridor)
 "msv" = (
 /obj/random/trash,
-/obj/machinery/atmospherics/binary/passive_gate{
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -40273,6 +40276,13 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/SouthernCrossV2/Domicile/Public_Hydroponics)
+"mKF" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "mKK" = (
 /obj/structure/bed/double/padded{
 	pixel_y = 25
@@ -42073,14 +42083,6 @@
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber1)
-"nqB" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 1;
-	start_pressure = 4559.63
-	},
-/obj/effect/floor_decal/industrial/hatch/blue,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "nqE" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -43976,6 +43978,13 @@
 	name = "Lockdown Gate";
 	desc = "A heavily reinforced gate, sector lockdown!"
 	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
+"nUv" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "nUL" = (
@@ -58317,11 +58326,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Medical/Stairwell)
-"svR" = (
-/obj/random/junk,
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "svX" = (
 /obj/structure/closet/emergsuit_wall{
 	pixel_y = 27;
@@ -61011,6 +61015,13 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Medical/Stairwell)
+"tkY" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	target_pressure = 200;
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "tld" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -71326,6 +71337,12 @@
 	},
 /turf/simulated/floor/tiled/old_cargo,
 /area/SouthernCrossV2/Medical/Deck3_Corridor)
+"wAy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "wAG" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/closet/crate/solar,
@@ -73079,12 +73096,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Dorm_Foyer)
-"wYS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "wYT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -73358,14 +73369,6 @@
 "xco" = (
 /turf/simulated/wall,
 /area/SouthernCrossV2/Domicile/Dormitory_05)
-"xcB" = (
-/obj/random/trash,
-/obj/machinery/atmospherics/valve/shutoff{
-	name = "Dorms level automatic shutoff valve";
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "xcG" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -76096,10 +76099,8 @@
 /turf/simulated/floor/tiled/kafel_full,
 /area/SouthernCrossV2/Domicile/Dormitory_07)
 "xPM" = (
-/obj/structure/lattice,
-/obj/machinery/shield_diffuser,
-/turf/space,
-/area/space)
+/turf/simulated/floor/glass/reinforced,
+/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
 "xPN" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -80511,7 +80512,7 @@ apc
 apc
 apc
 aqj
-xPM
+cDl
 aqj
 apc
 apc
@@ -80521,7 +80522,7 @@ apc
 apc
 apc
 aqj
-xPM
+cDl
 aqj
 apc
 apc
@@ -85423,11 +85424,11 @@ rZl
 xJY
 xJY
 vnV
-aqd
-nqB
+tkY
+dHZ
 mCr
 tBT
-ezJ
+gxz
 tXX
 ngU
 vTE
@@ -85680,7 +85681,7 @@ ptJ
 ipc
 xJY
 xJY
-bRy
+fQk
 sJT
 vnp
 yfm
@@ -85943,7 +85944,7 @@ vLY
 lJP
 iVU
 aZg
-jph
+gHy
 sSl
 iVU
 yaQ
@@ -86201,7 +86202,7 @@ vLY
 uZK
 mCr
 urH
-jpP
+gqX
 hDJ
 mCr
 kXf
@@ -86413,7 +86414,7 @@ apc
 apc
 apc
 aqj
-xPM
+cDl
 aqj
 apc
 apc
@@ -86523,7 +86524,7 @@ apc
 apc
 apc
 aqj
-xPM
+cDl
 aqj
 apc
 apc
@@ -86670,9 +86671,9 @@ apc
 apc
 apc
 apc
-xPM
+cDl
 mmN
-xPM
+cDl
 apc
 apc
 apc
@@ -86780,9 +86781,9 @@ apc
 apc
 apc
 apc
-xPM
+cDl
 jwm
-xPM
+cDl
 apc
 apc
 apc
@@ -90621,7 +90622,7 @@ oFF
 wPJ
 puR
 gtE
-enk
+nUv
 puR
 dFh
 puR
@@ -91134,7 +91135,7 @@ csy
 twp
 epU
 xBe
-haa
+koQ
 dFh
 puR
 nhg
@@ -91651,7 +91652,7 @@ puR
 dFh
 puR
 puR
-adJ
+mKF
 gtE
 puR
 puR
@@ -104877,7 +104878,7 @@ dHa
 dHa
 nbo
 sgy
-xPM
+cDl
 aqj
 apc
 apc
@@ -105136,7 +105137,7 @@ dHa
 bYA
 mlm
 piu
-xPM
+cDl
 apc
 dvf
 apc
@@ -105393,7 +105394,7 @@ dHa
 dHa
 nev
 sgy
-xPM
+cDl
 aqj
 apc
 apc
@@ -108687,7 +108688,7 @@ dHa
 dHa
 lmX
 eRe
-jFO
+gXM
 xmc
 sxE
 xmc
@@ -108945,9 +108946,9 @@ dHa
 dHa
 lmX
 eRe
-svR
+enk
 sOH
-cDl
+mpw
 pZU
 pZU
 xmc
@@ -109203,9 +109204,9 @@ dHa
 dHa
 lmX
 lmX
-hBT
-jFO
-cDl
+eIx
+gXM
+mpw
 sOH
 cLw
 xmc
@@ -109462,7 +109463,7 @@ dHa
 dHa
 lmX
 jhL
-msv
+jpB
 gao
 lAu
 wWn
@@ -109521,7 +109522,7 @@ dHa
 dHa
 nev
 sgy
-xPM
+cDl
 aqj
 apc
 apc
@@ -109720,8 +109721,8 @@ dHa
 dHa
 lmX
 jhL
-xcB
-jof
+izE
+msv
 sOH
 vCk
 xmc
@@ -109780,7 +109781,7 @@ dHa
 kSC
 mlm
 piu
-xPM
+cDl
 apc
 dvf
 apc
@@ -109978,8 +109979,8 @@ dHa
 dHa
 lmX
 lmX
-hBT
-wYS
+eIx
+wAy
 sOH
 uPq
 xmc
@@ -110037,7 +110038,7 @@ dHa
 dHa
 nbo
 sgy
-xPM
+cDl
 aqj
 apc
 apc
@@ -124120,8 +124121,8 @@ tmS
 dVi
 nvI
 xKh
-eIx
-gXM
+xPM
+jFO
 bxE
 oHa
 ouJ
@@ -124378,8 +124379,8 @@ fjT
 fjT
 nvI
 xKh
-eIx
-gXM
+xPM
+jFO
 bxE
 sIP
 ouJ
@@ -124636,8 +124637,8 @@ bYw
 ohH
 nvI
 xKh
-eIx
-gXM
+xPM
+jFO
 bxE
 gJr
 ouJ
@@ -124894,8 +124895,8 @@ eAD
 dVi
 nvI
 xKh
-eIx
-gXM
+xPM
+jFO
 bxE
 acO
 ipX
@@ -125152,8 +125153,8 @@ dVi
 qDY
 nvI
 xKh
-eIx
-gXM
+xPM
+jFO
 bxE
 qwe
 ipX
@@ -125410,8 +125411,8 @@ pIX
 pIX
 sRP
 xKh
-eIx
-gXM
+xPM
+jFO
 avh
 xym
 qiA
@@ -125668,8 +125669,8 @@ dVi
 seu
 nvI
 xKh
-eIx
-gXM
+xPM
+jFO
 vzW
 vzW
 ipX
@@ -127950,9 +127951,9 @@ apc
 apc
 apc
 apc
-xPM
+cDl
 naz
-xPM
+cDl
 apc
 apc
 apc
@@ -127964,9 +127965,9 @@ apc
 apc
 apc
 apc
-xPM
+cDl
 naz
-xPM
+cDl
 apc
 apc
 apc
@@ -128046,9 +128047,9 @@ apc
 apc
 apc
 apc
-xPM
+cDl
 biI
-xPM
+cDl
 apc
 apc
 apc
@@ -128060,9 +128061,9 @@ apc
 apc
 apc
 apc
-xPM
+cDl
 biI
-xPM
+cDl
 apc
 apc
 apc
@@ -128209,7 +128210,7 @@ apc
 apc
 apc
 aqj
-xPM
+cDl
 aqj
 apc
 apc
@@ -128223,7 +128224,7 @@ apc
 apc
 apc
 aqj
-xPM
+cDl
 aqj
 apc
 apc
@@ -128305,7 +128306,7 @@ apc
 apc
 apc
 aqj
-xPM
+cDl
 aqj
 apc
 apc
@@ -128319,7 +128320,7 @@ apc
 apc
 apc
 aqj
-xPM
+cDl
 aqj
 apc
 apc

--- a/maps/southern_sun/southern_cross-3.dmm
+++ b/maps/southern_sun/southern_cross-3.dmm
@@ -22512,9 +22512,18 @@
 /turf/simulated/wall,
 /area/SouthernCrossV2/Domicile/Central_Restroom)
 "hgP" = (
-/obj/machinery/atmospherics/unary/outlet_injector{
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
 	frequency = 1441;
-	id = "SC-o2IN";
+	icon_state = "map_vent_in";
+	id_tag = "SC-o2OUT";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
 	use_power = 1
 	},
 /obj/machinery/light/small{
@@ -35909,12 +35918,16 @@
 	},
 /area/SouthernCrossV2/Bridge/Firstaid_Post)
 "lyu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/machinery/atmospherics/valve{
+	name = "Bridge emergency air supply"
+	},
 /obj/machinery/camera/network/security{
 	dir = 8;
 	c_tag = "D3-Eng-Substation Bridge1";
 	network = list("engineering")
 	},
+/obj/effect/floor_decal/industrial/danger/full,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "lyD" = (
@@ -39411,18 +39424,9 @@
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_AftPortChamber1)
 "mtW" = (
-/obj/machinery/atmospherics/unary/vent_pump{
-	external_pressure_bound = 0;
-	external_pressure_bound_default = 0;
+/obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1441;
-	icon_state = "map_vent_in";
-	id_tag = "SC-o2OUT";
-	initialize_directions = 1;
-	internal_pressure_bound = 4000;
-	internal_pressure_bound_default = 4000;
-	pressure_checks = 2;
-	pressure_checks_default = 2;
-	pump_direction = 0;
+	id = "SC-o2IN";
 	use_power = 1
 	},
 /turf/simulated/floor/reinforced/oxygen,
@@ -53044,11 +53048,7 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Engineering/Engine2_Access_Hall)
 "qLY" = (
-/obj/machinery/atmospherics/valve{
-	name = "Bridge emergency air supply"
-	},
-/obj/effect/floor_decal/industrial/danger/full,
-/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "qMb" = (

--- a/maps/southern_sun/southern_cross-3.dmm
+++ b/maps/southern_sun/southern_cross-3.dmm
@@ -371,6 +371,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Chomp_Lounge)
+"adJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "adS" = (
 /obj/machinery/light{
 	dir = 8;
@@ -983,6 +990,13 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Medical/Lounge)
+"aqd" = (
+/obj/machinery/atmospherics/binary/pump/on{
+	target_pressure = 200;
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "aqj" = (
 /obj/structure/lattice,
 /turf/space,
@@ -5243,6 +5257,17 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Bridge_AftStarCorridor1)
+"bRy" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "bRF" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -7347,13 +7372,12 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/SouthernCrossV2/Domicile/Observation_Atrium)
 "cDl" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/catwalk_plated/techmaint,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/SouthernCrossV2/Engineering/Engine1_Chamber)
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "cDq" = (
 /obj/machinery/vending/donksoft,
 /turf/simulated/floor/tiled/dark,
@@ -10341,8 +10365,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/SouthernCrossV2/Domicile/Observation_Atrium)
 "dEo" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -12808,12 +12832,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Bridge/RD_Quarters)
 "enk" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "enm" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13428,6 +13452,14 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/durasteel,
 /area/SouthernCrossV2/Bridge/AI_Core_Chamber)
+"ezJ" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Airlock_Access)
 "ezK" = (
 /obj/machinery/newscaster{
 	pixel_x = -28;
@@ -13969,8 +14001,7 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Engineering/Engine1_Control_Room)
 "eIx" = (
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
 "eIA" = (
 /obj/structure/railing/grey{
@@ -14248,7 +14279,6 @@
 "eMz" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/shield_gen/external,
-/obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "eMJ" = (
@@ -14699,7 +14729,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/SouthernCrossV2/Engineering/Engine_Tech_Storage)
 "eRe" = (
-/obj/random/crate,
+/obj/machinery/atmospherics/pipe/tank/air/full,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "eRh" = (
@@ -19138,6 +19168,9 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "gaI" = (
@@ -22095,8 +22128,7 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
 "gXS" = (
 /obj/effect/floor_decal/industrial/warning/color/corner{
@@ -22220,6 +22252,13 @@
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_StarChamber2)
+"haa" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine2_Chamber)
 "hag" = (
 /obj/structure/cable/white{
 	d1 = 2;
@@ -22458,11 +22497,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -23562,6 +23596,12 @@
 /obj/structure/table/wooden_reinforced,
 /turf/simulated/floor/wood/alt,
 /area/SouthernCrossV2/Bridge/Embassy)
+"hBT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "hBX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -25626,9 +25666,6 @@
 "iip" = (
 /obj/structure/railing/grey{
 	color = "yellow";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
@@ -29085,6 +29122,13 @@
 "jnO" = (
 /turf/simulated/wall/r_wall,
 /area/SouthernCrossV2/Commons/Stairwell_Port)
+"jof" = (
+/obj/random/trash,
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "jol" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -29112,7 +29156,7 @@
 	color = "yellow";
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
 "joD" = (
 /obj/effect/graffitispawner,
@@ -29141,6 +29185,13 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Engineering_AftStarCorridor1)
+"jph" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Airlock_Access)
 "jpj" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -29176,6 +29227,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Bridge/Firstaid_Post)
+"jpP" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Airlock_Access)
 "jqa" = (
 /obj/structure/cable/pink{
 	d1 = 1;
@@ -30154,11 +30213,11 @@
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Bridge/Deck3_Corridor)
 "jFO" = (
-/obj/structure/railing/grey{
-	color = "yellow"
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
 	},
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "jFT" = (
 /obj/machinery/airlock_sensor{
 	pixel_y = 24
@@ -33772,6 +33831,7 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_3_Deck_Central_Corridor_1)
 "kPn" = (
@@ -36626,10 +36686,10 @@
 	name = "1S-light fixture"
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/atmospherics/pipe/tank{
-	dir = 1;
-	start_pressure = 0
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "lKg" = (
@@ -39293,6 +39353,9 @@
 /area/SouthernCrossV2/Engineering/Deck3_2_Corridor)
 "msv" = (
 /obj/random/trash,
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "msL" = (
@@ -39857,7 +39920,7 @@
 /turf/simulated/floor/tiled/white,
 /area/SouthernCrossV2/Domicile/Dormitory_05)
 "mEf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Airlock_Access)
@@ -42010,6 +42073,14 @@
 	},
 /turf/simulated/open,
 /area/SouthernCrossV2/Maints/Deck3_Medical_AftPortChamber1)
+"nqB" = (
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1;
+	start_pressure = 4559.63
+	},
+/obj/effect/floor_decal/industrial/hatch/blue,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "nqE" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -44883,7 +44954,7 @@
 	color = "yellow";
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
 "ojb" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
@@ -47604,8 +47675,8 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/SouthernCrossV2/Domicile/Dormitory_02)
 "paF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -55823,6 +55894,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_3_Deck_Central_Corridor_1)
 "rIF" = (
@@ -58243,6 +58317,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Medical/Stairwell)
+"svR" = (
+/obj/random/junk,
+/obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "svX" = (
 /obj/structure/closet/emergsuit_wall{
 	pixel_y = 27;
@@ -58333,6 +58412,9 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/maintenance/int,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "sxL" = (
@@ -63513,7 +63595,7 @@
 	color = "yellow";
 	dir = 8
 	},
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
 "ugV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -66460,10 +66542,10 @@
 	network = list("engineering","Engine");
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/tank{
-	dir = 1;
-	start_pressure = 0
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/SouthernCrossV2/Engineering/Engine1_Chamber)
 "uZQ" = (
@@ -68138,6 +68220,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/sign/department/shield{
+	desc = "Sign of some important station compartment.";
+	pixel_y = 31
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/SouthernCrossV2/Maints/Bridge_Substation)
 "vAz" = (
@@ -68783,6 +68869,7 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Commons/Aft_3_Deck_Central_Corridor_1)
 "vJH" = (
@@ -72992,6 +73079,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/SouthernCrossV2/Domicile/Dorm_Foyer)
+"wYS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "wYT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -73265,6 +73358,14 @@
 "xco" = (
 /turf/simulated/wall,
 /area/SouthernCrossV2/Domicile/Dormitory_05)
+"xcB" = (
+/obj/random/trash,
+/obj/machinery/atmospherics/valve/shutoff{
+	name = "Dorms level automatic shutoff valve";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/SouthernCrossV2/Maints/Deck3_Dorms_ForStarChamber1)
 "xcG" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -75542,8 +75643,7 @@
 	color = "yellow";
 	dir = 1
 	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/turf/simulated/floor/glass/reinforced,
 /area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
 "xKn" = (
 /obj/machinery/shower{
@@ -75996,8 +76096,10 @@
 /turf/simulated/floor/tiled/kafel_full,
 /area/SouthernCrossV2/Domicile/Dormitory_07)
 "xPM" = (
-/turf/simulated/open,
-/area/SouthernCrossV2/Maints/Deck3_Medical_ForStarChamber3)
+/obj/structure/lattice,
+/obj/machinery/shield_diffuser,
+/turf/space,
+/area/space)
 "xPN" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -80409,8 +80511,8 @@ apc
 apc
 apc
 aqj
+xPM
 aqj
-aqj
 apc
 apc
 apc
@@ -80419,7 +80521,7 @@ apc
 apc
 apc
 aqj
-aqj
+xPM
 aqj
 apc
 apc
@@ -85320,12 +85422,12 @@ eJk
 rZl
 xJY
 xJY
-cDl
-xJY
-pqS
+vnV
+aqd
+nqB
 mCr
 tBT
-liR
+ezJ
 tXX
 ngU
 vTE
@@ -85578,7 +85680,7 @@ ptJ
 ipc
 xJY
 xJY
-vnV
+bRy
 sJT
 vnp
 yfm
@@ -85841,7 +85943,7 @@ vLY
 lJP
 iVU
 aZg
-liR
+jph
 sSl
 iVU
 yaQ
@@ -86099,7 +86201,7 @@ vLY
 uZK
 mCr
 urH
-liR
+jpP
 hDJ
 mCr
 kXf
@@ -86311,7 +86413,7 @@ apc
 apc
 apc
 aqj
-aqj
+xPM
 aqj
 apc
 apc
@@ -86421,7 +86523,7 @@ apc
 apc
 apc
 aqj
-aqj
+xPM
 aqj
 apc
 apc
@@ -86568,9 +86670,9 @@ apc
 apc
 apc
 apc
-aqj
+xPM
 mmN
-aqj
+xPM
 apc
 apc
 apc
@@ -86678,9 +86780,9 @@ apc
 apc
 apc
 apc
-aqj
+xPM
 jwm
-aqj
+xPM
 apc
 apc
 apc
@@ -90519,7 +90621,7 @@ oFF
 wPJ
 puR
 gtE
-nhg
+enk
 puR
 dFh
 puR
@@ -91032,7 +91134,7 @@ csy
 twp
 epU
 xBe
-wPJ
+haa
 dFh
 puR
 nhg
@@ -91549,7 +91651,7 @@ puR
 dFh
 puR
 puR
-dFh
+adJ
 gtE
 puR
 puR
@@ -104775,7 +104877,7 @@ dHa
 dHa
 nbo
 sgy
-aqj
+xPM
 aqj
 apc
 apc
@@ -105034,7 +105136,7 @@ dHa
 bYA
 mlm
 piu
-aqj
+xPM
 apc
 dvf
 apc
@@ -105291,7 +105393,7 @@ dHa
 dHa
 nev
 sgy
-aqj
+xPM
 aqj
 apc
 apc
@@ -108494,7 +108596,7 @@ ylu
 lyu
 qLY
 xdq
-dNd
+rai
 kWm
 xLJ
 uDu
@@ -108585,7 +108687,7 @@ dHa
 dHa
 lmX
 eRe
-sOH
+jFO
 xmc
 sxE
 xmc
@@ -108843,9 +108945,9 @@ dHa
 dHa
 lmX
 eRe
-uPq
+svR
 sOH
-lAu
+cDl
 pZU
 pZU
 xmc
@@ -109101,9 +109203,9 @@ dHa
 dHa
 lmX
 lmX
-sOH
-sOH
-lAu
+hBT
+jFO
+cDl
 sOH
 cLw
 xmc
@@ -109419,7 +109521,7 @@ dHa
 dHa
 nev
 sgy
-aqj
+xPM
 aqj
 apc
 apc
@@ -109618,8 +109720,8 @@ dHa
 dHa
 lmX
 jhL
-msv
-msv
+xcB
+jof
 sOH
 vCk
 xmc
@@ -109678,7 +109780,7 @@ dHa
 kSC
 mlm
 piu
-aqj
+xPM
 apc
 dvf
 apc
@@ -109876,8 +109978,8 @@ dHa
 dHa
 lmX
 lmX
-sOH
-sOH
+hBT
+wYS
 sOH
 uPq
 xmc
@@ -109935,7 +110037,7 @@ dHa
 dHa
 nbo
 sgy
-aqj
+xPM
 aqj
 apc
 apc
@@ -124017,9 +124119,9 @@ nxp
 tmS
 dVi
 nvI
-enk
-xPM
-jFO
+xKh
+eIx
+gXM
 bxE
 oHa
 ouJ
@@ -124533,9 +124635,9 @@ nxp
 bYw
 ohH
 nvI
-enk
-xPM
-jFO
+xKh
+eIx
+gXM
 bxE
 gJr
 ouJ
@@ -124791,9 +124893,9 @@ nxp
 eAD
 dVi
 nvI
-enk
-xPM
-jFO
+xKh
+eIx
+gXM
 bxE
 acO
 ipX
@@ -125307,9 +125409,9 @@ vJH
 pIX
 pIX
 sRP
-enk
-xPM
-jFO
+xKh
+eIx
+gXM
 avh
 xym
 qiA
@@ -127848,9 +127950,9 @@ apc
 apc
 apc
 apc
-aqj
+xPM
 naz
-aqj
+xPM
 apc
 apc
 apc
@@ -127862,9 +127964,9 @@ apc
 apc
 apc
 apc
-aqj
+xPM
 naz
-aqj
+xPM
 apc
 apc
 apc
@@ -127944,9 +128046,9 @@ apc
 apc
 apc
 apc
-aqj
+xPM
 biI
-aqj
+xPM
 apc
 apc
 apc
@@ -127958,9 +128060,9 @@ apc
 apc
 apc
 apc
-aqj
+xPM
 biI
-aqj
+xPM
 apc
 apc
 apc
@@ -128107,8 +128209,8 @@ apc
 apc
 apc
 aqj
+xPM
 aqj
-aqj
 apc
 apc
 apc
@@ -128121,7 +128223,7 @@ apc
 apc
 apc
 aqj
-aqj
+xPM
 aqj
 apc
 apc
@@ -128203,8 +128305,8 @@ apc
 apc
 apc
 aqj
+xPM
 aqj
-aqj
 apc
 apc
 apc
@@ -128217,7 +128319,7 @@ apc
 apc
 apc
 aqj
-aqj
+xPM
 aqj
 apc
 apc


### PR DESCRIPTION
## About The Pull Request

Some more map fixes, too tired to work on much else sorry

## Changelog
:cl:
add: Added shield diffusers to airlocks at the docks
add: Added shield diffusers around a few point defence turrets so that their diagonal angles don't get blocked off by shields.
add: Added a powernet sensor for the mains (master) grid and tweaked the names of a few others.
add: Added a few meters onto pipes in the supermatter engine that could be useful, and I forgot to add some before
del: Trimmed some redundant wires around shield gens
qol: Increased the amount of signs around shield gen rooms to make them more obvious and easier to find
balance: Closed the hole above misc science with glass for the meantime to prevent easy break-ins
fix: Added terminals to the cell rack PSU's in engineering so they can actually recharge now. Removed a few of them though cause they had way too many.
fix: Fixed the shutters in Xenobio to be solid and opaque instead of see through at round start.
fix: Fixed the oxygen tank in atmos that had the vent and injector the wrong way around
fix: Fixed a valve and adaptor that were the wrong way around in the command emergency atmos station
maptweak: Remapped the centre shield gen spot to be ready to hook up to mains
maptweak: Remapped the secondary engine airlock to be a bit more effective at cycling in AND out without wasting air (hopefully).
maptweak: Properly isolated the dorms area with it's own private distro and returned the southern side of the map to the distro loop which had been previously disconnected (previously dorms were still connected to the southern station parts including parts of medical, but the whole of these rooms were cut off from distro. Now it's all reconnected except specifically deck 3's dorm rooms which feed from their own atmos tank)
maptweak: Replaced the air tank in engineering's suit storage with an oxygen tank so it can be used for internals refill
spellcheck: Fixed a typo in the CE office, RIP emergecny bag of holding
/:cl:
