### PR TITLE
Fixes some map errors

### DIFF
--- a/maps/southern_cross/southern_cross-2.dmm
+++ b/maps/southern_cross/southern_cross-2.dmm
@@ -28213,9 +28213,6 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/secondary/firstdeck/research_access)
-"rYm" = (
-/turf/simulated/wall,
-/area/maintenance/firstdeck/centralstarboard)
 "rZP" = (
 /obj/effect/wingrille_spawn/reinforced,
 /obj/machinery/door/firedoor/border_only,
@@ -80425,13 +80422,13 @@ xIH
 moQ
 alI
 kcv
-rYm
-fiA
-fiA
-fiA
-fiA
-fiA
-fiA
+moQ
+dHz
+dHz
+dHz
+dHz
+dHz
+dHz
 dHz
 hvg
 dHz
@@ -80684,7 +80681,7 @@ moQ
 jUv
 fVu
 bjM
-fiA
+dHz
 hbK
 gAa
 ppt
@@ -80694,7 +80691,7 @@ kJV
 uPj
 wHq
 aMP
-dHz
+fiA
 sal
 wZo
 lIC
@@ -80942,7 +80939,7 @@ moQ
 axo
 fVu
 lrd
-fiA
+dHz
 ybM
 iEb
 iEb
@@ -80952,7 +80949,7 @@ iEb
 taP
 iEb
 uvG
-dHz
+fiA
 sal
 poW
 lIC
@@ -81200,7 +81197,7 @@ moQ
 asx
 bnA
 dLu
-fiA
+dHz
 bJP
 yks
 tMg
@@ -81210,7 +81207,7 @@ exY
 thk
 iEb
 iGI
-dHz
+fiA
 sal
 qwb
 wnb
@@ -81458,7 +81455,7 @@ moQ
 upc
 wDG
 mGR
-fiA
+dHz
 vhz
 iEb
 iEb
@@ -81468,7 +81465,7 @@ iEb
 npi
 iEb
 uRT
-dHz
+fiA
 jVV
 sal
 ghB
@@ -81716,7 +81713,7 @@ moQ
 dsS
 mRt
 moQ
-fiA
+dHz
 kfy
 tYn
 tYn

--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -52068,14 +52068,6 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/medbay2)
-"gSb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
 "gSn" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -57860,7 +57852,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/roller_holder,
+/obj/item/roller,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "jQa" = (
@@ -64856,7 +64848,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/roller_holder,
+/obj/item/roller,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "nMj" = (
@@ -66978,6 +66970,14 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/chargebay)
+"oWS" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_primary_storage)
 "oWW" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/assembly/chargebay)
@@ -80019,14 +80019,6 @@
 /obj/structure/grille,
 /turf/space,
 /area/space)
-"wSM" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay_primary_storage)
 "wSU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81455,6 +81447,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D1)
+"xFB" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_primary_storage)
 "xFC" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -124276,8 +124276,8 @@ bys
 lvy
 bKt
 tAA
-wSM
-gSb
+oWS
+xFB
 bcR
 aql
 xLY

--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -72536,14 +72536,14 @@
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control switch for the medbay foyer.";
 	id = "chemcounter";
-	name = "Medbay Doors Control";
+	name = "Chemistry Counter";
 	pixel_y = 24;
 	pixel_x = 5
 	},
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control switch for the medbay foyer.";
 	id = "chemwindow";
-	name = "Medbay Doors Control";
+	name = "Chemistry Windows";
 	pixel_y = 24;
 	pixel_x = -5
 	},

--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -17914,6 +17914,11 @@
 	pixel_x = -6;
 	pixel_y = 10
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
 "bcS" = (
@@ -27548,6 +27553,10 @@
 	dir = 8
 	},
 /obj/machinery/r_n_d/protolathe/medical,
+/obj/machinery/light{
+	dir = 8;
+	name = "1E-light fixture"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
 "bFv" = (
@@ -28602,6 +28611,10 @@
 	pixel_x = -34;
 	pixel_y = 1
 	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
 "bIO" = (
@@ -29450,10 +29463,6 @@
 	pixel_y = 5
 	},
 /obj/item/storage/firstaid/toxin,
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
 "bMf" = (
@@ -44507,8 +44516,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction/flipped{
+	name = "Genetics"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
@@ -49392,7 +49401,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/mixing)
 "fAK" = (
-/obj/structure/table/glass,
 /obj/item/roller,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
@@ -49400,6 +49408,7 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 10
 	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/steel,
 /area/medical/genetics)
 "fAL" = (
@@ -50790,6 +50799,10 @@
 	dir = 4
 	},
 /obj/machinery/organ_printer/flesh/full,
+/obj/machinery/light{
+	dir = 4;
+	name = "1E-light fixture"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/cryo)
 "gju" = (
@@ -50993,11 +51006,6 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "goD" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
@@ -52060,6 +52068,14 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/medbay2)
+"gSb" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_primary_storage)
 "gSn" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -52339,10 +52355,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fscenter)
 "hai" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23
-	},
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12;
@@ -53306,14 +53318,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "hBX" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_y = 24;
-	req_access = list(39)
-	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 1
 	},
@@ -53494,16 +53498,16 @@
 "hHj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_primary_storage)
@@ -53998,10 +54002,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/quartermaster/warehouse)
 "hPZ" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled/white,
 /area/medical/distillery)
 "hQg" = (
@@ -54553,7 +54557,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
 "ief" = (
-/obj/structure/table/glass,
 /obj/item/packageWrap,
 /obj/item/hand_labeler,
 /obj/item/reagent_containers/spray/cleaner{
@@ -54566,6 +54569,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "iej" = (
@@ -62860,6 +62864,10 @@
 	c_tag = "MED - Virology Airlock";
 	dir = 5
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/simulated/floor/tiled/steel,
 /area/medical/virology)
 "mFY" = (
@@ -65996,6 +66004,15 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "SC-ALCvirology";
+	name = "Virology Access Button";
+	pixel_y = 0;
+	req_access = list(39);
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/medical/virology)
@@ -78266,20 +78283,16 @@
 /area/maintenance/research_medical)
 "vLc" = (
 /obj/structure/closet/l3closet/virology,
-/obj/machinery/light_switch{
-	pixel_x = 11;
-	pixel_y = -24
-	},
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "xenostation_airlock_control";
-	name = "Xenobiology Access Button";
-	pixel_y = -26;
-	req_access = list(55)
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "SC-ALCvirology";
+	name = "Virology Access Console";
+	tag_exterior_door = "SC-ALEvirology";
+	tag_interior_door = "SC-ALIvirology";
+	dir = 1;
+	pixel_y = -23
 	},
 /turf/simulated/floor/tiled/steel,
 /area/medical/virology)
@@ -78819,6 +78832,10 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	name = "1E-light fixture"
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/distillery)
@@ -80002,6 +80019,14 @@
 /obj/structure/grille,
 /turf/space,
 /area/space)
+"wSM" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/medbay_primary_storage)
 "wSU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81535,6 +81560,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "xIB" = (
@@ -124250,8 +124276,8 @@ bys
 lvy
 bKt
 tAA
-tAA
-tAA
+wSM
+gSb
 bcR
 aql
 xLY

--- a/maps/southern_cross/southern_cross-3.dmm
+++ b/maps/southern_cross/southern_cross-3.dmm
@@ -57764,7 +57764,7 @@
 /area/hallway/secondary/entry/D3)
 "jMw" = (
 /obj/structure/sign/nosmoking_1,
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/medical/medical_lockerroom)
 "jMO" = (
 /obj/structure/table/standard,
@@ -62166,7 +62166,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/medical/medical_lockerroom)
 "mjR" = (
 /obj/item/roller,
@@ -63861,9 +63861,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/holodeck_control)
-"njW" = (
-/turf/simulated/wall,
-/area/medical/genetics)
 "nke" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
@@ -67754,10 +67751,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay_emt_bay)
-"ppR" = (
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
-/area/space)
 "ppW" = (
 /obj/machinery/atmospherics/valve/shutoff{
 	name = "Deck 2 Starboard automatic shutoff valve"
@@ -78209,7 +78202,7 @@
 	dir = 8
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/airless,
 /area/space)
 "vIB" = (
 /obj/machinery/firealarm{
@@ -133044,15 +133037,15 @@ nSZ
 mSO
 qrI
 hBo
-njW
+oMg
 sKv
-njW
+oMg
 jMw
 mjF
-guk
-guk
-guk
-guk
+qNE
+qNE
+qNE
+qNE
 qNE
 aaa
 aaa
@@ -135618,9 +135611,9 @@ rJB
 pzW
 aaa
 aaa
-ppR
+abx
 dLq
-ppR
+abx
 vIA
 aaa
 aaa


### PR DESCRIPTION

## About The Pull Request

Title

## Changelog
:cl:
maptweak: Places lights on Distillery, Chemistry and Cryo
maptweak: Genetics receiving all items throw into disposals
maptweak: Replaced roller beds next to the scanners
maptweak: Fixed virology door buttons
maptweak: Changed wrong tables in Genetics and Chemistry
maptweak: Manifold in Distillery is now hidden
/:cl:
