### PR TITLE
Changes the selected to Southern Cross.

### DIFF
--- a/modular_chomp/maps/~map_system/_map_selection.dm
+++ b/modular_chomp/maps/~map_system/_map_selection.dm
@@ -5,8 +5,8 @@
 /* FOR LIVE SERVER   */
 /*********************/
 
-// #define USE_MAP_SOUTHERN_CROSS
-#define USE_MAP_SOLUNA_NEXUS
+#define USE_MAP_SOUTHERN_CROSS
+// #define USE_MAP_SOLUNA_NEXUS
 // #define USE_MAP_RELIC_BASE
 
 // Debug


### PR DESCRIPTION

## About The Pull Request
Thanks to community feedback and staff feedback, it is generally accepted that this map needs a bit more time to be considered finished. The map will be switched back to southern cross due to overwhelming community feedback. 

Please discuss within staff before merging.
## Changelog
:cl:
maptweak: Switched maps from Soluna Nexus to Southern Cross
/:cl:
