### PR TITLE
Increase Skrell's min age due to lore adulthood

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -360,7 +360,7 @@
 	icobase = 'icons/mob/human_races/r_skrell_vr.dmi'
 	deform = 'icons/mob/human_races/r_def_skrell_vr.dmi'
 	color_mult = 1
-	min_age = 18
+	min_age = 19 //ChompEDIT Lore-based adulthood age for this species is greater than 18.
 	inherent_verbs = list(/mob/living/carbon/human/proc/tie_hair, /mob/living/carbon/human/proc/water_stealth, /mob/living/carbon/human/proc/underwater_devour)
 	reagent_tag = null
 	allergens = null


### PR DESCRIPTION
similar to Unathi, another lore-adulthood greater than 18.

Context: some of the min ages were set badly a while ago, and in a sanity check, a lot of stuff was increased to 18. Some species have an adulthood greater than 18, and this was missed. 

:cl:
fix: Increase Skrell min age to 19
/:cl:
