### PR TITLE
BESK rigsuit enabling

### DIFF
--- a/modular_chomp/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/modular_chomp/code/modules/clothing/spacesuits/rig/rig.dm
@@ -2,3 +2,22 @@
 	var/protean = 0
 	var/obj/item/storage/backpack/rig_storage
 	permeability_coefficient = 0  //Protect the squishies, after all this shit should be waterproof.
+
+/obj/item/clothing/head/helmet/space/rig
+	species_restricted = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_TAJ, SPECIES_UNATHI, SPECIES_PROMETHEAN, SPECIES_TESHARI, SPECIES_SHADEKIN)
+	sprite_sheets = list(
+		SPECIES_TAJ = 'icons/inventory/suit/mob_tajaran.dmi',
+		SPECIES_UNATHI = 'icons/inventory/suit/mob_unathi.dmi',
+		SPECIES_VOX = 'icons/inventory/suit/mob_vox.dmi',
+		SPECIES_TESHARI = 'icons/inventory/suit/mob_teshari.dmi',
+		SPECIES_SHADEKIN = 'icons/inventory/suit/mob_tajaran.dmi'
+		)
+
+/obj/item/clothing/gloves/gauntlets/rig
+	species_restricted = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_TAJ, SPECIES_UNATHI, SPECIES_PROMETHEAN, SPECIES_TESHARI, SPECIES_SHADEKIN)
+
+/obj/item/clothing/shoes/magboots/rig
+	species_restricted = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_TAJ, SPECIES_UNATHI, SPECIES_PROMETHEAN, SPECIES_TESHARI, SPECIES_SHADEKIN)
+
+/obj/item/clothing/suit/space/rig
+	species_restricted = list(SPECIES_HUMAN, SPECIES_SKRELL, SPECIES_TAJ, SPECIES_UNATHI, SPECIES_PROMETHEAN, SPECIES_TESHARI, SPECIES_SHADEKIN)


### PR DESCRIPTION
TGUI my beloathed.

Anyway, adds shadekin to the list of creatures allowed to touch rigsuits soley for the sake of custom species with the shadekin base model. This is meant for them, and not shadekin proper.

Appeared to work, allowing equiping of said items.
## About The Pull Request
## Changelog
:cl:
add: custom species of shadekin variety should be able to wear rigsuits. Normal shadekin please remember the guidelines and such.
/:cl:
