### PR TITLE
Revert "Revert "Missing kelpie init check""

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/horse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/horse.dm
@@ -140,7 +140,9 @@
 	vore_bump_emote	= "chomps down on"
 
 /mob/living/simple_mob/vore/horse/kelpie/init_vore()
-	..()
+	if(!voremob_loaded) // CHOMPedit start
+		return
+	.=..() // CHOMPedit end
 	var/obj/belly/B = vore_selected
 	B.name = "stomach"
 	B.desc = "With a final few gulps, the kelpie finishes swallowing you down into its hot, humid gut... and with a slosh, your weight makes the equine's belly hang down slightly like some sort of organic hammock. The thick, damp air is tinged with the smell of seaweed, and the surrounding flesh wastes no time in clenching and massaging down over its newfound fodder."


### PR DESCRIPTION
## About The Pull Request
Wasn't expecting this to get merged and reverted while I was at work so a little elaboration:
Vore init check needs to be set on every child to prevent runtime during mapload. Parent proc does not avert the runtime, hence why we already have this check on child voremobs throughout this codebase. No, spawning the mob after round init will not generate the runtime; it's a mapping runtime.

Here's the runtime that's fixed:
[2024-10-01T18:34:13] Runtime in code/modules/mob/living/simple_mob/subtypes/vore/horse.dm,145: Cannot modify null.name.
   proc name: init vore (/mob/living/simple_mob/vore/horse/kelpie/init_vore)
   src: the kelpie (/mob/living/simple_mob/vore/horse/kelpie)
   src.loc: the sand (126,8,6) (/turf/simulated/mineral/floor/ignore_mapgen/sif)
   call stack:
   the kelpie (/mob/living/simple_mob/vore/horse/kelpie): init vore()
   /hook/living_new (/hook/living_new): vore setup(the kelpie (/mob/living/simple_mob/vore/horse/kelpie))

## Changelog

:cl:
fix: fixes kelpie init again
/:cl:
