### PR TITLE
fix old input naming

### DIFF
--- a/code/modules/mob/say_ch.dm
+++ b/code/modules/mob/say_ch.dm
@@ -76,7 +76,7 @@
 	set name = "Pme CH"
 	set category = "IC.Subtle"
 
-	var/message = tgui_input_text(usr, "Emote to people affected by complete absorbed or dominate predator/prey.\nType your message:", "Psay")
+	var/message = tgui_input_text(usr, "Emote to people affected by complete absorbed or dominate predator/prey.\nType your message:", "Pme")
 
 	if(message)
 		pme(message)
@@ -85,7 +85,7 @@
 	set name = "Narrate (Player) CH"
 	set category = "IC.Chat"
 
-	var/message = tgui_input_text(usr, "Narrate an action or event! An alternative to emoting, for when your emote shouldn't start with your name!\nType your message:", "Psay")
+	var/message = tgui_input_text(usr, "Narrate an action or event! An alternative to emoting, for when your emote shouldn't start with your name!\nType your message:", "Narrate (Player)")
 
 	if(message)
 		player_narrate(message)


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:
fix: naming of the pme ch and player narrate ch input windows
/:cl:
