### PR TITLE
Fix the size implant having it's own clamping.

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_vr.dm
+++ b/code/game/objects/items/weapons/implants/implant_vr.dm
@@ -104,7 +104,7 @@
 				var/static/regex/size_mult = new/regex("\\d+")
 				if(size_mult.Find(msg))
 					var/resizing_value = text2num(size_mult.match)
-					H.resize(CLAMP(resizing_value/100 , 0.01, 6), uncapped = M.has_large_resize_bounds()) //CHOMPEdit - Let resize handle size limits. It's meant to do that.
+					H.resize(CLAMP(resizing_value/100 , 0.01, 6), uncapped = H.has_large_resize_bounds()) //CHOMPEdit - Let resize handle size limits. It's meant to do that.
 
 
 

--- a/code/game/objects/items/weapons/implants/implant_vr.dm
+++ b/code/game/objects/items/weapons/implants/implant_vr.dm
@@ -104,7 +104,7 @@
 				var/static/regex/size_mult = new/regex("\\d+")
 				if(size_mult.Find(msg))
 					var/resizing_value = text2num(size_mult.match)
-					H.resize(resizing_value/100) //CHOMPEdit - Let resize handle size limits. It's meant to do that.
+					H.resize(CLAMP(resizing_value/100 , 0.01, 6), uncapped = M.has_large_resize_bounds()) //CHOMPEdit - Let resize handle size limits. It's meant to do that.
 
 
 

--- a/code/game/objects/items/weapons/implants/implant_vr.dm
+++ b/code/game/objects/items/weapons/implants/implant_vr.dm
@@ -104,7 +104,7 @@
 				var/static/regex/size_mult = new/regex("\\d+")
 				if(size_mult.Find(msg))
 					var/resizing_value = text2num(size_mult.match)
-					H.resize(CLAMP(resizing_value/100 , 0.25, 2))
+					H.resize(resizing_value/100) //CHOMPEdit - Let resize handle size limits. It's meant to do that.
 
 
 

--- a/code/game/objects/items/weapons/implants/implant_vr.dm
+++ b/code/game/objects/items/weapons/implants/implant_vr.dm
@@ -104,7 +104,7 @@
 				var/static/regex/size_mult = new/regex("\\d+")
 				if(size_mult.Find(msg))
 					var/resizing_value = text2num(size_mult.match)
-					H.resize(CLAMP(resizing_value/100 , 0.01, 6), uncapped = H.has_large_resize_bounds()) //CHOMPEdit - Let resize handle size limits. It's meant to do that.
+					H.resize(CLAMP(resizing_value/100 , RESIZE_MINIMUM_DORMS, RESIZE_MAXIMUM_DORMS), uncapped = H.has_large_resize_bounds()) //CHOMPEdit - Let resize handle size limits. It's meant to do that.
 
 
 


### PR DESCRIPTION

## About The Pull Request
Removes the clamping size implants did on their own, allowing larger/smaller sizes to work when in spaces like the dorms that support it.
## Changelog
:cl: AzulKitsune
fix: fixed the size implant not supporting larger/smaller sizes in dorms.
:cl:
