### PR TITLE
Fixes leopardmander autotransfer

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander_ch.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/leopardmander_ch.dm
@@ -136,6 +136,8 @@
 		"The drake's thick tongue presses against your form, smothering you with thick, gooey saliva as it pushes you around in it's maw.",
 		"The exotic drake lets out a deep rumble as it idly maws over you, shifting you in a warm, slimy embrace as it passively prepares to send you into a deeper embrace."
 	)
+	B.autotransfer_enabled = TRUE
+	B.autotransferchance = 30
 	B.autotransferwait = 5
 	B.autotransferlocation = "stomach"
 	B.escapetime = 1 SECONDS


### PR DESCRIPTION
Makes autotransfer on leopardmander maws functional, sets proc chance to 30

:cl:
fix: makes leopardmander maw autotransfer functional
/:cl: