### PR TITLE
Soluna Nexus map fixes 1.4

### DIFF
--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
@@ -1738,12 +1738,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor1)
 "aiM" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/cable/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -1751,11 +1745,6 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/light_switch{
-	pixel_x = 27;
-	pixel_y = -12;
-	dir = 8
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -3481,7 +3470,7 @@
 /obj/machinery/door/airlock/angled_bay/double/glass/research{
 	name = "Research Ship Bay";
 	dir = 8;
-	req_one_access = list(7,47,5);
+	req_one_access = list(5,47,67);
 	req_access = null
 	},
 /obj/structure/cable/white{
@@ -5186,19 +5175,10 @@
 /area/harbor/Dock3)
 "aFG" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/Aft_1_Deck_Stairwell)
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock4)
 "aFI" = (
 /obj/structure/table,
 /turf/simulated/floor/tiled,
@@ -5392,8 +5372,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Central Air Distribution";
-	req_one_access = null
+	name = "Central Air Distribution"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5455,6 +5434,7 @@
 	c_tag = "D1-Eng-Substation Harbor";
 	network = list("engineering")
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Harbor_Substation)
 "aIN" = (
@@ -6712,11 +6692,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -7432,6 +7407,9 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "aVB" = (
@@ -7474,15 +7452,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock3)
 "aVI" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/Distro_Central)
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock1)
 "aVL" = (
 /obj/machinery/atmospherics/pipe/tank/air/full{
 	dir = 4
@@ -8990,26 +8964,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortCorridor1)
 "btZ" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/Aft_1_Deck_Stairwell)
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForStar_Corridor3)
 "buj" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable{
@@ -10126,6 +10083,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock2)
 "bMN" = (
@@ -11088,15 +11046,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay3)
 "cet" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 27;
+	pixel_y = -12;
+	dir = 8
+	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Gateway)
 "ceA" = (
@@ -13654,6 +13618,15 @@
 /obj/effect/floor_decal/corner/white/border,
 /turf/simulated/floor/tiled/dark,
 /area/security/Quantum_Pad_Checkpoint)
+"cZl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock2)
 "cZm" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
 	starts_with = null
@@ -14348,7 +14321,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/PA_Chamber)
 "djA" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
@@ -15911,6 +15883,10 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortCorridor1)
+"dKf" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Security_PortCorridor1)
 "dKt" = (
 /obj/random/trash,
 /turf/simulated/floor/wood/alt/panel{
@@ -16324,6 +16300,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor2)
 "dSc" = (
@@ -18634,7 +18611,7 @@
 /obj/machinery/door/airlock/angled_bay/double/glass/research{
 	name = "Particle Accelerator Atrium";
 	dir = 8;
-	req_one_access = list(7,47,5);
+	req_one_access = list(5,47,67);
 	req_access = null
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -19072,6 +19049,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	color = "#989898"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock2)
@@ -20326,6 +20306,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortCorridor1)
+"eNR" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Security_StarCorridor1)
 "eOj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -20804,11 +20788,6 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -20876,8 +20855,8 @@
 /obj/machinery/door/airlock/angled_bay/double/glass/atmos{
 	dir = 8;
 	name = "Cargo Bay";
-	req_access = list(50);
-	req_one_access = list(48)
+	req_access = null;
+	req_one_access = list(48,10,67)
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -21551,7 +21530,7 @@
 "fjy" = (
 /obj/machinery/door/window/survival_pod{
 	dir = 2;
-	req_one_access = list(48)
+	req_one_access = list(48,10,67)
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
@@ -21948,8 +21927,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Harbor Air Distribution";
-	req_one_access = null
+	name = "Harbor Air Distribution"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Distro_Harbor)
@@ -22289,8 +22267,10 @@
 /obj/machinery/button/remote/airlock{
 	id = "needle_hatch";
 	name = "Side Hatch Control";
-	pixel_y = -26;
-	specialfunctions = 4
+	pixel_y = -24;
+	specialfunctions = 4;
+	req_one_access = list(1,19,67);
+	dir = 1
 	},
 /obj/structure/cable/blue{
 	d1 = 4;
@@ -24258,7 +24238,7 @@
 	},
 /obj/machinery/door/airlock/angled_bay/standard/color/security{
 	req_access = null;
-	req_one_access = list(19,1)
+	req_one_access = list(1,19,67)
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Stairwell_For)
@@ -26132,17 +26112,17 @@
 	pixel_y = 22
 	},
 /obj/structure/bed/pillowpile/orange,
-/obj/item/card/id/security/detective,
+/obj/item/card/id/assistant,
+/obj/item/storage/vore_egg/chicken{
+	pixel_y = -4;
+	pixel_x = -11
+	},
 /obj/item/storage/vore_egg/chicken{
 	pixel_x = 6
 	},
 /obj/item/storage/vore_egg/red{
 	pixel_y = 5;
 	pixel_x = -3
-	},
-/obj/item/storage/vore_egg/chicken{
-	pixel_y = -4;
-	pixel_x = -11
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/maintenance/Deck1_ForPort_Chamber1)
@@ -26429,6 +26409,15 @@
 /obj/structure/shuttle/window,
 /turf/simulated/shuttle/plating,
 /area/shuttle/escape_pod8/station)
+"gUZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock4)
 "gVz" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -27212,13 +27201,11 @@
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/spacebus)
 "hkH" = (
-/obj/structure/ladder/up,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/small/warning/emerg_only{
 	desc = "Ladder for emergency use only";
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/plating,
 /area/maintenance/Distro_Harbor)
 "hkK" = (
 /obj/machinery/camera/network/security{
@@ -28248,8 +28235,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Harbor Air Distribution";
-	req_one_access = null
+	name = "Harbor Air Distribution"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Distro_Harbor)
@@ -28852,6 +28838,9 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "hPY" = (
@@ -29039,6 +29028,9 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	color = "#989898"
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock4)
@@ -30193,7 +30185,7 @@
 /obj/machinery/door/airlock/angled_bay/double/color{
 	door_color = "#8c1d11";
 	name = "Exploration Ship Bay";
-	req_one_access = list(19,1)
+	req_one_access = list(1,19,67)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -30541,6 +30533,27 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/engineering/Telecomms_Foyer)
+"iwf" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 3
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Aft_1_Deck_Stairwell)
 "iwk" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -30685,7 +30698,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/security/Quantum_Pad_Checkpoint)
 "izz" = (
 /obj/structure/cable/green{
@@ -32059,6 +32072,9 @@
 	color = "#00B8B2"
 	},
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/For_Transit_Foyer)
 "jge" = (
@@ -32544,7 +32560,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/security/Quantum_Pad_Checkpoint)
 "joM" = (
 /obj/structure/closet/emcloset,
@@ -32936,15 +32952,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor2)
 "jvg" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/maintenance/Distro_Central)
+/turf/simulated/floor/tiled/dark,
+/area/security/Quantum_Pad_Checkpoint)
 "jvm" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
@@ -35960,6 +35972,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor3)
 "kDc" = (
@@ -36513,6 +36526,10 @@
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/tiled,
 /area/maintenance/Deck1_Cargo_Chamber1)
+"kND" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Security_StarCorridor3)
 "kNJ" = (
 /obj/random/trash_pile,
 /turf/simulated/floor/plating,
@@ -36825,7 +36842,7 @@
 /obj/structure/urinal{
 	pixel_y = 28
 	},
-/obj/item/card/id/security,
+/obj/item/card/id/event/accessset/itg/crew/service,
 /obj/item/digestion_remains/ribcage,
 /obj/item/digestion_remains{
 	pixel_y = -8;
@@ -36989,7 +37006,7 @@
 /area/maintenance/Distro_Central)
 "kWK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/security/Quantum_Pad_Checkpoint)
 "kWW" = (
 /obj/structure/table/rack{
@@ -37597,6 +37614,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -38321,6 +38341,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock2)
+"ltR" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftPort_Corridor3)
 "lue" = (
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
@@ -39134,8 +39158,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Central Air Distribution";
-	req_one_access = null
+	name = "Central Air Distribution"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Distro_Central)
@@ -41425,6 +41448,10 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	color = "#989898"
 	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 3
+	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock3)
 "mvG" = (
@@ -41971,7 +41998,7 @@
 /area/hallway/Cryostorage_Lounge)
 "mDO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/security/Quantum_Pad_Checkpoint)
 "mDP" = (
 /obj/machinery/door/firedoor/border_only,
@@ -42412,8 +42439,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Central Air Distribution";
-	req_one_access = null
+	name = "Central Air Distribution"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Distro_Central)
@@ -44872,8 +44898,10 @@
 /obj/machinery/button/remote/airlock{
 	id = "ursula_hatch";
 	name = "Side Hatch Control";
-	pixel_y = -26;
-	specialfunctions = 4
+	pixel_y = -24;
+	specialfunctions = 4;
+	req_one_access = list(5,47,67);
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/ursula)
@@ -44924,7 +44952,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/security/Quantum_Pad_Checkpoint)
 "nIY" = (
 /obj/machinery/alarm{
@@ -46288,8 +46316,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Central Air Distribution";
-	req_one_access = null
+	name = "Central Air Distribution"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Distro_Central)
@@ -46470,6 +46497,13 @@
 /obj/random/forgotten_tram,
 /turf/simulated/floor/tiled,
 /area/maintenance/ab_GeneralStore)
+"ogJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock4)
 "ogY" = (
 /obj/random/tank,
 /turf/simulated/floor/plating,
@@ -47874,6 +47908,9 @@
 "oFa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
@@ -49381,8 +49418,8 @@
 	id = "echidna_hatch";
 	name = "Rear Hatch Control";
 	pixel_x = 26;
-	req_access = list(67);
-	specialfunctions = 4
+	specialfunctions = 4;
+	req_one_access = list(48,10,67)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
@@ -50776,6 +50813,15 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_5)
+"pzY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock1)
 "pAh" = (
 /obj/structure/bed/chair/backed_red{
 	dir = 1
@@ -54684,7 +54730,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock2)
 "qRs" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Star_Corridor)
 "qRx" = (
@@ -57835,8 +57881,8 @@
 /obj/effect/floor_decal/industrial/arrows/blue,
 /obj/machinery/door/airlock/angled_bay/standard/color/cargo{
 	name = "Mining Ship Bay";
-	req_one_access = list(48);
-	req_access = list(50)
+	req_one_access = list(48,10,67);
+	req_access = null
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/Mining_Ship_Bay)
@@ -60055,6 +60101,15 @@
 	name = "Nitrogen plating"
 	},
 /area/maintenance/ab_Kitchen)
+"sHW" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock2)
 "sIc" = (
 /obj/machinery/camera/network/security{
 	dir = 5;
@@ -62242,7 +62297,7 @@
 	},
 /obj/machinery/door/airlock/angled_bay/standard/color/security{
 	req_access = null;
-	req_one_access = list(19,1)
+	req_one_access = list(1,19,67)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -62698,7 +62753,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/harbor/Dock2)
 "tEX" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Port_Corridor)
 "tEY" = (
@@ -63009,6 +63064,12 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/Xenobiology_Lab)
+"tMx" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/Quantum_Pad_Checkpoint)
 "tMD" = (
 /obj/structure/bed/pillowpilefront/white,
 /obj/item/storage/vore_egg/shark{
@@ -63487,11 +63548,6 @@
 /obj/machinery/atm{
 	pixel_x = 29;
 	name = "1E-Automatic Teller Machine"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -64065,6 +64121,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/Mining_Ship_Bay)
+"ufQ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftStar1_Corridor2)
 "ugg" = (
 /obj/machinery/camera/network/security{
 	dir = 10;
@@ -64411,6 +64471,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor2)
+"umx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Aft_1_Deck_Stairwell)
 "umz" = (
 /obj/structure/bed/chair/backed_red,
 /obj/structure/window/basic{
@@ -64681,6 +64756,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobotany_Lab)
+"urE" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftPort_Corridor1)
 "urG" = (
 /obj/effect/floor_decal/industrial/danger/corner{
 	dir = 1
@@ -65452,7 +65531,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Harbor_Substation)
 "uHz" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -68133,6 +68211,13 @@
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Star_Corridor)
+"vAj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock1)
 "vAs" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -68169,13 +68254,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Depot1)
 "vAV" = (
-/obj/structure/ladder/up,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/small/warning/emerg_only{
 	desc = "Ladder for emergency use only";
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/plating,
 /area/maintenance/Distro_Central)
 "vAY" = (
 /obj/structure/loot_pile/surface/medicine_cabinet/fresh{
@@ -69940,7 +70023,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/dark,
 /area/security/Quantum_Pad_Checkpoint)
 "weO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -70019,6 +70102,9 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	color = "#989898"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock1)
@@ -71793,6 +71879,10 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 3
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "wQu" = (
@@ -73316,8 +73406,8 @@
 /obj/effect/floor_decal/industrial/arrows/blue,
 /obj/machinery/door/airlock/angled_bay/standard/color/cargo{
 	name = "Mining Ship Bay";
-	req_one_access = list(48);
-	req_access = list(50)
+	req_one_access = list(48,10,67);
+	req_access = null
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -75363,6 +75453,9 @@
 "ydF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
@@ -88620,7 +88713,7 @@ iFw
 cmI
 aaf
 aBe
-cNg
+aVI
 kgv
 cNg
 aBe
@@ -88628,7 +88721,7 @@ aaa
 aaa
 aaa
 aBe
-cNg
+aVI
 aBe
 aaa
 aaa
@@ -88638,7 +88731,7 @@ aaf
 aaa
 aaa
 aBe
-cNg
+aVI
 aBe
 aaa
 aaa
@@ -88648,7 +88741,7 @@ aaa
 aaa
 aaa
 aBe
-cNg
+aVI
 aBe
 aaa
 aaa
@@ -90699,13 +90792,13 @@ aaa
 aaa
 aBe
 suH
-kgv
+vAj
 aBe
 aaa
 aaa
 aaa
 aBe
-kgv
+pzY
 uIA
 aBe
 aaa
@@ -94833,7 +94926,7 @@ aaa
 aaa
 aaa
 act
-bMw
+cZl
 bCH
 act
 aaa
@@ -95848,7 +95941,7 @@ xlE
 xlE
 lYo
 act
-ngZ
+sHW
 aBK
 dXq
 aBK
@@ -101202,7 +101295,7 @@ oXp
 cqF
 nDP
 bPD
-auk
+urE
 fNq
 auk
 cnG
@@ -103043,7 +103136,7 @@ uWP
 lvn
 nhN
 obP
-uTo
+ltR
 aiz
 uxS
 xjv
@@ -103207,7 +103300,7 @@ bci
 bci
 crv
 cFn
-bci
+dKf
 niG
 vZT
 oqO
@@ -103465,7 +103558,7 @@ nNJ
 bci
 crv
 cFn
-bci
+dKf
 niG
 nxs
 muN
@@ -103739,7 +103832,7 @@ qgI
 rzO
 izm
 mDO
-lZC
+jvg
 sfG
 qCT
 lCm
@@ -103996,7 +104089,7 @@ fMw
 fHV
 mwb
 nIQ
-xVH
+sfG
 qsy
 eZh
 lok
@@ -104252,10 +104345,10 @@ kZC
 jsm
 jsm
 hPg
-xVH
+sfG
 joI
 kWK
-nQJ
+tMx
 ubt
 dtT
 cBZ
@@ -104604,9 +104697,9 @@ qIw
 qOe
 mfA
 qwt
+umx
 ujl
 ujl
-aFG
 ujl
 jKE
 aVA
@@ -105340,7 +105433,7 @@ aoJ
 tLu
 uOt
 qMo
-aVI
+tTG
 vAV
 ruo
 gne
@@ -105598,7 +105691,7 @@ aoJ
 vUD
 jwa
 mxE
-jvg
+jII
 lhI
 ocN
 jII
@@ -106668,9 +106761,9 @@ dvt
 xHz
 ycy
 pUx
+iwf
 cRb
 cRb
-btZ
 cRb
 wQG
 wQk
@@ -107864,7 +107957,7 @@ aww
 sFF
 kfW
 inQ
-aHH
+kND
 amM
 aHH
 iMj
@@ -109748,7 +109841,7 @@ kBL
 oVU
 xaJ
 kBU
-oVU
+ufQ
 oVU
 vUq
 ahZ
@@ -109906,7 +109999,7 @@ aiL
 hfA
 aiL
 aiL
-aiL
+eNR
 obx
 hAh
 lZO
@@ -110006,7 +110099,7 @@ kBL
 orY
 xaJ
 kBU
-oVU
+ufQ
 oVU
 oVU
 ahZ
@@ -120627,13 +120720,13 @@ aaa
 aaa
 oAw
 eVQ
-cMm
+ogJ
 oAw
 aaa
 aaa
 aaa
 oAw
-cMm
+gUZ
 eVQ
 oAw
 aaa
@@ -120795,7 +120888,7 @@ dXL
 dYA
 eaE
 cPO
-wBA
+btZ
 ijM
 bcr
 jww
@@ -122676,7 +122769,7 @@ iFw
 htS
 aaf
 oAw
-eVQ
+aFG
 cMm
 eVQ
 oAw
@@ -122684,7 +122777,7 @@ aaa
 aaa
 aaa
 oAw
-eVQ
+aFG
 oAw
 aaa
 aaa
@@ -122694,7 +122787,7 @@ aaf
 aaa
 aaa
 oAw
-eVQ
+aFG
 oAw
 aaa
 aaa
@@ -122704,7 +122797,7 @@ aaa
 aaa
 aaa
 oAw
-eVQ
+aFG
 oAw
 aaa
 aaa

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
@@ -276,7 +276,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/security/Evidence_Storage)
 "aay" = (
 /obj/structure/cable/white{
@@ -284,7 +284,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/security/Evidence_Storage)
 "aaA" = (
 /obj/item/ammo_magazine/m9mm/compact/flash{
@@ -614,12 +614,13 @@
 	dir = 1;
 	pixel_y = 5
 	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
-	},
 /obj/structure/window/titanium,
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/light/spot{
+	dir = 8;
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
+	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/hallway/Port_Transit_Foyer)
 "abb" = (
@@ -2238,7 +2239,7 @@
 "aeK" = (
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/white,
-/obj/mecha/combat/fighter/pinnace/loaded{
+/obj/mecha/combat/fighter/pinnace{
 	dir = 8
 	},
 /turf/space,
@@ -4240,13 +4241,13 @@
 /turf/simulated/floor/plating/turfpack/airless,
 /area/space)
 "ajw" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/item/storage/smolebrickcase{
 	pixel_y = 5;
 	pixel_x = 4
+	},
+/obj/structure/window/basic{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/brown/turfpack/station,
 /area/security/Prison_Wing)
@@ -4419,7 +4420,7 @@
 "ajY" = (
 /obj/machinery/turretid/lethal{
 	pixel_x = -29;
-	req_access = list(29);
+	req_access = list(3);
 	control_area = "\improper Armory"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -6020,6 +6021,7 @@
 /area/hallway/Aft_2_Deck_Central_Corridor_1)
 "aqh" = (
 /obj/machinery/light/small,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_ForPortCorridor1)
 "aqi" = (
@@ -8037,15 +8039,17 @@
 /area/hallway/Star_2_Deck_Central_Corridor_2)
 "axv" = (
 /obj/structure/bed/chair/sofa/left/blue,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1;
 	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 4;
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/hallway/Star_Transit_Foyer)
@@ -8252,7 +8256,7 @@
 /turf/simulated/floor/carpet/blue2,
 /area/security/Internal_Affairs_Office)
 "ayk" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/security/HoS_Office)
 "ayl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11176,7 +11180,9 @@
 /area/hallway/For_2_Deck_Stairwell)
 "aHJ" = (
 /obj/machinery/mech_recharger,
-/obj/mecha/working/hoverpod/shuttlepod,
+/obj/mecha/working/hoverpod/shuttlepod{
+	req_one_access = list(47)
+	},
 /obj/effect/floor_decal/milspec/box,
 /obj/machinery/status_display{
 	layer = 4;
@@ -11723,7 +11729,8 @@
 /area/security/Evidence_Storage)
 "aJP" = (
 /obj/machinery/door/window/northleft{
-	layer = 2.9
+	layer = 2.9;
+	req_one_access = list(48)
 	},
 /obj/structure/table/steel,
 /obj/machinery/door/firedoor/glass/hidden/steel{
@@ -11752,13 +11759,13 @@
 /obj/machinery/vending/fitness{
 	dir = 1
 	},
-/obj/structure/window/reinforced/tinted/frosted,
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 4
 	},
+/obj/structure/window/basic,
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Gym)
 "aJY" = (
@@ -12953,7 +12960,7 @@
 /obj/machinery/mech_recharger{
 	icon = 'icons/turf/shuttle_alien_blue.dmi'
 	},
-/obj/mecha/combat/fighter/baron/loaded{
+/obj/mecha/combat/fighter/baron{
 	dir = 1
 	},
 /turf/space,
@@ -16131,9 +16138,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/RD_Office)
 "aXp" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
@@ -17112,11 +17116,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	name = "Kitchen Shutters";
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
-	layer = 3.3
+	layer = 3.3;
+	name = "Dinner Shutters";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Chomp_Kitchen)
@@ -18687,7 +18691,7 @@
 /area/quartermaster/QM_Office)
 "bfS" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/autolathe,
+/obj/machinery/lapvend,
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/Aft_Tool_Storage)
 "bfV" = (
@@ -19092,6 +19096,9 @@
 /obj/structure/table/reinforced,
 /obj/machinery/status_display{
 	pixel_y = -32
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -26
 	},
 /turf/simulated/floor/carpet,
 /area/bridge/HoP_Office)
@@ -20460,6 +20467,14 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/Deck2_Security_AftStarCorridor2)
+"blj" = (
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/security/Evidence_Storage)
 "blk" = (
 /turf/simulated/wall/r_wall,
 /area/quartermaster/Warehouse)
@@ -20695,12 +20710,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/machinery/button/windowtint/multitint{
-	pixel_y = -26;
-	pixel_x = -12;
-	id = "sc-WTkitchen";
-	range = 12
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Chomp_Kitchen)
@@ -23244,12 +23253,9 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/ForPort_2_Deck_Observatory)
 "bvr" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 22
-	},
-/turf/simulated/floor/boxing/gym,
-/area/crew_quarters/Gym)
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_ForStar_Corridor)
 "bvu" = (
 /turf/simulated/wall/r_wall,
 /area/quartermaster/Waste_Disposals)
@@ -24902,7 +24908,7 @@
 	layer = 10.1;
 	dir = 8
 	},
-/obj/mecha/combat/fighter/allure/loaded{
+/obj/mecha/combat/fighter/allure{
 	dir = 1
 	},
 /turf/space,
@@ -25519,10 +25525,10 @@
 /turf/simulated/floor/plating,
 /area/hallway/Port_2_Deck_Corridor_1)
 "bCV" = (
-/obj/structure/window/reinforced/tinted/frosted{
+/obj/structure/table/reinforced,
+/obj/structure/window/basic{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
 /turf/simulated/floor/carpet/bcarpet/turfpack/station,
 /area/security/Prison_Wing)
 "bDc" = (
@@ -26981,11 +26987,10 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/storage/box/lights/mixed,
 /obj/item/flashlight,
-/obj/item/storage/belt/utility/full/multitool,
 /obj/item/cell/high,
-/obj/item/multitool,
 /obj/item/cell/high,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/item/storage/belt/utility,
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/For_Tool_Storage)
 "bJo" = (
@@ -29598,9 +29603,7 @@
 /turf/simulated/wall,
 /area/maintenance/Deck2_Civilian_ForPortCorridor2)
 "bTi" = (
-/obj/structure/ladder/updown{
-	pixel_y = 3
-	},
+/obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/small/warning/emerg_only{
 	desc = "Ladder for emergency use only";
@@ -30031,7 +30034,9 @@
 "bUN" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/milspec/box,
-/obj/mecha/combat/gygax/old,
+/obj/mecha/combat/gygax/old{
+	req_access = list(1)
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/Armory)
 "bUP" = (
@@ -30808,16 +30813,17 @@
 /area/rnd/Toxins_Mixing_Room)
 "bXb" = (
 /obj/structure/bed/chair/sofa/right/blue,
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
-	},
 /obj/structure/window/titanium{
 	dir = 1;
 	layer = 3
 	},
 /obj/effect/floor_decal/spline/fancy{
 	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 8;
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/hallway/Star_Transit_Foyer)
@@ -31877,8 +31883,14 @@
 /turf/simulated/floor/boxing/gym,
 /area/security/Prison_Wing)
 "cbj" = (
-/obj/machinery/autolathe,
+/obj/structure/closet/toolcloset,
+/obj/item/storage/box/lights/mixed,
+/obj/item/storage/box/lights/mixed,
+/obj/item/flashlight,
+/obj/item/cell/high,
+/obj/item/cell/high,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/item/storage/belt/utility,
 /obj/machinery/firealarm{
 	pixel_y = 25
 	},
@@ -39945,7 +39957,8 @@
 /area/hallway/ForStar_2_Deck_Observatory)
 "cCe" = (
 /obj/machinery/door/window/southright{
-	layer = 2.9
+	layer = 2.9;
+	req_one_access = list(48)
 	},
 /obj/structure/table/steel,
 /obj/machinery/door/firedoor/glass/hidden/steel{
@@ -40063,10 +40076,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_StarCorridor1)
 "cCC" = (
-/obj/structure/window/reinforced/tinted/frosted{
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/structure/window/basic{
 	dir = 1
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -43165,6 +43178,10 @@
 	name = "Timmothy"
 	},
 /obj/structure/table/bench/marble,
+/obj/machinery/light/spot{
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
+	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/security/Lobby)
 "ddS" = (
@@ -43229,6 +43246,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Prison_Wing)
+"deZ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Medical_AftPortChamber1)
 "dfc" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
@@ -44366,7 +44387,7 @@
 	name = "Brig Lockdown";
 	pixel_x = 26;
 	pixel_y = 38;
-	req_access = list(2)
+	req_access = list(3)
 	},
 /obj/machinery/button/remote/blast_door{
 	dir = 8;
@@ -44374,7 +44395,7 @@
 	name = "Privacy Shutters";
 	pixel_x = 26;
 	pixel_y = 27;
-	req_access = list(2)
+	req_access = list(3)
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -46205,8 +46226,8 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	pixel_y = 25
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_2)
@@ -46403,10 +46424,10 @@
 /obj/item/bedsheet/orangedouble{
 	pixel_y = 1
 	},
-/obj/structure/window/reinforced/tinted/frosted{
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/window/basic{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/bcarpet/turfpack/station,
 /area/security/Prison_Wing)
 "dTp" = (
@@ -48794,7 +48815,7 @@
 /obj/machinery/alarm{
 	pixel_y = 25
 	},
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Engineering_ForStarChamber2)
 "ezZ" = (
@@ -50187,6 +50208,9 @@
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 25
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_2)
@@ -51802,11 +51826,11 @@
 "fjU" = (
 /obj/structure/table/marble,
 /obj/item/toy/chewtoy,
-/obj/machinery/door/blast/shutters{
-	dir = 8;
-	name = "Kitchen Shutters";
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
-	layer = 3.3
+	layer = 3.3;
+	name = "Dinner Shutters";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Chomp_Dinner_1)
@@ -52665,6 +52689,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/Treatment_Hall)
+"fuO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/techmaint,
+/obj/random/junk,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_For_Corridor)
 "fuR" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -57643,6 +57683,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/Deck2_1_Corridor)
 "gCr" = (
@@ -57731,13 +57774,13 @@
 /turf/simulated/floor/tiled,
 /area/security/Firing_Range)
 "gCT" = (
-/obj/machinery/lapvend,
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
 	},
+/obj/machinery/vending/cola/soft,
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/Aft_2_Deck_Corridor_2)
 "gDc" = (
@@ -58894,11 +58937,11 @@
 /obj/machinery/cash_register/civilian{
 	dir = 4
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 8;
-	name = "Kitchen Shutters";
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
-	layer = 3.3
+	layer = 3.3;
+	name = "Dinner Shutters";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Chomp_Dinner_1)
@@ -59905,10 +59948,10 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/window/reinforced/tinted/frosted{
+/obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
-/obj/effect/floor_decal/spline/fancy/wood{
+/obj/structure/window/basic{
 	dir = 1
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -64738,7 +64781,9 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/mecha/medical/odysseus/old,
+/obj/mecha/medical/odysseus/old{
+	req_one_access = list(5)
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/medical/EMT_Bay)
 "isH" = (
@@ -66877,15 +66922,15 @@
 /area/medical/Patient_Ward)
 "iTv" = (
 /obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 8;
-	name = "Kitchen Shutters";
-	id = "sc-GCkitchen";
-	layer = 3.3
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/door/blast/gate/thin{
+	id = "sc-GCkitchen";
+	layer = 3.3;
+	name = "Dinner Shutters";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Chomp_Dinner_1)
@@ -68736,6 +68781,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Armory)
+"jrH" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_StarCorridor1)
 "jrP" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -69085,6 +69134,18 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/brown,
 /area/engineering/Breakroom)
+"jxV" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_For_Corridor)
 "jxY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloor/corner{
@@ -71288,6 +71349,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/Armory)
+"kdP" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_AftPort_Corridor)
 "kec" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -71715,9 +71780,6 @@
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Midnight_Bar)
 "kip" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
@@ -71725,6 +71787,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1
+	},
+/obj/structure/window/basic{
 	dir = 1
 	},
 /turf/simulated/floor/wood/alt/parquet,
@@ -72360,8 +72425,17 @@
 "kqM" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "sc-WTkitchen"
+/obj/structure/grille,
+/obj/structure/window/basic/full,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -72403,6 +72477,7 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Emergency_EVA)
 "kru" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Medical_AftPortCorridor1)
 "krL" = (
@@ -77895,7 +77970,7 @@
 /obj/machinery/vending/cola/soft{
 	dir = 1
 	},
-/obj/structure/window/reinforced/tinted/frosted,
+/obj/structure/window/basic,
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Gym)
 "lSj" = (
@@ -78547,8 +78622,17 @@
 "lYw" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "sc-WTkitchen"
+/obj/structure/grille,
+/obj/structure/window/basic/full,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79798,7 +79882,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Chomp_Kitchen)
 "msQ" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftStarCorridor2)
 "msX" = (
@@ -80698,6 +80782,7 @@
 /obj/machinery/alarm{
 	pixel_y = 25
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_ForStarCorridor1)
 "mGI" = (
@@ -83609,7 +83694,7 @@
 /turf/simulated/wall,
 /area/security/Forensics_Office)
 "nxC" = (
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/bridge/HoP_Office)
 "nxR" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -88292,11 +88377,13 @@
 	dir = 1;
 	pixel_y = 5
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/window/titanium,
 /obj/effect/floor_decal/spline/fancy,
+/obj/machinery/light/spot{
+	dir = 4;
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
+	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/hallway/Star_Transit_Foyer)
 "oOS" = (
@@ -88475,11 +88562,12 @@
 	dir = 1;
 	pixel_y = 5
 	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
-	},
 /obj/structure/window/titanium,
+/obj/machinery/light/spot{
+	dir = 8;
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
+	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/hallway/Star_Transit_Foyer)
 "oSe" = (
@@ -88787,6 +88875,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Civilian)
 "oWn" = (
@@ -89335,12 +89424,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/RD_Office)
 "pcH" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 4
-	},
 /obj/item/lego,
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/brown/turfpack/station,
 /area/security/Prison_Wing)
@@ -92203,15 +92292,16 @@
 /area/crew_quarters/Gym)
 "pPd" = (
 /obj/structure/bed/chair/sofa/right/blue,
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 8;
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
 	},
 /turf/simulated/floor/carpet/brown,
 /area/hallway/Port_Transit_Foyer)
@@ -92549,11 +92639,11 @@
 /obj/machinery/cash_register/civilian{
 	dir = 8
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	name = "Kitchen Shutters";
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
-	layer = 3.3
+	layer = 3.3;
+	name = "Dinner Shutters";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Chomp_Kitchen)
@@ -93289,6 +93379,10 @@
 /obj/structure/fitness/punchingbag,
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = 22
 	},
 /turf/simulated/floor/boxing/gym,
 /area/crew_quarters/Gym)
@@ -94590,11 +94684,11 @@
 	nutriment_desc = list("sweet    bread" = 3, "tamarind" = 2, "gummy" = 1);
 	pixel_y = 10
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	name = "Kitchen Shutters";
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
-	layer = 3.3
+	layer = 3.3;
+	name = "Dinner Shutters";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Chomp_Kitchen)
@@ -99131,11 +99225,11 @@
 /area/hallway/Star_2_Deck_Corridor_1)
 "rBr" = (
 /obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 8;
-	name = "Kitchen Shutters";
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
-	layer = 3.3
+	layer = 3.3;
+	name = "Dinner Shutters";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Chomp_Dinner_1)
@@ -99266,7 +99360,9 @@
 "rCN" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/milspec/box,
-/obj/mecha/working/ripley/mining/old,
+/obj/mecha/working/ripley/mining/old{
+	req_one_access = list(11,24)
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/Mech_Bay)
 "rCR" = (
@@ -99949,11 +100045,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Star_Transit_Foyer)
 "rKQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/glass,
-/area/security/Lobby)
+/turf/simulated/wall/r_wall,
+/area/security/Internal_Affairs_Office)
 "rKU" = (
 /obj/structure/sign/directions/eva,
 /obj/structure/sign/directions/engineering/gravgen{
@@ -101481,7 +101574,7 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/security/Lobby)
 "sgY" = (
-/obj/structure/window/reinforced/tinted/frosted{
+/obj/structure/window/basic{
 	dir = 4
 	},
 /turf/simulated/floor/carpet/bcarpet/turfpack/station,
@@ -105529,15 +105622,8 @@
 /turf/simulated/floor/lino,
 /area/crew_quarters/Chapel_Office)
 "tiT" = (
-/obj/structure/closet/toolcloset,
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/box/lights/mixed,
-/obj/item/flashlight,
-/obj/item/cell/high,
-/obj/item/multitool,
-/obj/item/cell/high,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/item/storage/belt/utility/full,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/Star_Tool_Storage)
 "tjb" = (
@@ -106964,9 +107050,6 @@
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 8
-	},
 /obj/machinery/light,
 /obj/item/tape_roll{
 	pixel_x = -8;
@@ -106979,6 +107062,9 @@
 /obj/item/sticky_pad/random{
 	pixel_y = 9;
 	pixel_x = -6
+	},
+/obj/structure/window/basic{
+	dir = 8
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/Gym)
@@ -107634,14 +107720,16 @@
 /area/hallway/Port_2_Deck_Central_Corridor_2)
 "tPA" = (
 /obj/structure/bed/chair/sofa/left/blue,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
+	},
+/obj/machinery/light/spot{
+	dir = 4;
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
 	},
 /turf/simulated/floor/carpet/brown,
 /area/hallway/Port_Transit_Foyer)
@@ -109556,10 +109644,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck2_Engineering_PortCorridor2)
 "umT" = (
-/obj/structure/window/reinforced/tinted/frosted{
+/obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/window/basic{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/bcarpet/turfpack/station,
 /area/security/Prison_Wing)
 "umX" = (
@@ -110469,6 +110557,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_ForPort_Corridor)
 "uCt" = (
@@ -111446,8 +111535,17 @@
 "uSr" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/effect/wingrille_spawn/reinforced/polarized{
-	id = "sc-WTkitchen"
+/obj/structure/grille,
+/obj/structure/window/basic/full,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/Chomp_Kitchen)
@@ -113220,14 +113318,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Port_Transit_Foyer)
 "vqB" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/white,
-/obj/machinery/mech_recharger{
-	icon = 'icons/turf/shuttle_alien_blue.dmi'
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/mecha/combat/fighter/scoralis/loaded,
-/turf/space,
-/area/harbor/Star_Shuttlebay)
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/green/border,
+/obj/machinery/light/floortube{
+	dir = 1;
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/Gym)
 "vqQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -113509,6 +113610,9 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/ForPort_2_Deck_Observatory)
+"vuK" = (
+/turf/simulated/wall/r_wall,
+/area/security/Evidence_Storage)
 "vuU" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -114471,8 +114575,8 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/Star_Tool_Storage)
 "vID" = (
-/obj/machinery/autolathe,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/autolathe,
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/Star_Tool_Storage)
 "vIQ" = (
@@ -116331,15 +116435,15 @@
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 4
-	},
 /obj/structure/table/standard,
 /obj/machinery/light,
 /obj/item/reagent_containers/food/snacks/foam_banana,
 /obj/item/reagent_containers/food/snacks/foam_shrimp{
 	pixel_y = 5;
 	pixel_x = -5
+	},
+/obj/structure/window/basic{
+	dir = 4
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Gym)
@@ -116687,19 +116791,11 @@
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Rec_Lounge)
 "wna" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
 	dir = 1
 	},
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
 /area/maintenance/Deck2_Aft_Corridor)
 "wnb" = (
 /obj/machinery/light/small,
@@ -116880,6 +116976,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/ab_TeshDen)
+"woF" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/boxing/gym,
+/area/crew_quarters/Gym)
 "woJ" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -116943,7 +117045,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/obj/random/trash,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_AftCorridor1)
 "wpP" = (
@@ -117330,6 +117432,7 @@
 /area/harbor/Star_2_Deck_Airlock_Access)
 "wuA" = (
 /obj/machinery/light/small,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Cargo_AftStarChamber1)
 "wuC" = (
@@ -118287,6 +118390,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_For_Corridor)
 "wHC" = (
@@ -119489,11 +119593,11 @@
 /area/maintenance/Deck2_Science_ForCorridor1)
 "wYI" = (
 /obj/structure/table/marble,
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	name = "Kitchen Shutters";
+/obj/machinery/door/blast/gate/thin{
 	id = "sc-GCkitchen";
-	layer = 3.3
+	layer = 3.3;
+	name = "Dinner Shutters";
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Chomp_Kitchen)
@@ -120013,6 +120117,9 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_2)
 "xft" = (
@@ -120305,13 +120412,13 @@
 	dir = 4;
 	layer = 3
 	},
-/obj/machinery/door/blast/shutters{
-	dir = 8;
-	name = "Kitchen Shutters";
-	id = "sc-GCkitchen";
-	layer = 3.3
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/blast/gate/thin{
+	id = "sc-GCkitchen";
+	layer = 3.3;
+	name = "Dinner Shutters";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Chomp_Dinner_1)
 "xjG" = (
@@ -122252,11 +122359,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_AftPort_Corridor)
 "xMg" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 1
-	},
-/turf/simulated/open,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/plating,
 /area/maintenance/Deck2_Aft_Corridor)
 "xMr" = (
 /turf/simulated/floor/tiled/white,
@@ -122333,11 +122437,13 @@
 	dir = 1;
 	pixel_y = 5
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/window/titanium,
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/machinery/light/spot{
+	dir = 4;
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
+	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/hallway/Port_Transit_Foyer)
 "xOn" = (
@@ -150794,7 +150900,7 @@ byz
 bum
 aAT
 oZk
-aYe
+kdP
 bQz
 ctj
 ctj
@@ -152410,7 +152516,7 @@ tQg
 ejC
 tQg
 wpH
-gDg
+sqb
 xtd
 vGB
 bKO
@@ -153333,7 +153439,7 @@ kzJ
 oCX
 wBy
 kzJ
-oCX
+fuO
 kzJ
 oCX
 kzJ
@@ -153591,7 +153697,7 @@ bkY
 emF
 bAm
 aoA
-aoA
+jxV
 emF
 bsn
 cmj
@@ -154089,7 +154195,7 @@ aJm
 tHl
 ddO
 ccH
-rKQ
+aJm
 aJm
 qPi
 cCb
@@ -155227,7 +155333,7 @@ kXk
 cin
 lwJ
 aWM
-rfR
+jrH
 eGw
 iKC
 cEi
@@ -157433,10 +157539,10 @@ sSp
 aax
 bxg
 afR
-ahu
-ahu
-ahu
-ahu
+rKQ
+rKQ
+rKQ
+rKQ
 ahu
 aKZ
 aPp
@@ -157985,7 +158091,7 @@ aaa
 kLW
 qrT
 ikY
-iEX
+bvr
 sDy
 arK
 arK
@@ -158841,13 +158947,13 @@ cnD
 aWM
 vaY
 qPt
-tYk
+woF
 tYk
 tYk
 tYk
 mrF
 edf
-gdA
+vqB
 hTF
 reH
 pMu
@@ -159236,7 +159342,7 @@ mfM
 smP
 dYz
 apc
-aZB
+blj
 adP
 agf
 agf
@@ -159494,7 +159600,7 @@ ber
 ohP
 aJO
 xUK
-sSp
+vuK
 rNC
 agi
 ait
@@ -159752,7 +159858,7 @@ sSp
 sSp
 sSp
 sSp
-sSp
+vuK
 ayk
 ayk
 ayk
@@ -159873,7 +159979,7 @@ xGd
 vhw
 mkf
 qPt
-bvr
+iJt
 tYk
 tYk
 tYk
@@ -160131,13 +160237,13 @@ xGd
 vhw
 cnN
 qPt
-iJt
+woF
 tYk
 tYk
 tYk
 mrF
 edf
-gdA
+vqB
 hTF
 reH
 pMu
@@ -164211,7 +164317,7 @@ aRh
 bwl
 yfv
 bBC
-bBC
+deZ
 byg
 sNN
 puB
@@ -168290,7 +168396,7 @@ aaa
 xRY
 slm
 pxs
-vqB
+hmH
 aWJ
 lSj
 bcb

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
@@ -4690,6 +4690,7 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Center_Port)
 "bJP" = (
@@ -5003,6 +5004,9 @@
 /area/engineering/Construction_Area)
 "bNG" = (
 /obj/structure/bed/chair/comfy/orange,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/brown,
 /area/bridge/Deck3_Corridor)
 "bOl" = (
@@ -7856,6 +7860,7 @@
 /area/engineering/Atmospherics_Chamber)
 "cLw" = (
 /obj/machinery/light/small,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_ForStarChamber1)
 "cLD" = (
@@ -10077,6 +10082,14 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	id_tag = "SC-ALCvirology";
+	name = "Virology Access Console";
+	pixel_x = -26;
+	tag_exterior_door = "SC-ALEvirology";
+	tag_interior_door = "SC-ALIvirology";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Virology)
 "dCl" = (
@@ -11595,6 +11608,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Central_Restroom)
+"dYI" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_ForStarChamber1)
 "dYN" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14433,6 +14450,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_AftCorridor2)
 "ePx" = (
@@ -15953,6 +15971,9 @@
 /area/maintenance/Deck3_Engineering_AftStarChamber3)
 "fgf" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/crew_quarters/Dorm_Corridor_3)
 "fgj" = (
@@ -16034,7 +16055,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_StarChamber1)
 "fhI" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_AftCorridor1)
 "fhW" = (
@@ -16711,12 +16732,12 @@
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
 "fqE" = (
-/obj/machinery/portable_atmospherics/canister/empty,
 /obj/structure/window/reinforced{
 	dir = 1;
 	health = 1e+006
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "fqG" = (
@@ -20359,11 +20380,18 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_1)
 "gyc" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/machinery/light/floortube{
+	dir = 4;
+	pixel_x = 2
 	},
 /turf/simulated/floor/tiled,
-/area/bridge/Deck3_Corridor)
+/area/hallway/Aft_3_Deck_Central_Corridor_1)
 "gyq" = (
 /obj/machinery/atmospherics/valve/open,
 /turf/simulated/floor/plating,
@@ -25325,15 +25353,15 @@
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
 "ihn" = (
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /obj/machinery/power/smes/buildable{
 	charge = 5e+006;
 	input_attempt = 1;
 	input_level = 200000;
 	output_level = 200000
-	},
-/obj/structure/cable/white{
-	d2 = 4;
-	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
 /area/bridge/AI_Core_Chamber)
@@ -27261,6 +27289,7 @@
 /area/engineering/Atmospherics_Chamber)
 "iOb" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "iOf" = (
@@ -27753,6 +27782,12 @@
 	},
 /turf/simulated/floor/tiled/kafel_full,
 /area/bridge/sleeping/CE_Quarters)
+"iWj" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood/sif,
+/area/bridge/Breakroom)
 "iWl" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -29727,6 +29762,26 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Substation)
+"jED" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/medical/Lounge)
 "jEN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 10
@@ -30407,6 +30462,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/Stairwell)
 "jPb" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForPort_Corridor1)
 "jPi" = (
@@ -32392,6 +32448,9 @@
 /area/crew_quarters/Public_Hydroponics)
 "kxT" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/crew_quarters/Dorm_Corridor_4)
 "kyq" = (
@@ -33430,20 +33489,9 @@
 /turf/simulated/floor/reinforced/carbon_dioxide,
 /area/engineering/Atmospherics_Chamber)
 "kQo" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
-/area/bridge/Deck3_Corridor)
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_ForChamber1)
 "kQp" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -34492,9 +34540,9 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "lhX" = (
-/obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "lib" = (
@@ -40392,10 +40440,6 @@
 /obj/effect/floor_decal/corner/brown/diagonal{
 	dir = 4
 	},
-/obj/structure/fireaxecabinet{
-	name = "1N-fire axe cabinet";
-	pixel_y = 27
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Dorm_Foyer)
 "mXH" = (
@@ -41825,8 +41869,10 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/powered/scrubber/huge,
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/powered/scrubber/huge{
+	scrub_id = "SC_Atmos"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "nvI" = (
@@ -42262,6 +42308,10 @@
 /obj/effect/floor_decal/corner/beige/bordercorner,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_2)
+"nCt" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_StarCorridor1)
 "nCz" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -42308,15 +42358,15 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleeping/Dormitory_05)
 "nCY" = (
-/obj/machinery/light/floortube{
-	dir = 4;
-	pixel_x = 2
-	},
 /obj/effect/floor_decal/borderfloor{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/white/border{
-	dir = 8
+	dir = 4
+	},
+/obj/machinery/light/floortube{
+	dir = 8;
+	pixel_x = -3
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_3_Deck_Central_Corridor_1)
@@ -43323,18 +43373,11 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
 "nTh" = (
-/obj/machinery/light/floortube{
-	dir = 8;
-	pixel_x = -3
+/obj/machinery/computer/area_atmos/tag{
+	scrub_id = "SC_Atmos"
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/Aft_3_Deck_Central_Corridor_1)
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Chamber)
 "nTk" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -46237,6 +46280,9 @@
 /area/maintenance/Deck3_Medical_AftPortChamber2)
 "oLY" = (
 /obj/machinery/vending/snack,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/medical/Lounge)
 "oMt" = (
@@ -46463,9 +46509,9 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/bridge/Captain_Office)
 "oQl" = (
-/obj/machinery/portable_atmospherics/canister/empty,
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "oQM" = (
@@ -47610,10 +47656,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForStarCorridor2)
 "plP" = (
-/obj/structure/railing/grey{
-	color = "yellow";
-	dir = 4
-	},
+/obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/glass/reinforced,
 /area/maintenance/Deck3_Engineering_ForStarChamber2)
 "plR" = (
@@ -48342,7 +48385,6 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/effect/landmark/free_ai_shell,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -48610,7 +48652,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/bridge/Conference_Room)
 "pAw" = (
 /obj/structure/table/rack/steel,
@@ -49391,8 +49433,8 @@
 /turf/simulated/floor/wood/alt,
 /area/hallway/Port_Breakroom)
 "pOf" = (
-/obj/machinery/portable_atmospherics/canister/empty,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "pOt" = (
@@ -52572,9 +52614,11 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/powered/scrubber/huge,
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/portable_atmospherics/powered/scrubber/huge{
+	scrub_id = "SC_Atmos"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "qMY" = (
@@ -53023,7 +53067,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForStarCorridor2)
 "qXq" = (
-/obj/structure/reagent_dispensers/foam,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_AftCorridor2)
 "qXt" = (
@@ -55150,7 +55194,6 @@
 /turf/simulated/floor/tiled,
 /area/medical/Lounge)
 "rFL" = (
-/obj/machinery/portable_atmospherics/canister/empty,
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/machinery/light{
@@ -55158,6 +55201,7 @@
 	layer = 3
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "rFQ" = (
@@ -55769,6 +55813,10 @@
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 4
+	},
+/obj/machinery/light/floortube{
+	dir = 8;
+	pixel_x = -3
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_3_Deck_Central_Corridor_1)
@@ -57478,6 +57526,7 @@
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Chamber)
 "sun" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForStarCorridor1)
 "suw" = (
@@ -58433,6 +58482,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/Lounge)
+"sJN" = (
+/obj/machinery/atmospherics/pipe/simple/visible/purple,
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Chamber)
 "sJT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -59209,18 +59264,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_StarCorridor1)
 "sWO" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/machinery/light/floortube{
-	dir = 4;
-	pixel_x = 2
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/Aft_3_Deck_Central_Corridor_1)
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_AftPortChamber1)
 "sXw" = (
 /obj/machinery/light{
 	dir = 1
@@ -60405,6 +60451,7 @@
 /area/bridge/Embassy)
 "tnv" = (
 /obj/machinery/light/small,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Center_Star)
 "tnz" = (
@@ -61141,6 +61188,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "tFp" = (
@@ -63236,6 +63284,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_StarChamber1)
 "uoy" = (
@@ -63316,7 +63365,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Center_Port)
 "upB" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_AftStarCorridor1)
 "upJ" = (
@@ -64420,6 +64469,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Engine1_Control_Room)
+"uHC" = (
+/obj/effect/landmark/free_ai_shell,
+/turf/simulated/floor/glass/reinforced,
+/area/bridge/AI_Core_Chamber)
 "uHI" = (
 /obj/structure/sign/directions/engineering/solars{
 	pixel_y = 9
@@ -64672,6 +64725,10 @@
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Public_Garden)
+"uML" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Engineering_ForCorridor1)
 "uMP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -66165,6 +66222,7 @@
 /obj/structure/bed/chair/comfy/orange{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/simulated/floor/carpet/brown,
 /area/bridge/Deck3_Corridor)
 "vht" = (
@@ -67567,14 +67625,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
-	},
-/obj/machinery/embedded_controller/radio/airlock/access_controller{
-	id_tag = "SC-ALCvirology";
-	name = "Virology Access Console";
-	pixel_x = -26;
-	tag_exterior_door = "SC-ALEvirology";
-	tag_interior_door = "SC-ALIvirology";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/medical/Virology)
@@ -71157,6 +71207,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine1_Substation)
+"wLE" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Bridge_AftPortCorridor1)
 "wLN" = (
 /obj/structure/bed/chair/sofa/left/beige{
 	dir = 1
@@ -72913,18 +72970,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "xko" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/machinery/light/floortube{
-	dir = 8;
-	pixel_x = -3
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/Aft_3_Deck_Central_Corridor_1)
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_ForPort_Chamber1)
 "xku" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -74132,6 +74180,13 @@
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "xDu" = (
+/obj/structure/railing/grey{
+	color = "yellow";
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	color = "yellow"
+	},
 /turf/simulated/floor/glass/reinforced,
 /area/maintenance/Deck3_Engineering_ForStarChamber2)
 "xDw" = (
@@ -75888,6 +75943,10 @@
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 8
+	},
+/obj/machinery/light/floortube{
+	dir = 4;
+	pixel_x = 2
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_3_Deck_Central_Corridor_1)
@@ -87899,7 +87958,7 @@ uSU
 jgV
 dOd
 tEU
-lhX
+sJN
 lhX
 rFL
 wiE
@@ -92044,7 +92103,7 @@ fTh
 miM
 nik
 vYL
-fTh
+uML
 uhz
 fXe
 fXe
@@ -92804,7 +92863,7 @@ rfS
 ycN
 nRD
 rSq
-rfS
+nTh
 ciB
 pAf
 rLN
@@ -96170,8 +96229,8 @@ dOf
 oUk
 clf
 nhu
-xDu
-xDu
+aWE
+plP
 qTm
 qTm
 qTm
@@ -96428,9 +96487,9 @@ bBk
 imS
 clf
 wFS
-plP
-plP
 xDu
+plP
+wYU
 oAF
 uNr
 nAa
@@ -100516,7 +100575,7 @@ uhA
 qmc
 gyV
 eTi
-pbE
+wLE
 yeT
 yeT
 iJa
@@ -102150,7 +102209,7 @@ tNl
 vXB
 inY
 its
-vXB
+xko
 jZH
 lDM
 eTD
@@ -105156,7 +105215,7 @@ ebr
 rqF
 nmK
 aaM
-gyc
+aaM
 aaM
 aaM
 kXp
@@ -105743,17 +105802,17 @@ oMC
 tAo
 lDp
 gOI
-xOH
-oCp
-xko
+nCY
 oCp
 xOH
+oCp
+nCY
 oCp
 xOH
 yhv
-xOH
+nCY
 oCp
-nTh
+xOH
 oCp
 rTn
 sGb
@@ -106157,7 +106216,7 @@ gKH
 sGW
 tTr
 pxy
-wvZ
+uHC
 ghf
 cDS
 hoZ
@@ -106775,17 +106834,17 @@ qTV
 eSH
 pTW
 har
-kpS
-lqG
-sWO
+gyc
 lqG
 kpS
+lqG
+gyc
 lqG
 kpS
 aFa
-kpS
+gyc
 lqG
-nCY
+kpS
 lqG
 ydi
 tIh
@@ -107220,7 +107279,7 @@ lqk
 aVq
 eUH
 gjC
-kQo
+gjC
 gjC
 fPx
 kXp
@@ -107327,7 +107386,7 @@ uXE
 tRN
 xUy
 rgB
-wmr
+nCt
 aoL
 lIv
 nlH
@@ -108078,7 +108137,7 @@ lmX
 eIx
 gXM
 mpw
-sOH
+dYI
 cLw
 xmc
 vZm
@@ -111349,7 +111408,7 @@ cSp
 lEX
 jPi
 vSL
-tzt
+iWj
 oWw
 nAZ
 kSk
@@ -116059,7 +116118,7 @@ gxf
 gxf
 dpB
 xgV
-tbD
+sWO
 vyx
 cZW
 wNx
@@ -118351,7 +118410,7 @@ ikG
 tBM
 yaW
 xfg
-ctH
+kQo
 niE
 iDQ
 hgE
@@ -120691,7 +120750,7 @@ twW
 twW
 gKO
 fjQ
-fjQ
+hOs
 pAE
 fhI
 hBX
@@ -121207,7 +121266,7 @@ twW
 twW
 gKO
 hfj
-hOs
+fjQ
 pAE
 xJC
 eNm
@@ -121723,7 +121782,7 @@ wfX
 wfX
 qIN
 fjQ
-fjQ
+hOs
 pAE
 oJX
 hBX
@@ -122773,7 +122832,7 @@ pXf
 fnj
 yfA
 dfo
-iyP
+jED
 mDg
 bzX
 ssw
@@ -123529,7 +123588,7 @@ osd
 gKS
 cGX
 kNR
-fjQ
+hOs
 onu
 rng
 wJE


### PR DESCRIPTION
-Added missing APC in maints, 2-deck north hall.
-Central and Harbor Distro is now engineering access only. Fixed some ladders & pipes. 
-Added water tanks in maints.
-Fixed access in the armory, Warden now has access. 
-Fixed access in cargo reception windoors.
-Replaced both security ID's in maints with civilian ID's. 
-Added missing keycard authen in HOP office.
-Reinforced walls for HoP and HoS offices.
-Fixed access to every ship respective to its departments. Echidna=Engineering/Cargo, Ursula=Medical/Science, Needle=Security/Command. All have pilot access too. 
-Removed various public autolathes. Only one public one. 
-Added additional scrubbers/air pumps in atmos. Added scrubber control console (Large air pumps code is broken, currently) 
-Reduced the amount of space shuttles in shuttlebays, removed all mech attachments. 
-Dinner is now more visible to the public.
-Replaced various frosted windows with normal glass. 
-Added more lights in dark areas.

