### PR TITLE
Bliss no longer forces crawling

### DIFF
--- a/code/modules/reagents/reagents/drugs.dm
+++ b/code/modules/reagents/reagents/drugs.dm
@@ -64,7 +64,7 @@
 		drug_strength = drug_strength * 1.2
 
 	M.druggy = max(M.druggy, drug_strength)
-	if(prob_proc == TRUE && prob(10) && isturf(M.loc) && !istype(M.loc, /turf/space) && M.canmove && !M.restrained())
+	if(prob_proc == TRUE && prob(10) && isturf(M.loc) && !istype(M.loc, /turf/space) && M.canmove && !M.restrained() && !M.resting) // CHOMPstation edit - Stop drug movement from forcing crawling
 		step(M, pick(cardinal))
 		prob_proc = FALSE
 	if(prob_proc == TRUE && prob(7))


### PR DESCRIPTION
Bliss causes random movement; once crawling was added, it began forced crawling when laying. This prevents forced crawling and returns bliss movement to previous behavior.

## Changelog
:cl:
qol: bliss no longer forces crawling
/:cl:
