### PR TITLE
Soluna Nexus Map Fixes 1.3

### DIFF
--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
@@ -238,15 +238,12 @@
 /turf/simulated/floor/tiled,
 /area/harbor/Dock5)
 "abe" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/glass,
 /area/hallway/Port_1Deck_Atrium)
 "abh" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
@@ -287,9 +284,7 @@
 /obj/item/seeds/glowshroom{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "abs" = (
 /turf/simulated/wall/r_wall,
@@ -530,8 +525,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -569,7 +563,6 @@
 "acK" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1056,8 +1049,7 @@
 /area/quartermaster/Depot1)
 "afV" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/table/bench/sifwooden/padded,
 /turf/simulated/floor/tiled/white,
@@ -1377,8 +1369,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1446,8 +1437,7 @@
 /obj/machinery/portable_atmospherics/canister/empty/phoron,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -1519,7 +1509,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/machinery/suit_storage_unit/mining_alt,
@@ -1664,7 +1653,6 @@
 "aip" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/machinery/alarm{
@@ -1766,7 +1754,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -1793,8 +1780,7 @@
 "aiP" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Deck1_Transit_Hall)
@@ -1844,8 +1830,7 @@
 	pixel_x = -3
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -2045,7 +2030,6 @@
 /area/space)
 "ake" = (
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/dark,
@@ -2304,8 +2288,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	pixel_y = -30;
-	name = "1S-newscaster"
+	pixel_y = -30
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/rnd/Observation_Hall)
@@ -2334,8 +2317,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -2394,7 +2376,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite,
@@ -2842,8 +2823,7 @@
 /area/maintenance/Deck1_ForPort_Corridor2)
 "aoI" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2872,9 +2852,7 @@
 /obj/structure/bed/chair/wood{
 	dir = 4
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "ape" = (
 /obj/structure/cable/green{
@@ -2964,8 +2942,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2994,8 +2971,7 @@
 /area/harbor/Fueling_Storage)
 "apY" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -3056,9 +3032,7 @@
 /area/shuttle/echidna)
 "aql" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "aqp" = (
 /obj/structure/flora/lily2,
@@ -3143,9 +3117,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "aqK" = (
 /obj/structure/disposalpipe/segment,
@@ -3254,8 +3226,7 @@
 /obj/structure/bed/chair/wheelchair/smallmotor,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Star_Docking_Foyer)
@@ -3405,7 +3376,6 @@
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/item/tool/crowbar/red{
@@ -3430,8 +3400,7 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -3656,8 +3625,7 @@
 "aun" = (
 /obj/structure/closet/wardrobe/suit,
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/green/border,
@@ -3667,7 +3635,6 @@
 /obj/machinery/lapvend,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -3681,7 +3648,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -3730,8 +3696,7 @@
 	},
 /obj/machinery/door/window/westleft,
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/effect/floor_decal/borderfloorblack,
@@ -3817,44 +3782,28 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Aft)
 "avb" = (
-/obj/item/gun/energy/locked/frontier/rifle{
-	pixel_y = 9
-	},
-/obj/item/cell/device/weapon{
-	pixel_y = 4
-	},
-/obj/item/cell/device/weapon{
-	pixel_y = 2
-	},
-/obj/item/cell/device/weapon,
 /obj/structure/closet/secure_closet/guncabinet{
 	req_one_access = list(1,19)
 	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
-	pixel_x = 5
+/obj/item/gun/energy/taser{
+	pixel_y = 7
 	},
-/obj/item/gun/energy/locked/frontier/rifle{
-	pixel_y = 6
-	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
+/obj/item/gun/energy/taser{
+	pixel_y = 4;
 	pixel_x = 2
 	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
-	pixel_x = -1
+/obj/item/melee/baton{
+	pixel_y = -3
 	},
-/obj/item/gun/projectile/shotgun/pump/rifle{
-	pixel_y = -2
+/obj/item/melee/baton{
+	pixel_y = -6;
+	pixel_x = 1
 	},
-/obj/item/gun/projectile/shotgun/pump/rifle{
-	pixel_y = -5
+/obj/item/cell/device/weapon{
+	pixel_y = -7
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 4;
-	pixel_y = 23;
-	name = "1N-wall recharger"
+/obj/item/cell/device/weapon{
+	pixel_y = -4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -3890,8 +3839,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -3908,7 +3856,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -4032,13 +3979,11 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -4124,7 +4069,6 @@
 /area/shuttle/escape_pod1/station)
 "awC" = (
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /turf/simulated/floor/glass,
@@ -4247,7 +4191,6 @@
 "axP" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -4268,8 +4211,7 @@
 	dir = 8
 	},
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Star_Docking_Foyer)
@@ -4280,7 +4222,6 @@
 /obj/structure/table/glass,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -4391,8 +4332,7 @@
 /area/maintenance/Deck1_Science_AftCorridor1)
 "azk" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Deck1_Transit_Hall)
@@ -4539,10 +4479,6 @@
 	pixel_x = 9;
 	pixel_y = -9
 	},
-/obj/item/t_scanner/upgraded{
-	pixel_x = 11;
-	pixel_y = 3
-	},
 /obj/item/clothing/glasses/meson{
 	pixel_x = -6;
 	pixel_y = -13
@@ -4550,9 +4486,6 @@
 /obj/item/clothing/glasses/welding{
 	pixel_x = -6;
 	pixel_y = -8
-	},
-/obj/structure/closet/crate/large/nanotrasen{
-	req_one_access = list(10)
 	},
 /obj/item/stack/material/plasteel{
 	amount = 30;
@@ -4569,12 +4502,19 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
-/obj/item/clothing/gloves/yellow{
-	pixel_x = -7;
-	pixel_y = 2
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/item/t_scanner{
+	pixel_y = 3;
+	pixel_x = 11
 	},
 /obj/item/multitool{
 	pixel_x = 4
+	},
+/obj/structure/closet/crate/secure/large/nanotrasen{
+	req_access = list(10)
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -4682,11 +4622,9 @@
 /turf/simulated/floor/tiled/hydro,
 /area/rnd/Xenobotany_Lab)
 "aBD" = (
-/obj/structure/flora/tree/sif,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
-/area/hallway/Star_1Deck_Atrium)
+/obj/structure/table/fancyblack,
+/turf/simulated/floor/grass2/turfpack/station,
+/area/hallway/Port_1Deck_Atrium)
 "aBE" = (
 /obj/random/junk,
 /obj/effect/floor_decal/rust,
@@ -4731,8 +4669,7 @@
 "aBU" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -4934,8 +4871,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -5095,9 +5031,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "aEI" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5158,8 +5092,7 @@
 /area/maintenance/ab_ChuteTrade)
 "aFd" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -5253,8 +5186,7 @@
 /area/harbor/Dock3)
 "aFG" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5281,9 +5213,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "aGe" = (
 /obj/machinery/alarm{
@@ -5350,7 +5280,6 @@
 "aGB" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -5378,7 +5307,6 @@
 "aHg" = (
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner,
@@ -5448,9 +5376,7 @@
 /obj/machinery/sleeper{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod2/station)
 "aIi" = (
@@ -5504,8 +5430,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod1/station)
@@ -5553,7 +5478,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -5675,9 +5599,7 @@
 /area/hallway/Stairwell_Port)
 "aJT" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
 	},
@@ -5900,9 +5822,7 @@
 "aLf" = (
 /obj/structure/flora/tree/sif,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "aLh" = (
 /turf/simulated/floor/tiled/hydro,
@@ -5971,7 +5891,6 @@
 	pixel_y = 4
 	},
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -6031,9 +5950,7 @@
 "aLA" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled/dark,
@@ -6117,7 +6034,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/white{
@@ -6191,7 +6107,6 @@
 "aMD" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -6208,7 +6123,6 @@
 "aMJ" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/structure/cable/green{
@@ -6320,7 +6234,6 @@
 	dir = 10
 	},
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6412,8 +6325,7 @@
 /obj/structure/reagent_dispensers/fueltank/high,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Xenobotany_Isolation_Chamber)
@@ -6455,7 +6367,6 @@
 /area/maintenance/Deck1_AftPort_Corridor2)
 "aNG" = (
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -6504,8 +6415,7 @@
 /area/quartermaster/Supply_Ship_Bay)
 "aNY" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/table/bench/sifwooden/padded,
 /turf/simulated/floor/tiled/white,
@@ -6528,7 +6438,6 @@
 "aOm" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -6671,9 +6580,7 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/cryo/station)
 "aPE" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -6705,7 +6612,6 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -6749,19 +6655,16 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/PA_Chamber)
 "aQp" = (
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -6800,16 +6703,14 @@
 /area/harbor/Dock2)
 "aQW" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/table/bench/sifwooden/padded,
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock3)
 "aQX" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6880,9 +6781,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "aRv" = (
 /obj/structure/filingcabinet/security,
@@ -6894,8 +6793,7 @@
 /obj/item/storage/toolbox/emergency,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/cryo/station)
@@ -6937,8 +6835,7 @@
 "aRL" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -7035,9 +6932,7 @@
 /obj/structure/bed/chair/sofa/left/beige{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/ForPort_1_Deck_Observatory)
 "aSk" = (
@@ -7065,8 +6960,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /turf/simulated/floor/plating,
 /area/rnd/Xenobotany_Isolation_Chamber)
@@ -7117,8 +7011,7 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobotany_Lab)
@@ -7181,7 +7074,6 @@
 /area/security/Aft_Security_Post)
 "aTt" = (
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
@@ -7418,9 +7310,7 @@
 "aVh" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "aVi" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -7465,8 +7355,7 @@
 /area/hallway/Cryostorage_Lounge)
 "aVs" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -7514,12 +7403,10 @@
 /area/space)
 "aVy" = (
 /obj/machinery/newscaster{
-	name = "1N-newscaster";
 	pixel_y = 28
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -7633,7 +7520,6 @@
 /area/harbor/Fueling_Post)
 "aWa" = (
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -7786,9 +7672,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor1)
 "aWS" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled,
@@ -7849,8 +7733,7 @@
 	color = "#0000ff"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -7998,8 +7881,7 @@
 /area/harbor/Dock5)
 "baw" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -8043,9 +7925,7 @@
 /area/maintenance/Deck1_Security_PortCorridor2)
 "baX" = (
 /obj/effect/catwalk_plated,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/engineering/Telecomms_Foyer)
 "baY" = (
@@ -8479,8 +8359,7 @@
 	pixel_x = 5
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -8634,8 +8513,7 @@
 	pixel_x = -5
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/borderfloorblack{
@@ -9092,8 +8970,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
@@ -9115,8 +8992,7 @@
 "btZ" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9177,7 +9053,6 @@
 	},
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -9213,9 +9088,7 @@
 /area/maintenance/Market_Stall_6)
 "bvo" = (
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the Particle Accelerator chamber.";
 	layer = 4;
@@ -9433,7 +9306,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
@@ -9474,8 +9346,7 @@
 /area/maintenance/Deck1_Star_Corridor)
 "bzX" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "1N-extinguisher cabinet"
+	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -9614,8 +9485,7 @@
 	dir = 6
 	},
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Supply_Ship_Bay)
@@ -9739,8 +9609,7 @@
 /area/maintenance/Deck1_Security_PortChamber1)
 "bDN" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	name = "1E-entertainment monitor";
@@ -9765,8 +9634,7 @@
 "bDS" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/disposalpipe/sortjunction/wildcard{
 	dir = 4
@@ -10009,8 +9877,7 @@
 "bHB" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/harbor/Star_Docking_Foyer)
@@ -10221,9 +10088,7 @@
 	pixel_x = 1
 	},
 /obj/structure/table/fancyblack,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "bMe" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
@@ -10284,7 +10149,6 @@
 "bNk" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
-	name = "1E-extinguisher cabinet";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10338,7 +10202,6 @@
 /area/hallway/Port_1Deck_Atrium)
 "bOk" = (
 /obj/machinery/newscaster{
-	name = "1N-newscaster";
 	pixel_y = 28
 	},
 /obj/machinery/camera/network/security{
@@ -10362,8 +10225,7 @@
 "bOS" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -4;
@@ -10483,8 +10345,7 @@
 /obj/structure/table/standard,
 /obj/item/tool/wirecutters/clippers/trimmers,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_1)
@@ -10555,7 +10416,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -10625,8 +10485,7 @@
 /area/maintenance/Deck1_ForStar_Corridor3)
 "bSu" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10647,8 +10506,7 @@
 /area/quartermaster/Supply_Ship_Bay)
 "bSz" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -10689,8 +10547,7 @@
 /area/maintenance/Deck1_AftStar1_Corridor2)
 "bST" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -10708,6 +10565,10 @@
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
+"bTk" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/r_wall,
+/area/maintenance/Deck1_ForStar_Corridor2)
 "bTL" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -10761,8 +10622,7 @@
 /obj/structure/window/basic,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod1/station)
@@ -10902,7 +10762,6 @@
 "bYa" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -11072,7 +10931,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -11112,7 +10970,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/carpet/sblucarpet/turfpack/station,
@@ -11311,7 +11168,6 @@
 "cgH" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/hydro,
@@ -11401,8 +11257,7 @@
 	},
 /obj/structure/window/basic,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod2/station)
@@ -11485,7 +11340,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/tiled,
@@ -11921,8 +11775,7 @@
 "cpG" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -12283,7 +12136,6 @@
 /area/hallway/Stairwell_Port)
 "cxF" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/glass/reinforced,
@@ -13204,8 +13056,7 @@
 /area/rnd/Xenobotany_Isolation_Chamber)
 "cOQ" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
@@ -13258,8 +13109,7 @@
 "cPL" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -13544,8 +13394,7 @@
 /obj/item/vac_attachment,
 /obj/structure/closet/jequipcloset,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -13558,8 +13407,7 @@
 "cUy" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -14089,9 +13937,7 @@
 "ddb" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/hand_labeler,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled/dark,
@@ -14177,9 +14023,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "dem" = (
 /obj/random/junk,
@@ -14322,8 +14166,7 @@
 "dgp" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/white{
 	d1 = 4;
@@ -14460,7 +14303,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/white,
@@ -14714,7 +14556,6 @@
 "dnB" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -14811,7 +14652,6 @@
 /area/harbor/Fueling_Storage)
 "doV" = (
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -14883,8 +14723,7 @@
 /area/shuttle/escape_pod13/station)
 "dpV" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -15142,9 +14981,7 @@
 /turf/simulated/wall/r_wall,
 /area/engineering/Telecomms_Foyer)
 "dvj" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -15270,8 +15107,7 @@
 /area/security/Exploration_Ship_Bay)
 "dwT" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -15285,9 +15121,7 @@
 /obj/random/junk,
 /obj/effect/catwalk_plated/dark,
 /obj/structure/table/steel,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/random/maintenance/misc,
 /turf/simulated/floor/plating,
 /area/maintenance/ab_ChuteTrade)
@@ -15462,7 +15296,6 @@
 /area/rnd/Xenobiology_Lab)
 "dzI" = (
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -15519,8 +15352,7 @@
 /area/hallway/Port_1Deck_Atrium)
 "dAE" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -15611,8 +15443,7 @@
 /area/hallway/Central_1_Deck_Hall)
 "dBV" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_3)
@@ -15818,8 +15649,7 @@
 /area/engineering/Telecomms_Network)
 "dGh" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/ForStar_1_Deck_Observatory)
@@ -16108,8 +15938,7 @@
 /area/hallway/For_Transit_Foyer)
 "dLu" = (
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -16330,9 +16159,7 @@
 /obj/item/seeds/rose{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "dPk" = (
 /obj/effect/floor_decal/borderfloorwhite{
@@ -16345,8 +16172,7 @@
 /area/rnd/Xenobiology_Lab)
 "dPz" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/blue/bordercorner,
@@ -16354,9 +16180,7 @@
 /area/engineering/Telecomms_Control_Room)
 "dPH" = (
 /obj/structure/table/steel_reinforced,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -16385,8 +16209,7 @@
 /area/hallway/Star_1Deck_Central_Corridor_1)
 "dQd" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/ab_GeneralStore)
@@ -16582,7 +16405,6 @@
 /area/maintenance/Deck1_AftPort_Corridor3)
 "dTG" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16610,9 +16432,7 @@
 	pixel_x = 9
 	},
 /obj/structure/table/fancyblack,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "dTR" = (
 /obj/machinery/door/firedoor/border_only,
@@ -16628,8 +16448,7 @@
 /area/maintenance/Deck1_ForPort_Corridor2)
 "dTS" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack/station,
 /area/hallway/Cryostorage_Lounge)
@@ -16653,7 +16472,6 @@
 /area/maintenance/ab_StripBar)
 "dUu" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16933,8 +16751,7 @@
 	dir = 8
 	},
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock2)
@@ -16981,8 +16798,7 @@
 "dWj" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17157,12 +16973,10 @@
 "dWU" = (
 /obj/machinery/seed_storage/xenobotany,
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobotany_Lab)
@@ -17395,7 +17209,6 @@
 /area/hallway/Planetside_Equipment)
 "dXv" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/glass/reinforced,
@@ -17428,8 +17241,7 @@
 "dXF" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "1N-newscaster"
+	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/blue,
 /area/harbor/Port_Docking_Foyer)
@@ -17448,9 +17260,7 @@
 "dXI" = (
 /obj/structure/ore_box,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Mining_Ship_Bay)
 "dXK" = (
@@ -17459,7 +17269,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -17477,8 +17286,7 @@
 "dXM" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Mining_Ship_Bay)
@@ -17513,8 +17321,7 @@
 "dXQ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -17742,12 +17549,9 @@
 /obj/structure/bed/chair/sofa/green{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/rnd/Observation_Hall)
@@ -17764,7 +17568,6 @@
 "dYE" = (
 /obj/machinery/disposal,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/structure/disposalpipe/trunk{
@@ -17780,18 +17583,14 @@
 /obj/structure/bed/chair/sofa/green{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/rnd/Observation_Hall)
 "dYJ" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -17853,8 +17652,7 @@
 	pixel_x = -14
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -18088,8 +17886,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Telecomms_Control_Room)
@@ -18164,9 +17961,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "eaj" = (
 /obj/machinery/portable_atmospherics/canister/empty/phoron,
@@ -18255,8 +18050,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod2/station)
@@ -18287,7 +18081,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled,
@@ -18308,9 +18101,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/shuttle/spacebus)
 "eaG" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
@@ -18394,7 +18185,6 @@
 	pixel_y = -2;
 	pixel_x = -6
 	},
-/obj/item/stock_parts/capacitor/hyper,
 /obj/item/stock_parts/manipulator/nano{
 	pixel_y = 2;
 	pixel_x = 4
@@ -18416,8 +18206,7 @@
 	name = "Circuitry"
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/maintenance/Telecomms_Substation)
@@ -18460,8 +18249,7 @@
 "eaV" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -18535,13 +18323,11 @@
 /obj/machinery/deployable/barrier,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -18554,8 +18340,7 @@
 "ebj" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/security/Quantum_Pad_Checkpoint)
@@ -18962,9 +18747,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Central_1_Deck_Hall)
 "ejO" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -18983,7 +18766,6 @@
 /obj/effect/floor_decal/corner/white/border,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
@@ -19116,9 +18898,7 @@
 /obj/item/seeds/lustflower{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "emE" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
@@ -19340,7 +19120,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
@@ -19373,9 +19152,7 @@
 "esa" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/tree/sif,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "esc" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -19418,7 +19195,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -19494,8 +19270,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Xenobiology_Lab)
@@ -19624,7 +19399,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/green,
@@ -19710,8 +19484,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock3)
@@ -19841,8 +19614,7 @@
 "eBZ" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -19973,8 +19745,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -19984,7 +19755,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled,
@@ -20129,16 +19899,12 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/Supply_Ship_Bay)
 "eHg" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/AftPort_1_Deck_Observatory)
 "eHi" = (
 /obj/structure/table/wooden_reinforced,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/maintenance/ab_CardTrading)
 "eHl" = (
@@ -20168,8 +19934,7 @@
 "eHx" = (
 /obj/machinery/disposal,
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -20331,11 +20096,9 @@
 "eKl" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -20353,8 +20116,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -20454,7 +20216,6 @@
 "eLq" = (
 /obj/machinery/vending/snack,
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -20535,7 +20296,6 @@
 /area/hallway/Central_1_Deck_Hall)
 "eNk" = (
 /obj/machinery/ai_status_display{
-	name = "1E-AI display";
 	pixel_x = 32
 	},
 /obj/structure/cable/green{
@@ -20794,8 +20554,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -21083,8 +20842,7 @@
 "eWd" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -21356,7 +21114,6 @@
 "eZW" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/structure/cable/green{
@@ -21382,7 +21139,6 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -21504,8 +21260,7 @@
 	name = "fire-safety closet"
 	},
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -21517,8 +21272,7 @@
 /area/rnd/Observation_Hall)
 "fcU" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -21680,8 +21434,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod2/station)
@@ -21783,9 +21536,7 @@
 	pixel_x = 1
 	},
 /obj/structure/table/fancyblack,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "fiK" = (
 /obj/structure/disposalpipe/segment,
@@ -22064,12 +21815,10 @@
 /area/rnd/Observation_Hall)
 "fnu" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/status_display{
-	pixel_x = 32;
-	name = "E-status display"
+	pixel_x = 32
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -22115,7 +21864,6 @@
 "foi" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/structure/cable{
@@ -22482,8 +22230,7 @@
 "fwR" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Ship_Bay4)
@@ -22622,7 +22369,6 @@
 "fzE" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
-	name = "1E-extinguisher cabinet";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -22650,7 +22396,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -22695,45 +22440,34 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/Mining_Ship_Bay)
 "fBA" = (
-/obj/item/gun/energy/locked/frontier/rifle{
-	pixel_y = 9
-	},
-/obj/item/cell/device/weapon{
-	pixel_y = 4
-	},
-/obj/item/cell/device/weapon{
-	pixel_y = 2
-	},
-/obj/item/cell/device/weapon,
 /obj/structure/closet/secure_closet/guncabinet{
 	req_one_access = list(1,19)
-	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
-	pixel_x = 5
-	},
-/obj/item/gun/energy/locked/frontier/rifle{
-	pixel_y = 6
-	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
-	pixel_x = 2
-	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
-	pixel_x = -1
-	},
-/obj/item/gun/projectile/shotgun/pump/rifle{
-	pixel_y = -2
-	},
-/obj/item/gun/projectile/shotgun/pump/rifle{
-	pixel_y = -5
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
+	},
+/obj/item/gun/energy/taser{
+	pixel_y = 7
+	},
+/obj/item/gun/energy/taser{
+	pixel_y = 4;
+	pixel_x = 2
+	},
+/obj/item/melee/baton{
+	pixel_y = -3
+	},
+/obj/item/melee/baton{
+	pixel_y = -6;
+	pixel_x = 1
+	},
+/obj/item/cell/device/weapon{
+	pixel_y = -7
+	},
+/obj/item/cell/device/weapon{
+	pixel_y = -4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Aft_Security_Post)
@@ -22784,7 +22518,6 @@
 "fCD" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -22965,7 +22698,6 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -23131,8 +22863,7 @@
 "fKK" = (
 /obj/machinery/conveyor,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/Mining_Ship_Bay)
@@ -23235,8 +22966,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Xenobiology_Lab)
@@ -23378,7 +23108,6 @@
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /turf/simulated/shuttle/floor/white,
@@ -23522,8 +23251,7 @@
 "fRL" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -24028,7 +23756,6 @@
 /obj/structure/cable/white,
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -24233,7 +23960,6 @@
 "gaf" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -24301,8 +24027,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Xenobiology_Lab)
@@ -24459,8 +24184,7 @@
 /obj/machinery/computer/secure_data,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -24534,7 +24258,8 @@
 	layer = 2.5
 	},
 /obj/machinery/door/airlock/angled_bay/standard/color/security{
-	req_access = null
+	req_access = null;
+	req_one_access = list(19,1)
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Stairwell_For)
@@ -24687,7 +24412,6 @@
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -24721,8 +24445,7 @@
 /area/quartermaster/Supply_Ship_Bay)
 "giw" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -24827,9 +24550,7 @@
 /obj/machinery/sleeper{
 	dir = 8
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod1/station)
 "gkN" = (
@@ -24944,8 +24665,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ab_StripBar)
@@ -24987,8 +24707,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Telecomms_Foyer)
@@ -25476,8 +25195,7 @@
 "gxx" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Ship_Bay3)
@@ -25538,7 +25256,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -25844,9 +25561,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Mining_Ship_Bay)
 "gEd" = (
@@ -25860,7 +25575,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -25985,9 +25699,7 @@
 "gHQ" = (
 /obj/structure/table/standard,
 /obj/random_multi/single_item/hand_tele,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/dark,
@@ -26017,9 +25729,7 @@
 /obj/machinery/chemical_dispenser/kettle/full{
 	pixel_y = 7
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white{
 	nitrogen = 101.3;
 	oxygen = 0;
@@ -26076,8 +25786,7 @@
 "gKh" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
@@ -26314,7 +26023,6 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -26361,7 +26069,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -26385,9 +26092,7 @@
 "gQI" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/porta_turret/industrial/teleport_defense,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/security/Quantum_Pad_Checkpoint)
 "gQV" = (
@@ -26485,8 +26190,7 @@
 "gSP" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -26669,7 +26373,6 @@
 /area/shuttle/spacebus)
 "gUz" = (
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -26910,7 +26613,6 @@
 /obj/structure/table/glass,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -27095,8 +26797,7 @@
 /obj/machinery/portable_atmospherics/canister/empty/nitrous_oxide,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -27268,7 +26969,6 @@
 "hga" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27381,7 +27081,6 @@
 /area/maintenance/Market_Stall_3)
 "hhP" = (
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloor/corner,
@@ -27619,7 +27318,6 @@
 "hon" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -27753,8 +27451,7 @@
 	pixel_x = 22
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27975,8 +27672,7 @@
 "htY" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -28285,7 +27981,7 @@
 	sort_tag = "Resleeving";
 	dir = 2
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/maintenance/Deck1_ForStar_Corridor2)
 "hzI" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -28309,9 +28005,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "hAh" = (
 /obj/structure/closet/emcloset/legacy,
@@ -28395,8 +28089,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod1/station)
@@ -28762,7 +28455,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -29360,9 +29052,7 @@
 /obj/item/seeds/sunflowerseed{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "hVG" = (
 /obj/structure/sign/directions/cargo{
@@ -29419,9 +29109,7 @@
 /obj/structure/bed/chair/wood{
 	dir = 8
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "hWv" = (
 /obj/machinery/light/small{
@@ -29637,20 +29325,12 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay4)
-"iau" = (
-/obj/structure/flora/sif/eyes,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
-/area/hallway/Star_1Deck_Atrium)
 "iaC" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "iaE" = (
 /turf/simulated/wall,
@@ -29659,7 +29339,6 @@
 /obj/machinery/vending/desatti,
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -29847,8 +29526,7 @@
 /area/maintenance/Deck1_AftPort_Corridor3)
 "iev" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled/techmaint,
@@ -30040,8 +29718,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Harbor)
@@ -30248,7 +29925,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/maintenance/Deck1_ForStar_Corridor2)
 "ilD" = (
 /obj/machinery/door/firedoor/border_only,
@@ -30344,8 +30021,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -30410,9 +30086,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/ab_SportsField)
 "inz" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -30477,9 +30151,7 @@
 /obj/structure/bed/chair/wood{
 	dir = 4
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "ipa" = (
 /obj/structure/table/glass,
@@ -30684,8 +30356,7 @@
 /obj/structure/table/glass,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/corner/purple/diagonal,
 /obj/effect/floor_decal/corner/purple/diagonal{
@@ -30701,8 +30372,7 @@
 "isR" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -30792,8 +30462,7 @@
 	id = "SC-CBcargobay2"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/Supply_Ship_Bay)
@@ -31075,7 +30744,6 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/tiled/dark,
@@ -31083,8 +30751,7 @@
 "iAV" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -31191,9 +30858,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Mining_Ship_Bay)
 "iDD" = (
@@ -31260,9 +30925,7 @@
 	name = "Scrable";
 	faction = "nanotrasen"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "iEf" = (
 /obj/random/junk,
@@ -31371,8 +31034,7 @@
 /area/shuttle/large_escape_pod1/station)
 "iJo" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31390,9 +31052,7 @@
 "iJv" = (
 /obj/machinery/portable_atmospherics/canister/empty/nitrous_oxide,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled/dark,
@@ -31588,9 +31248,7 @@
 /obj/item/seeds/rose{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "iOk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -31661,8 +31319,7 @@
 "iPp" = (
 /obj/machinery/disposal,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -31878,9 +31535,7 @@
 	req_access = list(47)
 	},
 /obj/item/multitool,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
@@ -32649,9 +32304,7 @@
 /obj/item/seeds/siflettuce{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "jkR" = (
 /obj/machinery/door/firedoor/glass,
@@ -32707,7 +32360,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -32912,8 +32564,7 @@
 	dir = 8
 	},
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock3)
@@ -32962,8 +32613,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
 /area/rnd/Xenobotany_Isolation_Chamber)
@@ -33005,7 +32655,6 @@
 	},
 /obj/machinery/iv_drip,
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /turf/simulated/shuttle/floor/white,
@@ -33024,7 +32673,6 @@
 "jqw" = (
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -33148,7 +32796,6 @@
 "jsR" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -33433,7 +33080,6 @@
 "jzJ" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloor/corner,
@@ -33496,9 +33142,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/Supply_Ship_Bay)
 "jAH" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/glass,
 /area/hallway/Star_1Deck_Atrium)
 "jAM" = (
@@ -33782,8 +33426,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -33843,7 +33486,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -33919,7 +33561,6 @@
 /area/hallway/Port_1Deck_Atrium)
 "jGg" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -33986,7 +33627,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/ai_status_display{
-	name = "1E-AI display";
 	pixel_x = 32
 	},
 /obj/structure/cable/white{
@@ -34110,8 +33750,7 @@
 "jJV" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "1N-newscaster"
+	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/harbor/Star_Docking_Foyer)
@@ -34155,7 +33794,6 @@
 	pixel_x = -8
 	},
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -34511,8 +34149,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Xenobiology_Lab)
@@ -35065,9 +34702,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor1)
 "kbc" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled,
@@ -35120,7 +34755,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
@@ -35390,8 +35024,7 @@
 /obj/item/radio/intercom/department/security{
 	dir = 4;
 	icon_override = "secintercom";
-	pixel_x = 22;
-	name = "1E-station intercom (Security)"
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -35416,8 +35049,7 @@
 /area/hallway/Aft_Transit_Lobby)
 "kjp" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -35535,8 +35167,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Mining_EVA)
@@ -35891,7 +35522,6 @@
 "ktb" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -35991,9 +35621,7 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/ab_Hydroponics)
 "kvV" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_5)
 "kwi" = (
@@ -36030,8 +35658,7 @@
 /area/maintenance/Deck1_Security_StarChamber1)
 "kwt" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -36216,7 +35843,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -36245,8 +35871,7 @@
 "kAD" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Ship_Bay3)
@@ -36344,9 +35969,7 @@
 /area/maintenance/Deck1_AftStar1_Corridor3)
 "kDc" = (
 /obj/structure/table/fancyblack,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "kDj" = (
 /obj/structure/cable/blue{
@@ -36418,7 +36041,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -36515,7 +36137,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -36558,8 +36179,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Locker_Room)
@@ -36620,8 +36240,7 @@
 /obj/structure/dispenser/phoron,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -36768,9 +36387,7 @@
 "kKy" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "kKD" = (
 /obj/random/maintenance/clean,
@@ -36978,9 +36595,7 @@
 /obj/structure/prop/statue/stump_plaque{
 	desc = "A wooden stump adorned with a little plaque. -Sif's botanical garden-"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "kPu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -37050,8 +36665,7 @@
 /area/rnd/Observation_Hall)
 "kRj" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/table/bench/sifwooden/padded,
 /turf/simulated/floor/tiled/white,
@@ -37070,9 +36684,7 @@
 	pixel_y = 10;
 	name = "Zwei"
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/harbor/Dock5)
 "kRy" = (
@@ -37086,9 +36698,7 @@
 /area/rnd/PA_Chamber)
 "kRH" = (
 /obj/structure/flora/rocks1,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "kSm" = (
 /obj/structure/cable{
@@ -37101,7 +36711,6 @@
 "kSv" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -37131,8 +36740,7 @@
 /area/crew_quarters/Custodial_Office)
 "kSY" = (
 /obj/machinery/status_display{
-	pixel_x = 32;
-	name = "E-status display"
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -37242,6 +36850,7 @@
 /obj/machinery/light_construct/small{
 	dir = 4
 	},
+/obj/item/headpods,
 /turf/simulated/floor/tiled/kafel_full{
 	nitrogen = 101.3;
 	oxygen = 0;
@@ -37420,8 +37029,7 @@
 	},
 /obj/machinery/door/window/westleft,
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -37638,8 +37246,7 @@
 	dir = 4
 	},
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Port_Docking_Foyer)
@@ -37691,9 +37298,7 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
@@ -37782,8 +37387,7 @@
 "lcF" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/ab_GeneralStore)
@@ -37866,9 +37470,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor3)
 "leN" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -38014,8 +37616,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
@@ -38283,8 +37884,7 @@
 "llY" = (
 /obj/structure/table/standard,
 /obj/machinery/newscaster{
-	pixel_y = -30;
-	name = "1S-newscaster"
+	pixel_y = -30
 	},
 /obj/item/towel/random{
 	pixel_y = 10;
@@ -38337,8 +37937,7 @@
 "lmN" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -38423,7 +38022,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -38565,7 +38163,6 @@
 /area/maintenance/Deck1_AftPort_Chamber2)
 "lps" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -38587,8 +38184,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Harbor)
@@ -38736,8 +38332,7 @@
 /area/maintenance/Deck1_Security_PortChamber2)
 "lun" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/Port_1Deck_Central_Corridor_1)
@@ -38849,9 +38444,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "lwN" = (
 /obj/machinery/door/firedoor/border_only,
@@ -39006,8 +38599,7 @@
 /area/rnd/Research_Ship_Bay)
 "lzq" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -39016,7 +38608,6 @@
 	dir = 1
 	},
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -39107,8 +38698,7 @@
 /area/maintenance/Deck1_AftStar1_Corridor1)
 "lAG" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	name = "1E-AI display"
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -39775,12 +39365,10 @@
 	pixel_y = 4
 	},
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "1N-newscaster"
+	pixel_y = 28
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobotany_Lab)
@@ -39933,8 +39521,7 @@
 /area/security/Exploration_Ship_Bay)
 "lQf" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/shuttle/loading{
 	dir = 8;
@@ -40184,7 +39771,6 @@
 "lTi" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/structure/cable{
@@ -40196,8 +39782,7 @@
 /area/maintenance/Market_Stall_4)
 "lTm" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -40227,7 +39812,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -40271,8 +39855,7 @@
 "lTO" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -40501,8 +40084,7 @@
 /area/maintenance/ab_Kitchen)
 "lXH" = (
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "1N-newscaster"
+	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -40723,9 +40305,7 @@
 /area/hallway/Port_1Deck_Atrium)
 "maQ" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "maR" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -40811,7 +40391,6 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/machinery/newscaster{
-	name = "1S-newscaster";
 	pixel_y = -30
 	},
 /turf/simulated/floor/tiled,
@@ -40988,9 +40567,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/Stairwell_For)
 "mgT" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/hallway/For_Transit_Foyer)
 "mhu" = (
@@ -41090,7 +40667,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -41404,8 +40980,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/Market_Stall_6)
@@ -41510,8 +41085,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Central)
@@ -41562,7 +41136,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
@@ -41616,8 +41189,7 @@
 "mrx" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/corner/purple/diagonal,
 /obj/effect/floor_decal/corner/purple/diagonal{
@@ -41716,7 +41288,6 @@
 /area/harbor/Dock3)
 "mtA" = (
 /obj/machinery/ai_status_display{
-	name = "1E-AI display";
 	pixel_x = 32
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -41760,7 +41331,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/tiled/dark,
@@ -41780,9 +41350,7 @@
 "mun" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "muA" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -42083,9 +41651,7 @@
 /obj/structure/bed/chair/sofa/right/beige{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/ForStar_1_Deck_Observatory)
 "mxn" = (
@@ -42096,8 +41662,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Port_Docking_Foyer)
@@ -42119,9 +41684,7 @@
 /turf/space,
 /area/space)
 "myr" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -42260,8 +41823,7 @@
 	pixel_x = 6
 	},
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/machinery/camera/network/security{
 	dir = 5;
@@ -42329,9 +41891,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 5
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "mBt" = (
 /obj/effect/floor_decal/borderfloor{
@@ -42492,7 +42052,6 @@
 /area/maintenance/Deck1_Security_StarCorridor1)
 "mED" = (
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -42551,8 +42110,7 @@
 /obj/item/mop/advanced,
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "1W-newscaster"
+	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -42619,7 +42177,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
@@ -42701,8 +42258,7 @@
 "mIl" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -42883,9 +42439,7 @@
 	pixel_y = 8;
 	pixel_x = -4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/white,
@@ -42954,7 +42508,6 @@
 /obj/machinery/vending/snack,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -43080,8 +42633,7 @@
 /area/maintenance/Deck1_Science_AftCorridor1)
 "mOg" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/Star_1Deck_Central_Corridor_1)
@@ -43238,7 +42790,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -43457,8 +43008,7 @@
 	dir = 8
 	},
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock4)
@@ -43783,7 +43333,6 @@
 /area/maintenance/Deck1_Security_StarCorridor2)
 "naS" = (
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloor/corner{
@@ -43871,7 +43420,6 @@
 "ndt" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -44072,7 +43620,6 @@
 /obj/effect/floor_decal/corner/white/border,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
@@ -44134,8 +43681,7 @@
 "nkB" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -44265,8 +43811,7 @@
 /area/quartermaster/Deck1_Corridor)
 "noF" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/AftStar_1_Deck_Observatory)
@@ -44425,9 +43970,7 @@
 /area/shuttle/spacebus)
 "nrb" = (
 /obj/structure/flora/sif/eyes,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "nrf" = (
 /obj/effect/decal/cleanable/flour,
@@ -44522,9 +44065,7 @@
 /obj/structure/railing/grey{
 	color = "yellow"
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
 	},
@@ -44682,7 +44223,6 @@
 "nvF" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -44704,7 +44244,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -44780,7 +44319,6 @@
 "nyb" = (
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner{
@@ -44858,9 +44396,7 @@
 /area/maintenance/ab_Hydroponics)
 "nzf" = (
 /obj/structure/flora/tree/sif,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "nzv" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -44945,9 +44481,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "nBE" = (
 /obj/machinery/door/firedoor/border_only,
@@ -45082,7 +44616,6 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -45457,7 +44990,6 @@
 "nKL" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
@@ -45494,8 +45026,7 @@
 /area/harbor/Dock1)
 "nLa" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -46121,9 +45652,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/maintenance/Market_Stall_6)
 "nVk" = (
@@ -46244,11 +45773,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Harbor)
 "nWh" = (
-/obj/machinery/smartfridge/secure{
-	req_access = list(47)
+/obj/effect/catwalk_plated,
+/obj/structure/fireaxecabinet{
+	pixel_y = -29;
+	name = "1S-fire axe cabinet"
 	},
-/turf/simulated/wall/r_wall,
-/area/rnd/Observation_Hall)
+/turf/simulated/floor/plating,
+/area/engineering/Telecomms_Foyer)
 "nWy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
@@ -46370,7 +45901,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -46413,9 +45943,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled,
@@ -46802,8 +46330,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/rnd/Xenobiology_Lab)
@@ -47076,8 +46603,7 @@
 /area/maintenance/ab_Hydroponics)
 "okz" = (
 /obj/machinery/status_display{
-	pixel_x = 32;
-	name = "E-status display"
+	pixel_x = 32
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -47145,7 +46671,6 @@
 "olG" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/structure/cable/green{
@@ -47188,7 +46713,6 @@
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -47238,8 +46762,7 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/telecomms/server/presets/unused,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating{
 	nitrogen = 100;
@@ -47436,7 +46959,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -47727,8 +47249,7 @@
 "ovx" = (
 /obj/structure/bed/chair/sofa/lime,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/wood/alt/panel{
 	nitrogen = 101.3;
@@ -48145,8 +47666,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Star_1Deck_Atrium)
@@ -48322,7 +47842,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/tiled,
@@ -48397,9 +47916,7 @@
 /area/hallway/Central_1_Deck_Hall)
 "oFF" = (
 /obj/machinery/mineral/stacking_machine,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/quartermaster/Mining_Ship_Bay)
 "oGl" = (
@@ -48477,8 +47994,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
@@ -48577,8 +48093,7 @@
 /area/maintenance/Deck1_AftPort_Chamber2)
 "oIN" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -48632,8 +48147,7 @@
 "oJL" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Deck1_Transit_Hall)
@@ -48862,7 +48376,6 @@
 "oMN" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor/corner{
@@ -48892,8 +48405,7 @@
 /area/maintenance/Deck1_Cargo_Corridor1)
 "oNg" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/harbor/Dock5)
@@ -48956,7 +48468,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -49200,8 +48711,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Deck1_Transit_Hall)
@@ -49601,7 +49111,6 @@
 /area/quartermaster/Depot1)
 "oZp" = (
 /obj/machinery/status_display{
-	name = "W-status display";
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -49678,9 +49187,7 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/ab_Kitchen)
 "paZ" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -49800,7 +49307,6 @@
 	pixel_x = -3
 	},
 /obj/machinery/newscaster{
-	name = "1S-newscaster";
 	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
@@ -49922,7 +49428,6 @@
 /area/shuttle/echidna)
 "pfi" = (
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -49978,9 +49483,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 9
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "pgf" = (
 /obj/machinery/door/firedoor/border_only,
@@ -50185,8 +49688,7 @@
 	dir = 8
 	},
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock1)
@@ -50265,8 +49767,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/structure/cable/white{
 	d1 = 1;
@@ -50713,7 +50214,6 @@
 "poY" = (
 /obj/machinery/disposal,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/structure/disposalpipe/trunk{
@@ -50853,7 +50353,6 @@
 /area/maintenance/Deck1_AftStar1_Corridor3)
 "prB" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/structure/cable/green{
@@ -50878,9 +50377,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/white/bordercorner,
 /turf/simulated/floor/tiled,
@@ -50902,11 +50399,50 @@
 	},
 /area/maintenance/ab_Kitchen)
 "psu" = (
-/obj/structure/flora/rocks2,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
+/obj/item/stack/material/phoron{
+	amount = 25;
+	pixel_x = 9;
+	pixel_y = -9
 	},
-/area/hallway/Star_1Deck_Atrium)
+/obj/item/clothing/glasses/meson{
+	pixel_x = -6;
+	pixel_y = -13
+	},
+/obj/item/clothing/glasses/welding{
+	pixel_x = -6;
+	pixel_y = -8
+	},
+/obj/item/stack/material/plasteel{
+	amount = 30;
+	pixel_y = 1;
+	pixel_x = -8
+	},
+/obj/item/stack/material/steel{
+	amount = 50;
+	pixel_y = 4;
+	pixel_x = -8
+	},
+/obj/item/stack/material/glass{
+	amount = 50;
+	pixel_x = -8;
+	pixel_y = 7
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/item/t_scanner{
+	pixel_y = 3;
+	pixel_x = 11
+	},
+/obj/item/multitool{
+	pixel_x = 4
+	},
+/obj/structure/closet/crate/secure/large/nanotrasen{
+	req_access = list(10)
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "psG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -50960,9 +50496,7 @@
 /turf/simulated/wall,
 /area/crew_quarters/Public_EVA)
 "puG" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
@@ -51011,9 +50545,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "pvi" = (
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "pvk" = (
 /obj/machinery/door/firedoor/multi_tile/glass{
@@ -51045,12 +50577,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Star_Corridor)
-"pvA" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
-/area/hallway/Star_1Deck_Atrium)
 "pvG" = (
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -51088,7 +50614,6 @@
 /obj/structure/table/steel,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -51241,9 +50766,7 @@
 /area/harbor/Dock5)
 "pzk" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "pzK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -51551,7 +51074,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -51589,8 +51111,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
@@ -51710,9 +51231,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "pIs" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/white/border,
 /turf/simulated/floor/tiled/dark,
@@ -51720,7 +51239,6 @@
 "pIt" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28;
-	name = "1W-extinguisher cabinet";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -51887,8 +51405,7 @@
 "pLm" = (
 /obj/machinery/vending/hydroseeds,
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_1)
@@ -51945,8 +51462,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/PA_Chamber)
@@ -52015,9 +51531,7 @@
 /obj/item/seeds/rose{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "pOq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -52078,8 +51592,7 @@
 /area/rnd/Research_Ship_Bay)
 "pOF" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -52549,11 +52062,6 @@
 	pixel_y = 23;
 	name = "1N-wall recharger"
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = 4;
-	pixel_y = 33;
-	name = "1N-wall recharger"
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
 	},
@@ -52845,9 +52353,7 @@
 	nutriment_amt = 1
 	},
 /obj/structure/table/fancyblack,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "pYg" = (
 /obj/structure/table/bench/sifwooden/padded,
@@ -52877,8 +52383,7 @@
 "pYC" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/hallway/Port_1Deck_Atrium)
@@ -53016,9 +52521,7 @@
 /area/maintenance/Deck1_Cargo_Corridor2)
 "qbg" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled/dark,
@@ -53105,9 +52608,7 @@
 /area/maintenance/ab_StripBar)
 "qdT" = (
 /obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "qed" = (
 /obj/structure/cable{
@@ -53122,8 +52623,7 @@
 /obj/item/mop/advanced,
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -53231,7 +52731,6 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
@@ -53366,8 +52865,7 @@
 "qhH" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -53416,9 +52914,7 @@
 /area/rnd/Research_Ship_Bay)
 "qiR" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "qjA" = (
 /obj/structure/disposalpipe/segment{
@@ -53432,9 +52928,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "qjR" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -53596,9 +53090,7 @@
 /area/maintenance/Deck1_AftPort_Chamber1)
 "qnA" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "qnC" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -53630,7 +53122,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
@@ -53871,8 +53362,7 @@
 /area/security/Exploration_Sling_Shuttle)
 "qrL" = (
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -53934,9 +53424,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock3)
 "qtH" = (
@@ -53970,8 +53458,7 @@
 /area/quartermaster/Mining_Ship_Bay)
 "quc" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/ForPort_1_Deck_Observatory)
@@ -54059,7 +53546,6 @@
 "qvD" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloorwhite,
@@ -54359,8 +53845,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/PA_Chamber)
@@ -54436,8 +53921,7 @@
 /area/shuttle/needle)
 "qGi" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_2)
@@ -54457,7 +53941,6 @@
 /obj/machinery/vending/snix,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -54470,8 +53953,7 @@
 /area/harbor/Dock3)
 "qGK" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/disposalpipe/sortjunction/wildcard/flipped{
 	dir = 8
@@ -54757,10 +54239,6 @@
 	pixel_x = 9;
 	pixel_y = -9
 	},
-/obj/item/t_scanner/upgraded{
-	pixel_x = 11;
-	pixel_y = 3
-	},
 /obj/item/clothing/glasses/meson{
 	pixel_x = -6;
 	pixel_y = -13
@@ -54768,9 +54246,6 @@
 /obj/item/clothing/glasses/welding{
 	pixel_x = -6;
 	pixel_y = -8
-	},
-/obj/structure/closet/crate/large/nanotrasen{
-	req_one_access = list(10)
 	},
 /obj/item/stack/material/plasteel{
 	amount = 30;
@@ -54787,13 +54262,6 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
-/obj/item/clothing/gloves/yellow{
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/item/multitool{
-	pixel_x = 4
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -54802,6 +54270,16 @@
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/item/t_scanner{
+	pixel_y = 3;
+	pixel_x = 11
+	},
+/obj/item/multitool{
+	pixel_x = 4
+	},
+/obj/structure/closet/crate/secure/large/nanotrasen{
+	req_access = list(10)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Central)
@@ -55369,9 +54847,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Science_AftCorridor1)
 "qTw" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/airlock_sensor{
 	pixel_y = -24;
 	dir = 1
@@ -55482,8 +54958,7 @@
 	name = "Drei"
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Star_Docking_Foyer)
@@ -55492,9 +54967,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "qUU" = (
 /obj/effect/floor_decal/arrivals/right,
@@ -55604,8 +55077,7 @@
 "qVM" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Ship_Bay4)
@@ -55635,8 +55107,7 @@
 "qWM" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -55836,8 +55307,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/status_display{
-	pixel_x = 32;
-	name = "E-status display"
+	pixel_x = 32
 	},
 /obj/structure/cable/white{
 	d1 = 1;
@@ -55963,8 +55433,7 @@
 /area/engineering/Telecomms_Network)
 "rbp" = (
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -56144,8 +55613,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
@@ -56235,7 +55703,6 @@
 "reM" = (
 /obj/structure/closet/l3closet/scientist/double,
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -56371,9 +55838,7 @@
 /area/maintenance/Deck1_Security_StarCorridor2)
 "rhu" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "rhK" = (
 /obj/structure/disposalpipe/segment{
@@ -56507,7 +55972,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/maintenance/ab_Kitchen)
 "rkp" = (
 /obj/structure/table,
@@ -56678,8 +56143,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Fueling_Post)
@@ -56718,7 +56182,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
@@ -56781,9 +56244,7 @@
 /obj/item/seeds/lustflower{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "rqj" = (
 /obj/machinery/alarm{
@@ -56872,8 +56333,7 @@
 /area/rnd/Observation_Hall)
 "rrm" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_For)
@@ -57020,9 +56480,7 @@
 /area/maintenance/Harbor_Substation)
 "rtA" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled/dark,
@@ -57275,7 +56733,6 @@
 	RCon_tag = "Tcoms Substation Bypass"
 	},
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
@@ -57457,8 +56914,7 @@
 "rzO" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -57865,7 +57321,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -57949,7 +57404,8 @@
 	},
 /obj/machinery/power/emitter/antique{
 	dir = 4;
-	anchored = 1
+	anchored = 1;
+	id = "SC-PARoomEmitter"
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/techfloor,
@@ -57960,8 +57416,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -58004,9 +57459,7 @@
 /area/maintenance/ab_GeneralStore)
 "rLd" = (
 /obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "rLt" = (
 /obj/effect/floor_decal/borderfloor{
@@ -58067,7 +57520,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -58136,7 +57588,6 @@
 "rPG" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/glass/reinforced,
@@ -58223,8 +57674,7 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Port_Docking_Foyer)
@@ -58403,8 +57853,7 @@
 /area/quartermaster/Mining_Ship_Bay)
 "rUM" = (
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -58568,8 +58017,7 @@
 /area/rnd/Xenobiology_Lab)
 "rXO" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
@@ -58785,8 +58233,7 @@
 "saS" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Locker_Room)
@@ -58809,8 +58256,7 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/For_Locker_Room)
@@ -58888,9 +58334,7 @@
 	pixel_y = -2;
 	pixel_x = 2
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/airlock_sensor{
 	pixel_y = -24;
 	dir = 1
@@ -59009,7 +58453,6 @@
 "sdp" = (
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack/station,
@@ -59099,9 +58542,7 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape_pod13/station)
 "seB" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/AftStar_1_Deck_Observatory)
 "seD" = (
@@ -59140,7 +58581,6 @@
 	dir = 8
 	},
 /obj/machinery/status_display{
-	name = "W-status display";
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled,
@@ -59269,8 +58709,7 @@
 /obj/structure/table/standard,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -59427,7 +58866,6 @@
 /area/maintenance/Deck1_AftPort_Chamber2)
 "skF" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -59745,7 +59183,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -59924,8 +59361,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -59946,7 +59382,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -60148,9 +59583,7 @@
 /obj/structure/sign/warning/high_voltage{
 	pixel_y = -32
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/engineering/Telecomms_Foyer)
 "sAE" = (
@@ -60383,9 +59816,7 @@
 /area/security/Aft_Security_Post)
 "sEE" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "sEM" = (
 /obj/machinery/alarm{
@@ -60404,9 +59835,7 @@
 /obj/item/seeds/sunflowerseed{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "sET" = (
 /obj/machinery/alarm{
@@ -60438,8 +59867,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/carpet/sblucarpet/turfpack/station,
 /area/hallway/Cryostorage_Lounge)
@@ -60483,14 +59911,11 @@
 /obj/item/seeds/poppyseed{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "sGw" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -60547,9 +59972,7 @@
 /turf/simulated/floor/plating,
 /area/harbor/Ship_Bay1)
 "sHh" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/green/border,
@@ -60707,7 +60130,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
@@ -60893,9 +60315,7 @@
 /turf/simulated/floor/tiled/hydro,
 /area/maintenance/ab_Hydroponics)
 "sMI" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/white/border,
 /turf/simulated/floor/tiled/dark,
@@ -61204,8 +60624,7 @@
 /area/maintenance/Deck1_Cargo_Chamber1)
 "sSr" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -61382,8 +60801,7 @@
 /area/hallway/Star_1Deck_Atrium)
 "sXr" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/AftPort_1_Deck_Observatory)
@@ -62293,7 +61711,6 @@
 "tpj" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/status_display{
-	name = "E-status display";
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -62360,8 +61777,7 @@
 "tqg" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	name = "1E-AI display"
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Deck1_Corridor)
@@ -62402,9 +61818,7 @@
 /obj/item/seeds/rose/blood{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "tqB" = (
 /obj/item/reagent_containers/food/snacks/monkeycube/wrapped/stokcube,
@@ -62544,7 +61958,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/white,
@@ -62569,8 +61982,7 @@
 	req_one_access = list(7,47)
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -62583,9 +61995,7 @@
 "tsU" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "tts" = (
 /obj/structure/lattice,
@@ -62842,7 +62252,8 @@
 	layer = 2.5
 	},
 /obj/machinery/door/airlock/angled_bay/standard/color/security{
-	req_access = null
+	req_access = null;
+	req_one_access = list(19,1)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -62921,9 +62332,7 @@
 /obj/item/seeds/poppyseed{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "tzt" = (
 /obj/machinery/door/firedoor/glass,
@@ -62974,13 +62383,12 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 4
 	},
-/obj/random/soap,
+/obj/random/soap_common,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Custodial_Office)
 "tzZ" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -63048,9 +62456,7 @@
 /obj/item/seeds/sifbulb{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "tAZ" = (
 /obj/machinery/power/apc{
@@ -63060,7 +62466,6 @@
 	},
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -63110,17 +62515,14 @@
 /obj/item/seeds/shrinkshroom{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "tCf" = (
 /turf/simulated/wall,
 /area/maintenance/ab_ChuteTrade)
 "tCi" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/security/Quantum_Pad_Checkpoint)
@@ -63208,7 +62610,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloor/corner{
@@ -63236,9 +62637,7 @@
 /area/hallway/Star_1Deck_Atrium)
 "tDP" = (
 /obj/structure/flora/rocks2,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "tDY" = (
 /obj/structure/reagent_dispensers/foam,
@@ -63599,7 +62998,6 @@
 /area/engineering/Telecomms_Control_Room)
 "tLK" = (
 /obj/machinery/status_display{
-	name = "W-status display";
 	pixel_x = -32
 	},
 /turf/simulated/floor/glass/reinforced,
@@ -63826,8 +63224,7 @@
 /area/rnd/Xenobotany_Lab)
 "tQH" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber2)
@@ -63869,9 +63266,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Chamber1)
 "tRr" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_4)
 "tRt" = (
@@ -63892,8 +63287,7 @@
 "tRR" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/table/standard,
 /obj/machinery/cell_charger{
@@ -63914,7 +63308,6 @@
 /area/rnd/Xenobiology_Lab)
 "tSh" = (
 /obj/machinery/ai_status_display{
-	name = "1E-AI display";
 	pixel_x = 32
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -64065,7 +63458,6 @@
 "tUx" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -64231,8 +63623,7 @@
 /obj/structure/closet/crate/large,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -64286,9 +63677,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Port_1Deck_Atrium)
 "tZQ" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -64360,8 +63749,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Xenobiology_Lab)
@@ -64430,8 +63818,7 @@
 /area/rnd/Xenobiology_Lab)
 "ubt" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Quantum_Pad_Checkpoint)
@@ -64555,9 +63942,7 @@
 "udx" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "udF" = (
 /obj/effect/floor_decal/borderfloorblack,
@@ -64823,8 +64208,7 @@
 /area/maintenance/Deck1_Cargo_Corridor3)
 "uhW" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/blue,
 /area/harbor/Port_Docking_Foyer)
@@ -64986,7 +64370,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -65168,8 +64551,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -65221,9 +64603,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "uqt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -65252,7 +64632,6 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	name = "1S-newscaster";
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
@@ -65284,7 +64663,6 @@
 "urj" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
-	name = "1E-extinguisher cabinet";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -65506,8 +64884,7 @@
 /area/harbor/Dock1)
 "uvr" = (
 /obj/machinery/status_display{
-	pixel_x = 32;
-	name = "E-status display"
+	pixel_x = 32
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -65551,8 +64928,7 @@
 "uvW" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -65621,7 +64997,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green,
@@ -65684,9 +65059,7 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/For_Restroom)
 "uzg" = (
@@ -66014,7 +65387,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -66223,12 +65595,9 @@
 	dir = 5
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/white,
@@ -66312,7 +65681,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/maintenance/ab_Kitchen)
 "uKn" = (
 /obj/structure/table/standard,
@@ -66416,9 +65785,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/closet/crate/freezer/nanotrasen,
 /obj/random/maintenance/cargo,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled/dark,
@@ -66630,7 +65997,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -66668,18 +66034,14 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "uRj" = (
 /obj/item/laserdome_flag/red,
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/ab_SportsField)
 "uRD" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -66698,7 +66060,6 @@
 /obj/effect/floor_decal/corner/white/border,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
@@ -66709,8 +66070,7 @@
 /area/hallway/Port_1Deck_Atrium)
 "uSp" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -66795,7 +66155,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green,
@@ -66960,8 +66319,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -66990,8 +66348,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -67001,7 +66358,6 @@
 "uXa" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -67147,7 +66503,6 @@
 "uZJ" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /obj/effect/floor_decal/borderfloor/corner,
@@ -67181,9 +66536,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Harbor)
 "vaz" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
 	},
@@ -67413,7 +66766,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/structure/cable/white{
@@ -67754,7 +67106,6 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
-	name = "1E-extinguisher cabinet";
 	pixel_x = 27
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -67852,7 +67203,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -67897,7 +67247,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -68064,9 +67413,7 @@
 /obj/item/seeds/lustflower{
 	icon_state = "seed"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "voF" = (
 /obj/structure/shuttle/engine/heater,
@@ -68507,9 +67854,7 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "vvi" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
@@ -68541,9 +67886,7 @@
 "vwb" = (
 /obj/structure/reagent_dispensers/foam,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Central)
 "vwq" = (
@@ -68557,7 +67900,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/corner/purple/diagonal,
@@ -68610,7 +67952,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -68637,7 +67978,6 @@
 /obj/structure/closet/malf/suits,
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -68898,8 +68238,7 @@
 /area/quartermaster/Mining_Ship_Bay)
 "vBl" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/purple/bordercorner,
@@ -68908,7 +68247,6 @@
 "vBs" = (
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
@@ -69065,7 +68403,6 @@
 "vDc" = (
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -69541,9 +68878,7 @@
 /obj/structure/bed/chair/wood{
 	dir = 8
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "vMr" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -69566,9 +68901,7 @@
 /area/maintenance/Deck1_Security_PortCorridor1)
 "vMv" = (
 /obj/structure/flora/sif/tendrils,
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "vMw" = (
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
@@ -69645,7 +68978,6 @@
 "vNk" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -69739,8 +69071,7 @@
 /area/maintenance/Deck1_AftStar1_Corridor2)
 "vOZ" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -69795,8 +69126,7 @@
 "vQw" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -69906,8 +69236,7 @@
 /area/maintenance/ab_GeneralStore)
 "vTb" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -70018,9 +69347,7 @@
 "vUn" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "vUq" = (
 /obj/random/junk,
@@ -70135,7 +69462,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite,
@@ -70313,9 +69639,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -70349,8 +69673,7 @@
 /obj/structure/table/rack/shelf,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/item/clothing/mask/gas{
 	pixel_y = 5;
@@ -70393,9 +69716,7 @@
 /turf/simulated/floor/tiled/white,
 /area/maintenance/ab_Medical)
 "vZY" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/table/reinforced,
 /obj/item/clipboard{
 	pixel_x = -3
@@ -70449,8 +69770,7 @@
 /area/quartermaster/Deck1_Corridor)
 "wax" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/shuttle/loading{
 	dir = 1;
@@ -70811,9 +70131,7 @@
 "whF" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/floor_decal/spline/fancy/wood,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "wie" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -70834,7 +70152,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -70875,8 +70192,7 @@
 /area/shuttle/escape_pod3/station)
 "wiP" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -70937,9 +70253,7 @@
 /area/hallway/Aft_1_Deck_Stairwell)
 "wjR" = (
 /obj/structure/flora/ausbushes/fernybush,
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
 "wjT" = (
 /obj/structure/cable/green{
@@ -70957,11 +70271,6 @@
 /obj/random/cutout,
 /turf/simulated/floor/tiled,
 /area/maintenance/ab_GeneralStore)
-"wjZ" = (
-/turf/simulated/floor/outdoors/grass/sif/turfpack/station{
-	outdoors = -1
-	},
-/area/hallway/Star_1Deck_Atrium)
 "wkg" = (
 /obj/item/toy/baseball,
 /turf/simulated/floor/grass2/turfpack/station,
@@ -71242,8 +70551,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -71409,8 +70717,7 @@
 /obj/fiftyspawner/retrocarpet,
 /obj/fiftyspawner/retrocarpet_red,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -71433,8 +70740,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
@@ -71615,7 +70921,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
@@ -71709,7 +71014,6 @@
 "wAp" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -71833,9 +71137,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/rnd/Xenobotany_Isolation_Chamber)
 "wCY" = (
@@ -72454,7 +71756,6 @@
 /obj/structure/bed/chair/oldsofa/left,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/carpet/sblucarpet/turfpack/station,
@@ -72547,8 +71848,7 @@
 	pixel_x = 22
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -72676,6 +71976,11 @@
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 10
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = -30;
+	name = "1S-wall recharger"
 	},
 /turf/simulated/floor/tiled/monotile{
 	color = "#989898"
@@ -72896,8 +72201,7 @@
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -73079,8 +72383,7 @@
 /area/hallway/Aft_1_Deck_Stairwell)
 "wZo" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -73195,7 +72498,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -73256,8 +72558,7 @@
 /area/maintenance/Deck1_ForStar_Chamber2)
 "xcz" = (
 /obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "1W-newscaster"
+	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -73293,8 +72594,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Telecomms_Foyer)
@@ -73343,9 +72643,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/turf/simulated/floor/outdoors/grass/sif/forest/turfpack/station{
-	outdoors = -1
-	},
+/turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "xdz" = (
 /obj/machinery/button/remote/blast_door{
@@ -73388,8 +72686,7 @@
 /area/harbor/Fueling_Post)
 "xdS" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 4
@@ -73499,8 +72796,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -73517,7 +72813,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/machinery/button/windowtint{
@@ -73687,8 +72982,7 @@
 /area/rnd/PA_Chamber)
 "xjp" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -73895,7 +73189,6 @@
 "xmI" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -74092,9 +73385,7 @@
 /area/harbor/Ship_Bay4)
 "xqr" = (
 /obj/structure/table/steel,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/item/stack/cable_coil{
 	pixel_x = -5;
 	pixel_y = 5
@@ -74157,8 +73448,7 @@
 /area/maintenance/Deck1_ForStar_Corridor2)
 "xrK" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -74184,13 +73474,11 @@
 /obj/machinery/vending/event/costume,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -74289,8 +73577,7 @@
 /area/quartermaster/Supply_Ship_Bay)
 "xtn" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	name = "1E-AI display"
+	pixel_x = 32
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/security/Quantum_Pad_Checkpoint)
@@ -74518,7 +73805,6 @@
 	dir = 1
 	},
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
@@ -74543,8 +73829,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating/turfpack/station,
 /area/maintenance/ab_SportsField)
@@ -74774,7 +74059,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /turf/simulated/floor/plating{
@@ -74890,8 +74174,7 @@
 "xIE" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -75191,9 +74474,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay1)
 "xPO" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -75289,9 +74570,7 @@
 /area/maintenance/ab_Medical)
 "xRw" = (
 /obj/structure/dispenser/oxygen,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled/dark,
@@ -75586,7 +74865,6 @@
 "xWo" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -76066,7 +75344,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/white{
@@ -76265,7 +75542,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/structure/disposalpipe/segment{
@@ -76320,7 +75596,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -76422,8 +75697,7 @@
 /obj/structure/table/glass,
 /obj/item/clipboard,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -94450,7 +93724,7 @@ xrX
 uRT
 xdx
 voc
-kDc
+aBD
 fiF
 voc
 qdT
@@ -104603,7 +103877,7 @@ chQ
 ekA
 iKg
 aaa
-aaa
+psu
 aaa
 aaa
 aaa
@@ -106055,7 +105329,7 @@ aFf
 rFW
 mdg
 iLt
-uad
+nWh
 jYA
 oex
 oex
@@ -114802,11 +114076,11 @@ wOF
 dHE
 aCO
 gSY
-aCO
-aCO
-aCO
+dXG
+dXG
+dXG
 dMi
-aCO
+dXG
 agl
 jDS
 vgh
@@ -115065,7 +114339,7 @@ dXG
 kyf
 efy
 exI
-kuG
+agl
 kuG
 vEL
 kuG
@@ -115323,7 +114597,7 @@ dXG
 auI
 oyL
 ntZ
-kuG
+agl
 gBw
 vgh
 qMi
@@ -115581,7 +114855,7 @@ dXG
 ubX
 dFb
 tbL
-kuG
+agl
 awK
 pnz
 feA
@@ -115833,13 +115107,13 @@ aOh
 nRj
 aOh
 ilx
-fVh
+bTk
 hzy
-fVh
-fVh
-fVh
-fVh
-fVh
+bTk
+bTk
+bTk
+bTk
+bTk
 fVh
 sxL
 fyP
@@ -116379,13 +115653,13 @@ pvi
 pvi
 pvi
 pvi
-psu
+tDP
 qHG
 npu
 tAW
-wjZ
-wjZ
-wjZ
+pvi
+pvi
+pvi
 akg
 qrc
 ijM
@@ -116634,16 +115908,16 @@ efI
 ijM
 abq
 aLf
-wjZ
-pvA
-wjZ
+pvi
+aql
+pvi
 pvi
 qHG
 npu
 pvi
 kRH
-wjZ
-wjZ
+pvi
+pvi
 osw
 fqS
 ijM
@@ -116895,12 +116169,12 @@ mYa
 kXb
 iEe
 nrb
-pvA
+aql
 qHG
 npu
 tBN
 pvi
-iau
+nrb
 pvi
 osw
 wEw
@@ -118190,8 +117464,8 @@ qHG
 npu
 adY
 kEx
-wjZ
-wjZ
+pvi
+pvi
 dIc
 ygN
 ijM
@@ -118447,9 +117721,9 @@ pat
 qHG
 npu
 tCH
-pvA
+aql
 wjR
-wjZ
+pvi
 osw
 sea
 ijM
@@ -118704,10 +117978,10 @@ pvi
 tBN
 qHG
 npu
-pvA
+aql
 nrb
-wjZ
-pvA
+pvi
+aql
 osw
 jpu
 ijM
@@ -118959,12 +118233,12 @@ jkC
 kRH
 maQ
 nzf
-wjZ
+pvi
 qHG
 npu
 tDP
-wjZ
-wjZ
+pvi
+pvi
 pvi
 oZI
 bco
@@ -119212,16 +118486,16 @@ awX
 awX
 awX
 awX
-aBD
+nzf
 aql
 pvi
 pvi
-wjZ
+pvi
 tAW
 qHG
 npu
-wjZ
-wjZ
+pvi
+pvi
 pvi
 pvi
 qHB
@@ -123617,7 +122891,7 @@ nZM
 bqm
 pXi
 beQ
-nWh
+hwu
 fAa
 olG
 gsI

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
@@ -18,8 +18,7 @@
 "aac" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -36,11 +35,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
-	},
-/obj/item/mecha_parts/mecha_equipment/weapon/energy/ion{
-	pixel_y = 12
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -209,7 +204,6 @@
 "aaq" = (
 /obj/structure/bed/chair/office/dark,
 /obj/machinery/newscaster{
-	name = "1N-newscaster";
 	pixel_y = 28
 	},
 /obj/effect/landmark/start{
@@ -622,8 +616,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/window/titanium,
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -654,19 +647,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
+/obj/effect/floor_decal/industrial/arrows/red{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/arrows/red{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/security/Reception)
 "abd" = (
 /obj/machinery/power/apc{
@@ -688,8 +681,7 @@
 /area/hallway/Central_2_Deck_Hall)
 "abe" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -699,20 +691,17 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
 /obj/machinery/alarm{
 	pixel_y = 25
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/Reception)
@@ -818,7 +807,6 @@
 "abl" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/structure/bed/chair,
@@ -992,7 +980,6 @@
 "abA" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/structure/bed/chair/oldsofa{
@@ -1122,7 +1109,6 @@
 "abO" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1155,8 +1141,7 @@
 	pixel_x = -3
 	},
 /obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "1W-newscaster"
+	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/kafel_full/blue,
@@ -1209,8 +1194,7 @@
 "abW" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1;
@@ -1295,8 +1279,7 @@
 /area/crew_quarters/Chomp_Dinner_1)
 "act" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -1416,8 +1399,7 @@
 /area/crew_quarters/Gym)
 "acE" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1432,8 +1414,7 @@
 /area/hallway/Aft_2_Deck_Corridor_1)
 "acI" = (
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
@@ -1539,12 +1520,10 @@
 /area/medical/Surgery_Room_1)
 "acW" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/milspec/cargo_arrow,
@@ -1568,7 +1547,6 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -1597,8 +1575,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/Equipment_Storage)
@@ -1648,7 +1625,6 @@
 "adh" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1720,7 +1696,6 @@
 "adp" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	name = "1W-extinguisher cabinet";
 	pixel_x = -28
 	},
 /turf/simulated/floor/wood/alt,
@@ -1837,8 +1812,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/machinery/button/windowtint{
 	pixel_x = -11;
@@ -1984,8 +1958,7 @@
 /area/space)
 "aed" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Aft_2_Deck_Airlock_Access)
@@ -1999,8 +1972,7 @@
 "aeg" = (
 /obj/machinery/papershredder,
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /obj/machinery/camera/network/security{
 	dir = 1;
@@ -2042,13 +2014,11 @@
 /obj/structure/closet/secure_closet/paramedic,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/item/extraction_pack,
 /obj/item/fulton_core,
@@ -2059,8 +2029,7 @@
 "aeo" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -2183,7 +2152,6 @@
 "aev" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/structure/cable/green{
@@ -2223,7 +2191,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -2249,8 +2216,7 @@
 "aeG" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -2292,8 +2258,7 @@
 "aeM" = (
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -2311,6 +2276,9 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/For_Medical_Post)
 "aeN" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 8
+	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 1
 	},
@@ -2359,7 +2327,6 @@
 "aeV" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/item/gps/engineering,
@@ -2386,8 +2353,7 @@
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /obj/item/gps/engineering,
 /obj/effect/floor_decal/borderfloorblack{
@@ -2434,12 +2400,10 @@
 "afm" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /obj/structure/table/reinforced,
@@ -2598,15 +2562,12 @@
 	},
 /obj/effect/floor_decal/corner/brown/bordercorner,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Central_Corridor_2)
 "afz" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
@@ -2660,8 +2621,7 @@
 /obj/item/gps/engineering,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -2790,8 +2750,7 @@
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
@@ -2804,11 +2763,11 @@
 "afV" = (
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/white,
-/obj/mecha/combat/fighter/gunpod/loaded{
-	dir = 4
-	},
 /obj/machinery/atmospherics/portables_connector{
 	layer = 10.1
+	},
+/obj/mecha/combat/fighter/gunpod{
+	dir = 4
 	},
 /turf/space,
 /area/harbor/For_Shuttlebay)
@@ -2825,8 +2784,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = 28;
-	name = "1E-newscaster"
+	pixel_x = 28
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -2840,9 +2798,7 @@
 /obj/machinery/vending/snack,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_1)
 "agc" = (
@@ -2895,8 +2851,7 @@
 /obj/item/radio/intercom/department/security{
 	dir = 4;
 	icon_override = "secintercom";
-	pixel_x = 22;
-	name = "1E-station intercom (Security)"
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -2935,7 +2890,6 @@
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -2999,14 +2953,12 @@
 /area/harbor/Star_Shuttlebay)
 "agt" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/glass,
 /area/hallway/For_2_Deck_Central_Corridor_2)
 "agu" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -3020,8 +2972,7 @@
 "agv" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -3054,8 +3005,7 @@
 /area/quartermaster/Mail_Room)
 "agz" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/holoposter{
 	pixel_y = 32;
@@ -3084,8 +3034,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_2)
@@ -3147,8 +3096,7 @@
 /area/shuttle/large_escape_pod3/station)
 "agK" = (
 /obj/machinery/newscaster{
-	pixel_x = 28;
-	name = "1E-newscaster"
+	pixel_x = 28
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -3228,8 +3176,7 @@
 /area/quartermaster/Aft_Tool_Storage)
 "agO" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -3348,8 +3295,7 @@
 /area/crew_quarters/Port_Restroom)
 "ahc" = (
 /obj/item/radio/intercom/department/security{
-	pixel_y = -22;
-	name = "1S-station intercom (Security)"
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -3452,11 +3398,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/arrows/red,
-/obj/machinery/door/airlock/angled_bay/double/color{
-	door_color = "#8c1d11";
-	name = "Security Lobby";
-	id_tag = "SC-ODsecurityfoyer"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -3464,6 +3405,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/angled_bay/double/color{
+	door_color = "#8c1d11";
+	name = "Security Lobby";
+	id_tag = "SC-ODsecurityfoyer";
+	req_access = list(1)
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/Lobby)
 "ahq" = (
@@ -3573,7 +3520,6 @@
 /area/maintenance/Deck2_Cargo_AftCorridor2)
 "ahL" = (
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -3693,7 +3639,6 @@
 /area/medical/Patient_Ward)
 "aih" = (
 /obj/machinery/status_display{
-	name = "W-status display";
 	pixel_x = -32
 	},
 /turf/simulated/floor/wood/alt,
@@ -3916,8 +3861,7 @@
 /obj/structure/closet/wardrobe/robotics_black,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/purple/border,
@@ -4030,7 +3974,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -4270,7 +4213,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -4339,14 +4281,12 @@
 "ajD" = (
 /obj/machinery/papershredder,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/lino,
 /area/security/Forensics_Office)
 "ajE" = (
 /obj/machinery/newscaster{
-	name = "1E-newscaster";
 	pixel_x = 28
 	},
 /obj/structure/disposalpipe/segment{
@@ -4426,7 +4366,6 @@
 /area/security/Reception)
 "ajO" = (
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /obj/structure/table/steel,
@@ -4471,7 +4410,6 @@
 /obj/item/cell/high/empty,
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -4529,8 +4467,7 @@
 /area/maintenance/Cargo_Substation)
 "akd" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -4614,7 +4551,6 @@
 "akA" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -4717,8 +4653,7 @@
 "akO" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/table/standard,
 /obj/item/paper/fluff/love_letter{
@@ -4828,7 +4763,6 @@
 /obj/machinery/washing_machine,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -4860,9 +4794,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/Warehouse)
 "alx" = (
-/obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/status_display{
-	name = "E-status display";
 	pixel_x = 32
 	},
 /obj/structure/cable/green{
@@ -4873,6 +4805,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/arrows/red,
+/obj/effect/floor_decal/industrial/arrows/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/Deck2_1_Corridor)
 "aly" = (
@@ -4896,8 +4832,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Chomp_Dinner_1)
@@ -4943,7 +4878,6 @@
 "alL" = (
 /obj/machinery/appliance/cooker/grill,
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/corner/lightorange/diagonal,
@@ -5113,8 +5047,7 @@
 /obj/item/storage/bag/detective,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/security/Forensics_Office)
@@ -5129,8 +5062,7 @@
 /area/engineering/Storage)
 "amP" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloor{
@@ -5219,7 +5151,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -5266,7 +5197,6 @@
 /area/engineering/Technical_Storage)
 "anr" = (
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/machinery/camera/network/research{
@@ -5298,8 +5228,7 @@
 /area/maintenance/ab_TeshDen)
 "any" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	name = "1E-AI display"
+	pixel_x = 32
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -5359,8 +5288,7 @@
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Technical_Storage)
@@ -5626,13 +5554,11 @@
 "aoP" = (
 /obj/machinery/disposal,
 /obj/machinery/newscaster{
-	name = "1W-newscaster";
 	pixel_x = -28
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -5710,27 +5636,16 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/security/Shuttlebay_Storage)
 "aoW" = (
-/obj/fiftyspawner/wood,
-/obj/fiftyspawner/wood,
-/obj/fiftyspawner/wood/sif,
-/obj/fiftyspawner/wood/sif,
 /obj/fiftyspawner/turcarpet,
 /obj/fiftyspawner/tealcarpet,
 /obj/fiftyspawner/sblucarpet,
 /obj/fiftyspawner/purcarpet,
 /obj/fiftyspawner/oracarpet,
 /obj/fiftyspawner/blucarpet,
-/obj/fiftyspawner/marble,
-/obj/item/storage/briefcase/inflatable,
-/obj/item/storage/briefcase/inflatable,
-/obj/item/storage/briefcase/inflatable,
-/obj/fiftyspawner/cardboard,
-/obj/fiftyspawner/cardboard,
 /obj/structure/closet/crate/secure/large/reinforced,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -5753,9 +5668,7 @@
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -5789,8 +5702,7 @@
 /obj/item/radio/intercom/department/security{
 	dir = 8;
 	icon_override = "secintercom";
-	pixel_x = -22;
-	name = "1W-station intercom (Security)"
+	pixel_x = -22
 	},
 /obj/item/reagent_containers/spray/sterilizine{
 	pixel_y = 4;
@@ -5877,7 +5789,6 @@
 /area/quartermaster/Waste_Disposals)
 "aps" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6048,8 +5959,7 @@
 /area/security/Boardroom)
 "aqa" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -6244,8 +6154,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -6377,35 +6286,16 @@
 /turf/simulated/floor/tiled/kafel_full/red,
 /area/security/Restroom)
 "arC" = (
-/obj/structure/table/rack{
-	pixel_y = 34
-	},
-/obj/structure/table/rack{
-	pixel_y = 17
-	},
 /obj/structure/table/rack,
-/obj/item/mecha_parts/mecha_equipment/tool/powertool/screwdriver{
-	pixel_y = 10;
-	pixel_x = 3
-	},
 /obj/item/mecha_parts/mecha_equipment/tool/cable_layer{
-	pixel_y = 6
+	pixel_y = 8
 	},
 /obj/item/mecha_parts/mecha_equipment/tool/powertool/welding{
-	pixel_y = 4
-	},
-/obj/item/mecha_parts/mecha_equipment/tool/rcd{
-	pixel_x = -4;
-	pixel_y = 1
+	pixel_y = -2
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
-	},
-/obj/item/mecha_parts/mecha_equipment/hardpoint_actuator{
-	pixel_y = -6;
-	pixel_x = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -6445,9 +6335,7 @@
 /obj/item/packageWrap,
 /obj/item/clothing/gloves/sterile/latex,
 /obj/item/clothing/gloves/sterile/latex,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/corner/lightorange/diagonal,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/orange/border,
@@ -6540,8 +6428,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/large_escape_pod3/station)
@@ -6552,7 +6439,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -6566,7 +6452,6 @@
 "arU" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/status_display{
-	name = "W-status display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -6714,7 +6599,6 @@
 /obj/structure/table/standard,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -6847,7 +6731,6 @@
 "atr" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28;
-	name = "1W-extinguisher cabinet";
 	dir = 4
 	},
 /obj/effect/floor_decal/milspec/box,
@@ -6939,9 +6822,7 @@
 /obj/effect/floor_decal/carpet/blue{
 	dir = 6
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -7021,13 +6902,10 @@
 	pixel_x = 3;
 	pixel_y = -5
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/table/steel_reinforced,
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -7035,9 +6913,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Canister_Storage)
 "atP" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/shuttle/loading{
 	dir = 8;
 	color = "#00B8B2"
@@ -7118,7 +6994,7 @@
 	},
 /obj/machinery/door/airlock/angled_bay/standard/glass/common{
 	dir = 4;
-	name = "Hydroponics";
+	name = "Kitchen";
 	req_access = list(28);
 	tintable = 1;
 	id_tint = "sc-WTkitchen"
@@ -7153,8 +7029,7 @@
 /area/maintenance/Deck2_For_Corridor)
 "auf" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/computer/crew{
 	dir = 8;
@@ -7239,9 +7114,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/Office_Lounge)
 "auz" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
 	},
@@ -7250,8 +7123,7 @@
 "auB" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/sign/securearea{
 	icon_state = "radiation_small";
@@ -7277,13 +7149,8 @@
 	pixel_y = 9;
 	pixel_x = 7
 	},
-/obj/item/floor_painter{
-	pixel_y = -2;
-	pixel_x = -1
-	},
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
-	name = "1E-extinguisher cabinet";
 	pixel_x = 27
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -7291,6 +7158,14 @@
 	},
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 4
+	},
+/obj/item/storage/box/nifsofts_engineering{
+	pixel_y = 14;
+	pixel_x = -6
+	},
+/obj/item/floor_painter{
+	pixel_y = -2;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engineering_Workshop)
@@ -7408,9 +7283,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/EMT_Bay)
-"avc" = (
-/turf/simulated/floor/plating,
-/area/hallway/Port_2_Deck_Stairwell)
 "ave" = (
 /obj/effect/floor_decal/milspec/box,
 /turf/simulated/floor/tiled/techmaint,
@@ -7436,8 +7308,7 @@
 /area/crew_quarters/Gym_Sauna)
 "avm" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/bed/chair/oldsofa/left,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -7458,7 +7329,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -7635,12 +7505,9 @@
 "avH" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
@@ -7652,7 +7519,6 @@
 "avJ" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7771,8 +7637,7 @@
 /area/engineering/Technical_Storage)
 "avU" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -7814,7 +7679,6 @@
 "awe" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -7880,7 +7744,6 @@
 /area/quartermaster/Reception)
 "awm" = (
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -7947,7 +7810,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -8159,8 +8021,7 @@
 /area/security/Brig)
 "axu" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -8177,8 +8038,7 @@
 "axv" = (
 /obj/structure/bed/chair/sofa/left/blue,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1;
@@ -8194,8 +8054,7 @@
 	name = "Robotics Operating Computer"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -8227,8 +8086,7 @@
 "axA" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -8237,7 +8095,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -8314,7 +8171,6 @@
 "axO" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -8407,9 +8263,7 @@
 /turf/simulated/floor/carpet,
 /area/crew_quarters/Chapel_Lobby)
 "aym" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
 	},
@@ -8611,7 +8465,6 @@
 /obj/structure/table/rack/shelf,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/status_display{
-	name = "W-status display";
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8622,8 +8475,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "1W-newscaster"
+	pixel_x = -28
 	},
 /obj/item/mail/junkmail,
 /obj/item/mail/junkmail,
@@ -8646,8 +8498,7 @@
 "ayU" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8674,7 +8525,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/int,
 /turf/simulated/floor/tiled/techmaint,
-/area/hallway/Port_2_Deck_Stairwell)
+/area/maintenance/Deck2_Cargo_AftCorridor2)
 "ayW" = (
 /obj/machinery/suit_cycler/engineering{
 	req_one_access = list(11,24);
@@ -8682,7 +8533,6 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8900,8 +8750,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/item/mail/envelope,
 /obj/item/mail/envelope,
@@ -8965,8 +8814,7 @@
 /area/maintenance/Deck2_Science_StarCorridor1)
 "aAc" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -8982,8 +8830,7 @@
 "aAd" = (
 /obj/item/radio/intercom/department/security{
 	dir = 1;
-	pixel_y = 22;
-	name = "1N-station intercom (Security)"
+	pixel_y = 22
 	},
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/borderfloor{
@@ -9002,8 +8849,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/item/toy/figure/hop{
 	pixel_y = 1;
@@ -9062,8 +8908,7 @@
 "aAq" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/floor_decal/borderfloor{
@@ -9091,8 +8936,7 @@
 /area/hallway/Aft_2_Deck_Stairwell)
 "aAt" = (
 /obj/machinery/status_display{
-	pixel_x = 32;
-	name = "E-status display"
+	pixel_x = 32
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -9105,7 +8949,6 @@
 "aAu" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloorwhite,
@@ -9150,8 +8993,7 @@
 	},
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/lino,
 /area/security/Forensics_Office)
@@ -9189,8 +9031,7 @@
 /area/medical/CMO_Office)
 "aAR" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -9221,9 +9062,7 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/Warehouse)
 "aAW" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -9282,7 +9121,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
-	name = "1E-extinguisher cabinet";
 	pixel_x = 27
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
@@ -9532,8 +9370,7 @@
 	pixel_y = 7
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -9614,8 +9451,7 @@
 "aCq" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -9628,15 +9464,13 @@
 "aCt" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/Rec_Lounge)
 "aCu" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloorblack{
@@ -9673,8 +9507,7 @@
 "aCx" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -9938,9 +9771,7 @@
 /obj/structure/window/basic{
 	dir = 8
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/harbor/Aft_2_Deck_Airlock_Access)
 "aDw" = (
@@ -9966,8 +9797,7 @@
 	},
 /obj/machinery/computer/guestpass{
 	dir = 4;
-	pixel_x = -19;
-	name = "1W-guest pass terminal"
+	pixel_x = -19
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_Transit_Foyer)
@@ -10051,8 +9881,7 @@
 	},
 /obj/item/book/tome/imbued,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/Library_Office)
@@ -10063,9 +9892,7 @@
 	pixel_y = 3;
 	pixel_x = 8
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled/dark,
@@ -10088,8 +9915,7 @@
 "aDS" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -10110,8 +9936,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -10310,8 +10135,7 @@
 /obj/structure/easel,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Gallery)
@@ -10380,7 +10204,6 @@
 "aEU" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/carpet,
@@ -10624,10 +10447,6 @@
 	pixel_x = 9;
 	pixel_y = -9
 	},
-/obj/item/t_scanner/upgraded{
-	pixel_x = 11;
-	pixel_y = 3
-	},
 /obj/item/clothing/glasses/meson{
 	pixel_x = -6;
 	pixel_y = -13
@@ -10635,9 +10454,6 @@
 /obj/item/clothing/glasses/welding{
 	pixel_x = -6;
 	pixel_y = -8
-	},
-/obj/structure/closet/crate/large/nanotrasen{
-	req_one_access = list(10)
 	},
 /obj/item/stack/material/plasteel{
 	amount = 30;
@@ -10654,12 +10470,19 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
-/obj/item/clothing/gloves/yellow{
-	pixel_x = -7;
-	pixel_y = 2
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/item/t_scanner{
+	pixel_y = 3;
+	pixel_x = 11
 	},
 /obj/item/multitool{
 	pixel_x = 4
+	},
+/obj/structure/closet/crate/secure/large/nanotrasen{
+	req_access = list(10)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Domicile_Substation)
@@ -10770,7 +10593,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green,
@@ -10862,8 +10684,6 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled,
 /area/security/Deck2_1_Corridor)
 "aGu" = (
@@ -10954,7 +10774,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -11134,7 +10953,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/machinery/button/windowtint{
@@ -11242,7 +11060,6 @@
 /obj/structure/table/steel_reinforced,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28;
-	name = "1W-extinguisher cabinet";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -11363,12 +11180,10 @@
 /obj/effect/floor_decal/milspec/box,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Mech_Bay)
@@ -11542,8 +11357,7 @@
 /area/quartermaster/Reception)
 "aIJ" = (
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
@@ -11613,10 +11427,6 @@
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chapel_Morgue)
 "aIT" = (
-/obj/structure/fireaxecabinet{
-	name = "1W-sfire axe cabinet";
-	pixel_x = -32
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
@@ -11633,7 +11443,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/machinery/button/windowtint{
@@ -11650,9 +11459,7 @@
 /obj/structure/bed/chair/comfy/brown{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/Rec_Lounge)
 "aIY" = (
@@ -11693,8 +11500,7 @@
 "aJb" = (
 /obj/structure/table/steel,
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/ForPort_2_Deck_Observatory)
@@ -11712,7 +11518,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/lino,
@@ -11902,7 +11707,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -12015,11 +11819,9 @@
 	pixel_x = 4
 	},
 /obj/item/clothing/head/helmet/space/void/security/alt{
-	pixel_y = 0;
 	pixel_x = 6
 	},
 /obj/item/clothing/head/helmet/space/void/security/alt{
-	pixel_y = 0;
 	pixel_x = -8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -12258,8 +12060,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -12567,7 +12368,6 @@
 	},
 /obj/item/clothing/gloves/boxing,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/wood/alt,
@@ -12623,12 +12423,10 @@
 /obj/item/radio/intercom/department/security{
 	dir = 4;
 	icon_override = "secintercom";
-	pixel_x = 22;
-	name = "1E-station intercom (Security)"
+	pixel_x = 22
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -12694,9 +12492,7 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_1)
 "aMc" = (
@@ -12785,8 +12581,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -12799,8 +12594,7 @@
 /area/medical/Chemistry)
 "aMo" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
@@ -12841,9 +12635,7 @@
 /area/medical/Distillery)
 "aMr" = (
 /obj/machinery/photocopier,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
@@ -12931,7 +12723,6 @@
 	dir = 1
 	},
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/carpet/blue,
@@ -12997,7 +12788,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -13147,7 +12937,6 @@
 "aNH" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -13210,12 +12999,9 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
@@ -13295,8 +13081,7 @@
 /area/hallway/Stairwell_Star)
 "aOa" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -13358,8 +13143,7 @@
 /area/security/Internal_Affairs_Office)
 "aOg" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13405,8 +13189,7 @@
 /area/quartermaster/Reception)
 "aOj" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13522,9 +13305,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engineering_EVA)
 "aOG" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightorange/border,
@@ -13568,8 +13349,7 @@
 /obj/structure/window/reinforced,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/structure/closet/secure_closet/chemical,
 /obj/item/tool/screwdriver,
@@ -13633,8 +13413,7 @@
 /area/quartermaster/Breakroom)
 "aPc" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/shuttle/loading{
 	dir = 8;
@@ -13689,8 +13468,7 @@
 /area/medical/FirstAid_Storage)
 "aPm" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/shield_diffuser,
@@ -13713,7 +13491,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -13859,7 +13636,6 @@
 /area/crew_quarters/Chomp_Kitchen)
 "aPO" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -13878,7 +13654,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -13974,8 +13749,7 @@
 "aQt" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/steel_ridged{
@@ -14037,7 +13811,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -14069,8 +13842,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -14106,8 +13878,7 @@
 "aQR" = (
 /obj/machinery/washing_machine,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -14119,8 +13890,7 @@
 /area/crew_quarters/Gym)
 "aQV" = (
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -14159,8 +13929,7 @@
 /obj/item/deck/cah/black,
 /obj/item/deck/cah,
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Rec_Lounge)
@@ -14185,9 +13954,7 @@
 	pixel_y = -5
 	},
 /obj/structure/table/woodentable,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Rec_Lounge)
 "aRc" = (
@@ -14204,8 +13971,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/landmark/start{
 	name = "Security Officer"
@@ -14280,7 +14046,6 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /obj/effect/floor_decal/borderfloorwhite,
@@ -14319,8 +14084,7 @@
 "aRo" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -14483,7 +14247,6 @@
 "aRV" = (
 /obj/structure/table/standard,
 /obj/machinery/newscaster{
-	name = "1E-newscaster";
 	pixel_x = 28
 	},
 /obj/item/soap/red_soap{
@@ -14598,7 +14361,6 @@
 "aSp" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -14607,7 +14369,8 @@
 /obj/machinery/button/windowtint/multitint{
 	pixel_y = -11;
 	pixel_x = -27;
-	id = "sc-WTsauna"
+	id = "sc-WTsauna";
+	range = 9
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -14625,7 +14388,6 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	name = "1E-newscaster";
 	pixel_x = 28
 	},
 /obj/effect/landmark/start{
@@ -14690,8 +14452,7 @@
 /obj/item/canvas/twentythree_twentythree,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -14815,7 +14576,6 @@
 /obj/structure/cable/green,
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -14894,8 +14654,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/machinery/button/windowtint{
 	pixel_x = -11;
@@ -14968,8 +14727,7 @@
 /area/quartermaster/Waste_Disposals)
 "aTq" = (
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14991,8 +14749,7 @@
 "aTt" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -15013,8 +14770,7 @@
 "aTv" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -15083,8 +14839,7 @@
 /area/hallway/Port_Transit_Foyer)
 "aTH" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -15140,7 +14895,6 @@
 "aTR" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -15253,8 +15007,7 @@
 /area/maintenance/Deck2_Port_Corridor)
 "aTZ" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -15291,9 +15044,7 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/security/Lobby)
 "aUg" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/open,
 /area/security/Lobby)
 "aUh" = (
@@ -15356,8 +15107,7 @@
 	pixel_y = -4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -15472,7 +15222,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -15499,9 +15248,7 @@
 /area/security/Prison_Wing)
 "aUz" = (
 /obj/machinery/papershredder,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
@@ -15620,18 +15367,38 @@
 /turf/simulated/floor/plating,
 /area/medical/For_Medical_Post)
 "aUJ" = (
-/obj/structure/fireaxecabinet{
-	name = "1N-fire axe cabinet";
-	pixel_y = 27
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 23;
+	name = "1N-wall recharger"
 	},
-/turf/simulated/floor/glass,
-/area/hallway/Central_2_Deck_Hall)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/security/Reception)
 "aUK" = (
 /obj/structure/closet/secure_closet/cargotech,
 /obj/item/stamp/cargo,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -15644,8 +15411,7 @@
 "aUM" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15731,7 +15497,6 @@
 "aUW" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/structure/bed/chair/sofa/left/blue{
@@ -15786,7 +15551,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/green,
@@ -15799,7 +15563,6 @@
 /obj/machinery/papershredder,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -15925,7 +15688,6 @@
 "aWa" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
@@ -16099,7 +15861,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -16171,7 +15932,6 @@
 /obj/machinery/computer/rdconsole/core,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -16294,8 +16054,7 @@
 	pixel_x = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -16323,7 +16082,6 @@
 	layer = 3
 	},
 /obj/machinery/newscaster{
-	name = "1E-newscaster";
 	pixel_x = 28
 	},
 /turf/simulated/floor/tiled,
@@ -16341,8 +16099,7 @@
 "aXk" = (
 /obj/structure/table/bench/sifwooden,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/flora/pottedplant/drooping{
 	pixel_y = 10;
@@ -16375,8 +16132,7 @@
 /area/rnd/RD_Office)
 "aXp" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -16492,8 +16248,7 @@
 /area/crew_quarters/Chomp_Dinner_2)
 "aXR" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -16536,9 +16291,7 @@
 "aXX" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/tool/wrench/pipe,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating/turfpack/airless,
 /area/harbor/Port_Shuttlebay)
 "aXY" = (
@@ -16725,14 +16478,13 @@
 "aYB" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 6
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/Deck2_1_Corridor)
@@ -16856,7 +16608,6 @@
 /area/crew_quarters/Chapel_Lobby)
 "aYX" = (
 /obj/machinery/newscaster{
-	name = "1E-newscaster";
 	pixel_x = 28
 	},
 /turf/simulated/floor/lino,
@@ -16882,8 +16633,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Central_Corridor_1)
@@ -16894,7 +16644,6 @@
 /obj/item/rig/ch/pursuit/equipped,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -17137,9 +16886,7 @@
 	dir = 8
 	},
 /obj/item/tool/screwdriver,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/security/Firing_Range)
 "aZW" = (
@@ -17184,7 +16931,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -17204,8 +16950,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -17349,7 +17094,6 @@
 "baC" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
@@ -17413,9 +17157,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/Port_Transit_Foyer)
 "baK" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/computer/cryopod{
 	layer = 3.3;
 	pixel_y = -32
@@ -17458,9 +17200,7 @@
 /area/maintenance/Deck2_Cargo_AftPortCorridor1)
 "baY" = (
 /obj/structure/table/woodentable,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/item/clothing/accessory/permit/gun/bar,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17547,9 +17287,7 @@
 	},
 /area/crew_quarters/Chomp_Dinner_1)
 "bbE" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
@@ -17696,8 +17434,7 @@
 "bcd" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/machinery/shieldgen{
 	req_access = list(47)
@@ -17765,7 +17502,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -17795,9 +17531,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Stairwell)
 "bcp" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -17832,7 +17566,6 @@
 "bcu" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -17960,8 +17693,7 @@
 "bcM" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/closet/emcloset,
 /obj/structure/disposalpipe/segment{
@@ -18077,8 +17809,7 @@
 	},
 /obj/structure/railing,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/open,
 /area/hallway/Central_2_Deck_Hall)
@@ -18248,8 +17979,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -18276,9 +18006,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "SC-Recycle"
@@ -18390,8 +18118,7 @@
 "bet" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -18627,8 +18354,7 @@
 "bfo" = (
 /obj/effect/floor_decal/industrial/outline/cut_corners/red,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile{
 	color = "#989898"
@@ -18643,8 +18369,7 @@
 "bfr" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/sign/securearea{
 	icon_state = "radiation_small";
@@ -18830,9 +18555,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/Treatment_Hall)
 "bfE" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/medical/Treatment_Hall)
 "bfF" = (
@@ -18911,9 +18634,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/Armory)
 "bfO" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
 /obj/effect/floor_decal/shuttle/loading{
 	dir = 8;
@@ -19041,7 +18762,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/machinery/button/windowtint{
@@ -19371,7 +19091,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/carpet,
@@ -19438,9 +19157,7 @@
 	pixel_x = -5
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "bhm" = (
@@ -19612,9 +19329,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Toxins_Viewing_Port)
 "bii" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -19714,8 +19429,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/Armory)
@@ -19742,7 +19456,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -19837,8 +19550,7 @@
 "biN" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -19857,8 +19569,7 @@
 /area/security/Visitation_Room)
 "biP" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/bed/chair/sofa/left/orange{
 	dir = 8
@@ -19883,7 +19594,6 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/ai_status_display{
-	name = "1E-AI display";
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/dark,
@@ -19892,7 +19602,6 @@
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -19970,7 +19679,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -20004,8 +19712,7 @@
 "bjc" = (
 /obj/machinery/photocopier,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -20125,8 +19832,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/open,
 /area/security/Lobby)
@@ -20371,8 +20077,7 @@
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
@@ -20398,7 +20103,6 @@
 /obj/effect/floor_decal/industrial/stand_clear/blue,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
@@ -20510,7 +20214,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -20573,9 +20276,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/Port_2_Deck_Central_Corridor_2)
 "bkJ" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
@@ -20766,8 +20467,7 @@
 /obj/machinery/washing_machine,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -20908,7 +20608,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/machinery/navbeacon/delivery/north{
@@ -20954,7 +20653,6 @@
 /area/crew_quarters/Emergency_EVA)
 "bmd" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/medical_kiosk,
@@ -20973,7 +20671,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -21003,7 +20700,7 @@
 	pixel_y = -26;
 	pixel_x = -12;
 	id = "sc-WTkitchen";
-	range = 10
+	range = 12
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Chomp_Kitchen)
@@ -21015,7 +20712,6 @@
 "bml" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -21167,8 +20863,7 @@
 "bmY" = (
 /obj/machinery/computer/arcade/clawmachine,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Rec_Lounge)
@@ -21213,8 +20908,7 @@
 "bnk" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/Testing_Lab)
@@ -21244,8 +20938,7 @@
 	},
 /obj/item/instrument/violin/golden,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/white{
 	d1 = 4;
@@ -21269,7 +20962,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -21311,8 +21003,7 @@
 /area/security/Visitation_Room)
 "bnB" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -21361,7 +21052,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -21404,7 +21094,6 @@
 /area/maintenance/Deck2_Cargo_StarChamber1)
 "bnM" = (
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/machinery/disposal/wall{
@@ -21445,8 +21134,7 @@
 /area/hallway/Port_Transit_Foyer)
 "bnQ" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -21486,7 +21174,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -21534,8 +21221,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
@@ -21551,8 +21237,7 @@
 "bog" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /obj/machinery/vending/engineering,
 /obj/effect/floor_decal/borderfloorblack{
@@ -21605,9 +21290,7 @@
 /area/security/Lobby)
 "boC" = (
 /obj/machinery/vending/snack,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
@@ -21668,8 +21351,7 @@
 "boU" = (
 /obj/structure/table/gamblingtable,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/item/storage/pill_bottle/dice_nerd{
 	pixel_y = 14;
@@ -21737,8 +21419,7 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 1;
-	pixel_y = 22;
-	name = "1N-station intercom (Medbay)"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -21767,8 +21448,7 @@
 	},
 /obj/structure/table/standard,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 1
@@ -21801,8 +21481,7 @@
 /area/medical/Chemistry)
 "bph" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
 /obj/effect/floor_decal/shuttle/loading{
@@ -21845,8 +21524,7 @@
 /area/quartermaster/Waste_Disposals)
 "bpn" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21938,10 +21616,8 @@
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/milspec/box,
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
-/obj/mecha/combat/scarab,
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Mech_Bay)
 "bpw" = (
@@ -21994,8 +21670,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -22108,7 +21783,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -22153,9 +21827,7 @@
 /obj/machinery/sleeper{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -22405,8 +22077,7 @@
 "brx" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -22456,8 +22127,7 @@
 "brC" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
@@ -22477,9 +22147,7 @@
 "brG" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "brH" = (
@@ -22523,8 +22191,7 @@
 "brN" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -22565,7 +22232,6 @@
 /obj/effect/floor_decal/corner/lightorange/bordercorner,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/newscaster{
-	name = "1E-newscaster";
 	pixel_x = 28
 	},
 /turf/simulated/floor/tiled,
@@ -22701,7 +22367,6 @@
 "bso" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -22820,8 +22485,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -22870,8 +22534,7 @@
 /area/hallway/ForStar_2_Deck_Observatory)
 "btf" = (
 /obj/machinery/status_display{
-	pixel_x = 32;
-	name = "E-status display"
+	pixel_x = 32
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/structure/cable{
@@ -22979,7 +22642,6 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	name = "1W-extinguisher cabinet";
 	pixel_x = -28
 	},
 /turf/simulated/floor/tiled,
@@ -23211,7 +22873,6 @@
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -23224,9 +22885,7 @@
 /area/quartermaster/QM_Office)
 "btV" = (
 /obj/machinery/papershredder,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled/dark,
@@ -23239,7 +22898,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/machinery/button/windowtint{
@@ -23335,9 +22993,7 @@
 /obj/structure/bed/chair/oldsofa{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/Rec_Lounge)
 "buz" = (
@@ -23404,9 +23060,7 @@
 	pixel_y = -3;
 	pixel_x = 7
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white{
@@ -23592,7 +23246,6 @@
 "bvr" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/boxing/gym,
@@ -23697,7 +23350,6 @@
 "bvH" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -23734,8 +23386,7 @@
 /obj/structure/table/woodentable,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -23895,8 +23546,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -24031,7 +23681,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -24102,15 +23751,13 @@
 "bxc" = (
 /obj/structure/railing,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/open,
 /area/quartermaster/Deck2_Stairwell)
 "bxd" = (
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "1N-newscaster"
+	pixel_y = 28
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24219,8 +23866,7 @@
 	layer = 2.9
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/random/material,
 /obj/random/material,
@@ -24427,8 +24073,7 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 8;
-	pixel_x = -22;
-	name = "1W-station intercom (Medbay)"
+	pixel_x = -22
 	},
 /obj/effect/landmark/start{
 	name = "Paramedic"
@@ -24494,7 +24139,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -24700,8 +24344,7 @@
 /obj/machinery/suit_cycler/security,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/radio/intercom/department/security{
-	pixel_y = -22;
-	name = "1S-station intercom (Security)"
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
@@ -24768,8 +24411,7 @@
 /obj/item/radio/intercom/department/security{
 	dir = 4;
 	icon_override = "secintercom";
-	pixel_x = 22;
-	name = "1E-station intercom (Security)"
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/Armory)
@@ -24801,7 +24443,6 @@
 	layer = 3
 	},
 /obj/machinery/newscaster{
-	name = "1W-newscaster";
 	pixel_x = -28
 	},
 /turf/simulated/floor/tiled,
@@ -24827,8 +24468,7 @@
 	layer = 2.6
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/item/tool/transforming/jawsoflife{
 	pixel_y = -2
@@ -24855,7 +24495,6 @@
 /area/maintenance/Deck2_Security_AftStarCorridor2)
 "byN" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/structure/table/glass,
@@ -24992,8 +24631,7 @@
 /area/bridge/Vault_Reception)
 "bzm" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -25082,7 +24720,6 @@
 "bzy" = (
 /obj/machinery/disposal,
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/structure/disposalpipe/trunk{
@@ -25093,8 +24730,7 @@
 "bzz" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -25111,7 +24747,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -25149,7 +24784,6 @@
 "bzU" = (
 /obj/machinery/deployable/barrier,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -25209,7 +24843,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/machinery/button/windowtint{
@@ -25314,7 +24947,6 @@
 "bAr" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28;
-	name = "1W-extinguisher cabinet";
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central5,
@@ -25378,9 +25010,7 @@
 "bAx" = (
 /obj/structure/closet,
 /obj/item/storage/backpack/dufflebag,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled/dark,
@@ -25602,7 +25232,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/tiled,
@@ -25699,7 +25328,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -25749,7 +25377,6 @@
 "bCl" = (
 /obj/machinery/disposal,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/structure/disposalpipe/trunk,
@@ -25947,7 +25574,6 @@
 /area/engineering/Canister_Storage)
 "bDl" = (
 /obj/machinery/newscaster{
-	name = "1E-newscaster";
 	pixel_x = 28
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -25956,29 +25582,15 @@
 /area/security/Prison_Wing)
 "bDn" = (
 /obj/item/mecha_parts/mecha_equipment/tool/passenger{
-	pixel_x = 3
-	},
-/obj/item/mecha_parts/mecha_equipment/tool/passenger{
 	pixel_x = -3
 	},
 /obj/item/mecha_parts/mecha_equipment/tool/extinguisher{
 	pixel_y = 13;
 	pixel_x = 3
 	},
-/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp{
-	pixel_y = 8;
-	pixel_x = -1
-	},
-/obj/item/mecha_parts/mecha_equipment/tool/powertool/cutter{
-	pixel_y = 3
-	},
 /obj/item/mecha_parts/mecha_equipment/tool/powertool/inflatables{
 	pixel_y = -3;
 	pixel_x = -3
-	},
-/obj/item/mecha_parts/mecha_equipment/tool/powertool/prybar{
-	pixel_y = -8;
-	pixel_x = 2
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -25986,6 +25598,7 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 4
 	},
+/obj/structure/table/rack,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/Mech_Bay)
 "bDo" = (
@@ -26032,7 +25645,6 @@
 "bDE" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -26086,7 +25698,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -26142,7 +25753,6 @@
 "bEh" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -26186,8 +25796,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Corridor_2)
@@ -26207,7 +25816,6 @@
 "bEx" = (
 /obj/structure/table/standard,
 /obj/machinery/newscaster{
-	name = "1E-newscaster";
 	pixel_x = 28
 	},
 /obj/random/soap,
@@ -26512,8 +26120,7 @@
 	name = "1E-entertainment monitor"
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -26529,7 +26136,6 @@
 "bFV" = (
 /obj/machinery/bookbinder,
 /obj/machinery/newscaster{
-	name = "1S-newscaster";
 	pixel_y = -30
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -26590,7 +26196,6 @@
 "bGn" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/structure/cable/green{
@@ -26631,8 +26236,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Canister_Storage)
@@ -26750,8 +26354,7 @@
 /area/engineering/Engineering_Workshop)
 "bHd" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable{
@@ -26769,8 +26372,7 @@
 /area/hallway/Star_2_Deck_Corridor_1)
 "bHf" = (
 /obj/machinery/computer/guestpass{
-	pixel_y = 19;
-	name = "1N-guest pass terminal"
+	pixel_y = 19
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -26788,8 +26390,7 @@
 "bHh" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -26821,8 +26422,7 @@
 /obj/effect/floor_decal/milspec/box,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/Mech_Bay)
@@ -27072,7 +26672,6 @@
 /area/security/Prison_Wing)
 "bHZ" = (
 /obj/machinery/newscaster{
-	name = "1W-newscaster";
 	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -27104,7 +26703,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -27207,6 +26805,10 @@
 	},
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 1
+	},
+/obj/structure/fireaxecabinet{
+	name = "1N-fire axe cabinet";
+	pixel_y = 27
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engineering_Workshop)
@@ -27355,11 +26957,9 @@
 	pixel_x = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/status_display{
-	name = "E-status display";
 	pixel_x = 32
 	},
 /obj/item/gunbox/stun,
@@ -27399,8 +26999,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -27425,8 +27024,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/carpet,
 /area/bridge/Vault_Reception)
@@ -27522,8 +27120,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod4/station)
@@ -27664,8 +27261,7 @@
 /area/bridge/Vault_Reception)
 "bKJ" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/Vault_Reception)
@@ -27999,8 +27595,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -28034,8 +27629,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/Warehouse)
@@ -28047,7 +27641,6 @@
 	pixel_x = 31
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/milspec/raised,
@@ -28113,7 +27706,6 @@
 "bMq" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -28177,9 +27769,7 @@
 /turf/simulated/floor/plating,
 /area/rnd/Robotics_Lab)
 "bMw" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/light/small/neon/booze1{
 	dir = 1;
 	pixel_x = -1;
@@ -28217,9 +27807,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/open,
 /area/hallway/ForStar_2_Deck_Observatory)
 "bMK" = (
@@ -28255,7 +27843,6 @@
 "bMU" = (
 /obj/structure/bed/chair/sofa/right/brown,
 /obj/machinery/newscaster{
-	name = "1N-newscaster";
 	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/purcarpet,
@@ -28292,7 +27879,6 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -28328,7 +27914,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/brown,
@@ -28344,7 +27929,6 @@
 	dir = 5
 	},
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/carpet/brown,
@@ -28495,8 +28079,7 @@
 "bNG" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/kafel_full/blue,
@@ -28572,8 +28155,7 @@
 "bNR" = (
 /obj/item/stool/padded,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -28599,8 +28181,7 @@
 "bNT" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
@@ -28791,7 +28372,6 @@
 /obj/structure/reagent_dispensers/foam,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/dark,
@@ -28839,7 +28419,6 @@
 /obj/random/trash,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor,
@@ -29032,7 +28611,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloor/corner,
@@ -29075,10 +28653,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/medical/Surgery_Room_1)
 "bPA" = (
-/obj/structure/fireaxecabinet{
-	name = "1E-fire axe cabinet";
-	pixel_x = 32
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
@@ -29098,8 +28672,7 @@
 "bPG" = (
 /obj/item/radio/intercom/department/medbay{
 	dir = 1;
-	pixel_y = 22;
-	name = "1N-station intercom (Medbay)"
+	pixel_y = 22
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -29141,8 +28714,7 @@
 	pixel_x = 22
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -29178,8 +28750,7 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 8;
-	pixel_x = -22;
-	name = "1W-station intercom (Medbay)"
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -29216,7 +28787,6 @@
 "bPV" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/machinery/disposal,
@@ -29293,8 +28863,7 @@
 /area/security/Firing_Range)
 "bQl" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -29324,8 +28893,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
@@ -29467,7 +29035,6 @@
 /obj/machinery/appliance/cooker/grill,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white,
@@ -29573,8 +29140,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Prison_Wing)
@@ -29583,8 +29149,7 @@
 	name = "CondiMaster Neo"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Midnight_Kitchen)
@@ -29863,6 +29428,10 @@
 	pixel_y = 9;
 	pixel_x = -2
 	},
+/obj/item/storage/box/nifsofts_medical{
+	pixel_y = 1;
+	pixel_x = 6
+	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -29908,8 +29477,7 @@
 /area/bridge/Vault_Reception)
 "bSL" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -30058,7 +29626,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -30127,7 +29694,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/machinery/mineral/mint{
@@ -30138,8 +29704,7 @@
 "bTG" = (
 /obj/machinery/iv_drip,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -30203,8 +29768,7 @@
 "bTS" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -30237,8 +29801,7 @@
 "bUg" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -30368,7 +29931,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/machinery/button/windowtint{
@@ -30469,7 +30031,7 @@
 "bUN" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/milspec/box,
-/obj/mecha/combat/durand/old,
+/obj/mecha/combat/gygax/old,
 /turf/simulated/floor/tiled/techfloor,
 /area/security/Armory)
 "bUP" = (
@@ -30491,7 +30053,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -30558,7 +30119,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -30705,7 +30265,6 @@
 	on = 0
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/lino,
@@ -30730,15 +30289,12 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner{
 	dir = 8
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/AftStar_2_Deck_Observatory)
 "bVI" = (
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/Drone_Fab)
@@ -30859,8 +30415,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/Library)
@@ -31003,8 +30558,7 @@
 "bWq" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -31256,8 +30810,7 @@
 /obj/structure/bed/chair/sofa/right/blue,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/window/titanium{
 	dir = 1;
@@ -31352,8 +30905,7 @@
 "bXA" = (
 /obj/structure/table/sifwoodentable,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/item/starcaster_news,
 /obj/machinery/light/small/neon/looktoucheat{
@@ -31387,8 +30939,7 @@
 /obj/machinery/iv_drip,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -31400,8 +30951,7 @@
 /area/medical/Surgery_Room_2)
 "bXI" = (
 /obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "1W-newscaster"
+	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
@@ -31539,7 +31089,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -31566,8 +31115,7 @@
 /area/bridge/HoP_Office)
 "bYf" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -32071,8 +31619,7 @@
 /area/medical/EMT_Bay)
 "cad" = (
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32138,8 +31685,7 @@
 "car" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -32334,7 +31880,6 @@
 /obj/machinery/autolathe,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -32400,7 +31945,6 @@
 /obj/structure/window/reinforced,
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -32589,8 +32133,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -32679,7 +32222,6 @@
 	layer = 2.9
 	},
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/carpet/oracarpet,
@@ -32694,9 +32236,7 @@
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Library)
 "ccq" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -32736,7 +32276,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/machinery/button/windowtint{
@@ -32784,8 +32323,7 @@
 "ccA" = (
 /obj/effect/floor_decal/industrial/outline/cut_corners/red,
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "1N-extinguisher cabinet"
+	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/monotile{
 	color = "#989898"
@@ -33003,8 +32541,7 @@
 "cdx" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	id_tag = "SC-ALCvault";
@@ -33046,8 +32583,7 @@
 "cdA" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "1W-newscaster"
+	pixel_x = -28
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/EMT_Bay)
@@ -33089,8 +32625,7 @@
 /area/crew_quarters/Chomp_Dinner_1)
 "cdL" = (
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -33130,9 +32665,7 @@
 /area/crew_quarters/Midnight_Kitchen)
 "cdO" = (
 /obj/effect/mist,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/water/pool,
 /area/crew_quarters/Gym_Sauna)
 "cdR" = (
@@ -33176,7 +32709,6 @@
 "cdU" = (
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/structure/closet/emcloset,
@@ -33318,8 +32850,7 @@
 /area/crew_quarters/Library)
 "cel" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -33332,8 +32863,7 @@
 "cem" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -33467,12 +32997,10 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/For_Tool_Storage)
@@ -33551,7 +33079,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -33596,8 +33123,7 @@
 "cfa" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -33614,8 +33140,7 @@
 /obj/item/radio/intercom/department/security{
 	dir = 8;
 	icon_override = "secintercom";
-	pixel_x = -22;
-	name = "1W-station intercom (Security)"
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled,
@@ -33756,8 +33281,7 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	pixel_y = -27;
-	name = "1S-extinguisher cabinet"
+	pixel_y = -27
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Midnight_Kitchen)
@@ -33777,7 +33301,6 @@
 "cfq" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/bcarpet,
@@ -33862,13 +33385,11 @@
 "cfO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28;
-	name = "1W-extinguisher cabinet";
 	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/security/Forensics_Office)
@@ -33961,8 +33482,7 @@
 	name = "8eep_5ky"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -34008,13 +33528,11 @@
 /area/engineering/CE_Office)
 "cga" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 1;
-	pixel_y = 22;
-	name = "1N-station intercom (Medbay)"
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -34027,8 +33545,7 @@
 "cge" = (
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Drone_Fab)
@@ -34059,7 +33576,6 @@
 "cgo" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -34138,7 +33654,6 @@
 	faction = "nanotrasen"
 	},
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/milspec/cargo_arrow{
@@ -34176,7 +33691,6 @@
 "cgP" = (
 /obj/machinery/photocopier,
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/spline/fancy{
@@ -34221,7 +33735,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -34276,8 +33789,7 @@
 	},
 /obj/item/a_gift/advanced,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/Vault)
@@ -34287,7 +33799,6 @@
 "cgW" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/structure/cable/green{
@@ -34466,7 +33977,6 @@
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/milspec/box,
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -34475,8 +33985,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/For_Tool_Storage)
@@ -34536,8 +34045,7 @@
 /obj/structure/closet/crate/secure/large/reinforced,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/For_Tool_Storage)
@@ -34811,7 +34319,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/carpet/bcarpet,
@@ -34925,7 +34432,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -35025,8 +34531,7 @@
 	},
 /obj/machinery/computer/guestpass{
 	dir = 8;
-	pixel_x = 19;
-	name = "1E-guest pass terminal"
+	pixel_x = 19
 	},
 /turf/simulated/floor/tiled/white,
 /area/hallway/Star_Transit_Foyer)
@@ -35069,7 +34574,6 @@
 /area/maintenance/Deck2_Medical_AftCorridor2)
 "cjg" = (
 /obj/machinery/status_display{
-	name = "W-status display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
@@ -35282,7 +34786,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -35422,9 +34925,7 @@
 /obj/item/toner{
 	pixel_y = 7
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
@@ -35449,7 +34950,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -35679,7 +35179,6 @@
 /obj/structure/table/rack,
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -35689,15 +35188,12 @@
 	name = "1S-entertainment monitor";
 	pixel_y = -36
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/wood/alt/parquet,
 /area/hallway/Aft_2_Deck_Lobby)
 "clm" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor/corner,
@@ -35875,8 +35371,7 @@
 /area/engineering/CE_Office)
 "clT" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/filingcabinet/security,
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -36043,13 +35538,11 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 1;
-	pixel_y = 22;
-	name = "1N-station intercom (Medbay)"
+	pixel_y = 22
 	},
 /obj/item/hand_labeler,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -36068,7 +35561,6 @@
 "cmu" = (
 /obj/machinery/disposal,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/structure/disposalpipe/trunk{
@@ -36166,8 +35658,7 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/Drone_Fab)
@@ -36219,7 +35710,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green,
@@ -36297,9 +35787,7 @@
 	pixel_x = -1;
 	name = "Alive"
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Mech_Bay)
 "cnD" = (
@@ -36354,12 +35842,10 @@
 	pixel_y = -7
 	},
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -36412,8 +35898,7 @@
 	pixel_x = 6
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -36673,12 +36158,9 @@
 /turf/simulated/wall,
 /area/quartermaster/Mail_Room)
 "coU" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -36696,8 +36178,7 @@
 "cpd" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/Drone_Fab)
@@ -36891,8 +36372,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/department/security{
-	pixel_y = -22;
-	name = "1S-station intercom (Security)"
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -36989,8 +36469,7 @@
 /obj/structure/closet/secure_closet/medical1,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -37069,8 +36548,7 @@
 	pixel_x = 6
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Gym_Sauna)
@@ -37137,8 +36615,7 @@
 "cra" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
@@ -37248,8 +36725,7 @@
 /obj/structure/closet/crate/secure,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/white{
 	d1 = 4;
@@ -37353,7 +36829,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -37493,8 +36968,7 @@
 /area/security/Boardroom)
 "csp" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -37616,8 +37090,7 @@
 /area/security/Shuttlebay_Storage)
 "csH" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -37692,8 +37165,7 @@
 /area/medical/Deck2_Corridor)
 "csN" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable{
@@ -38004,8 +37476,7 @@
 "ctv" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -38051,7 +37522,6 @@
 "ctN" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/glass,
@@ -38092,9 +37562,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/security/Prison_Wing)
 "ctQ" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/catwalk_plated,
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/plating/turfpack/airless,
@@ -38115,8 +37583,7 @@
 "ctU" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/vending/security,
 /obj/effect/floor_decal/borderfloorblack{
@@ -38170,8 +37637,7 @@
 /obj/structure/table/glass,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -38195,7 +37661,6 @@
 /area/bridge/Vault)
 "cue" = (
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/lino,
@@ -38300,7 +37765,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/white{
@@ -38373,8 +37837,7 @@
 "cuE" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -38401,8 +37864,7 @@
 "cuH" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -38463,9 +37925,7 @@
 	name = "1S-entertainment monitor";
 	pixel_y = -36
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
 /obj/structure/table/steel,
@@ -38500,7 +37960,6 @@
 /obj/item/storage/bag/circuits/basic,
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -38539,8 +37998,7 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Aft_2_Deck_Airlock_Access)
@@ -38601,12 +38059,10 @@
 /area/crew_quarters/Midnight_Bar)
 "cve" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	name = "1E-AI display"
+	pixel_x = 32
 	},
 /obj/structure/closet/l3closet/security,
 /obj/effect/floor_decal/borderfloorblack{
@@ -38726,7 +38182,6 @@
 /obj/effect/catwalk_plated,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/plating,
@@ -38881,7 +38336,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -38976,9 +38430,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightorange/border,
 /turf/simulated/floor/tiled/steel_grid,
@@ -39024,7 +38476,6 @@
 /area/harbor/Aft_Shuttlebay)
 "cwJ" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -39076,8 +38527,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Toxins_Storage)
@@ -39162,7 +38612,6 @@
 /area/crew_quarters/Library)
 "cxi" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/kafel_full/red,
@@ -39170,8 +38619,7 @@
 "cxn" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -39277,7 +38725,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -39306,8 +38753,7 @@
 /area/security/Equipment_Storage)
 "cxO" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/steel_ridged{
@@ -39322,8 +38768,7 @@
 "cxW" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -39473,8 +38918,7 @@
 	use_power = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -39488,7 +38932,6 @@
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -39557,12 +39000,9 @@
 /area/rnd/Server_Room)
 "cyy" = (
 /obj/item/radio/intercom/department/medbay{
-	pixel_y = -22;
-	name = "1S-station intercom (Medbay)"
+	pixel_y = -22
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/shuttle/floor,
 /area/shuttle/large_escape_pod3/station)
 "cyz" = (
@@ -39593,8 +39033,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/alarm{
 	dir = 4;
@@ -39735,8 +39174,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/sign/warning/nosmoking_2{
 	pixel_x = -32
@@ -39787,7 +39225,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -39848,9 +39285,18 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/Chomp_Dinner_2)
 "czL" = (
-/obj/random/trash,
-/turf/simulated/floor/plating,
-/area/hallway/Port_2_Deck_Stairwell)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/red/bordercorner,
+/turf/simulated/floor/tiled,
+/area/security/Deck2_1_Corridor)
 "czO" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -39898,8 +39344,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/flora/pottedplant{
 	pixel_y = 13;
@@ -39969,7 +39414,6 @@
 /area/crew_quarters/Library)
 "cAq" = (
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/structure/cable{
@@ -39987,9 +39431,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/green/bordercorner,
 /obj/structure/cable{
@@ -40241,9 +39683,7 @@
 /area/rnd/Toxins_Storage)
 "cBj" = (
 /obj/machinery/vending/phoronresearch,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Toxins_Mixing_Room)
 "cBk" = (
@@ -40257,7 +39697,6 @@
 "cBp" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /obj/structure/closet/bombcloset,
@@ -40296,7 +39735,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/table/reinforced,
@@ -40329,8 +39767,20 @@
 /turf/simulated/open,
 /area/hallway/ForPort_2_Deck_Observatory)
 "cBx" = (
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 8
+/obj/effect/floor_decal/industrial/arrows/red,
+/obj/effect/floor_decal/industrial/arrows/red{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "testthis";
+	name = "Doorframe mounted flash";
+	layer = 2.5
+	},
+/obj/machinery/door/firedoor/multi_tile/glass,
+/obj/machinery/door/airlock/angled_bay/double/glass/security{
+	name = "Brig Hall";
+	req_one_access = list(1,5,11,24);
+	req_access = null
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/Deck2_1_Corridor)
@@ -40362,8 +39812,7 @@
 /area/hallway/AftStar_2_Deck_Observatory)
 "cBI" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/Gym)
@@ -40372,8 +39821,7 @@
 	pixel_y = 22
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/oracarpet,
@@ -40436,8 +39884,7 @@
 	pixel_y = 22
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/oracarpet,
@@ -40634,7 +40081,6 @@
 "cCI" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -40654,7 +40100,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -40688,8 +40133,7 @@
 "cCR" = (
 /obj/item/mecha_parts/mecha_equipment/tool/passenger,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Mech_Bay)
@@ -40766,8 +40210,7 @@
 "cCX" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -40838,8 +40281,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Toxins_Storage)
@@ -41008,7 +40450,6 @@
 "cDB" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -41031,8 +40472,7 @@
 /obj/machinery/suit_cycler/medical,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/radio/intercom/department/medbay{
-	pixel_y = -22;
-	name = "1S-station intercom (Medbay)"
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
@@ -41123,8 +40563,7 @@
 /area/hallway/Star_2_Deck_Corridor_2)
 "cEb" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -41177,8 +40616,7 @@
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Robotics_Lab)
@@ -41214,7 +40652,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -41257,9 +40694,7 @@
 /obj/machinery/computer/message_monitor{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/dark,
@@ -41349,8 +40784,7 @@
 	pixel_y = -1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple/diagonal,
 /obj/effect/floor_decal/corner/purple/diagonal{
@@ -41504,8 +40938,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Testing_Lab)
@@ -41751,7 +41184,6 @@
 /area/crew_quarters/Gallery)
 "cFt" = (
 /obj/machinery/ai_status_display{
-	name = "1E-AI display";
 	pixel_x = 32
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -41991,7 +41423,6 @@
 /obj/effect/floor_decal/corner/lightorange/border,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -42053,13 +41484,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Star_Restroom)
-"cGp" = (
-/obj/structure/fireaxecabinet{
-	name = "1N-fire axe cabinet";
-	pixel_y = 27
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/Stairwell_For)
 "cGq" = (
 /obj/structure/bed/chair/wood/wings{
 	color = "#004b9a"
@@ -42129,11 +41553,9 @@
 "cGE" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -42169,8 +41591,7 @@
 	pixel_y = -3
 	},
 /obj/machinery/newscaster{
-	pixel_y = -30;
-	name = "1S-newscaster"
+	pixel_y = -30
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -42223,8 +41644,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "1W-newscaster"
+	pixel_x = -28
 	},
 /obj/effect/floor_decal/corner/purple/diagonal,
 /obj/effect/floor_decal/corner/purple/diagonal{
@@ -42377,9 +41797,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/Lobby)
 "cKh" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/eris/steel/techfloor,
 /area/maintenance/ab_Pdance)
 "cKs" = (
@@ -42543,8 +41961,7 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
@@ -42570,10 +41987,10 @@
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/red/border{
+/obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -42638,9 +42055,7 @@
 	amount = 24
 	},
 /obj/random/maintenance/clean,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/maintenance/ab_TeshDen)
 "cPg" = (
@@ -42722,7 +42137,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/milspec/raised,
@@ -42959,9 +42373,14 @@
 /turf/simulated/floor/plating,
 /area/rnd/Toxins_Viewing_Port)
 "cUg" = (
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/hallway/Star_2_Deck_Stairwell)
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/Deck2_1_Corridor)
 "cUk" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -42998,8 +42417,7 @@
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Canister_Storage)
@@ -43300,8 +42718,7 @@
 /obj/structure/closet/secure_closet/RD,
 /obj/random_multi/single_item/hand_tele,
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -43460,8 +42877,7 @@
 "dbg" = (
 /obj/structure/bed/chair/sofa/beige,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/ForPort_2_Deck_Observatory)
@@ -43623,10 +43039,6 @@
 	pixel_x = 9;
 	pixel_y = -9
 	},
-/obj/item/t_scanner/upgraded{
-	pixel_x = 11;
-	pixel_y = 3
-	},
 /obj/item/clothing/glasses/meson{
 	pixel_x = -6;
 	pixel_y = -13
@@ -43634,9 +43046,6 @@
 /obj/item/clothing/glasses/welding{
 	pixel_x = -6;
 	pixel_y = -8
-	},
-/obj/structure/closet/crate/large/nanotrasen{
-	req_one_access = list(10)
 	},
 /obj/item/stack/material/plasteel{
 	amount = 30;
@@ -43653,12 +43062,19 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
-/obj/item/clothing/gloves/yellow{
-	pixel_x = -7;
-	pixel_y = 2
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/item/t_scanner{
+	pixel_y = 3;
+	pixel_x = 11
 	},
 /obj/item/multitool{
 	pixel_x = 4
+	},
+/obj/structure/closet/crate/secure/large/nanotrasen{
+	req_access = list(10)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Engineering_Substation)
@@ -43754,8 +43170,7 @@
 "ddS" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Technical_Storage)
@@ -43906,8 +43321,7 @@
 /obj/structure/closet/secure_closet/brig,
 /obj/item/radio/headset,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Wardens_Office)
@@ -44004,7 +43418,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
@@ -44226,7 +43639,6 @@
 "djZ" = (
 /obj/machinery/appliance/cooker/fryer,
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/machinery/camera/network/security{
@@ -44246,9 +43658,7 @@
 "dkf" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/quartermaster/Breakroom)
 "dkA" = (
@@ -44440,9 +43850,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled,
@@ -44788,8 +44196,7 @@
 /area/medical/Chemistry)
 "drb" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/shuttle/loading{
 	dir = 4;
@@ -45210,7 +44617,6 @@
 /area/rnd/Toxins_Mixing_Room)
 "dwV" = (
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
@@ -45293,7 +44699,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -45332,7 +44737,6 @@
 /area/maintenance/Distro_Civilian)
 "dzb" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -45387,7 +44791,6 @@
 "dzN" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -45569,9 +44972,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/Port_2_Deck_Central_Corridor_1)
 "dCR" = (
@@ -45665,12 +45066,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftPortCorridor1)
 "dDQ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/door/firedoor/multi_tile/glass{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/effect/floor_decal/corner/red/bordercorner,
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/industrial/arrows/red{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/arrows/red{
+	dir = 4
+	},
+/obj/machinery/door/airlock/angled_bay/double/color{
+	door_color = "#8c1d11";
+	name = "Security Lobby";
+	id_tag = "SC-ODsecurityfoyer";
+	req_access = list(1);
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/security/Reception)
 "dDR" = (
 /obj/structure/cable{
@@ -45725,7 +45137,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green,
@@ -45790,7 +45201,6 @@
 	pixel_x = 1
 	},
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -45930,7 +45340,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -45944,8 +45353,7 @@
 "dGC" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloor{
@@ -46007,7 +45415,7 @@
 /obj/random/trash,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/hallway/Star_2_Deck_Stairwell)
+/area/maintenance/Deck2_Science_StarCorridor2)
 "dIf" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -46164,8 +45572,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -46182,7 +45589,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/brown/border{
@@ -46326,8 +45732,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
@@ -46356,8 +45761,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod3/station)
@@ -46636,9 +46040,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/Warehouse)
 "dOv" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/shuttle/loading{
 	dir = 4;
 	color = "#00B8B2"
@@ -46804,8 +46206,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_2)
@@ -46942,8 +46343,7 @@
 /area/engineering/Breakroom)
 "dSW" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -47390,8 +46790,7 @@
 /area/crew_quarters/Office_Lounge)
 "dYu" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -47415,7 +46814,6 @@
 "dYC" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -47946,7 +47344,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled,
@@ -48073,9 +47470,7 @@
 /area/hallway/Aft_2_Deck_Central_Corridor_1)
 "ehE" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightorange/border,
 /turf/simulated/floor/tiled/dark,
@@ -48086,8 +47481,7 @@
 /area/maintenance/Deck2_Cargo_AftCorridor2)
 "eia" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/crew_quarters/Gym)
@@ -48730,8 +48124,7 @@
 /area/maintenance/Deck2_Security_ForStar_Chamber)
 "eqD" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -48785,8 +48178,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
@@ -48815,8 +48207,7 @@
 /area/crew_quarters/Chapel_Lobby)
 "erJ" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -4;
@@ -48945,8 +48336,7 @@
 /area/harbor/Star_2_Deck_Airlock_Access)
 "etC" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable{
@@ -49087,7 +48477,6 @@
 "evM" = (
 /obj/structure/closet/secure_closet/paramedic,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/white{
@@ -49391,7 +48780,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/orange/border,
@@ -49430,9 +48818,9 @@
 /area/maintenance/Deck2_Security_AftStarCorridor2)
 "eAr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/hallway/Star_Transit_Foyer)
 "eAy" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -49458,7 +48846,6 @@
 	pixel_x = -31
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/milspec/raised,
@@ -49467,7 +48854,6 @@
 /obj/structure/table/bench/padded,
 /obj/effect/floor_decal/chapel,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorblack,
@@ -49476,8 +48862,7 @@
 /area/crew_quarters/Chapel_Lobby)
 "eBv" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Aft_2_Deck_Airlock_Access)
@@ -49538,11 +48923,11 @@
 /area/hallway/Star_2_Deck_Stairwell)
 "eCM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/Reception)
@@ -49642,7 +49027,6 @@
 /obj/structure/table/woodentable,
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/wood/alt/tile,
@@ -49906,8 +49290,7 @@
 /area/crew_quarters/Chapel_Morgue)
 "eHK" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/quartermaster/QM_Office)
@@ -50218,8 +49601,7 @@
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -50335,7 +49717,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green,
@@ -50399,21 +49780,16 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/arrows/red,
-/obj/machinery/flasher{
-	id = "testthis";
-	name = "Doorframe mounted flash";
-	layer = 2.5
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/angled_bay/double/color{
 	door_color = "#8c1d11";
 	req_access = list(2);
 	name = "Non-Lethal Armament";
 	req_one_access = list(1)
-	},
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/Equipment_Storage)
@@ -50610,7 +49986,6 @@
 "eNs" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
-	name = "1N-newscaster";
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -50649,7 +50024,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -50778,7 +50152,6 @@
 /area/rnd/Toxins_Storage)
 "eOl" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/structure/cable/green{
@@ -50822,9 +50195,7 @@
 /obj/random/maintenance/research,
 /obj/random/maintenance/research,
 /obj/random/maintenance/medical,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/harbor/Star_2_Deck_Airlock_Access)
 "eOz" = (
@@ -51329,7 +50700,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -51343,8 +50713,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/disposal/wall{
 	dir = 8;
@@ -51439,8 +50808,7 @@
 "eXP" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/structure/reagent_dispensers/water_cooler/full,
 /obj/effect/floor_decal/borderfloorblack{
@@ -51722,7 +51090,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled,
@@ -51916,9 +51283,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/Engineering_EVA)
 "fek" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
@@ -52300,8 +51665,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_2)
@@ -52474,8 +51838,7 @@
 /obj/item/radio/intercom/department/security{
 	dir = 4;
 	icon_override = "secintercom";
-	pixel_x = 22;
-	name = "1E-station intercom (Security)"
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
@@ -52726,19 +52089,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/security/Reception)
 "foz" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Aft_2_Deck_Lobby)
@@ -53250,8 +52609,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -53294,8 +52652,7 @@
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Star_2_Deck_Airlock_Access)
@@ -53328,8 +52685,7 @@
 "fuU" = (
 /obj/structure/table/marble,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/item/toy/figure/secofficer{
 	pixel_x = -2
@@ -53370,7 +52726,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -53609,8 +52964,7 @@
 	},
 /obj/item/storage/box/cups,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -53673,7 +53027,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -53850,8 +53203,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/sign/warning/high_voltage{
 	pixel_y = 32
@@ -53893,7 +53245,6 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/carpet,
@@ -53985,9 +53336,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/Storage)
 "fDf" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
 	},
@@ -54127,9 +53476,7 @@
 "fFv" = (
 /obj/structure/table/woodentable,
 /obj/item/universal_translator,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/computer/security/telescreen/entertainment{
 	name = "1S-entertainment monitor";
 	pixel_y = -36
@@ -54326,7 +53673,6 @@
 /area/maintenance/Deck2_Security_ForPortChamber1)
 "fHQ" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -54406,7 +53752,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -54738,7 +54083,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
@@ -55298,7 +54642,6 @@
 	pixel_x = -5
 	},
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/structure/table/reinforced,
@@ -55512,11 +54855,8 @@
 	pixel_y = 12
 	},
 /obj/structure/table/rack/shelf,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
@@ -55631,9 +54971,7 @@
 /area/hallway/AftPort_2_Deck_Observatory)
 "fVu" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/reagent_dispensers/he3,
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Robotics_Lab)
@@ -55664,9 +55002,7 @@
 	pixel_y = -5
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/purple/bordercorner,
 /turf/simulated/floor/tiled/dark,
@@ -55714,9 +55050,7 @@
 /area/maintenance/Deck2_Security_AftStarCorridor1)
 "fWd" = (
 /obj/machinery/disposal,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -55886,15 +55220,13 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_2)
 "fYw" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/table/steel,
 /obj/item/binoculars,
@@ -56323,7 +55655,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -56462,8 +55793,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Robotics_Lab)
@@ -56724,7 +56054,6 @@
 "ghX" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/structure/cable/green{
@@ -56787,8 +56116,7 @@
 	name = "Pill cabinet"
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -56801,7 +56129,6 @@
 "git" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/milspec/box,
-/obj/mecha/working/ripley/firefighter,
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/Mech_Bay)
 "giv" = (
@@ -56868,10 +56195,6 @@
 	pixel_x = 9;
 	pixel_y = -9
 	},
-/obj/item/t_scanner/upgraded{
-	pixel_x = 11;
-	pixel_y = 3
-	},
 /obj/item/clothing/glasses/meson{
 	pixel_x = -6;
 	pixel_y = -13
@@ -56879,9 +56202,6 @@
 /obj/item/clothing/glasses/welding{
 	pixel_x = -6;
 	pixel_y = -8
-	},
-/obj/structure/closet/crate/large/nanotrasen{
-	req_one_access = list(10)
 	},
 /obj/item/stack/material/plasteel{
 	amount = 30;
@@ -56898,12 +56218,19 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
-/obj/item/clothing/gloves/yellow{
-	pixel_x = -7;
-	pixel_y = 2
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/item/t_scanner{
+	pixel_y = 3;
+	pixel_x = 11
 	},
 /obj/item/multitool{
 	pixel_x = 4
+	},
+/obj/structure/closet/crate/secure/large/nanotrasen{
+	req_access = list(10)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Medical_Substation)
@@ -57072,7 +56399,6 @@
 "gkl" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -57100,7 +56426,6 @@
 /obj/machinery/disposal,
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk{
@@ -57126,8 +56451,7 @@
 "glE" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/shield_gen/external,
 /turf/simulated/floor/plating,
@@ -57161,8 +56485,7 @@
 "gmp" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	pixel_y = -27;
-	name = "1S-extinguisher cabinet"
+	pixel_y = -27
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
@@ -57264,8 +56587,7 @@
 /area/crew_quarters/Rec_Lounge)
 "goF" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -57459,8 +56781,7 @@
 /area/security/Prison_Wing)
 "gqp" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -57624,8 +56945,7 @@
 /obj/structure/table/rack,
 /obj/item/radio/intercom/department/security{
 	dir = 1;
-	pixel_y = 22;
-	name = "1N-station intercom (Security)"
+	pixel_y = 22
 	},
 /obj/item/gun/projectile/automatic/z8{
 	desc = "The Z9 Shepherd is the newer model of the old Z8 battle rifle, made by the now defunct Zendai Foundries. Makes you feel like an old-school badass when you hold it. This one fits AR-10 magazines. Chambered in 7.62x51mm, and has an under barrel grenade launcher.";
@@ -57762,9 +57082,7 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/structure/sign/poster/nanotrasen,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_2)
 "gvF" = (
@@ -58177,8 +57495,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/sign/chemdiamond{
 	pixel_y = 32
@@ -58194,7 +57511,6 @@
 "gAK" = (
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -58312,8 +57628,7 @@
 "gCo" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	name = "1E-AI display"
+	pixel_x = 32
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -58372,7 +57687,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
@@ -58682,7 +57996,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -58704,8 +58017,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
@@ -58844,7 +58156,6 @@
 	pixel_y = 5
 	},
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -58891,8 +58202,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/structure/closet/emcloset,
@@ -59016,8 +58326,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -59140,7 +58449,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
@@ -59149,8 +58457,7 @@
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/milspec/box,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/Mech_Bay)
@@ -59471,7 +58778,6 @@
 /area/quartermaster/Star_Tool_Storage)
 "gQu" = (
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/structure/closet/emcloset,
@@ -59571,8 +58877,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/Patient_Ward)
@@ -59638,9 +58943,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
 "gSJ" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -59649,9 +58952,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Corridor_2)
 "gSR" = (
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -59665,6 +58965,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/Reception)
@@ -60017,7 +59320,6 @@
 "gXW" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
-	name = "1E-extinguisher cabinet";
 	pixel_x = 27
 	},
 /turf/simulated/floor/wood/alt,
@@ -60041,8 +59343,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Toxins_Mixing_Room)
@@ -60176,7 +59477,6 @@
 "haO" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -60433,7 +59733,6 @@
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/monotile{
@@ -60478,12 +59777,10 @@
 /obj/structure/flora/skeleton,
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60564,8 +59861,7 @@
 "hft" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -61110,7 +60406,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -61471,9 +60766,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Central_2_Deck_Hall)
 "hqk" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
@@ -61685,16 +60978,14 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Library)
 "htb" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -61783,8 +61074,7 @@
 /obj/structure/table/glass,
 /obj/item/roller/adv,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -61925,7 +61215,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green,
@@ -62009,8 +61298,7 @@
 	dir = 1
 	},
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "1N-newscaster"
+	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/green,
 /area/medical/CMO_Office)
@@ -62137,7 +61425,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -62269,8 +61556,7 @@
 /area/shuttle/large_escape_pod4/station)
 "hBq" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloor{
@@ -62304,8 +61590,7 @@
 /area/rnd/Robotics_Lab)
 "hBM" = (
 /obj/item/radio/intercom/department/medbay{
-	pixel_y = -22;
-	name = "1S-station intercom (Medbay)"
+	pixel_y = -22
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -62674,8 +61959,7 @@
 /area/quartermaster/Warehouse)
 "hIE" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment,
@@ -62720,7 +62004,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled,
@@ -62768,8 +62051,7 @@
 /area/maintenance/ab_Chapel)
 "hJU" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/Testing_Lab)
@@ -62845,8 +62127,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Security_Substation)
@@ -63362,8 +62643,7 @@
 /obj/structure/table/glass,
 /obj/item/radio/intercom/department/medbay{
 	dir = 8;
-	pixel_x = -22;
-	name = "1W-station intercom (Medbay)"
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/Patient_Ward)
@@ -63453,8 +62733,7 @@
 	req_access = list(24)
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -63610,7 +62889,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled,
@@ -63698,13 +62976,11 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -63813,7 +63089,6 @@
 /area/crew_quarters/VR)
 "hXE" = (
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -63826,7 +63101,6 @@
 /area/engineering/Storage)
 "hXY" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -64237,7 +63511,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green,
@@ -64386,7 +63659,6 @@
 	pixel_y = 2
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
@@ -64409,8 +63681,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -64430,12 +63701,10 @@
 "ifD" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/vending/tool,
 /turf/simulated/floor/tiled/steel_grid,
@@ -64770,8 +64039,7 @@
 /area/maintenance/Deck2_Security_AftStarCorridor2)
 "ijI" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorblack{
@@ -64837,8 +64105,7 @@
 "ijS" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloorblack{
@@ -64916,8 +64183,7 @@
 "ikk" = (
 /obj/structure/bed/chair/sofa/beige,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/ForStar_2_Deck_Observatory)
@@ -64960,8 +64226,7 @@
 	},
 /obj/machinery/computer/guestpass{
 	dir = 4;
-	pixel_x = -19;
-	name = "1W-guest pass terminal"
+	pixel_x = -19
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_2)
@@ -64980,8 +64245,7 @@
 /area/maintenance/Deck2_Medical_AftCorridor2)
 "ikX" = (
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/blue/border,
@@ -65011,7 +64275,7 @@
 /obj/random/junk,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/hallway/Star_2_Deck_Stairwell)
+/area/maintenance/Deck2_Science_StarCorridor2)
 "ilr" = (
 /obj/effect/landmark/event_spawn/morphspawn,
 /turf/simulated/floor/plating,
@@ -65136,12 +64400,9 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightorange/border,
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/engineering/Breakroom)
 "inE" = (
@@ -65359,7 +64620,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -65476,8 +64736,7 @@
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/milspec/box,
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /obj/mecha/medical/odysseus/old,
 /turf/simulated/floor/tiled/techfloor,
@@ -65738,8 +64997,7 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 1;
-	pixel_y = 22;
-	name = "1N-station intercom (Medbay)"
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/medical/Treatment_Hall)
@@ -65951,8 +65209,7 @@
 	dir = 1
 	},
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
@@ -66077,8 +65334,7 @@
 "izG" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -66176,9 +65432,7 @@
 /obj/item/clothing/glasses/meson{
 	pixel_y = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/CE_Office)
 "iAB" = (
@@ -66207,8 +65461,7 @@
 /area/hallway/AftPort_2_Deck_Observatory)
 "iAR" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -66313,9 +65566,7 @@
 /turf/simulated/wall,
 /area/maintenance/Deck2_Medical_AftCorridor1)
 "iCL" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -66385,8 +65636,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/conveyor{
 	id = "SC-PackageSort"
@@ -66402,7 +65652,6 @@
 "iEe" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -66530,8 +65779,7 @@
 	pixel_x = 22
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -66810,8 +66058,7 @@
 /area/engineering/Deck2_Evac_Corridor)
 "iIZ" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/reinforced{
 	name = "Holodeck Projector Floor"
@@ -66973,7 +66220,6 @@
 "iKg" = (
 /obj/machinery/libraryscanner,
 /obj/machinery/status_display{
-	name = "W-status display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -67068,8 +66314,7 @@
 /area/hallway/Central_2_Deck_Hall)
 "iKY" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -67343,9 +66588,7 @@
 	name = "1S-inset disposal unit";
 	pixel_y = -34
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -67374,9 +66617,7 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/Central_2_Deck_Hall)
 "iPq" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/dark,
@@ -67393,8 +66634,7 @@
 /area/hallway/Star_2_Deck_Stairwell)
 "iPF" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/cable{
@@ -67425,9 +66665,7 @@
 /area/quartermaster/Aft_Tool_Storage)
 "iQt" = (
 /obj/structure/table/steel,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/item/mail/junkmail,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/AftStar_2_Deck_Observatory)
@@ -67475,7 +66713,6 @@
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/newscaster{
-	name = "1S-newscaster";
 	pixel_y = -30
 	},
 /turf/simulated/floor/tiled/dark,
@@ -67735,9 +66972,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_ForPortChamber1)
 "iVk" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/reinforced,
 /area/rnd/Testing_Lab)
 "iVx" = (
@@ -67757,8 +66992,7 @@
 	pixel_y = 6
 	},
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
@@ -68062,8 +67296,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/Equipment_Storage)
@@ -68084,7 +67317,6 @@
 "iYD" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
@@ -68109,8 +67341,7 @@
 /area/security/Armory)
 "iZh" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -68186,9 +67417,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled/steel_grid,
@@ -68731,8 +67960,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/item/storage/fancy/cigarettes{
 	pixel_x = 6;
@@ -68836,9 +68064,7 @@
 /turf/simulated/wall,
 /area/quartermaster/Recycling)
 "jjA" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled,
@@ -69040,7 +68266,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -69101,8 +68326,7 @@
 /area/hallway/Central_2_Deck_Hall)
 "jmC" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -69492,8 +68716,7 @@
 	name = "1N-entertainment monitor"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/green,
 /area/medical/CMO_Office)
@@ -69637,7 +68860,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled,
@@ -69948,7 +69170,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -69975,7 +69196,6 @@
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -70058,8 +69278,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/sign/warning/high_voltage{
 	pixel_x = -32
@@ -70325,7 +69544,6 @@
 /obj/structure/table/hardwoodtable,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/item/radio/subspace{
@@ -70937,8 +70155,7 @@
 "jMS" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Rec_Lounge)
@@ -71144,9 +70361,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
 "jRb" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/reinforced{
 	name = "Holodeck Projector Floor"
 	},
@@ -71240,8 +70455,7 @@
 	},
 /obj/item/radio/intercom/department/security{
 	dir = 1;
-	pixel_y = 22;
-	name = "1N-station intercom (Security)"
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/Equipment_Storage)
@@ -71264,7 +70478,6 @@
 	pixel_x = 2
 	},
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -71288,8 +70501,7 @@
 "jSU" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloor{
@@ -71576,12 +70788,10 @@
 /obj/structure/table/woodentable,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/crew_quarters/Gym_Sauna)
@@ -71666,8 +70876,7 @@
 /obj/structure/closet/secure_closet/medical1,
 /obj/item/radio/intercom/department/medbay{
 	dir = 8;
-	pixel_x = -22;
-	name = "1W-station intercom (Medbay)"
+	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -71714,8 +70923,7 @@
 "jZo" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -71724,7 +70932,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -71807,7 +71014,6 @@
 "jZO" = (
 /obj/structure/table/woodentable,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -72184,7 +71390,6 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	name = "1N-newscaster";
 	pixel_y = 28
 	},
 /turf/simulated/floor/carpet/oracarpet,
@@ -72370,8 +71575,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/Chapel_Office)
@@ -72557,9 +71761,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Corridor_2)
 "kiP" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/Holodeck)
@@ -72717,7 +71919,6 @@
 /area/hallway/AftStar_2_Deck_Observatory)
 "klR" = (
 /obj/machinery/newscaster{
-	name = "1W-newscaster";
 	pixel_x = -28
 	},
 /obj/structure/disposalpipe/segment,
@@ -72940,7 +72141,6 @@
 "knE" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -73069,9 +72269,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/open,
 /area/hallway/ForPort_2_Deck_Observatory)
 "koF" = (
@@ -73120,8 +72318,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/machinery/shieldgen{
 	req_access = list(47)
@@ -73466,8 +72663,7 @@
 "kwy" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/spline/fancy{
@@ -73487,8 +72683,7 @@
 "kwB" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -73549,8 +72744,7 @@
 /area/crew_quarters/Gallery)
 "kxe" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable{
@@ -73768,9 +72962,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Robotics_Lab)
 "kBX" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/VR)
 "kCb" = (
@@ -73856,8 +73048,7 @@
 	pixel_y = 7
 	},
 /obj/item/radio/intercom/department/security{
-	pixel_y = -22;
-	name = "1S-station intercom (Security)"
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -73972,7 +73163,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -74008,8 +73198,7 @@
 /area/engineering/CE_Office)
 "kEW" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -74067,7 +73256,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -74098,12 +73286,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -74242,7 +73427,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/tiled,
@@ -74578,8 +73762,7 @@
 	pixel_y = -4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Chomp_Dinner_2)
@@ -74621,9 +73804,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/Storage)
 "kLG" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled/dark,
@@ -75120,8 +74301,7 @@
 	desc = "A heavily reinforced gate, sector lockdown!"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Research_Lab)
@@ -75143,7 +74323,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
@@ -75191,7 +74370,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -75276,7 +74454,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/tiled,
@@ -75287,8 +74464,7 @@
 	},
 /obj/item/radio/intercom/department/security{
 	dir = 1;
-	pixel_y = 22;
-	name = "1N-station intercom (Security)"
+	pixel_y = 22
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -75326,8 +74502,7 @@
 /area/hallway/Stairwell_Aft)
 "kVv" = (
 /obj/machinery/computer/guestpass{
-	pixel_y = 19;
-	name = "1N-guest pass terminal"
+	pixel_y = 19
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
@@ -75358,8 +74533,7 @@
 "kVB" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Chapel_Morgue)
@@ -75381,9 +74555,7 @@
 /turf/simulated/floor/tiled,
 /area/security/Firing_Range)
 "kVZ" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -75394,7 +74566,6 @@
 /obj/effect/floor_decal/corner/white/border,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
@@ -75452,7 +74623,6 @@
 "kWB" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -75506,7 +74676,6 @@
 "kXk" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10{
@@ -75519,8 +74688,7 @@
 /area/hallway/Aft_2_Deck_Lobby)
 "kXm" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/shuttle/loading{
 	dir = 4;
@@ -75606,8 +74774,7 @@
 "kZv" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -75723,9 +74890,7 @@
 	icon_state = "32-1"
 	},
 /obj/structure/lattice,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/door/blast/angled/open{
 	dir = 4;
 	id = "Star Lockdown";
@@ -75859,17 +75024,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
 "lce" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Testing_Lab)
 "lci" = (
@@ -76067,9 +75228,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Testing_Lab)
 "lft" = (
@@ -76212,8 +75371,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -76304,12 +75462,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/security/Deck2_1_Corridor)
 "ljC" = (
@@ -76330,7 +75482,6 @@
 /obj/machinery/disposal,
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
-	name = "1E-extinguisher cabinet";
 	pixel_x = 27
 	},
 /obj/structure/disposalpipe/trunk{
@@ -77189,7 +76340,6 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
@@ -77268,8 +76418,7 @@
 "lxM" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -77444,8 +76593,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -77611,7 +76759,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/tiled,
@@ -77710,12 +76857,10 @@
 /obj/machinery/papershredder,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "1W-newscaster"
+	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -77780,8 +76925,7 @@
 /area/engineering/Deck2_2_Corridor)
 "lFc" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -77861,7 +77005,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -77995,8 +77138,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 1
@@ -78013,8 +77155,7 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/rnd/Toxins_Mixing_Room)
@@ -78158,8 +77299,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -78205,7 +77345,7 @@
 /obj/random/junk,
 /obj/random/trash,
 /turf/simulated/floor/plating,
-/area/hallway/Star_2_Deck_Stairwell)
+/area/maintenance/Deck2_Science_StarCorridor2)
 "lJO" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
@@ -78275,8 +77415,7 @@
 /area/maintenance/Deck2_Cargo_AftCorridor2)
 "lLj" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -78427,8 +77566,7 @@
 "lND" = (
 /obj/structure/flora/underwater/grass1,
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /turf/simulated/floor/water/deep/indoors,
 /area/hallway/Port_2_Deck_Central_Corridor_1)
@@ -78509,7 +77647,6 @@
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -78532,7 +77669,6 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/orange/border,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white,
@@ -78707,8 +77843,7 @@
 	name = "Bar Shutters"
 	},
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Midnight_Kitchen)
@@ -78719,7 +77854,6 @@
 /obj/structure/closet/wardrobe/medic_gown,
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/dark,
@@ -78736,8 +77870,7 @@
 /obj/structure/table/glass,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/Patient_Ward)
@@ -78887,8 +78020,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -78963,17 +78095,14 @@
 "lUC" = (
 /obj/structure/closet/secure_closet/paramedic,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
 /area/medical/Locker_Room)
 "lUL" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -79040,8 +78169,7 @@
 /area/crew_quarters/VR)
 "lUZ" = (
 /obj/machinery/newscaster{
-	pixel_x = 28;
-	name = "1E-newscaster"
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -79285,7 +78413,6 @@
 /area/maintenance/Deck2_Cargo_AftPortCorridor1)
 "lWC" = (
 /obj/machinery/ai_status_display{
-	name = "1E-AI display";
 	pixel_x = 32
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -79527,8 +78654,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Chomp_Kitchen)
@@ -79627,7 +78753,6 @@
 "mba" = (
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/glass,
@@ -79676,9 +78801,7 @@
 /area/crew_quarters/Aft_Restroom)
 "mbH" = (
 /obj/structure/table/marble,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Midnight_Kitchen)
@@ -79849,8 +78972,7 @@
 "mfe" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/vending/wallmed1{
 	dir = 4;
@@ -79904,11 +79026,9 @@
 "mgk" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/machinery/disposal,
@@ -80038,8 +79158,7 @@
 "mif" = (
 /obj/machinery/disposal,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -80083,7 +79202,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/purcarpet,
@@ -80104,8 +79222,7 @@
 "mjS" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -80155,8 +79272,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -80191,12 +79307,6 @@
 "mlw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/security/Deck2_1_Corridor)
@@ -80869,9 +79979,7 @@
 /area/hallway/Aft_2_Deck_Corridor_1)
 "mwn" = (
 /obj/structure/table/steel,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/AftPort_2_Deck_Observatory)
 "mwR" = (
@@ -81323,8 +80431,7 @@
 "mCv" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/reinforced{
 	name = "Holodeck Projector Floor"
@@ -81643,8 +80750,7 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Research_Substation)
@@ -81670,7 +80776,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green,
@@ -81699,7 +80804,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
@@ -81915,8 +81019,7 @@
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -82052,7 +81155,6 @@
 	pixel_x = 7
 	},
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
@@ -82537,7 +81639,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green,
@@ -82552,8 +81653,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Central_Corridor_1)
@@ -82583,8 +81683,7 @@
 "mSi" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -82669,7 +81768,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -82696,14 +81794,12 @@
 "mTn" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/item/radio/intercom/department/security{
 	dir = 8;
 	icon_override = "secintercom";
-	pixel_x = -22;
-	name = "1W-station intercom (Security)"
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -82830,9 +81926,7 @@
 /turf/simulated/wall,
 /area/security/Boardroom)
 "mVL" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -82879,8 +81973,7 @@
 /area/rnd/Toxins_Mixing_Room)
 "mWi" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -83213,8 +82306,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner{
 	dir = 1
@@ -83244,7 +82336,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -83276,8 +82367,7 @@
 /area/security/Visitation_Room)
 "nbw" = (
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -83360,8 +82450,7 @@
 /area/hallway/Aft_2_Deck_Corridor_2)
 "ncQ" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -83378,7 +82467,6 @@
 "ncU" = (
 /obj/structure/dispenser/oxygen,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -83452,8 +82540,7 @@
 /area/rnd/Research_Lab)
 "nfq" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/water/deep/indoors,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
@@ -83584,8 +82671,7 @@
 "nhs" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -83686,9 +82772,7 @@
 "niK" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/AftPort_2_Deck_Observatory)
 "niZ" = (
@@ -83877,8 +82961,7 @@
 "nnN" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -84049,8 +83132,7 @@
 "nqB" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/Chomp_Kitchen)
@@ -84163,7 +83245,6 @@
 "nsN" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/structure/disposalpipe/segment,
@@ -84457,8 +83538,7 @@
 	name = "1N-entertainment monitor"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/Distillery)
@@ -84570,7 +83650,7 @@
 /obj/random/trash,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/hallway/Port_2_Deck_Stairwell)
+/area/maintenance/Deck2_Cargo_AftCorridor2)
 "nyH" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -84583,7 +83663,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/machinery/button/windowtint{
@@ -84703,7 +83782,6 @@
 "nBE" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/structure/cable/green{
@@ -84966,8 +84044,7 @@
 "nGq" = (
 /obj/structure/bed/chair/backed_red,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -85466,9 +84543,7 @@
 /obj/item/reagent_containers/food/drinks/textmug{
 	desc = "A mug with something written on it. 'Best doctor of the month' "
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
@@ -85512,8 +84587,7 @@
 /area/crew_quarters/Library_Office)
 "nOT" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -85533,7 +84607,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -85558,8 +84631,7 @@
 "nPL" = (
 /obj/structure/table/bench/sifwooden,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/flora/pottedplant/small{
 	pixel_y = 10;
@@ -85572,7 +84644,6 @@
 "nPX" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -85687,7 +84758,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/orange/border,
@@ -85841,13 +84911,11 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -85973,7 +85041,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/hallway/Star_Transit_Foyer)
 "nVF" = (
 /obj/structure/sign/department/eng{
@@ -86487,9 +85555,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Warehouse)
 "nZM" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -86542,27 +85608,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "oaV" = (
-/obj/fiftyspawner/wood,
-/obj/fiftyspawner/wood,
-/obj/fiftyspawner/wood/sif,
-/obj/fiftyspawner/wood/sif,
 /obj/fiftyspawner/turcarpet,
 /obj/fiftyspawner/tealcarpet,
 /obj/fiftyspawner/sblucarpet,
 /obj/fiftyspawner/purcarpet,
 /obj/fiftyspawner/oracarpet,
 /obj/fiftyspawner/blucarpet,
-/obj/fiftyspawner/marble,
-/obj/item/storage/briefcase/inflatable,
-/obj/item/storage/briefcase/inflatable,
-/obj/item/storage/briefcase/inflatable,
-/obj/fiftyspawner/cardboard,
-/obj/fiftyspawner/cardboard,
 /obj/structure/closet/crate/secure/large/reinforced,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/Star_Tool_Storage)
@@ -86585,7 +85640,6 @@
 	pixel_y = 12
 	},
 /obj/machinery/status_display{
-	name = "W-status display";
 	pixel_x = -32
 	},
 /turf/simulated/floor/carpet,
@@ -87136,9 +86190,7 @@
 /area/maintenance/ab_Pdance)
 "ohV" = (
 /obj/structure/table/steel_reinforced,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/item/mecha_parts/mecha_equipment/hardpoint_actuator,
 /turf/simulated/floor/plating/turfpack/airless,
 /area/harbor/Port_Shuttlebay)
@@ -87153,9 +86205,7 @@
 	pixel_y = -36;
 	name = "1S-entertainment monitor"
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet,
 /area/crew_quarters/Gym)
 "oiA" = (
@@ -87353,7 +86403,6 @@
 	},
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /turf/simulated/floor/carpet,
@@ -87472,7 +86521,6 @@
 /obj/structure/closet/wardrobe/chaplain_black,
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /turf/simulated/floor/lino,
@@ -87526,7 +86574,6 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
-	name = "1E-extinguisher cabinet";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white{
@@ -87621,7 +86668,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
@@ -87640,8 +86686,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -87736,8 +86781,7 @@
 /area/security/Wardens_Office)
 "osw" = (
 /obj/machinery/newscaster{
-	pixel_y = -30;
-	name = "1S-newscaster"
+	pixel_y = -30
 	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/black/border,
@@ -87800,8 +86844,7 @@
 "ots" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -87845,7 +86888,6 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
 /obj/item/flashlight,
-/obj/item/storage/belt/utility/full/multitool,
 /obj/item/cell/high,
 /obj/item/cell/high,
 /obj/effect/floor_decal/borderfloor{
@@ -87854,6 +86896,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
+/obj/item/storage/belt/utility/fluff,
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/Aft_Tool_Storage)
 "ouR" = (
@@ -88041,8 +87084,7 @@
 "oxg" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/crew_quarters/Gym)
@@ -88270,8 +87312,7 @@
 /area/crew_quarters/Chapel_Lobby)
 "oBh" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -88519,8 +87560,7 @@
 /obj/structure/bed/chair/comfy/black,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/carpet{
 	dir = 1
@@ -88591,7 +87631,6 @@
 /obj/structure/table/rack/shelf,
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /obj/effect/floor_decal/corner/beige/diagonal,
@@ -88758,9 +87797,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/Boardroom)
 "oGO" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
 /obj/effect/floor_decal/shuttle/loading{
 	dir = 4;
@@ -89021,7 +88058,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -89099,8 +88135,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/harbor/Star_Shuttlebay)
@@ -89201,8 +88236,7 @@
 	faction = "nanotrasen"
 	},
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/network/security{
@@ -89259,8 +88293,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/window/titanium,
 /obj/effect/floor_decal/spline/fancy,
@@ -89294,8 +88327,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/random/junk,
 /obj/structure/cable/green{
@@ -89387,8 +88419,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/Port_2_Deck_Central_Corridor_1)
@@ -89446,8 +88477,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/window/titanium,
 /turf/simulated/floor/carpet/purcarpet,
@@ -89501,7 +88531,6 @@
 /area/crew_quarters/Chomp_Kitchen)
 "oSA" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
@@ -89555,8 +88584,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -89597,8 +88625,7 @@
 "oUx" = (
 /obj/machinery/vending/wardrobe/bardrobe,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/Midnight_Kitchen)
@@ -89643,8 +88670,7 @@
 "oVc" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Gallery)
@@ -89654,8 +88680,7 @@
 /area/maintenance/ab_Chapel)
 "oVk" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	name = "1E-AI display"
+	pixel_x = 32
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/structure/cable{
@@ -89726,7 +88751,8 @@
 /obj/machinery/door/airlock/angled_bay/double/color{
 	door_color = "#8c1d11";
 	name = "Stairwell";
-	dir = 8
+	dir = 8;
+	req_access = list(1)
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Stairwell_For)
@@ -89744,8 +88770,7 @@
 /area/hallway/Central_2_Deck_Hall)
 "oWc" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -90073,7 +89098,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -90483,8 +89507,7 @@
 /area/maintenance/ab_TeshDen)
 "peJ" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -90743,7 +89766,6 @@
 	dir = 4
 	},
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/machinery/camera/network/security{
@@ -90767,7 +89789,7 @@
 /obj/random/trash,
 /obj/random/junk,
 /turf/simulated/floor/plating,
-/area/hallway/Port_2_Deck_Stairwell)
+/area/maintenance/Deck2_Cargo_AftCorridor2)
 "piF" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -90784,9 +89806,7 @@
 /area/quartermaster/Breakroom)
 "piO" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/reinforced,
 /area/rnd/Testing_Lab)
 "piW" = (
@@ -90969,8 +89989,7 @@
 /area/crew_quarters/Midnight_Kitchen)
 "plL" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/closet/emcloset,
 /obj/structure/disposalpipe/segment{
@@ -90980,9 +89999,7 @@
 /area/hallway/Central_2_Deck_Hall)
 "pmh" = (
 /obj/machinery/papershredder,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/dark,
@@ -90990,8 +90007,7 @@
 "pmo" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -91035,8 +90051,7 @@
 "pnB" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/plating,
@@ -91093,7 +90108,6 @@
 	dir = 8
 	},
 /obj/machinery/status_display{
-	name = "E-status display";
 	pixel_x = 32
 	},
 /obj/machinery/camera/network/security{
@@ -91437,8 +90451,7 @@
 /area/maintenance/Deck2_Science_ForCorridor1)
 "psn" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloorblack{
@@ -91451,8 +90464,7 @@
 /area/crew_quarters/Chapel_Lobby)
 "pss" = (
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /obj/structure/table/steel,
 /obj/item/taperoll{
@@ -91591,8 +90603,7 @@
 /area/maintenance/ab_TeshDen)
 "ptH" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -91778,7 +90789,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/machinery/button/windowtint{
@@ -91919,8 +90929,7 @@
 /area/crew_quarters/Library)
 "pxc" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -92038,13 +91047,11 @@
 "pyN" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/carpet,
 /turf/simulated/floor/carpet,
@@ -92083,9 +91090,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/Engineering_Workshop)
 "pzi" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
@@ -92186,7 +91191,6 @@
 /obj/structure/closet/crate,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -92298,7 +91302,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/structure/window/reinforced/tinted/frosted{
@@ -92378,8 +91381,7 @@
 /area/bridge/Vault)
 "pCR" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -92480,7 +91482,6 @@
 /area/rnd/RD_Office)
 "pEF" = (
 /obj/machinery/newscaster{
-	name = "1S-newscaster";
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -92600,7 +91601,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/machinery/button/windowtint{
@@ -92672,19 +91672,15 @@
 /area/maintenance/Deck2_Civilian_ForStarCorridor2)
 "pHx" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet/purple,
 /area/rnd/RD_Office)
 "pHZ" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -92807,8 +91803,7 @@
 /obj/structure/table/steel,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Domicile_Substation)
@@ -92857,8 +91852,7 @@
 /area/medical/Patient_Ward)
 "pJt" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloor{
@@ -93063,8 +92057,7 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 1;
-	pixel_y = 22;
-	name = "1N-station intercom (Medbay)"
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -93138,9 +92131,7 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = 9
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/security/Firing_Range)
 "pOh" = (
@@ -93171,7 +92162,6 @@
 /area/hallway/Port_Transit_Foyer)
 "pOp" = (
 /obj/machinery/newscaster{
-	name = "1S-newscaster";
 	pixel_y = -30
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -93215,8 +92205,7 @@
 /obj/structure/bed/chair/sofa/right/blue,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/window/titanium{
 	dir = 1
@@ -93259,12 +92248,10 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -93287,7 +92274,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -93367,9 +92353,7 @@
 	pixel_y = 9;
 	pixel_x = 6
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -93395,8 +92379,7 @@
 	pixel_y = -1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -93450,8 +92433,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_1)
@@ -93597,7 +92579,6 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
@@ -93808,7 +92789,6 @@
 /area/maintenance/Deck2_Civilian_StarChamber2)
 "pVe" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/structure/closet/bombclosetsecurity,
@@ -93929,8 +92909,7 @@
 	pixel_y = 2
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -93976,9 +92955,7 @@
 	layer = 10.1;
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/airless,
 /area/harbor/Aft_Shuttlebay)
 "pXH" = (
@@ -94183,8 +93160,7 @@
 /area/maintenance/Deck2_Medical_AftCorridor1)
 "qbv" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -94631,7 +93607,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -94661,7 +93636,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -95077,8 +94051,7 @@
 /obj/random/maintenance/engineering,
 /obj/random/maintenance/engineering,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/ab_TeshDen)
@@ -95533,9 +94506,7 @@
 /turf/simulated/floor/tiled,
 /area/bridge/Vault_Reception)
 "qsf" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -95563,7 +94534,6 @@
 	pixel_y = 1
 	},
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/corner/purple/diagonal,
@@ -95631,7 +94601,6 @@
 "qsK" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white{
@@ -95658,9 +94627,7 @@
 	pixel_y = -2;
 	pixel_x = 2
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/techfloor,
@@ -95751,8 +94718,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Breakroom)
@@ -95770,8 +94736,7 @@
 /area/harbor/Aft_Shuttlebay)
 "quL" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "1N-extinguisher cabinet"
+	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -95895,7 +94860,6 @@
 "qxk" = (
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -96153,8 +95117,7 @@
 /obj/item/radio/intercom/department/security{
 	dir = 8;
 	icon_override = "secintercom";
-	pixel_x = -22;
-	name = "1W-station intercom (Security)"
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -96269,7 +95232,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
@@ -96896,9 +95858,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/Deck2_Star_Corridor)
 "qMd" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -97109,8 +96069,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/AftStar_2_Deck_Observatory)
@@ -97212,7 +96171,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -97292,7 +96250,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/machinery/alarm{
 	pixel_y = -25;
-	name = "S-alarm";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -97339,8 +96296,7 @@
 /area/medical/FirstAid_Storage)
 "qQL" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/sign/securearea{
 	icon_state = "radiation_small";
@@ -98096,7 +97052,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -98326,9 +97281,7 @@
 	},
 /area/medical/Patient_Ward)
 "rfd" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -98431,8 +97384,7 @@
 "rgn" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -98566,9 +97518,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/Technical_Storage)
 "rii" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
@@ -99094,7 +98044,6 @@
 /obj/machinery/feeder,
 /obj/machinery/alarm{
 	pixel_y = -25;
-	name = "S-alarm";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -99151,7 +98100,6 @@
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/machinery/status_display{
-	name = "E-status display";
 	pixel_x = 32
 	},
 /turf/simulated/floor/carpet/oracarpet,
@@ -99276,8 +98224,7 @@
 /area/engineering/Engineering_Workshop)
 "rsM" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -99390,7 +98337,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
@@ -99679,8 +98625,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -99710,8 +98655,7 @@
 /area/engineering/Technical_Storage)
 "rxD" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -99913,8 +98857,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_1)
@@ -100237,8 +99180,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Central_Corridor_1)
@@ -100315,7 +99257,6 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28;
-	name = "1W-extinguisher cabinet";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white{
@@ -100361,20 +99302,10 @@
 /area/maintenance/Deck2_Security_ForCorridor2)
 "rDi" = (
 /obj/fiftyspawner/wood,
-/obj/fiftyspawner/wood,
 /obj/fiftyspawner/wood/sif,
-/obj/fiftyspawner/wood/sif,
-/obj/fiftyspawner/turcarpet,
-/obj/fiftyspawner/tealcarpet,
-/obj/fiftyspawner/sblucarpet,
-/obj/fiftyspawner/purcarpet,
-/obj/fiftyspawner/oracarpet,
-/obj/fiftyspawner/blucarpet,
 /obj/fiftyspawner/marble,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
-/obj/item/storage/briefcase/inflatable,
-/obj/fiftyspawner/cardboard,
 /obj/fiftyspawner/cardboard,
 /obj/structure/closet/crate/secure/large/reinforced,
 /obj/machinery/camera/network/security{
@@ -100515,8 +99446,7 @@
 "rEL" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Engineering_Substation)
@@ -100689,12 +99619,9 @@
 /area/maintenance/Deck2_Security_PortCorridor1)
 "rGX" = (
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
 	},
@@ -100905,7 +99832,6 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -100954,8 +99880,7 @@
 /area/rnd/Toxins_Viewing_Port)
 "rIN" = (
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /obj/structure/closet/secure_closet/sar,
 /turf/simulated/floor/tiled/white{
@@ -101025,8 +99950,7 @@
 /area/hallway/Star_Transit_Foyer)
 "rKQ" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/glass,
 /area/security/Lobby)
@@ -101079,7 +100003,6 @@
 	dir = 8
 	},
 /obj/machinery/status_display{
-	name = "W-status display";
 	pixel_x = -32
 	},
 /turf/simulated/floor/carpet/brown,
@@ -101209,7 +100132,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled,
@@ -101336,7 +100258,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28;
-	name = "1W-extinguisher cabinet";
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
@@ -101555,8 +100476,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
@@ -101567,7 +100487,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -101621,7 +100540,6 @@
 /area/maintenance/Distro_Civilian)
 "rUQ" = (
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -101796,8 +100714,7 @@
 "rXE" = (
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Central_Corridor_1)
@@ -102039,7 +100956,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -102150,7 +101066,6 @@
 /obj/item/stool/baystool/padded,
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/wood/sif,
@@ -102288,8 +101203,7 @@
 "sdb" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -102782,9 +101696,7 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
 "siY" = (
@@ -103239,9 +102151,6 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_AftCorridor1)
-"sqd" = (
-/turf/simulated/floor/plating,
-/area/hallway/Star_2_Deck_Stairwell)
 "sqi" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/red/bordercorner,
@@ -103296,8 +102205,7 @@
 "sqJ" = (
 /obj/machinery/autolathe,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Reception)
@@ -103330,8 +102238,7 @@
 "srf" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -103535,8 +102442,7 @@
 "stG" = (
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /obj/structure/closet/secure_closet/psych,
 /turf/simulated/floor/tiled/white{
@@ -103897,7 +102803,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -103909,8 +102814,7 @@
 /area/crew_quarters/Library_Cafe)
 "syt" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/reinforced{
 	name = "Holodeck Projector Floor"
@@ -103943,9 +102847,7 @@
 /area/hallway/Central_2_Deck_Hall)
 "syX" = (
 /obj/structure/table/hardwoodtable,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/item/storage/box/gum,
 /turf/simulated/floor/carpet/green,
 /area/quartermaster/Breakroom)
@@ -104033,7 +102935,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/tiled/milspec/raised,
@@ -104195,8 +103096,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Central_Corridor_1)
@@ -104267,9 +103167,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Corridor_2)
 "sCj" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -104326,8 +103224,7 @@
 /area/hallway/Aft_2_Deck_Lobby)
 "sCE" = (
 /obj/machinery/newscaster{
-	pixel_x = 28;
-	name = "1E-newscaster"
+	pixel_x = 28
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_Transit_Foyer)
@@ -104396,7 +103293,6 @@
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/white{
@@ -104888,8 +103784,7 @@
 /area/quartermaster/Breakroom)
 "sJH" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -104913,8 +103808,7 @@
 	dir = 6
 	},
 /obj/machinery/newscaster{
-	pixel_x = 28;
-	name = "1E-newscaster"
+	pixel_x = 28
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 6
@@ -105009,8 +103903,7 @@
 "sMc" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -105055,7 +103948,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/carpet,
@@ -105072,8 +103964,7 @@
 "sMS" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom/department/medbay{
-	pixel_y = -22;
-	name = "1S-station intercom (Medbay)"
+	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/Patient_Ward)
@@ -105152,8 +104043,7 @@
 "sNz" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
@@ -105191,7 +104081,6 @@
 /area/rnd/Toxins_Storage)
 "sNN" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/dark,
@@ -105233,8 +104122,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -105714,7 +104602,6 @@
 "sWr" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -105933,7 +104820,6 @@
 "sZj" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/white{
@@ -106083,8 +104969,7 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -106237,7 +105122,6 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	name = "1W-newscaster";
 	pixel_x = -28
 	},
 /obj/structure/disposalpipe/segment,
@@ -106323,8 +105207,7 @@
 /area/medical/Port_Medical_Post)
 "tfi" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/kafel_full/blue/turfpack/station,
 /area/security/Prison_Wing)
@@ -106369,7 +105252,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /obj/effect/landmark/start{
@@ -106384,7 +105266,6 @@
 "tfG" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet,
@@ -106418,7 +105299,6 @@
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled,
@@ -106441,8 +105321,7 @@
 /area/quartermaster/Star_Tool_Storage)
 "tgd" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -106553,8 +105432,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/brown,
 /area/crew_quarters/Library)
@@ -106655,11 +105533,11 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
 /obj/item/flashlight,
-/obj/item/storage/belt/utility/full/multitool,
 /obj/item/cell/high,
 /obj/item/multitool,
 /obj/item/cell/high,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/item/storage/belt/utility/full,
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/Star_Tool_Storage)
 "tjb" = (
@@ -106898,9 +105776,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/sign/warning/high_voltage{
 	pixel_y = -32
 	},
@@ -107000,8 +105876,7 @@
 /obj/structure/closet/coffin,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/Chapel_Morgue)
@@ -107069,8 +105944,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -107139,7 +106013,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/oracarpet,
@@ -107198,7 +106071,6 @@
 /area/crew_quarters/Midnight_Kitchen)
 "trT" = (
 /obj/machinery/newscaster{
-	name = "1E-newscaster";
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -107360,7 +106232,6 @@
 "tuX" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -107381,8 +106252,7 @@
 /area/crew_quarters/Chapel_Lobby)
 "tvD" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -107625,9 +106495,7 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/Packaging_Room)
 "tym" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -107753,7 +106621,6 @@
 /area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "tAj" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -107784,8 +106651,7 @@
 "tAA" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -107865,8 +106731,7 @@
 /area/maintenance/Deck2_Engineering_ForStarCorridor1)
 "tBM" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "1N-extinguisher cabinet"
+	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
@@ -108102,9 +106967,7 @@
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/item/tape_roll{
 	pixel_x = -8;
 	pixel_y = -3
@@ -108135,7 +106998,6 @@
 /area/quartermaster/Aft_Tool_Storage)
 "tEP" = (
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/machinery/door/firedoor/glass/hidden/steel{
@@ -108234,20 +107096,10 @@
 /area/medical/Port_Medical_Post)
 "tHe" = (
 /obj/fiftyspawner/wood,
-/obj/fiftyspawner/wood,
 /obj/fiftyspawner/wood/sif,
-/obj/fiftyspawner/wood/sif,
-/obj/fiftyspawner/turcarpet,
-/obj/fiftyspawner/tealcarpet,
-/obj/fiftyspawner/sblucarpet,
-/obj/fiftyspawner/purcarpet,
-/obj/fiftyspawner/oracarpet,
-/obj/fiftyspawner/blucarpet,
 /obj/fiftyspawner/marble,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
-/obj/item/storage/briefcase/inflatable,
-/obj/fiftyspawner/cardboard,
 /obj/fiftyspawner/cardboard,
 /obj/structure/closet/crate/secure/large/reinforced,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -108454,7 +107306,6 @@
 "tIN" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -108551,8 +107402,7 @@
 /area/quartermaster/Warehouse)
 "tLm" = (
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /obj/machinery/camera/network/research{
 	c_tag = "D2-Med-CMO Office1";
@@ -108785,8 +107635,7 @@
 "tPA" = (
 /obj/structure/bed/chair/sofa/left/blue,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
@@ -108821,10 +107670,6 @@
 	pixel_x = 9;
 	pixel_y = -9
 	},
-/obj/item/t_scanner/upgraded{
-	pixel_x = 11;
-	pixel_y = 3
-	},
 /obj/item/clothing/glasses/meson{
 	pixel_x = -6;
 	pixel_y = -13
@@ -108832,9 +107677,6 @@
 /obj/item/clothing/glasses/welding{
 	pixel_x = -6;
 	pixel_y = -8
-	},
-/obj/structure/closet/crate/large/nanotrasen{
-	req_one_access = list(10)
 	},
 /obj/item/stack/material/plasteel{
 	amount = 30;
@@ -108851,12 +107693,19 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
-/obj/item/clothing/gloves/yellow{
-	pixel_x = -7;
-	pixel_y = 2
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/item/t_scanner{
+	pixel_y = 3;
+	pixel_x = 11
 	},
 /obj/item/multitool{
 	pixel_x = 4
+	},
+/obj/structure/closet/crate/secure/large/nanotrasen{
+	req_access = list(10)
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Security_Substation)
@@ -108957,13 +107806,11 @@
 "tRm" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -109019,7 +107866,6 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
 /obj/machinery/firealarm{
 	dir = 4;
-	name = "E-fire alarm";
 	pixel_x = 25
 	},
 /turf/simulated/floor/tiled,
@@ -109048,8 +107894,7 @@
 /area/maintenance/Medical_Substation)
 "tSe" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -109183,8 +108028,7 @@
 "tTn" = (
 /obj/structure/table/steel,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/ForStar_2_Deck_Observatory)
@@ -109222,8 +108066,7 @@
 	},
 /obj/machinery/scale,
 /obj/machinery/newscaster{
-	pixel_y = -30;
-	name = "1S-newscaster"
+	pixel_y = -30
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Gym)
@@ -109586,7 +108429,6 @@
 	pixel_y = -9
 	},
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/machinery/camera/network/security{
@@ -109629,7 +108471,6 @@
 /obj/machinery/disposal,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/structure/disposalpipe/trunk,
@@ -109659,14 +108500,12 @@
 /area/hallway/Aft_2_Deck_Central_Corridor_1)
 "tZu" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/water/deep/indoors,
 /area/hallway/Port_2_Deck_Central_Corridor_2)
 "tZC" = (
 /obj/machinery/status_display{
-	name = "W-status display";
 	pixel_x = -32
 	},
 /obj/structure/cable{
@@ -109853,7 +108692,6 @@
 "uaD" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/newscaster{
-	name = "1N-newscaster";
 	pixel_y = 28
 	},
 /obj/machinery/vending/assist,
@@ -109955,8 +108793,7 @@
 /area/maintenance/ab_TeshDen)
 "ucm" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -110153,7 +108990,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white{
@@ -110165,8 +109001,7 @@
 	name = "Medical Forms"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -110181,7 +109016,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -110272,8 +109106,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Toxins_Storage)
@@ -110394,8 +109227,7 @@
 "uhW" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating/turfpack/airless,
@@ -110417,11 +109249,8 @@
 /area/maintenance/Medical_Substation)
 "uiD" = (
 /obj/machinery/photocopier,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/lino,
@@ -110742,7 +109571,6 @@
 "unr" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/carpet,
@@ -110783,13 +109611,11 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -110879,7 +109705,6 @@
 /obj/machinery/disposal,
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/trunk,
@@ -111164,7 +109989,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled,
@@ -111180,8 +110004,7 @@
 /area/hallway/Port_Transit_Foyer)
 "urG" = (
 /obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "1W-newscaster"
+	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/borderfloorwhite/corner2,
@@ -111330,8 +110153,7 @@
 /area/quartermaster/Deck2_Stairwell)
 "uvq" = (
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8
@@ -111382,8 +110204,7 @@
 "uwL" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/water/deep/indoors,
 /area/hallway/Star_2_Deck_Central_Corridor_2)
@@ -111496,9 +110317,7 @@
 "uzt" = (
 /obj/machinery/floodlight,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/maintenance/Security_Substation)
 "uzD" = (
@@ -111569,7 +110388,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -111669,7 +110487,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -112347,7 +111164,6 @@
 /area/engineering/Engineering_EVA)
 "uNW" = (
 /obj/machinery/newscaster{
-	name = "1E-newscaster";
 	pixel_x = 28
 	},
 /obj/machinery/alarm{
@@ -112370,8 +111186,7 @@
 /area/maintenance/Deck2_Cargo_AftCorridor2)
 "uOd" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -112453,7 +111268,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/corner/brown/border{
@@ -112468,9 +111282,7 @@
 /area/quartermaster/Breakroom)
 "uPu" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
 	},
@@ -112922,7 +111734,6 @@
 "uVm" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/structure/table/reinforced,
@@ -113119,8 +111930,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
@@ -113640,8 +112450,7 @@
 /area/hallway/Port_2_Deck_Stairwell)
 "vfk" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -113865,7 +112674,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/tiled,
@@ -113967,7 +112775,6 @@
 /area/security/Restroom)
 "vjM" = (
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /obj/machinery/media/jukebox,
@@ -113978,8 +112785,7 @@
 /area/crew_quarters/Midnight_Bar)
 "vkf" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -114255,7 +113061,6 @@
 /area/maintenance/Deck2_Engineering_PortChamber2)
 "voV" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -114545,8 +113350,7 @@
 /area/hallway/Port_Transit_Foyer)
 "vsO" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -114624,7 +113428,7 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/white,
 /area/hallway/Star_Transit_Foyer)
 "vty" = (
 /obj/structure/cable/green{
@@ -114695,7 +113499,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/int,
 /turf/simulated/floor/tiled/techmaint,
-/area/hallway/Star_2_Deck_Stairwell)
+/area/maintenance/Deck2_Science_StarCorridor2)
 "vuC" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -114756,7 +113560,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/tiled,
@@ -114796,7 +113599,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -115022,7 +113824,6 @@
 "vyA" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/structure/cable{
@@ -115156,8 +113957,7 @@
 /area/hallway/Central_2_Deck_Hall)
 "vAY" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -115185,7 +113985,6 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -115218,8 +114017,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/crew_quarters/Star_Restroom)
@@ -115330,7 +114128,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -115421,9 +114218,7 @@
 	pixel_x = -6;
 	pixel_y = -5
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/computer/security/telescreen/entertainment{
 	name = "1S-entertainment monitor";
 	pixel_y = -36
@@ -115660,8 +114455,7 @@
 /area/hallway/AftStar_2_Deck_Observatory)
 "vIB" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/shield_diffuser,
@@ -115995,7 +114789,6 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/brown,
@@ -116052,8 +114845,7 @@
 /area/engineering/Drone_Fab)
 "vQa" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -116071,8 +114863,7 @@
 "vQX" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
@@ -116145,8 +114936,7 @@
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightorange/border,
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Breakroom)
@@ -116200,7 +114990,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled,
@@ -116254,7 +115043,6 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /obj/structure/table/rack/shelf,
@@ -116332,8 +115120,7 @@
 "vUQ" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -116493,7 +115280,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -116507,8 +115293,7 @@
 "vXg" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/item/clipboard,
 /turf/simulated/floor/tiled/techfloor,
@@ -116724,8 +115509,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/boxing/gym,
 /area/crew_quarters/Gym)
@@ -116981,7 +115765,6 @@
 "wdd" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -117205,8 +115988,7 @@
 /area/harbor/Star_2_Deck_Airlock_Access)
 "wfB" = (
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/machinery/suit_cycler/refit_only,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -117225,8 +116007,7 @@
 "wfN" = (
 /obj/structure/closet/crate/freezer,
 /obj/machinery/alarm{
-	pixel_y = 25;
-	name = "N-alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/Chomp_Kitchen)
@@ -117323,7 +116104,6 @@
 /obj/structure/closet/l3closet/medical,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white{
@@ -117555,9 +116335,7 @@
 	dir = 4
 	},
 /obj/structure/table/standard,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/item/reagent_containers/food/snacks/foam_banana,
 /obj/item/reagent_containers/food/snacks/foam_shrimp{
 	pixel_y = 5;
@@ -117961,8 +116739,7 @@
 /area/engineering/Engineering_EVA)
 "wnt" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -118041,7 +116818,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /obj/machinery/alarm{
 	pixel_y = -25;
-	name = "S-alarm";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -118111,7 +116887,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -118272,8 +117047,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -118318,7 +117092,6 @@
 "wry" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -118356,8 +117129,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Corridor_1)
@@ -118527,7 +117299,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -118575,7 +117346,6 @@
 /obj/machinery/disposal,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/structure/disposalpipe/trunk{
@@ -118761,8 +117531,7 @@
 	pixel_y = 22
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -119528,7 +118297,6 @@
 /obj/machinery/libraryscanner,
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
-	name = "1E-extinguisher cabinet";
 	pixel_x = 27
 	},
 /obj/item/toy/figure/librarian{
@@ -119710,8 +118478,7 @@
 "wKf" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 9
@@ -119801,8 +118568,7 @@
 /area/hallway/ForPort_2_Deck_Observatory)
 "wLp" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -119956,7 +118722,6 @@
 	},
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -120051,12 +118816,6 @@
 	dir = 2;
 	icon_state = "pipe-j2"
 	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/security/Reception)
 "wOg" = (
@@ -120097,8 +118856,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/AftPort_2_Deck_Observatory)
@@ -120438,8 +119196,7 @@
 "wTX" = (
 /obj/machinery/vending/medical,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -120589,8 +119346,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -120690,7 +119446,6 @@
 /obj/machinery/vending/blood,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white{
@@ -120891,7 +119646,6 @@
 "xbv" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/glass,
@@ -120970,7 +119724,6 @@
 "xbZ" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	name = "1W-extinguisher cabinet";
 	pixel_x = -28
 	},
 /obj/structure/cable/green{
@@ -121275,7 +120028,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -121637,8 +120389,7 @@
 "xlj" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -121887,8 +120638,7 @@
 /area/maintenance/Engineering_Substation)
 "xof" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "1N-extinguisher cabinet"
+	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -122059,7 +120809,6 @@
 /area/crew_quarters/Library_Cafe)
 "xqE" = (
 /obj/machinery/ai_status_display{
-	name = "1E-AI display";
 	pixel_x = 32
 	},
 /turf/simulated/floor/wood/alt,
@@ -122341,12 +121090,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/security/Deck2_1_Corridor)
 "xuB" = (
@@ -122402,8 +121145,12 @@
 	dir = 1;
 	c_tag = "D2-Sec-Reception4"
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/red/border,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/Deck2_1_Corridor)
 "xvE" = (
@@ -122587,7 +121334,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/green,
@@ -122735,8 +121481,7 @@
 /area/medical/Locker_Room)
 "xBk" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -122978,8 +121723,7 @@
 "xDM" = (
 /obj/structure/closet/l3closet/medical,
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -123081,8 +121825,7 @@
 "xFz" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/table/reinforced,
 /obj/item/tool/screwdriver,
@@ -123184,8 +121927,7 @@
 /area/medical/Reception)
 "xHg" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -123559,8 +122301,7 @@
 "xMV" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -123593,8 +122334,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/window/titanium,
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -124269,7 +123009,7 @@
 /obj/effect/floor_decal/corner/purple/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/hallway/Star_Transit_Foyer)
 "xXg" = (
 /obj/structure/curtain/medical{
@@ -124602,7 +123342,6 @@
 /area/maintenance/Deck2_Medical_AftCorridor1)
 "xZy" = (
 /obj/machinery/ai_status_display{
-	name = "1N-AI display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/glass,
@@ -124873,7 +123612,6 @@
 "ydm" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/machinery/power/apc{
@@ -124884,7 +123622,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -27;
 	pixel_y = 12;
-	name = "W-light switch";
 	dir = 4
 	},
 /obj/structure/cable/green,
@@ -125261,7 +123998,6 @@
 "ygw" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -125409,8 +124145,7 @@
 "yiw" = (
 /obj/item/modular_computer/console/preset/medical,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control switch for the RD's office.";
@@ -139655,8 +138390,8 @@ why
 pJt
 pMS
 ayV
-avc
-czL
+wjP
+rfX
 nye
 piE
 nye
@@ -153789,7 +152524,7 @@ ijk
 xun
 cBx
 mlw
-rYQ
+cUg
 rYQ
 rYQ
 fTL
@@ -154047,7 +152782,7 @@ shx
 aGq
 alx
 liM
-xtn
+czL
 xtn
 xtn
 cOc
@@ -155084,7 +153819,7 @@ sqR
 sqR
 sqR
 amR
-abf
+aUJ
 aeQ
 mEe
 aeQ
@@ -155327,7 +154062,7 @@ lkB
 bVA
 bip
 sKU
-cGp
+rWd
 rWd
 yil
 yes
@@ -156683,7 +155418,7 @@ rft
 aQw
 aSq
 oSv
-aUJ
+bIq
 bIq
 bIq
 bAr
@@ -171134,8 +169869,8 @@ oZL
 dHX
 lJw
 ill
-cUg
-sqd
+ukR
+qMI
 vun
 rQB
 tzZ

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
@@ -1,7 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -45,7 +44,6 @@
 "aag" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	name = "1W-extinguisher cabinet";
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -60,7 +58,6 @@
 "aah" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -108,7 +105,6 @@
 "aak" = (
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood/alt,
@@ -382,8 +378,7 @@
 "adS" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -659,12 +654,10 @@
 /area/medical/Deck3_Corridor)
 "aiP" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -950,8 +943,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 10
@@ -1182,8 +1174,7 @@
 /area/maintenance/Deck3_Medical_AftCorridor1)
 "auR" = (
 /obj/machinery/newscaster{
-	pixel_x = 28;
-	name = "1E-newscaster"
+	pixel_x = 28
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_2)
@@ -1203,8 +1194,7 @@
 /obj/structure/railing,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/open,
 /area/hallway/Port_Breakroom)
@@ -1382,8 +1372,7 @@
 /obj/structure/table/woodentable,
 /obj/item/radio/intercom/department/medbay{
 	dir = 8;
-	pixel_x = -22;
-	name = "1W-station intercom (Medbay)"
+	pixel_x = -22
 	},
 /obj/structure/flora/pottedplant/flower{
 	name = "Hansel";
@@ -1655,7 +1644,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/landmark/start/visitor,
@@ -1710,8 +1698,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
@@ -1753,13 +1740,11 @@
 "aDE" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 8;
-	pixel_x = -22;
-	name = "1W-station intercom (Medbay)"
+	pixel_x = -22
 	},
 /turf/simulated/floor/glass,
 /area/medical/Stairwell)
@@ -1878,8 +1863,7 @@
 "aFL" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /turf/simulated/floor/airless,
 /area/engineering/Solar_Control_ForStar)
@@ -2005,8 +1989,7 @@
 "aIG" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/crew_quarters/sleeping/Dormitory_01)
@@ -2014,8 +1997,7 @@
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
@@ -2249,8 +2231,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/hallway/Port_Breakroom)
@@ -2271,9 +2252,7 @@
 /obj/item/modular_computer/console/preset/engineering{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightorange/border,
 /turf/simulated/floor/tiled,
@@ -2346,7 +2325,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -2529,8 +2507,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -2674,8 +2651,7 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 8;
-	pixel_x = -22;
-	name = "1W-station intercom (Medbay)"
+	pixel_x = -22
 	},
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -2684,7 +2660,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -2791,7 +2766,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -3163,9 +3137,7 @@
 /area/crew_quarters/sleeping/Dormitory_07)
 "beu" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "beO" = (
@@ -3205,8 +3177,7 @@
 "bga" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/bridge/sleeping/Captain_Quarters)
@@ -3326,7 +3297,6 @@
 /area/crew_quarters/Chomp_Dinner_2)
 "bip" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -3529,8 +3499,7 @@
 /area/crew_quarters/Chomp_Dinner_2)
 "blt" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/bridge/AI_Core_Chamber)
@@ -3725,8 +3694,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -3795,9 +3763,7 @@
 /turf/simulated/wall/r_wall,
 /area/bridge/AI_Core_Chamber)
 "bqS" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -4103,7 +4069,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -4133,7 +4098,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -4165,7 +4129,6 @@
 /area/maintenance/Deck3_Bridge_ForPort_Corridor2)
 "bzb" = (
 /obj/machinery/newscaster{
-	name = "1E-newscaster";
 	pixel_x = 28
 	},
 /obj/structure/cable/green{
@@ -4271,7 +4234,6 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	name = "1N-newscaster";
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/kafel_full/green,
@@ -4948,7 +4910,6 @@
 "bMs" = (
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/structure/closet/emcloset,
@@ -5094,8 +5055,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5399,7 +5359,6 @@
 "bUf" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -5662,7 +5621,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green,
@@ -5725,8 +5683,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/glass,
 /area/crew_quarters/Public_Garden)
@@ -5754,7 +5711,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -6000,6 +5956,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/shield_diffuser,
 /turf/simulated/floor/airless,
 /area/space)
 "cfy" = (
@@ -6222,7 +6179,6 @@
 "cjx" = (
 /obj/machinery/vending/wardrobe/detdrobe,
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/wood/sif,
@@ -6387,8 +6343,7 @@
 "clr" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6442,8 +6397,7 @@
 "cmm" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood/alt,
@@ -6571,12 +6525,10 @@
 /area/bridge/sleeping/CE_Quarters)
 "cpl" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
@@ -6773,8 +6725,7 @@
 "csD" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -6943,8 +6894,7 @@
 /area/maintenance/Deck3_Bridge_AftStarCorridor1)
 "cwb" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -7016,9 +6966,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightorange/border,
 /turf/simulated/floor/tiled/dark,
@@ -7106,7 +7054,6 @@
 "cyS" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/techfloor/orange/corner{
@@ -7152,7 +7099,6 @@
 "czh" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite,
@@ -7183,8 +7129,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -7303,8 +7248,7 @@
 "cCt" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/bed/chair/oldsofa{
 	dir = 4
@@ -7459,14 +7403,14 @@
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance/int{
-	name = "Kitchen Maintenance";
-	req_one_access = list(28)
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Central Substation";
+	req_one_access = list(10,28)
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/Central_Engineering_Post)
@@ -7705,8 +7649,7 @@
 /area/crew_quarters/sleeping/Dormitory_12)
 "cHn" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/kafel_full/white,
@@ -7815,8 +7758,7 @@
 "cKu" = (
 /obj/structure/coatrack,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/sleeping/Dormitory_03)
@@ -8078,7 +8020,6 @@
 /obj/random/toy,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -8092,7 +8033,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -8202,7 +8142,6 @@
 	pixel_x = 22
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/white{
@@ -8271,8 +8210,7 @@
 /area/bridge/Control_Atrium)
 "cRp" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/girder/reinforced{
 	default_material = "lead"
@@ -8611,9 +8549,7 @@
 /turf/simulated/floor/glass/reinforced,
 /area/maintenance/Deck3_Engineering_AftStarChamber2)
 "cYU" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8633,8 +8569,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -8677,7 +8612,6 @@
 /area/crew_quarters/Public_Hydroponics)
 "cZx" = (
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8706,7 +8640,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/carpet/bcarpet,
@@ -8717,8 +8650,7 @@
 /area/space)
 "cZV" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/airless,
@@ -8906,8 +8838,7 @@
 "dds" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/airless,
 /area/engineering/Solar_Control_ForStar)
@@ -9120,8 +9051,7 @@
 /area/crew_quarters/Chomp_Stage)
 "diR" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
@@ -9626,7 +9556,6 @@
 /area/space)
 "dst" = (
 /obj/machinery/newscaster{
-	name = "1W-newscaster";
 	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -9718,12 +9647,9 @@
 /area/engineering/Solar_Control_ForPort)
 "dwb" = (
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -9956,8 +9882,7 @@
 /area/harbor/For_3_Deck_Airlock_Access_2)
 "dzB" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/engineering/Engine2_Chamber)
@@ -10025,8 +9950,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/item/cell/apc,
 /turf/simulated/floor/plating,
@@ -10317,7 +10241,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -10346,8 +10269,7 @@
 "dFo" = (
 /obj/item/radio/intercom/department/medbay{
 	dir = 8;
-	pixel_x = -22;
-	name = "1W-station intercom (Medbay)"
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
@@ -10511,8 +10433,7 @@
 "dIm" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/carpet/blue,
@@ -10800,8 +10721,7 @@
 /area/engineering/Engine2_Canister_Storage)
 "dNI" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10888,7 +10808,6 @@
 /area/maintenance/Deck3_Center_Port)
 "dPn" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/structure/cable/green{
@@ -11105,7 +11024,6 @@
 /obj/structure/table/woodentable,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -11305,7 +11223,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/machinery/button/windowtint{
@@ -11370,12 +11287,10 @@
 /obj/structure/table/steel_reinforced,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/item/tool/screwdriver/brass,
 /turf/simulated/floor/plating,
@@ -11556,16 +11471,14 @@
 	desc = "A little lunchbox. This one has cute little hearts on it! Has a note that says 'DONT STEAL FOOD'."
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/closet/secure_closet/freezer/fridge{
 	starts_with = null
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloorblack/full,
 /turf/simulated/floor/tiled/dark,
@@ -11752,9 +11665,7 @@
 /turf/simulated/floor/plating,
 /area/harbor/For_3_Deck_Airlock_Access_2)
 "dZJ" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -11875,8 +11786,7 @@
 "eaO" = (
 /obj/machinery/vending/loadout/loadout_misc,
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -11961,7 +11871,6 @@
 /area/bridge/Deck3_Corridor)
 "ebu" = (
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -11991,8 +11900,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/disposal/wall{
 	dir = 4;
@@ -12036,8 +11944,7 @@
 /obj/structure/table/steel,
 /obj/item/binoculars,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -12055,7 +11962,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12211,8 +12117,7 @@
 "efi" = (
 /obj/machinery/computer/guestpass{
 	dir = 8;
-	pixel_x = 19;
-	name = "1E-guest pass terminal"
+	pixel_x = 19
 	},
 /turf/simulated/floor/wood/alt,
 /area/hallway/Port_Breakroom)
@@ -12404,7 +12309,6 @@
 	pixel_x = 2
 	},
 /obj/machinery/newscaster{
-	name = "1N-newscaster";
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
@@ -12696,7 +12600,6 @@
 /obj/machinery/dna_scannernew,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -12759,8 +12662,7 @@
 /area/bridge/Breakroom)
 "enW" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
@@ -12841,8 +12743,7 @@
 /area/engineering/Engine2_Waste_Handling)
 "eqC" = (
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -12883,9 +12784,7 @@
 /turf/simulated/floor/plating,
 /area/harbor/Aft_3_Deck_Airlock_Access)
 "ero" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
@@ -12915,7 +12814,6 @@
 /area/crew_quarters/Botanical_Shop)
 "ery" = (
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment{
@@ -12999,12 +12897,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_ForStarChamber2)
 "etz" = (
-/obj/structure/fireaxecabinet{
-	name = "1E-fire axe cabinet";
-	pixel_x = 32
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/Stairwell_Aft)
+/area/hallway/For_3_Deck_Stairwell)
 "etB" = (
 /obj/structure/transit_tube{
 	icon_state = "D-SW"
@@ -13081,7 +12978,6 @@
 /area/bridge/Control_Atrium)
 "euu" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -13114,8 +13010,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -13194,7 +13089,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -13226,8 +13120,7 @@
 "ewJ" = (
 /obj/structure/table/sifwoodentable,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -13285,8 +13178,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Waste_Handling)
@@ -13297,7 +13189,6 @@
 "eyi" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
-	name = "1E-extinguisher cabinet";
 	pixel_x = 27
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -13408,8 +13299,7 @@
 /area/bridge/AI_Core_Chamber)
 "ezK" = (
 /obj/machinery/newscaster{
-	pixel_x = -28;
-	name = "1W-newscaster"
+	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -13536,8 +13426,7 @@
 /area/engineering/Atmospherics_Chamber)
 "eBJ" = (
 /obj/item/radio/intercom/department/medbay{
-	pixel_y = -22;
-	name = "1S-station intercom (Medbay)"
+	pixel_y = -22
 	},
 /obj/structure/table/glass,
 /obj/effect/floor_decal/borderfloorwhite,
@@ -13567,8 +13456,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -13941,8 +13829,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -14034,15 +13921,12 @@
 "eJo" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /turf/simulated/floor/glass,
 /area/medical/Stairwell)
 "eJB" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/Psych_Room_2)
 "eJE" = (
@@ -14061,7 +13945,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -14099,7 +13982,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -14125,9 +14007,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleeping/Dormitory_11)
 "eKJ" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/table/glass,
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 8
@@ -14689,12 +14569,10 @@
 /area/maintenance/Deck3_Engineering_AftStarChamber1)
 "eQN" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
@@ -14936,8 +14814,7 @@
 /area/engineering/Engine2_Chamber)
 "eTA" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -14951,15 +14828,12 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine1_Chamber)
 "eTD" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14993,7 +14867,6 @@
 "eTN" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -15064,8 +14937,7 @@
 	pixel_x = -5
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Aft_3_Deck_Airlock_Access)
@@ -15076,9 +14948,7 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/Captain_Office)
 "eUt" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/sleeping/Dormitory_09)
 "eUC" = (
@@ -15446,9 +15316,7 @@
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/shield_capacitor{
 	dir = 1
 	},
@@ -15605,7 +15473,6 @@
 "faZ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28;
-	name = "1W-extinguisher cabinet";
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -15840,7 +15707,6 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -15931,9 +15797,7 @@
 /turf/simulated/floor/glass/reinforced,
 /area/maintenance/Deck3_Medical_AftPortChamber2)
 "fey" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -16176,8 +16040,7 @@
 "fhW" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -16213,8 +16076,7 @@
 /area/maintenance/Deck3_Medical_ForPortChamber1)
 "fiS" = (
 /obj/machinery/newscaster{
-	pixel_y = 28;
-	name = "1N-newscaster"
+	pixel_y = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -16229,8 +16091,7 @@
 "fji" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -16249,8 +16110,7 @@
 	color = "#004b9a"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -16305,8 +16165,7 @@
 "fjH" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/bridge/AI_Core_Chamber)
@@ -16452,7 +16311,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -16477,8 +16335,7 @@
 /area/medical/Patient_1)
 "flB" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -16488,7 +16345,6 @@
 "flM" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	name = "1W-extinguisher cabinet";
 	pixel_x = -28
 	},
 /obj/structure/cable/green{
@@ -16527,8 +16383,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -16788,9 +16643,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Port)
 "fpl" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -16811,8 +16664,7 @@
 "fpz" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/bridge/sleeping/CE_Quarters)
@@ -16984,7 +16836,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -17381,7 +17232,6 @@
 	dir = 4
 	},
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/wood/alt,
@@ -17616,8 +17466,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -17678,8 +17527,7 @@
 /area/medical/Genetics_Lab)
 "fCX" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
@@ -18081,8 +17929,7 @@
 /area/engineering/Deck3_1_Corridor)
 "fHW" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
@@ -18289,7 +18136,6 @@
 "fLv" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -18441,7 +18287,6 @@
 "fNB" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/techfloor/orange/corner{
@@ -18679,15 +18524,13 @@
 /obj/machinery/atmospherics/tvalve/mirrored/bypass,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /turf/simulated/floor/plating,
 /area/medical/Virology)
 "fSk" = (
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -18708,8 +18551,7 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -18719,7 +18561,6 @@
 "fSx" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -18776,8 +18617,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -18826,15 +18666,13 @@
 "fUr" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/Server_Room)
 "fUE" = (
 /obj/structure/bed/chair/sofa/right/blue,
 /obj/machinery/newscaster{
-	name = "1N-newscaster";
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -18845,7 +18683,6 @@
 "fUH" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/hydro,
@@ -19002,7 +18839,6 @@
 "fXW" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27;
-	name = "1E-extinguisher cabinet";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -19283,8 +19119,7 @@
 /area/engineering/Engine2_Chamber)
 "gbU" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -19312,8 +19147,7 @@
 "gct" = (
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
@@ -19386,7 +19220,6 @@
 	pixel_x = -7
 	},
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/wood/alt,
@@ -19490,9 +19323,7 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/For_3_Deck_Stairwell)
 "gfL" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
@@ -19858,8 +19689,7 @@
 "glK" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -19887,8 +19717,7 @@
 "gmz" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -20095,7 +19924,6 @@
 "gpR" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -20163,7 +19991,6 @@
 /area/maintenance/Deck3_Medical_AftPortChamber2)
 "gqj" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -20192,7 +20019,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -20211,13 +20037,15 @@
 /turf/simulated/open,
 /area/maintenance/Deck3_Bridge_ForStarCorridor1)
 "gqL" = (
-/obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	name = "1E-AI display"
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/arrows/red,
+/obj/effect/floor_decal/industrial/arrows/red{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/For_3_Deck_Stairwell)
 "gqT" = (
@@ -20342,8 +20170,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Star_3_Deck_Airlock_Access)
@@ -20533,8 +20360,7 @@
 /area/crew_quarters/Dorm_Corridor_1)
 "gyc" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Deck3_Corridor)
@@ -20933,12 +20759,10 @@
 "gFg" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -21347,7 +21171,6 @@
 "gKG" = (
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -21513,8 +21336,7 @@
 	},
 /obj/structure/window/plastitanium,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack/airless,
 /area/bridge/Captain_Office)
@@ -21571,8 +21393,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
@@ -21770,7 +21591,6 @@
 "gSX" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -21831,8 +21651,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -21904,7 +21723,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -21936,8 +21754,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -22018,9 +21835,7 @@
 /turf/simulated/floor/glass/reinforced,
 /area/maintenance/Deck3_Medical_PortChamber1)
 "gWO" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
@@ -22117,9 +21932,7 @@
 /turf/simulated/floor/tiled/white,
 /area/bridge/Firstaid_Post)
 "gXK" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/Captain_Office)
 "gXM" = (
@@ -22290,8 +22103,7 @@
 /area/maintenance/Deck3_Medical_ForStarChamber2)
 "hbE" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/open,
 /area/medical/Stairwell)
@@ -22351,8 +22163,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine1_Chamber)
@@ -22423,7 +22234,6 @@
 	pixel_x = 1
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -22461,8 +22271,7 @@
 /obj/structure/bed/chair/sofa/left/blue,
 /obj/item/radio/intercom/department/medbay{
 	dir = 1;
-	pixel_y = 22;
-	name = "1N-station intercom (Medbay)"
+	pixel_y = 22
 	},
 /obj/item/toy/plushie/teppi/alt{
 	desc = "No teppis were harmed in the creation of this plushie. It looks tattered and old, with various sewn patches from different plushies.";
@@ -22580,8 +22389,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -22670,8 +22478,7 @@
 /area/engineering/Engine2_Substation)
 "hkY" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "1N-extinguisher cabinet"
+	pixel_y = 28
 	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/Conference_Room)
@@ -22689,8 +22496,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -22725,9 +22531,7 @@
 	pixel_y = -3
 	},
 /obj/structure/table/wooden_reinforced,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -22745,9 +22549,7 @@
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/Atmospherics_Chamber)
 "hlM" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -23100,8 +22902,7 @@
 /obj/structure/window/reinforced/tinted/frosted,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/Embassy)
@@ -23122,6 +22923,10 @@
 	},
 /obj/effect/floor_decal/corner/blue/bordercorner{
 	dir = 1
+	},
+/obj/structure/fireaxecabinet{
+	name = "1N-fire axe cabinet";
+	pixel_y = 27
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Control_Atrium)
@@ -23398,7 +23203,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -23417,8 +23221,7 @@
 "hzi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -23503,9 +23306,7 @@
 /turf/simulated/floor/plating/turfpack/airless,
 /area/space)
 "hAE" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
 	},
@@ -23695,7 +23496,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -23749,8 +23549,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/landmark/start{
 	name = "Psychiatrist"
@@ -23997,7 +23796,6 @@
 /obj/machinery/vending/wardrobe/cargodrobe,
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack/full,
@@ -24049,8 +23847,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -24287,9 +24084,7 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -24349,9 +24144,7 @@
 /turf/simulated/floor/tiled/milspec/raised,
 /area/bridge/AI_Core_Chamber)
 "hOs" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/glass,
 /area/hallway/Star_3_Deck_Stairwell)
 "hOx" = (
@@ -24384,8 +24177,7 @@
 /area/maintenance/Deck3_Dorms_AftPortChamber2)
 "hOU" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24439,7 +24231,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -24457,7 +24248,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/structure/table/marble,
@@ -24584,7 +24374,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -24865,8 +24654,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -25285,7 +25073,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -25388,7 +25175,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -25420,6 +25206,10 @@
 /area/maintenance/Deck3_Engineering_ForStarChamber2)
 "ieB" = (
 /obj/structure/table/steel,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 8;
+	pixel_x = 3
+	},
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
 "ieL" = (
@@ -25506,9 +25296,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/Airlock_Access)
 "ifR" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/glass,
 /area/hallway/Stairwell_For)
 "ifU" = (
@@ -25807,9 +25595,7 @@
 /obj/structure/bed/chair/sofa/left/teal{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/sleeping/Dormitory_06)
 "imB" = (
@@ -25989,7 +25775,6 @@
 "ipi" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -26335,7 +26120,6 @@
 "ivn" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -26427,8 +26211,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/green/bordercorner,
@@ -26611,8 +26394,7 @@
 "izF" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -26626,9 +26408,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
 "izK" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
@@ -26870,8 +26650,7 @@
 "iCO" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/item/geiger/wall/west,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -26891,8 +26670,7 @@
 "iDv" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloor{
@@ -26991,12 +26769,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/blue/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
 "iFp" = (
@@ -27098,7 +26872,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -27128,7 +26901,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -27189,8 +26961,7 @@
 "iID" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/medical/Deck3_Corridor)
@@ -27237,16 +27008,15 @@
 /obj/machinery/door/firedoor/multi_tile/glass{
 	dir = 1
 	},
-/obj/machinery/door/airlock/angled_bay/double/glass/command{
-	dir = 8;
-	name = "Stairwell";
-	req_access = null
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/airlock/angled_bay/double/glass/command{
+	dir = 8;
+	name = "Stairwell"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Stairwell_For)
@@ -27390,7 +27160,6 @@
 "iMo" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/machinery/disposal,
@@ -27412,9 +27181,7 @@
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Botanical_Shop)
 "iMv" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -27474,7 +27241,6 @@
 /obj/structure/table/sifwoodentable,
 /obj/item/gps/medical/cmo,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/wood/alt/tile,
@@ -27834,8 +27600,7 @@
 /area/crew_quarters/Chomp_Dinner_1)
 "iUS" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/catwalk_plated/techfloor,
 /turf/simulated/floor/redgrid/animated,
@@ -27851,7 +27616,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -28025,12 +27789,10 @@
 "iWZ" = (
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/glass,
 /area/crew_quarters/Public_Garden)
@@ -28081,7 +27843,6 @@
 "iXG" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/machinery/computer/security/mining{
@@ -28269,7 +28030,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/spline/fancy{
@@ -28466,8 +28226,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
@@ -28562,15 +28321,12 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "jhb" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Substation)
 "jhg" = (
@@ -28604,7 +28360,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -28766,7 +28521,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
@@ -28774,8 +28528,7 @@
 "jjg" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -28785,8 +28538,7 @@
 "jji" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
@@ -28902,8 +28654,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/Central_Restroom)
@@ -28946,8 +28697,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -29094,7 +28844,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -29149,7 +28898,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -29479,7 +29227,6 @@
 /obj/structure/table/reinforced,
 /obj/item/tool/wrench/brass,
 /obj/machinery/newscaster{
-	name = "1S-newscaster";
 	pixel_y = -30
 	},
 /obj/item/cartridge/atmos{
@@ -29571,12 +29318,7 @@
 "jwY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
 "jxD" = (
@@ -29711,7 +29453,6 @@
 /area/engineering/Atmospherics_Chamber)
 "jzA" = (
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/structure/window/reinforced{
@@ -29756,8 +29497,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/machinery/button/windowtint{
 	pixel_x = -11;
@@ -29996,9 +29736,7 @@
 /area/bridge/sleeping/Secretary_Quarters)
 "jEr" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Substation)
@@ -30149,8 +29887,7 @@
 /obj/machinery/iv_drip,
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /turf/simulated/floor/wood/alt,
 /area/medical/Patient_1)
@@ -30223,8 +29960,7 @@
 /area/engineering/Engine2_Waste_Handling)
 "jHg" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleeping/Dormitory_06)
@@ -30413,9 +30149,6 @@
 /area/engineering/Engine2_Chamber)
 "jJL" = (
 /obj/structure/table/woodentable,
-/obj/item/storage/box/nifsofts_engineering{
-	pixel_y = 8
-	},
 /turf/simulated/floor/wood/alt,
 /area/hallway/Port_Breakroom)
 "jJP" = (
@@ -30430,8 +30163,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/Morgue)
@@ -30537,7 +30269,6 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -30576,8 +30307,7 @@
 "jMX" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -30597,8 +30327,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -30835,9 +30564,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/Engine_Tech_Storage)
 "jSS" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/glass,
 /area/bridge/Control_Atrium)
 "jTb" = (
@@ -30877,8 +30604,7 @@
 "jTl" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/crew_quarters/sleeping/Dormitory_06)
@@ -30915,9 +30641,7 @@
 "jUh" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/browndouble,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet/blucarpet,
 /area/crew_quarters/sleeping/Dormitory_01)
 "jUj" = (
@@ -30949,8 +30673,7 @@
 /area/engineering/Construction_Area)
 "jVb" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine1_Chamber)
@@ -31066,8 +30789,7 @@
 /area/engineering/Engine3_Control_Room)
 "jWS" = (
 /obj/machinery/computer/guestpass{
-	pixel_y = 19;
-	name = "1N-guest pass terminal"
+	pixel_y = 19
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -31113,7 +30835,6 @@
 /area/engineering/Engine2_Chamber)
 "jXc" = (
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -31228,7 +30949,6 @@
 /obj/structure/table/woodentable,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -31279,9 +30999,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_AftStarCorridor1)
 "kah" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightorange/border,
 /turf/simulated/floor/tiled,
@@ -31371,9 +31089,7 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleeping/Dormitory_07)
 "kbV" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightorange/border,
 /turf/simulated/floor/tiled/dark,
@@ -31538,8 +31254,7 @@
 /area/maintenance/Deck3_Engineering_AftStarCorridor2)
 "kfu" = (
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/airless,
@@ -31608,11 +31323,8 @@
 /area/hallway/Star_3_Deck_Stairwell)
 "kge" = (
 /obj/machinery/vending/wardrobe/chemdrobe,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloorblack/full,
@@ -31698,7 +31410,6 @@
 /obj/structure/table/woodentable,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/item/starcaster_news,
@@ -32081,7 +31792,6 @@
 "kpk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/newscaster{
-	name = "1N-newscaster";
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -32143,7 +31853,6 @@
 "kpE" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/techfloor/orange/corner{
@@ -32158,12 +31867,9 @@
 /area/medical/Autoresleeving)
 "kpI" = (
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -32315,7 +32021,6 @@
 	pixel_y = 1
 	},
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /obj/structure/cable/green{
@@ -32336,11 +32041,9 @@
 "kqN" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/newscaster{
-	name = "1W-newscaster";
 	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -32442,9 +32145,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Star_Breakroom)
 "ksx" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -32618,7 +32319,6 @@
 "kwm" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/white{
@@ -32747,8 +32447,7 @@
 "kyE" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32823,7 +32522,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -32962,9 +32660,7 @@
 	pixel_y = -2;
 	color = "white"
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleeping/Dormitory_11)
 "kCd" = (
@@ -33040,7 +32736,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/structure/cable/green{
@@ -33129,8 +32824,7 @@
 /area/hallway/Stairwell_Star)
 "kFd" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -33431,12 +33125,10 @@
 "kLs" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -33748,8 +33440,7 @@
 "kQo" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -34171,7 +33862,6 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -34260,7 +33950,6 @@
 /obj/structure/cable/cyan,
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -34391,8 +34080,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -34553,7 +34241,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -34671,7 +34358,6 @@
 "leC" = (
 /obj/structure/bed/chair/sofa/blue,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/carpet/green,
@@ -34715,9 +34401,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -34843,7 +34527,6 @@
 "lic" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/glass,
@@ -34857,8 +34540,7 @@
 /area/medical/Virology)
 "liI" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -35146,7 +34828,6 @@
 /area/maintenance/Deck3_Dorms_ForStarChamber1)
 "lnk" = (
 /obj/machinery/ai_status_display{
-	name = "1W-AI display";
 	pixel_x = -32
 	},
 /obj/structure/cable/green{
@@ -35227,7 +34908,6 @@
 "lou" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /turf/simulated/floor/glass,
@@ -35443,7 +35123,6 @@
 /area/engineering/Solar_Array_AftStar)
 "lsr" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/spline/fancy{
@@ -35482,8 +35161,7 @@
 /area/crew_quarters/sleeping/Dormitory_03)
 "lsW" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/glass,
 /area/bridge/Control_Atrium)
@@ -35503,8 +35181,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/open,
 /area/hallway/Port_Breakroom)
@@ -35896,8 +35573,7 @@
 /area/crew_quarters/Chomp_Dinner_2)
 "lzN" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 10
@@ -35991,7 +35667,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -36044,9 +35719,7 @@
 /turf/simulated/wall,
 /area/crew_quarters/sleeping/Dormitory_01)
 "lCs" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -36180,7 +35853,6 @@
 /area/engineering/Engine3_Control_Room)
 "lDM" = (
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -36285,7 +35957,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -36304,8 +35975,7 @@
 "lFA" = (
 /obj/item/radio/intercom/department/medbay{
 	dir = 8;
-	pixel_x = -22;
-	name = "1W-station intercom (Medbay)"
+	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -36337,7 +36007,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -36449,12 +36118,10 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/kafel_full/white,
@@ -36552,12 +36219,10 @@
 /area/engineering/Solar_Array_ForPort)
 "lJt" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/structure/disposalpipe/segment,
@@ -36575,9 +36240,7 @@
 /turf/simulated/wall/r_wall,
 /area/medical/Resleeving)
 "lJP" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -36739,7 +36402,6 @@
 "lMY" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/glass,
@@ -36850,9 +36512,7 @@
 /turf/simulated/wall/r_wall,
 /area/harbor/Port_3_Deck_Airlock_Access)
 "lOz" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/table/standard,
 /obj/item/clothing/head/welding/fancy{
 	pixel_y = 4;
@@ -36882,8 +36542,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/angled_bay/standard/glass/command{
 	dir = 4;
-	name = "Breakroom";
-	req_access = null
+	name = "Breakroom"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -36947,8 +36606,7 @@
 "lPs" = (
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/medical/Patient_4)
@@ -37049,7 +36707,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
@@ -37259,8 +36916,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/open,
 /area/hallway/Port_Breakroom)
@@ -37307,7 +36963,6 @@
 	pixel_y = 1
 	},
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/structure/cable/green{
@@ -37375,11 +37030,8 @@
 	},
 /obj/item/clothing/shoes/footwraps/teshari,
 /obj/item/clothing/shoes/footwraps/teshari,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloor,
@@ -37514,8 +37166,7 @@
 /area/hallway/Star_Breakroom)
 "lWu" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -37807,8 +37458,7 @@
 /area/maintenance/Deck3_Dorms_StarChamber1)
 "maz" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Substation)
@@ -38011,7 +37661,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/blue2,
@@ -38093,7 +37742,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/grass2,
@@ -38116,8 +37764,7 @@
 	pixel_x = 22
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/wood/sif,
@@ -38126,8 +37773,7 @@
 /obj/structure/table/glass,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -38484,8 +38130,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Chamber)
@@ -38559,7 +38204,6 @@
 "mkg" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/wood/alt/tile,
@@ -38578,7 +38222,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green,
@@ -38853,8 +38496,7 @@
 "mnd" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -38874,7 +38516,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -39043,8 +38684,7 @@
 	name = "Wiggle's bed"
 	},
 /obj/machinery/newscaster{
-	pixel_x = 28;
-	name = "1E-newscaster"
+	pixel_x = 28
 	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/Embassy)
@@ -39244,8 +38884,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/open,
 /area/hallway/Stairwell_Aft)
@@ -39582,9 +39221,7 @@
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "mAS" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
 	},
@@ -39926,8 +39563,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/Observation_Lounge)
@@ -39941,7 +39577,6 @@
 "mFQ" = (
 /obj/machinery/disposal,
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/structure/disposalpipe/trunk{
@@ -39963,8 +39598,7 @@
 "mGm" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/Captain_Office)
@@ -40122,8 +39756,7 @@
 	dir = 10
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Waste_Handling)
@@ -40466,8 +40099,7 @@
 "mPy" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/Conference_Room)
@@ -40562,7 +40194,6 @@
 "mSQ" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/steel_ridged{
@@ -40782,13 +40413,13 @@
 /area/engineering/Construction_Area)
 "mXD" = (
 /obj/structure/table/standard,
-/obj/machinery/vending/wallmed1{
-	name = "1N-NanoMed";
-	pixel_y = 26
-	},
 /obj/effect/floor_decal/corner/beige/diagonal,
 /obj/effect/floor_decal/corner/brown/diagonal{
 	dir = 4
+	},
+/obj/structure/fireaxecabinet{
+	name = "1N-fire axe cabinet";
+	pixel_y = 27
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Dorm_Foyer)
@@ -40922,8 +40553,7 @@
 /area/engineering/Engine1_Chamber)
 "mZP" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -40938,7 +40568,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -40971,7 +40600,6 @@
 "naj" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor/corner{
@@ -41058,8 +40686,7 @@
 /area/crew_quarters/sleeping/Dormitory_02)
 "naW" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -41086,10 +40713,6 @@
 	pixel_y = 13;
 	pixel_x = -6
 	},
-/obj/structure/fireaxecabinet{
-	name = "1E-fire axe cabinet";
-	pixel_x = 32
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
@@ -41100,8 +40723,7 @@
 /area/bridge/Firstaid_Post)
 "nbi" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -41151,8 +40773,7 @@
 "nbO" = (
 /obj/item/radio/intercom/department/medbay{
 	dir = 8;
-	pixel_x = -22;
-	name = "1W-station intercom (Medbay)"
+	pixel_x = -22
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor{
@@ -41219,8 +40840,7 @@
 "ncV" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "sc-GCbridgeLOCKDOWN";
@@ -41254,8 +40874,7 @@
 /area/engineering/Solar_Control_ForStar)
 "ndI" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -41359,8 +40978,7 @@
 "nfH" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -41533,7 +41151,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -41591,8 +41208,7 @@
 /area/crew_quarters/sleeping/Dormitory_06)
 "njd" = (
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/airless,
@@ -41635,7 +41251,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green,
@@ -41807,8 +41422,7 @@
 	id = "dloop_atm_meter"
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Substation)
@@ -42015,9 +41629,7 @@
 "nrx" = (
 /obj/structure/table/steel,
 /obj/item/binoculars,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled/dark,
@@ -42210,7 +41822,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -42310,8 +41921,7 @@
 /area/harbor/For_3_Deck_Airlock_Access_1)
 "nxg" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -42393,7 +42003,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/structure/cable/green{
@@ -42499,7 +42108,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/structure/sign/securearea{
@@ -42529,8 +42137,7 @@
 "nzU" = (
 /obj/machinery/vending/loadout/uniform,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -42564,16 +42171,14 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/open,
 /area/hallway/Star_Breakroom)
 "nAk" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -42666,9 +42271,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
 "nBF" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -42758,9 +42361,7 @@
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 9
 	},
@@ -42803,8 +42404,7 @@
 "nEO" = (
 /obj/structure/railing,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/open,
 /area/hallway/Port_Breakroom)
@@ -42946,7 +42546,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -43030,7 +42629,6 @@
 "nGN" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloorblack/full,
@@ -43249,11 +42847,8 @@
 /area/maintenance/Deck3_Bridge_ForPort_Corridor2)
 "nJE" = (
 /obj/machinery/vending/coffee,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloorblack/full,
@@ -43308,7 +42903,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -43330,7 +42924,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy,
@@ -43370,8 +42963,7 @@
 	pixel_x = -8
 	},
 /obj/item/radio/intercom/department/medbay{
-	pixel_y = -22;
-	name = "1S-station intercom (Medbay)"
+	pixel_y = -22
 	},
 /obj/item/implanter{
 	pixel_y = 1;
@@ -43595,8 +43187,7 @@
 /obj/effect/floor_decal/spline/plain,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/boxing/gym,
 /area/bridge/Leisure_Room)
@@ -43961,7 +43552,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -44036,8 +43626,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/medical/Lounge)
@@ -44049,7 +43638,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -44259,7 +43847,6 @@
 "obU" = (
 /obj/structure/bed/chair/comfy/blue,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/disposal/wall{
@@ -44634,7 +44221,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -44729,8 +44315,7 @@
 /area/engineering/Engine_Tech_Storage)
 "ohf" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/bed/chair/comfy/blue,
 /turf/simulated/floor/wood/alt,
@@ -44775,12 +44360,10 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/ai_status_display{
-	pixel_x = 32;
-	name = "1E-AI display"
+	pixel_x = 32
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -44942,8 +44525,7 @@
 /obj/structure/closet/wardrobe/mixed,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Dorm_Foyer)
@@ -45039,7 +44621,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/structure/cable/green{
@@ -45057,8 +44638,7 @@
 "omn" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/tealcarpet,
@@ -45074,8 +44654,7 @@
 "omS" = (
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -45203,8 +44782,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
@@ -45268,13 +44846,11 @@
 /area/medical/Patient_1)
 "opv" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/vending/wardrobe/hydrobe,
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloorblack/full,
 /turf/simulated/floor/tiled/dark,
@@ -45378,8 +44954,7 @@
 /area/maintenance/Deck3_Dorms_ForPort_Corridor1)
 "ort" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/Conference_Room)
@@ -45427,8 +45002,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Waste_Handling)
@@ -45539,8 +45113,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/structure/cable/yellow{
 	d2 = 2;
@@ -45809,9 +45382,7 @@
 /turf/simulated/floor/glass/reinforced,
 /area/maintenance/Deck3_Engineering_AftStarChamber2)
 "oxk" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleeping/Dormitory_10)
 "oxp" = (
@@ -45891,8 +45462,7 @@
 /area/crew_quarters/sleeping/Dormitory_01)
 "ozl" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/item/storage/box/rxglasses{
 	pixel_y = -5;
@@ -45989,8 +45559,7 @@
 "oAJ" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/Control_Atrium)
@@ -46040,7 +45609,6 @@
 "oCg" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled,
@@ -46724,7 +46292,6 @@
 /area/hallway/Central_3_Deck_Hall)
 "oMy" = (
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -47079,9 +46646,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/Virology)
 "oTq" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleeping/Dormitory_01)
 "oTG" = (
@@ -47185,7 +46750,6 @@
 	pixel_x = 7
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/wood/alt,
@@ -47358,9 +46922,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Star_Breakroom)
 "oYt" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/sleeping/Dormitory_08)
 "oYu" = (
@@ -47385,8 +46947,7 @@
 "oYU" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -47452,8 +47013,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/AI_Upload_Hall)
@@ -47715,8 +47275,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine1_Substation)
@@ -48069,7 +47628,6 @@
 "plL" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
-	name = "1W-extinguisher cabinet";
 	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -48256,8 +47814,7 @@
 /area/maintenance/Deck3_Dorms_StarChamber2)
 "ppf" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -48281,7 +47838,6 @@
 /area/medical/Psych_Room_1)
 "ppV" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /turf/simulated/floor/tiled/hydro,
@@ -48383,8 +47939,7 @@
 /area/engineering/Central_Engineering_Post)
 "prH" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/sleeping/Dormitory_06)
@@ -48397,8 +47952,7 @@
 "prU" = (
 /obj/machinery/vending/bepis,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Autoresleeving)
@@ -48421,10 +47975,6 @@
 	pixel_x = 9;
 	pixel_y = -9
 	},
-/obj/item/t_scanner/upgraded{
-	pixel_x = 11;
-	pixel_y = 3
-	},
 /obj/item/clothing/glasses/meson{
 	pixel_x = -6;
 	pixel_y = -13
@@ -48432,9 +47982,6 @@
 /obj/item/clothing/glasses/welding{
 	pixel_x = -6;
 	pixel_y = -8
-	},
-/obj/structure/closet/crate/large/nanotrasen{
-	req_one_access = list(10)
 	},
 /obj/item/stack/material/plasteel{
 	amount = 30;
@@ -48451,15 +47998,19 @@
 	pixel_x = -8;
 	pixel_y = 7
 	},
-/obj/item/clothing/gloves/yellow{
-	pixel_x = -7;
-	pixel_y = 2
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/item/t_scanner{
+	pixel_y = 3;
+	pixel_x = 11
 	},
 /obj/item/multitool{
 	pixel_x = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/closet/crate/secure/large/nanotrasen{
+	req_access = list(10)
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Central_Engineering_Post)
@@ -48537,8 +48088,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/HoP_Office)
@@ -48554,7 +48104,6 @@
 /area/maintenance/Dorms_Substation)
 "puH" = (
 /obj/machinery/newscaster{
-	name = "1W-newscaster";
 	pixel_x = -28
 	},
 /obj/structure/cable/green{
@@ -48748,8 +48297,7 @@
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/clowndouble,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/sleeping/Dormitory_08)
@@ -49149,8 +48697,7 @@
 /obj/item/modular_computer/console/preset/research,
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 9
@@ -49247,8 +48794,7 @@
 	pixel_y = -5
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -49408,7 +48954,6 @@
 "pGp" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -49536,8 +49081,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/open,
 /area/hallway/Star_Breakroom)
@@ -49607,9 +49151,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/medical/Lounge)
 "pJw" = (
@@ -49648,8 +49190,7 @@
 /obj/structure/window/plastitanium,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack/airless,
 /area/bridge/Captain_Office)
@@ -49746,8 +49287,7 @@
 "pLY" = (
 /obj/item/storage/toolbox/lunchbox/nt/filled,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/closet/secure_closet/freezer/fridge{
 	starts_with = null
@@ -49910,7 +49450,6 @@
 	pixel_y = 7
 	},
 /obj/machinery/status_display{
-	name = "S-status display";
 	pixel_y = -32
 	},
 /turf/simulated/floor/wood/alt,
@@ -50352,7 +49891,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -50407,7 +49945,6 @@
 /area/bridge/Embassy)
 "pWI" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -50491,8 +50028,7 @@
 /area/bridge/HoP_Office)
 "pXp" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/plating,
@@ -50588,8 +50124,7 @@
 /area/maintenance/Deck3_Dorms_ForStarChamber1)
 "qaj" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 9
@@ -50672,7 +50207,6 @@
 "qbV" = (
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/structure/table/glass,
@@ -50721,7 +50255,6 @@
 "qdj" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /turf/simulated/floor/glass,
@@ -50777,8 +50310,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Substation)
@@ -50868,9 +50400,7 @@
 /area/engineering/Engine2_Waste_Handling)
 "qgk" = (
 /obj/structure/table/standard,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/item/implant/sizecontrol{
 	pixel_y = -2;
 	pixel_x = 5
@@ -50940,8 +50470,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -50951,7 +50480,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -51173,7 +50701,6 @@
 /area/harbor/Port_3_Deck_Airlock_Access)
 "qiN" = (
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /turf/simulated/floor/plating,
@@ -51308,8 +50835,7 @@
 /obj/item/storage/laundry_basket,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Dorm_Foyer)
@@ -51440,8 +50966,7 @@
 "qmA" = (
 /obj/machinery/computer/guestpass{
 	dir = 4;
-	pixel_x = -19;
-	name = "1W-guest pass terminal"
+	pixel_x = -19
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -51453,8 +50978,7 @@
 /area/hallway/Star_Breakroom)
 "qmU" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -51523,8 +51047,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/machinery/button/windowtint{
 	pixel_x = -11;
@@ -51544,8 +51067,7 @@
 /area/bridge/Embassy)
 "qoP" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -51608,8 +51130,7 @@
 /area/hallway/Star_Breakroom)
 "qqO" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/Psych_Room_1)
@@ -51681,9 +51202,7 @@
 /area/crew_quarters/sleeping/Dormitory_01)
 "qru" = (
 /obj/machinery/pipedispenser/disposal,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "qrz" = (
@@ -51850,7 +51369,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -52021,6 +51539,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Aft_3_Deck_Central_Corridor_1)
+"qxT" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/For_3_Deck_Stairwell)
 "qyr" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/shield_capacitor{
@@ -52291,8 +51818,7 @@
 "qBa" = (
 /obj/structure/railing,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/open,
 /area/hallway/Star_Breakroom)
@@ -52480,8 +52006,7 @@
 /area/hallway/Aft_3_Deck_Central_Corridor_1)
 "qEY" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -52740,9 +52265,7 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/Stairwell_Star)
 "qIS" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
 	},
@@ -52780,8 +52303,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -52964,8 +52486,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Engine2_Access_Hall)
@@ -53085,9 +52606,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber/huge,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -53359,8 +52878,7 @@
 "qTR" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -53612,7 +53130,6 @@
 /obj/machinery/vending/loadout/clothing,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
@@ -53643,8 +53160,7 @@
 /area/maintenance/Deck3_Engineering_AftStarChamber1)
 "qZX" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_y = 28;
-	name = "1N-extinguisher cabinet"
+	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -53761,9 +53277,7 @@
 /obj/machinery/computer/transhuman/resleeving{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -53948,7 +53462,6 @@
 /obj/structure/bed/chair/comfy/brown,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -54004,8 +53517,7 @@
 /obj/structure/table/steel,
 /obj/item/binoculars,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -54158,8 +53670,7 @@
 	},
 /obj/structure/table/glass,
 /obj/item/radio/intercom/department/medbay{
-	pixel_y = -22;
-	name = "1S-station intercom (Medbay)"
+	pixel_y = -22
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 10
@@ -54175,8 +53686,7 @@
 /area/maintenance/Deck3_Dorms_StarCorridor1)
 "rgE" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -54345,8 +53855,13 @@
 /turf/simulated/floor/glass/reinforced,
 /area/crew_quarters/Chomp_Lounge)
 "rjS" = (
-/obj/machinery/door/firedoor/glass/hidden/steel{
-	dir = 8
+/obj/effect/floor_decal/industrial/arrows/red,
+/obj/effect/floor_decal/industrial/arrows/red{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/multi_tile/glass,
+/obj/machinery/door/airlock/angled_bay/double/glass/command{
+	name = "Hallway"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/For_3_Deck_Stairwell)
@@ -54504,8 +54019,7 @@
 /area/engineering/Deck3_1_Corridor)
 "rmQ" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -54553,8 +54067,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -54704,8 +54217,7 @@
 /area/crew_quarters/Dorm_Foyer)
 "rpl" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -54781,8 +54293,7 @@
 /area/maintenance/Deck3_Dorms_AftCorridor1)
 "rpJ" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -55061,7 +54572,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -55146,7 +54656,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/machinery/button/windowtint{
@@ -55269,12 +54778,10 @@
 	pixel_y = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/structure/cable/green{
@@ -55370,7 +54877,6 @@
 "ryq" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/structure/flora/pottedplant/small{
@@ -55503,9 +55009,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/Virology)
 "rBT" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -55644,7 +55148,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -55685,8 +55188,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
@@ -55708,8 +55210,7 @@
 /area/bridge/sleeping/RD_Quarters)
 "rGl" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/table/sifwoodentable,
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
@@ -55780,7 +55281,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/white{
@@ -55937,7 +55437,6 @@
 "rKh" = (
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/structure/closet/emcloset,
@@ -56012,8 +55511,7 @@
 /area/bridge/Deck3_Corridor)
 "rLC" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -56088,8 +55586,7 @@
 "rMJ" = (
 /obj/machinery/disease2/incubator,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -56185,8 +55682,7 @@
 "rNY" = (
 /obj/machinery/disease2/isolator,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
@@ -56241,8 +55737,7 @@
 "rQm" = (
 /obj/structure/table/marble,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleeping/Dormitory_05)
@@ -56257,7 +55752,6 @@
 /obj/structure/bed/chair/sofa/blue,
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/landmark/start{
@@ -56369,8 +55863,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -56456,8 +55949,7 @@
 "rUS" = (
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/Psych_Room_2)
@@ -56517,7 +56009,6 @@
 /obj/machinery/vending/loadout/uniform,
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloorwhite{
@@ -57175,12 +56666,9 @@
 	pixel_x = 2
 	},
 /obj/machinery/newscaster{
-	pixel_y = -30;
-	name = "1S-newscaster"
+	pixel_y = -30
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/medical/Restrooms)
 "sgy" = (
@@ -57240,8 +56728,7 @@
 /obj/structure/railing,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/open,
 /area/hallway/Star_Breakroom)
@@ -57303,8 +56790,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -57377,9 +56863,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/Stairwell)
 "skG" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
@@ -57692,8 +57176,7 @@
 "soW" = (
 /obj/item/bedsheet/captaindouble,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/sleeping/Dormitory_12)
@@ -57751,8 +57234,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -57776,7 +57258,6 @@
 /area/medical/Genetics_Lab)
 "spz" = (
 /obj/machinery/newscaster{
-	name = "1W-newscaster";
 	pixel_x = -28
 	},
 /turf/simulated/floor/wood/alt,
@@ -57911,8 +57392,7 @@
 /area/space)
 "sre" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Star_3_Deck_Stairwell)
@@ -57931,8 +57411,9 @@
 "ssl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/effect/floor_decal/corner/blue/bordercorner,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
 "ssq" = (
@@ -57942,7 +57423,6 @@
 "ssw" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /turf/simulated/floor/glass,
@@ -58042,9 +57522,7 @@
 /turf/simulated/floor/tiled,
 /area/medical/Deck3_Corridor)
 "sud" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Chamber)
@@ -58053,7 +57531,6 @@
 /area/maintenance/Deck3_Bridge_ForStarCorridor1)
 "suw" = (
 /obj/machinery/newscaster{
-	name = "1W-newscaster";
 	pixel_x = -28
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -58108,7 +57585,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -58397,7 +57873,6 @@
 /obj/structure/bed/chair/comfy/black,
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy{
@@ -58878,7 +58353,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -59004,8 +58478,7 @@
 	dir = 4
 	},
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/medical/Lounge)
@@ -59023,9 +58496,7 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck3_Dorms_ForCorridor1)
 "sKt" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 5
 	},
@@ -59266,8 +58737,7 @@
 /area/crew_quarters/Observation_Atrium)
 "sND" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Aft_3_Deck_Stairwell)
@@ -59396,7 +58866,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 27;
 	pixel_y = -12;
-	name = "E-light switch";
 	dir = 8
 	},
 /obj/machinery/button/windowtint{
@@ -59803,8 +59272,7 @@
 /area/hallway/Aft_3_Deck_Central_Corridor_1)
 "sXw" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -60310,8 +59778,7 @@
 "tfe" = (
 /obj/machinery/vending/wardrobe/engidrobe,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack/full,
 /turf/simulated/floor/tiled/dark,
@@ -60327,8 +59794,7 @@
 /area/crew_quarters/Observation_Lounge)
 "tfk" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleeping/Dormitory_07)
@@ -60642,8 +60108,7 @@
 /area/bridge/sleeping/Captain_Quarters)
 "thU" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/glass,
 /area/medical/Stairwell)
@@ -60759,9 +60224,7 @@
 "tjF" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/pink,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/power/rad_collector{
 	anchored = 1
 	},
@@ -60840,13 +60303,11 @@
 "tld" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/medical/Restrooms)
@@ -60996,9 +60457,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Center_Star)
 "tnz" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/beige/border,
 /turf/simulated/floor/tiled,
@@ -61131,7 +60590,6 @@
 "tpT" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -61215,9 +60673,7 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 1
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -61326,8 +60782,7 @@
 /area/engineering/Engine2_Chamber)
 "twr" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
@@ -61360,8 +60815,7 @@
 "txm" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/cable/cyan{
 	d1 = 1;
@@ -61388,8 +60842,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/Conference_Room)
@@ -61462,8 +60915,7 @@
 /obj/machinery/disposal,
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -61477,12 +60929,10 @@
 	pixel_y = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/structure/cable/green{
@@ -61538,8 +60988,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Waste_Handling)
@@ -61635,7 +61084,6 @@
 /area/engineering/Engine1_Control_Room)
 "tCJ" = (
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -61668,8 +61116,7 @@
 "tDd" = (
 /obj/machinery/vending/loadout/clothing,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -61747,8 +61194,7 @@
 /area/engineering/Atmospherics_Chamber)
 "tFp" = (
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -62091,7 +61537,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -62163,7 +61608,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -62471,7 +61915,6 @@
 "tRN" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -62574,7 +62017,6 @@
 /area/bridge/Captain_Office)
 "tSO" = (
 /obj/structure/extinguisher_cabinet{
-	name = "1N-extinguisher cabinet";
 	pixel_y = 28
 	},
 /obj/machinery/door/window/eastleft{
@@ -62719,8 +62161,7 @@
 "tWG" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/Conference_Room)
@@ -62896,7 +62337,6 @@
 /obj/effect/floor_decal/corner/lightorange/border{
 	dir = 1
 	},
-/obj/item/t_scanner/advanced,
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
 "tYA" = (
@@ -62958,7 +62398,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -63165,8 +62604,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display{
-	pixel_y = -32;
-	name = "S-status display"
+	pixel_y = -32
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -63269,7 +62707,6 @@
 "ueV" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/structure/cable/green{
@@ -63609,7 +63046,6 @@
 /obj/structure/table/sifwoodentable,
 /obj/item/gps/engineering/ce,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/disposal/wall{
@@ -63638,8 +63074,7 @@
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -63721,8 +63156,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Airlock_Access)
@@ -63757,8 +63191,7 @@
 /area/engineering/Atmospherics_Control_Room)
 "unk" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -63786,8 +63219,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Waste_Handling)
@@ -63978,10 +63410,10 @@
 	pixel_x = 25
 	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 6
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
@@ -64083,8 +63515,7 @@
 	pixel_y = 15
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/Embassy)
@@ -64134,7 +63565,6 @@
 "usN" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -64505,7 +63935,6 @@
 "uyY" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -64555,7 +63984,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -64584,8 +64012,7 @@
 /obj/machinery/atmospherics/pipe/tank/air/full,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Bridge_Substation)
@@ -64615,7 +64042,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -64751,8 +64177,7 @@
 /area/crew_quarters/sleeping/Dormitory_05)
 "uDp" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Star_3_Deck_Airlock_Access)
@@ -64862,7 +64287,6 @@
 /area/hallway/Port_3_Deck_Stairwell)
 "uEb" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -64935,8 +64359,7 @@
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 25;
-	name = "E-fire alarm"
+	pixel_x = 25
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Waste_Handling)
@@ -65058,7 +64481,6 @@
 "uIm" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	name = "W-fire alarm";
 	pixel_x = -25
 	},
 /obj/structure/disposalpipe/segment{
@@ -65359,8 +64781,7 @@
 /area/maintenance/Deck3_Bridge_ForStarChamber1)
 "uNJ" = (
 /obj/machinery/ai_status_display{
-	pixel_y = 32;
-	name = "1N-AI display"
+	pixel_y = 32
 	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/Conference_Room)
@@ -65404,8 +64825,7 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Aft_3_Deck_Airlock_Access)
@@ -65642,8 +65062,7 @@
 "uRm" = (
 /obj/machinery/vending/loadout/accessory,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Dorm_Foyer)
@@ -65652,7 +65071,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/structure/cable/green{
@@ -65765,9 +65183,7 @@
 /area/engineering/Engine1_Chamber)
 "uSH" = (
 /obj/machinery/vending/wardrobe/genedrobe,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack/full,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Port_Breakroom)
@@ -65799,8 +65215,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Port_3_Deck_Airlock_Access)
@@ -65855,8 +65270,7 @@
 "uUk" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -65874,8 +65288,7 @@
 /area/medical/Genetics_Lab)
 "uUo" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/airless,
@@ -65907,7 +65320,6 @@
 "uVg" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 1;
-	name = "1S-extinguisher cabinet";
 	pixel_y = -27
 	},
 /turf/simulated/floor/glass,
@@ -66008,8 +65420,7 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 8;
-	pixel_x = -22;
-	name = "1W-station intercom (Medbay)"
+	pixel_x = -22
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -66032,8 +65443,7 @@
 	},
 /obj/item/radio/intercom/department/medbay{
 	dir = 4;
-	pixel_x = 22;
-	name = "1E-station intercom (Medbay)"
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/Morgue)
@@ -66180,8 +65590,7 @@
 "uYr" = (
 /obj/item/stool/padded,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleeping/Dormitory_04)
@@ -66539,7 +65948,6 @@
 "vdm" = (
 /obj/machinery/firealarm{
 	pixel_y = -25;
-	name = "S-fire alarm";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -66671,7 +66079,6 @@
 "vfQ" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -66690,8 +66097,7 @@
 /area/maintenance/Deck3_Engineering_AftStarChamber1)
 "vgq" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/structure/bed/chair/comfy/blue,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -66744,6 +66150,14 @@
 /obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled,
 /area/bridge/Deck3_Corridor)
+"vgQ" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/turf/simulated/floor/tiled,
+/area/hallway/For_3_Deck_Stairwell)
 "vgZ" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/border_only,
@@ -66843,8 +66257,7 @@
 /area/engineering/Atmospherics_Chamber)
 "vik" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/dark,
@@ -66974,7 +66387,6 @@
 "vkH" = (
 /obj/structure/table/sifwoodentable,
 /obj/machinery/newscaster{
-	name = "1S-newscaster";
 	pixel_y = -30
 	},
 /turf/simulated/floor/wood/sif,
@@ -67116,8 +66528,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 4
@@ -67173,10 +66584,10 @@
 	c_tag = "D3-Brd-For Stairwell3";
 	network = list("Bridge")
 	},
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue/border{
+/obj/effect/floor_decal/corner/blue/bordercorner{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -67266,7 +66677,6 @@
 	pixel_x = 5
 	},
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/machinery/disposal/wall{
@@ -67464,9 +66874,6 @@
 /area/maintenance/Deck3_Dorms_StarChamber1)
 "vsu" = (
 /obj/structure/table/woodentable,
-/obj/item/storage/box/nifsofts_medical{
-	pixel_y = 8
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -67538,8 +66945,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -67777,13 +67183,11 @@
 	starts_with = null
 	},
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_y = 32;
-	name = "N-status display"
+	pixel_y = 32
 	},
 /obj/effect/floor_decal/borderfloorblack/full,
 /turf/simulated/floor/tiled/dark,
@@ -68137,9 +67541,7 @@
 /area/maintenance/Deck3_Bridge_AftStarCorridor1)
 "vDk" = (
 /obj/structure/table/marble,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleeping/Dormitory_06)
 "vDn" = (
@@ -68210,8 +67612,7 @@
 "vDX" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -68368,7 +67769,6 @@
 "vFo" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /turf/simulated/floor/wood/sif,
@@ -68498,8 +67898,7 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 12;
-	pixel_y = 27;
-	name = "N-light switch"
+	pixel_y = 27
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -68552,7 +67951,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/wood/sif,
@@ -68610,8 +68008,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -68626,21 +68023,20 @@
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance/int{
-	name = "Kitchen Maintenance";
-	req_one_access = list(28)
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance/engi{
+	name = "Central Substation";
+	req_one_access = list(10,28)
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/Central_Engineering_Post)
 "vJv" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -68740,7 +68136,6 @@
 /area/engineering/Engine2_Chamber)
 "vLx" = (
 /obj/item/radio/intercom{
-	name = "1S-Station Intercom (General)";
 	pixel_y = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -68758,7 +68153,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -69081,8 +68475,7 @@
 "vRg" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -69377,9 +68770,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck3_Center_Port)
 "vVx" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/glass,
 /area/medical/Lounge)
 "vVU" = (
@@ -69431,8 +68822,7 @@
 "vWX" = (
 /obj/machinery/vending/loadout/overwear,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Dorm_Foyer)
@@ -69457,7 +68847,6 @@
 /obj/structure/table/woodentable,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/wood/alt,
@@ -69631,9 +69020,7 @@
 	pixel_y = 5;
 	pixel_x = -4
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
@@ -69697,7 +69084,6 @@
 /area/crew_quarters/Dorm_Foyer)
 "wbm" = (
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -69788,7 +69174,6 @@
 "wcY" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/structure/cable/green{
@@ -69939,7 +69324,6 @@
 "wfg" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -69968,7 +69352,6 @@
 "wfu" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -70028,8 +69411,7 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/firealarm{
-	pixel_y = 25;
-	name = "N-fire alarm"
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/medical/Aft_Medical_Post)
@@ -70201,7 +69583,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/structure/cable/green{
@@ -70213,12 +69594,9 @@
 "wjf" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/effect/floor_decal/spline/fancy{
 	dir = 8
 	},
@@ -70755,7 +70133,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -70788,8 +70165,7 @@
 	dir = 8
 	},
 /obj/machinery/status_display{
-	pixel_x = 32;
-	name = "E-status display"
+	pixel_x = 32
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
@@ -70820,8 +70196,7 @@
 /area/engineering/Engine1_Chamber)
 "wtF" = (
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -70874,8 +70249,7 @@
 	pixel_y = -4
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/sleeping/Dormitory_05)
@@ -71149,7 +70523,6 @@
 "wAH" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -71286,8 +70659,7 @@
 	},
 /obj/structure/table/darkglass,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/item/soulstone,
 /turf/simulated/floor/wood/alt/parquet/turfpack/airless,
@@ -71600,12 +70972,9 @@
 /obj/structure/table/woodentable,
 /obj/machinery/firealarm{
 	dir = 1;
-	name = "S-fire alarm";
 	pixel_y = -25
 	},
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/sleeping/Dormitory_05)
 "wIm" = (
@@ -71682,8 +71051,7 @@
 /area/medical/Patient_4)
 "wJl" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine1_Chamber)
@@ -71768,7 +71136,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/bcarpet,
@@ -71789,7 +71156,6 @@
 /obj/structure/table/sifwoodentable,
 /obj/item/gps/science/rd,
 /obj/machinery/firealarm{
-	name = "N-fire alarm";
 	pixel_y = 25
 	},
 /turf/simulated/floor/wood/sif,
@@ -71848,11 +71214,8 @@
 /area/crew_quarters/Chomp_Lounge)
 "wLU" = (
 /obj/machinery/vending/snack,
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/ai_status_display{
-	name = "1S-AI display";
 	pixel_y = -32
 	},
 /obj/effect/floor_decal/borderfloorblack/full,
@@ -72045,7 +71408,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -72115,7 +71477,6 @@
 "wPe" = (
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -72223,7 +71584,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 4;
-	name = "W-light switch";
 	pixel_x = -27;
 	pixel_y = 12
 	},
@@ -72464,9 +71824,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/Engine2_Canister_Storage)
 "wTj" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -73192,8 +72550,7 @@
 "xei" = (
 /obj/structure/table/steel,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -73258,8 +72615,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/lightorange/bordercorner,
@@ -73552,8 +72908,7 @@
 "xjz" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -25;
-	name = "W-fire alarm"
+	pixel_x = -25
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -73633,8 +72988,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -74404,8 +73758,7 @@
 /area/engineering/Engine2_Chamber)
 "xvY" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleeping/Dormitory_04)
@@ -74464,7 +73817,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -74498,8 +73850,7 @@
 "xxJ" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -74858,7 +74209,6 @@
 /obj/structure/cable/green,
 /obj/machinery/light_switch{
 	dir = 8;
-	name = "E-light switch";
 	pixel_x = 27;
 	pixel_y = -12
 	},
@@ -75078,7 +74428,6 @@
 	},
 /obj/machinery/light_switch{
 	dir = 1;
-	name = "S-light switch";
 	pixel_x = 11;
 	pixel_y = -27
 	},
@@ -75272,8 +74621,7 @@
 	pixel_x = 4
 	},
 /obj/machinery/status_display{
-	pixel_x = -32;
-	name = "W-status display"
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -75401,8 +74749,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleeping/Dormitory_04)
@@ -75447,7 +74794,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/light_switch{
-	name = "N-light switch";
 	pixel_x = 12;
 	pixel_y = 27
 	},
@@ -75465,9 +74811,7 @@
 /turf/simulated/wall,
 /area/crew_quarters/Chomp_Stage)
 "xLV" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleeping/Dormitory_05)
 "xMa" = (
@@ -75549,7 +74893,6 @@
 "xMR" = (
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/structure/cable/green{
@@ -75581,9 +74924,7 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_3)
 "xNr" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet/gaycarpet,
 /area/crew_quarters/sleeping/Dormitory_05)
 "xNt" = (
@@ -75811,8 +75152,7 @@
 "xQK" = (
 /obj/machinery/vending/altevian,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Dorm_Foyer)
@@ -75832,8 +75172,7 @@
 /area/maintenance/Deck3_Dorms_StarChamber1)
 "xQR" = (
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -75856,8 +75195,7 @@
 "xRo" = (
 /obj/machinery/light{
 	dir = 8;
-	layer = 3;
-	name = "1W-light fixture"
+	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/carpet/turcarpet,
@@ -76007,8 +75345,7 @@
 /area/bridge/HoP_Office)
 "xUK" = (
 /obj/machinery/ai_status_display{
-	pixel_y = -32;
-	name = "1S-AI display"
+	pixel_y = -32
 	},
 /obj/structure/bed/chair/backed_grey{
 	color = "grey";
@@ -76114,7 +75451,6 @@
 "xVX" = (
 /obj/machinery/status_display{
 	layer = 4;
-	name = "N-status display";
 	pixel_y = 32
 	},
 /obj/structure/cable/green{
@@ -76152,9 +75488,7 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/medical/Virology)
 "xWh" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -76662,7 +75996,6 @@
 	},
 /obj/item/radio/intercom{
 	dir = 8;
-	name = "1W-Station Intercom (General)";
 	pixel_x = -22
 	},
 /obj/effect/landmark/start/visitor,
@@ -76820,7 +76153,6 @@
 /obj/structure/table/woodentable,
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /obj/item/starcaster_news,
@@ -77016,8 +76348,7 @@
 	name = "JoinLateCyborg"
 	},
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/Cyborg_Station)
@@ -77028,15 +76359,12 @@
 "ykf" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/light{
-	dir = 8;
-	name = "1E-light fixture"
+	dir = 8
 	},
 /turf/simulated/floor/airless,
 /area/engineering/Solar_Control_AftStar)
 "ykl" = (
-/obj/machinery/light{
-	name = "1S-light fixture"
-	},
+/obj/machinery/light,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
@@ -77044,7 +76372,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 11;
 	pixel_y = -27;
-	name = "S-light switch";
 	dir = 1
 	},
 /obj/machinery/button/windowtint{
@@ -77079,8 +76406,7 @@
 "ykJ" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/light{
-	dir = 4;
-	name = "1E-light fixture"
+	dir = 4
 	},
 /obj/random/trash,
 /turf/simulated/floor/airless,
@@ -77154,12 +76480,10 @@
 "ylV" = (
 /obj/item/modular_computer/console/preset/ert,
 /obj/machinery/light{
-	dir = 1;
-	name = "1N-lighting fixture"
+	dir = 1
 	},
 /obj/item/radio/intercom{
 	dir = 1;
-	name = "1N-Station Intercom (General)";
 	pixel_y = 22
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -77173,7 +76497,6 @@
 "ylX" = (
 /obj/item/radio/intercom{
 	dir = 4;
-	name = "1E-Station Intercom (General)";
 	pixel_x = 22
 	},
 /turf/simulated/floor/tiled,
@@ -105354,10 +104677,10 @@ gSX
 xXn
 sdA
 sdA
-sdA
-sdA
+qxT
+etz
 rjS
-sMO
+vgQ
 vni
 sdA
 qIf
@@ -107547,7 +106870,7 @@ lrZ
 mEG
 fCn
 qKL
-etz
+jgM
 mWW
 mrZ
 mEG


### PR DESCRIPTION
-Reduced and move fire axes inside departments.
-Added more doors and fixed accesses inside Security. Elevator is public access. 
-Removed some mech's and reduced starting mech gear. 
-Reduced the amount of resources in tool storages. -Added soap in Janitors room.
-Moved Medical nifsofts to Medical storage.
-Moved engineering nifsofts to Engineering storage. 
-Security checkpoints. Replaced guns with tasers and stun batons. 
-Substations, reduced resources and removed all insulated gloves. Emergency crate should be in a locked crate. Engineering access only. 
-Hydroponics has some extra tools.
-Downgraded gunpod in Security, reduced mech gear. 
-Removed Mapping name guides on items.
-Various fixes with window tints, switches and variables. 
-Various minor decal fixes.
-Fixed first deck sif grass to station grass (I would love a sif grass variant I can use on the station. Want that blue grass!)
