### PR TITLE
SMES coil price reduction plus some new reactions

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -17,21 +17,21 @@
 /datum/supply_pack/eng/smescoil
 	name = "Superconducting Magnetic Coil"
 	contains = list(/obj/item/smes_coil)
-	cost = 75
+	cost = 20 //CHOMPEdit - Reduced cost from 75 to 20 to be more in line with the rest of the engineering supplies
 	containertype = /obj/structure/closet/crate/focalpoint
 	containername = "Superconducting Magnetic Coil crate"
 
 /datum/supply_pack/eng/smescoil/super_capacity
 	name = "Superconducting Capacitance Coil"
 	contains = list(/obj/item/smes_coil/super_capacity)
-	cost = 90
+	cost = 35 //CHOMPEdit - Reduced cost from 90 to 35 to be more in line with the rest of the engineering supplies
 	containertype = /obj/structure/closet/crate/focalpoint
 	containername = "Superconducting Capacitance Coil crate"
 
 /datum/supply_pack/eng/smescoil/super_io
 	name = "Superconducting Transmission Coil"
 	contains = list(/obj/item/smes_coil/super_io)
-	cost = 90
+	cost = 35 //CHOMPEdit - Reduced cost from 90 to 35 to be more in line with the rest of the engineering supplies
 	containertype = /obj/structure/closet/crate/focalpoint
 	containername = "Superconducting Transmission Coil crate"
 

--- a/modular_chomp/code/modules/reagents/reactions/instant/instant.dm
+++ b/modular_chomp/code/modules/reagents/reactions/instant/instant.dm
@@ -142,3 +142,25 @@
 	required_reagents = list("liquidfire" = 1, "sulfur" = 1, "phoron" = 0.1)
 	catalysts = list("phoron" = 5)
 	result_amount = 1
+
+//Some extra metal solidification reactions
+/decl/chemical_reaction/instant/solidification/deuterium
+	name = "Solid Deuterium"
+	id = "soliddeuterium"
+	required_reagents = list("frostoil" = 5, "deuterium" = REAGENTS_PER_SHEET)
+	sheet_to_give = /obj/item/stack/material/deuterium
+
+//Injectable toxin reactions
+/decl/chemical_reaction/instant/succubi_paralize
+	name = "paralyzingfluid"
+	id = "paralyzingfluid"
+	result = "succubi_paralize"
+	required_reagents = list("benzilate" = 1, "cryptobiolin" = 1)
+	result_amount = 2
+
+/decl/chemical_reaction/instant/numbingenzyme
+	name = "numbingenzyme"
+	id = "numbingenzyme"
+	result = "numbenzyme"
+	required_reagents = list("tramadol" = 1, "protein" = 2, "adranol" = 1)
+	result_amount = 4


### PR DESCRIPTION

## About The Pull Request

Reduces the price of SMES coils to be more in line with the rest of the equipment instead of being ridiculously expensive, to make them more available for construction projects. Also added some new recipes for Deuterium solidification (currently will be the only non-explo source of Deuterium ingots), paralysing fluid and numbing enzyme. Recipes can always be adjusted and/or nerfed if deemed too strong later, but I wanted to make them more available for scene purposes.

Deuterium Solidification: 20 parts liquid Deuterium and 5 parts frost oil makes one ingot
Paralysing Fluid: 1 part Benzilate (aka Odd Goo) and 1 part Cryptobiolin
Numbing Enzyme: 1 part Tramadol, 2 parts Protein and 1 part Adranol

## Changelog
:cl:
add: Added reaction for Paralysing Fluid
add: Added reaction for Numbing Enzyme
add: Added reaction for Deuterium solidification
balance: Reduced the cost of the SMES coil crates. Standard coils are changed 75 -> 20. Upgraded coils are changed 90 -> 35
/:cl:
