### PR TITLE
Soluna Nexus Map fixes 1.5

### DIFF
--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
@@ -108,7 +108,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -192,13 +191,8 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/phoronreinforced/full,
-/obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
 	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 1
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4
@@ -218,16 +212,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/hallway/Port_1Deck_Central_Corridor_1)
@@ -245,7 +235,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
+	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
@@ -293,7 +285,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -452,13 +443,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -1047,6 +1034,19 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Depot1)
+"afC" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Star_1Deck_Central_Corridor_1)
 "afV" = (
 /obj/machinery/light{
 	dir = 1
@@ -1095,7 +1095,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -1293,13 +1292,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -1886,7 +1881,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -2167,13 +2161,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -2375,7 +2365,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -2536,7 +2525,6 @@
 /turf/simulated/wall/r_wall,
 /area/security/Quantum_Pad_Checkpoint)
 "anv" = (
-/obj/machinery/portable_atmospherics/powered/pump/huge,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -2544,6 +2532,7 @@
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "anw" = (
@@ -2565,13 +2554,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
-	},
-/obj/structure/window/basic{
-	dir = 1
 	},
 /obj/structure/window/basic{
 	dir = 4
@@ -2741,11 +2726,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -2861,7 +2842,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -3031,13 +3011,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -3046,10 +3021,10 @@
 /area/harbor/Dock3)
 "aqx" = (
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/portable_atmospherics/powered/pump/huge,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Harbor)
 "aqD" = (
@@ -3061,7 +3036,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -3089,16 +3063,12 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
 	},
 /obj/structure/window/basic{
 	dir = 1
-	},
-/obj/structure/window/basic{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/Public_Gateway)
@@ -3227,8 +3197,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -3508,7 +3476,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -4087,16 +4054,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Corridor2)
@@ -4117,11 +4080,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -4564,16 +4523,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Dock1)
@@ -5051,13 +5003,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -5109,12 +5056,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -5216,11 +5159,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -5989,6 +5928,19 @@
 /obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/carpet/purcarpet,
 /area/harbor/Star_Docking_Foyer)
+"aLV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock3)
 "aLW" = (
 /obj/random/flashlight,
 /turf/simulated/floor/plating,
@@ -6194,6 +6146,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Ship_Bay2)
+"aNg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock3)
 "aNh" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/retail_scanner/cargo{
@@ -6369,13 +6337,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -6452,7 +6416,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -6460,9 +6423,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/hallway/Planetside_Equipment)
 "aOw" = (
@@ -6497,6 +6457,16 @@
 /obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled,
 /area/engineering/GravGen_Room)
+"aOK" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForStar_Corridor1)
 "aOM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/borderfloor{
@@ -7234,6 +7204,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor3)
+"aUv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForPort_Corridor1)
 "aUH" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	dir = 1
@@ -7419,7 +7402,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -7523,7 +7505,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -7531,9 +7512,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/door/blast/multi_tile/four_tile_hor_sec{
 	layer = 3.5;
 	id = "sc-GCtelecoms"
@@ -7600,7 +7578,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -7897,6 +7874,16 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck1_Security_PortCorridor2)
+"baS" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 8;
+	color = "#989898"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock5)
 "baX" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/light,
@@ -8055,16 +8042,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Telecomms_Control_Room)
@@ -8086,6 +8069,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
+"bef" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock3)
 "beg" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/Telecomms_Control_Room)
@@ -8225,16 +8223,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -8273,7 +8264,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -8585,7 +8575,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -8817,7 +8806,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -9025,13 +9013,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/ForStar_1_Deck_Observatory)
 "buZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8;
 	color = "#989898"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "bvd" = (
@@ -9064,6 +9050,23 @@
 	},
 /turf/simulated/wall,
 /area/maintenance/Deck1_AftPort_Chamber1)
+"bvF" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Car Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Mining_Ship_Bay)
 "bvZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/filingcabinet/chestdrawer,
@@ -9349,6 +9352,18 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Science_ForCorridor1)
+"bAW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock1)
 "bBn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 9
@@ -9393,9 +9408,10 @@
 /turf/simulated/wall/r_wall,
 /area/rnd/Xenobotany_Isolation_Chamber)
 "bBM" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 8
 	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "bBQ" = (
@@ -9742,7 +9758,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -9815,6 +9830,29 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Mining_Ship_Bay)
+"bHa" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Xenobotany_Isolation_Chamber)
 "bHe" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
@@ -10000,8 +10038,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -10048,11 +10084,18 @@
 /turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "bMe" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
 	dir = 8
 	},
-/turf/simulated/floor/glass/reinforced,
-/area/hallway/Star_1Deck_Central_Corridor_1)
+/turf/simulated/floor/plating,
+/area/harbor/Dock1)
 "bMh" = (
 /obj/structure/table/woodentable,
 /obj/item/deck/tarot,
@@ -10462,6 +10505,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Supply_Ship_Bay)
+"bSy" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Port_Docking_Foyer)
 "bSz" = (
 /obj/machinery/light{
 	dir = 1
@@ -10671,16 +10730,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/hallway/ForPort_1_Deck_Observatory)
@@ -10692,6 +10747,36 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor2)
+"bXf" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Mining_EVA)
+"bXn" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Public_Gateway)
 "bXr" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/white,
@@ -10977,6 +11062,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Ship_Bay2)
+"cdn" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Mining_Ship_Bay)
 "cdz" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -11613,7 +11718,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -11705,6 +11809,23 @@
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber3)
+"cpe" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Mining_Ship_Bay)
 "cpg" = (
 /obj/random/trash,
 /obj/random/maintenance/misc,
@@ -12866,6 +12987,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor1)
+"cMu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Star_Docking_Foyer)
 "cMD" = (
 /obj/effect/floor_decal/industrial/stand_clear,
 /obj/structure/railing/grey{
@@ -12889,7 +13025,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -13022,7 +13157,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
+	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
@@ -13111,6 +13248,18 @@
 /obj/random/maintenance/research,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber3)
+"cQa" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Aft_1_Deck_Stairwell)
 "cQf" = (
 /obj/structure/table/rack,
 /obj/item/seeds/ghostchiliseed{
@@ -13207,7 +13356,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
 	dir = 8
@@ -13229,16 +13377,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/GravGen_Room)
@@ -13384,6 +13528,21 @@
 "cUA" = (
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortChamber2)
+"cUC" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Port_1Deck_Atrium)
 "cUK" = (
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/AftStar_1_Deck_Observatory)
@@ -13504,6 +13663,21 @@
 /obj/machinery/gravity_generator/main/station/admin,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/GravGen_Room)
+"cXL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Star_1Deck_Atrium)
 "cXM" = (
 /obj/structure/toilet{
 	dir = 1
@@ -14069,6 +14243,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock2)
+"dfv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock2)
 "dfC" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -14309,6 +14496,24 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/ab_Hydroponics)
+"djp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Security_PortChamber1)
 "djt" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -15202,6 +15407,32 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Planetside_Equipment)
+"dym" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Supply_Ship_Bay)
 "dyp" = (
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 9
@@ -15451,6 +15682,40 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/harbor/Dock2)
+"dCH" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Security_StarChamber1)
+"dCQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/GravGen_Room)
 "dDc" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/porta_turret/industrial/teleport_defense,
@@ -15619,6 +15884,26 @@
 	temperature = 80
 	},
 /area/engineering/Telecomms_Network)
+"dFU" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/rnd/PA_Chamber)
 "dGh" = (
 /obj/machinery/light{
 	dir = 1
@@ -16234,16 +16519,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/hallway/AftPort_1_Deck_Observatory)
@@ -16315,13 +16596,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -16372,6 +16648,28 @@
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Science_AftCorridor1)
+"dSZ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Cargo_Corridor3)
 "dTn" = (
 /obj/machinery/light/small,
 /obj/random/trash_pile,
@@ -16965,10 +17263,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -17020,10 +17314,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -17307,6 +17597,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Research_Ship_Bay)
+"dXT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Telecomms_Control_Room)
 "dXU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17365,8 +17668,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -17387,7 +17688,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -17427,8 +17727,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -17733,7 +18031,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -18121,11 +18418,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -18488,7 +18781,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -19414,6 +19706,21 @@
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor1)
+"eyi" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftPort_Corridor2)
 "eyu" = (
 /obj/structure/table/standard,
 /obj/item/storage/rollingpapers{
@@ -19518,7 +19825,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
 	dir = 8
@@ -20182,6 +20488,32 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
+"eLg" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "SC-BDxenobiolockdown";
+	name = "Containment Blast Doors";
+	opacity = 0;
+	layer = 3.5
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Xenobiology_Lab)
 "eLm" = (
 /obj/machinery/light/small/emergency,
 /obj/structure/cable/white{
@@ -20422,6 +20754,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Custodial_Office)
+"eQv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Cargo_Corridor3)
 "eQy" = (
 /obj/structure/table/marble,
 /obj/item/gun/projectile/revolver/capgun,
@@ -20570,7 +20920,6 @@
 "eTN" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -20756,7 +21105,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -21133,6 +21481,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Research_Ship_Bay)
+"faU" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/ab_StripBar)
 "faX" = (
 /obj/structure/sink{
 	pixel_y = 16
@@ -21306,7 +21667,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -21368,13 +21728,13 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Port)
 "ffk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/black{
+	dir = 9
+	},
 /obj/machinery/atmospherics/unary/freezer{
 	icon_state = "freezer_1";
 	set_temperature = 73;
 	use_power = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Telecomms_Control_Room)
@@ -21407,6 +21767,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
+"ffT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Fueling_Storage)
 "ffU" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -21657,7 +22030,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -22615,6 +22987,21 @@
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/security/Quantum_Pad_Checkpoint)
+"fGh" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftPort_1_Deck_Observatory)
 "fGi" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck1_ForPort_Corridor1)
@@ -22703,6 +23090,24 @@
 "fHV" = (
 /turf/simulated/wall,
 /area/security/Quantum_Pad_Storage)
+"fIl" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/engineering/Telecomms_Foyer)
 "fIm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/camera/network/security{
@@ -22844,6 +23249,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/mineral/input,
 /turf/simulated/floor/plating,
 /area/quartermaster/Mining_Ship_Bay)
 "fKQ" = (
@@ -23135,6 +23541,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/hydro,
 /area/rnd/Xenobotany_Lab)
+"fQz" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForPort_Corridor2)
 "fQD" = (
 /obj/structure/closet,
 /obj/random/junk,
@@ -23189,6 +23608,29 @@
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor1)
+"fQW" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Car Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Mining_Ship_Bay)
 "fQX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23385,16 +23827,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/hallway/ForStar_1_Deck_Observatory)
@@ -23508,6 +23943,16 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor2)
+"fVP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftPort_1_Deck_Observatory)
 "fWg" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -23703,16 +24148,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -23854,14 +24295,12 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -23949,6 +24388,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Depot1)
+"gaP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock4)
 "gbj" = (
 /obj/structure/sign/directions/cargo{
 	dir = 9
@@ -24041,11 +24493,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -24118,10 +24566,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -24984,8 +25428,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -25683,6 +26125,16 @@
 /obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Telecomms_Control_Room)
+"gHS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Port_1Deck_Central_Corridor_1)
 "gIx" = (
 /obj/machinery/vending/wallmed1{
 	dir = 1;
@@ -25691,6 +26143,12 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/mauve/border,
+/obj/structure/table/steel,
+/obj/item/storage/belt/janitor,
+/obj/item/holosign_creator{
+	pixel_y = 6;
+	pixel_x = 15
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Custodial_Office)
 "gID" = (
@@ -25973,6 +26431,19 @@
 /obj/random/maintenance/misc,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Chamber1)
+"gOu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock1)
 "gOv" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 1
@@ -26619,11 +27090,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -26836,6 +27303,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor2)
+"hcm" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForStar_Corridor1)
 "hcx" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -26954,6 +27434,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor1)
+"hfM" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Port_Docking_Foyer)
 "hga" = (
 /obj/item/radio/intercom{
 	dir = 1;
@@ -27318,6 +27810,28 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarChamber2)
+"hoE" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Security_PortChamber1)
 "hoP" = (
 /obj/machinery/camera/network/security{
 	dir = 5;
@@ -27485,8 +27999,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -27526,6 +28038,18 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber3)
+"hrJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForStar_Corridor2)
 "hrV" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck1_Security_PortChamber3)
@@ -27568,13 +28092,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -27848,11 +28367,20 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/Deck1_Security_StarCorridor3)
+"hxj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock4)
 "hxs" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -27905,7 +28433,6 @@
 /turf/simulated/wall/r_wall,
 /area/harbor/Dock4)
 "hxU" = (
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
@@ -27969,7 +28496,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
 	dir = 8
@@ -28568,8 +29094,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -28786,6 +29310,34 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock3)
+"hPz" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "SC-BDxenobiopen1";
+	name = "Containment Blast Doors";
+	opacity = 0;
+	layer = 3.5
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Xenobiology_Lab)
 "hPA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
@@ -28928,13 +29480,9 @@
 "hRQ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -28942,6 +29490,21 @@
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
 /area/rnd/Xenobotany_Isolation_Chamber)
+"hSg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForStar_Corridor2)
 "hSi" = (
 /obj/machinery/camera/network/security{
 	dir = 4;
@@ -29145,6 +29708,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/harbor/Ship_Bay4)
+"hXv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/ab_StripBar)
 "hXB" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29254,7 +29827,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -29518,6 +30090,19 @@
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/Supply_Ship_Bay)
+"iex" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForPort_Chamber1)
 "ieT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29615,6 +30200,26 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor3)
+"igl" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Research_Ship_Bay)
 "igo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -29709,6 +30314,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Harbor)
+"iic" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Supply_Ship_Bay)
 "iid" = (
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
@@ -29918,7 +30543,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -30196,6 +30820,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Stairwell_For)
+"ips" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Port_Docking_Foyer)
 "ipN" = (
 /obj/effect/floor_decal/industrial/arrows/blue{
 	dir = 4
@@ -30388,6 +31025,23 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor1)
+"itl" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Research_Ship_Bay)
 "itp" = (
 /obj/structure/shuttle/engine/heater,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -30475,6 +31129,18 @@
 	temperature = 80
 	},
 /area/engineering/Telecomms_Network)
+"iuJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftPort_1_Deck_Observatory)
 "iuY" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/reagent_dispensers/watertank/high,
@@ -30642,8 +31308,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance/rnd{
+	name = "Circuitry Access"
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck1_ForStar_Corridor3)
 "iyo" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -30814,7 +31483,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -31393,6 +32061,18 @@
 	icon_state = "orange"
 	},
 /area/shuttle/escape_pod7/station)
+"iQE" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Star_Docking_Foyer)
 "iQH" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -31864,7 +32544,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
 "jcH" = (
-/obj/effect/floor_decal/arrivals,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -31965,7 +32644,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Science_AftCorridor1)
 "jeQ" = (
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/reinforced/survival_pod,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 4
@@ -32218,7 +32896,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -32401,7 +33078,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -32777,16 +33453,12 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
 	},
 /obj/structure/window/basic{
 	dir = 1
-	},
-/obj/structure/window/basic{
-	dir = 4
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -33125,6 +33797,18 @@
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/Public_Gateway)
+"jAb" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftStar1_Corridor1)
 "jAk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -33231,7 +33915,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor3)
 "jDe" = (
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
@@ -33376,6 +34059,13 @@
 	dir = 4
 	},
 /obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/access_button{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/map_helper/airlock/button/int_button{
+	pixel_y = -14
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -33842,17 +34532,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/Quantum_Pad_Storage)
 "jLb" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/shuttle/blue{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
+/obj/structure/window/titanium{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/harbor/Dock5)
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Fueling_Post)
 "jLh" = (
 /mob/living/simple_mob/animal/passive/fish/rockfish{
 	name = "Bon";
@@ -34053,7 +34746,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -34160,6 +34852,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Xenobiology_Lab)
+"jSB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForStar_Corridor2)
 "jSJ" = (
 /obj/structure/closet/l3closet/virology,
 /turf/simulated/floor/tiled/kafel_full/blue,
@@ -35003,6 +35708,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/harbor/Ship_Bay3)
+"khu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForPort_Corridor1)
 "khv" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -35010,15 +35727,21 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Star)
 "khE" = (
-/obj/effect/shuttle_landmark{
-	base_area = /area/space;
-	base_turf = /turf/space;
-	docking_controller = "sc-D1_L5A1_airlock";
-	landmark_tag = "sc-D1_L5A1";
-	name = "Docking Lane 5 Airlock 1"
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/turf/space,
-/area/space)
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock1)
 "kio" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -35124,7 +35847,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -35273,16 +35995,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/machinery/door/blast/regular/open{
@@ -35643,7 +36361,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -35834,6 +36551,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/PA_Chamber)
+"kzO" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Public_Gateway)
 "kAl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -36879,7 +37609,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/ab_StripBar)
 "kUo" = (
-/obj/effect/floor_decal/arrivals,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -37171,7 +37900,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -37245,6 +37973,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor1)
+"kZQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Security_PortChamber1)
 "kZR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37556,6 +38303,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Research_Ship_Bay)
+"lgu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock2)
 "lgQ" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -37565,6 +38324,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/black{
 	dir = 1
 	},
+/obj/item/storage/briefcase/inflatable,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Telecomms_Control_Room)
 "lhu" = (
@@ -38234,6 +38994,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor2)
+"lqN" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Planetside_Equipment)
 "lqO" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -38292,7 +39065,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -38411,14 +39183,9 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -38494,6 +39261,21 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor3)
+"lxl" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftStar_1_Deck_Observatory)
 "lxD" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
@@ -38514,16 +39296,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -39025,6 +39803,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
+"lGW" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
+	},
+/obj/machinery/mineral/output,
+/turf/simulated/floor/plating,
+/area/quartermaster/Mining_Ship_Bay)
 "lGZ" = (
 /obj/structure/cable/white{
 	d1 = 4;
@@ -39077,6 +39863,19 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor2)
+"lIl" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForStar_1_Deck_Observatory)
 "lIo" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/fiftyspawner/steel,
@@ -39936,6 +40735,21 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Harbor)
+"lUx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock2)
 "lUC" = (
 /obj/random/trash_pile,
 /obj/random/trash,
@@ -40021,6 +40835,16 @@
 /obj/machinery/atmospherics/binary/pump,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Post)
+"lWV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Telecomms_Control_Room)
 "lXb" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -40253,6 +41077,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/Quantum_Pad_Checkpoint)
+"lZN" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
+/obj/machinery/door/airlock/angled_bay/external/glass{
+	dir = 4
+	},
+/obj/machinery/access_button{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/effect/map_helper/airlock/button/int_button{
+	pixel_y = -14
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/harbor/Dock5)
 "lZO" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/borderfloorblack{
@@ -40567,16 +41415,12 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
 	},
 /obj/structure/window/basic{
 	dir = 1
-	},
-/obj/structure/window/basic{
-	dir = 4
 	},
 /obj/structure/sign/directions/evac{
 	dir = 5;
@@ -41223,6 +42067,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock2)
+"mrM" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock4)
 "mrR" = (
 /obj/effect/floor_decal/rust,
 /turf/simulated/floor/plating,
@@ -41740,6 +42594,18 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Corridor3)
+"myO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForPort_1_Deck_Observatory)
 "mzf" = (
 /obj/item/gps{
 	pixel_x = 3;
@@ -41908,6 +42774,19 @@
 	name = "Nitrogen white floor"
 	},
 /area/maintenance/ab_Kitchen)
+"mBn" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock2)
 "mBs" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -42094,7 +42973,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -42129,7 +43007,6 @@
 /area/shuttle/cryo/station)
 "mFP" = (
 /obj/structure/mopbucket,
-/obj/item/mop/advanced,
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/newscaster{
 	pixel_x = -28
@@ -42140,6 +43017,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
+/obj/item/mop,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Custodial_Office)
 "mFX" = (
@@ -42347,6 +43225,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/Supply_Ship_Bay)
+"mJQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForStar_1_Deck_Observatory)
 "mKY" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -42658,6 +43548,29 @@
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/Star_1Deck_Central_Corridor_1)
+"mOq" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Supply_Ship_Bay)
 "mOu" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -42683,12 +43596,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 4
 	},
-/obj/structure/table/steel,
-/obj/item/storage/belt/janitor,
-/obj/item/storage/belt/janitor{
-	pixel_x = 2;
-	pixel_y = 6
-	},
+/obj/machinery/r_n_d/protolathe/service,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Custodial_Office)
 "mOM" = (
@@ -42723,25 +43631,17 @@
 /area/harbor/Dock2)
 "mOX" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows{
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 4
-	},
-/obj/machinery/door/airlock/angled_bay/external/glass{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/access_button{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/map_helper/airlock/button/int_button{
-	pixel_y = -14
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/harbor/Dock5)
+/turf/simulated/floor/plating,
+/area/harbor/Dock2)
 "mPf" = (
 /obj/machinery/door/window/survival_pod{
 	dir = 1
@@ -42958,16 +43858,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/hallway/AftStar_1_Deck_Observatory)
@@ -43191,7 +44084,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -43315,6 +44207,19 @@
 /obj/effect/floor_decal/industrial/danger/corner,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/harbor/Ship_Bay2)
+"mZW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock5)
 "nar" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/fiftyspawner/cardboard,
@@ -43712,6 +44617,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Deck1_Corridor)
+"nkG" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftPort_Corridor2)
 "nlq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
@@ -44268,6 +45186,26 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/PA_Chamber)
+"nwQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Security_StarChamber1)
 "nwU" = (
 /obj/structure/table/bench/sifwooden/padded,
 /turf/simulated/floor/tiled/white,
@@ -44348,6 +45286,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Star)
+"nyc" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftPort_1_Deck_Observatory)
 "nyh" = (
 /obj/structure/disposalpipe/tagger{
 	sort_tag = "transit_crew"
@@ -44537,10 +45485,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Corridor1)
 "nBS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -44762,6 +45713,18 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Corridor1)
+"nFc" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForStar_1_Deck_Observatory)
 "nFd" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
@@ -45064,6 +46027,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock2)
+"nLf" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftStar_1_Deck_Observatory)
 "nLk" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/red{
@@ -45353,6 +46326,22 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Depot1)
+"nQn" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock4)
 "nQw" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/arrows/blue{
@@ -45634,9 +46623,6 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8
-	},
-/obj/effect/floor_decal/arrivals{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -46598,17 +47584,25 @@
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/maintenance/ab_StripBar)
 "ojM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+/obj/structure/window/titanium{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/harbor/Dock5)
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/rnd/PA_Chamber)
 "okm" = (
 /turf/simulated/floor/glass/reinforced,
 /area/harbor/Dock4)
@@ -46640,6 +47634,34 @@
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
+"okI" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "SC-BDxenobiopen2";
+	name = "Containment Blast Doors";
+	opacity = 0;
+	layer = 3.5
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Xenobiology_Lab)
 "okJ" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -46670,7 +47692,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -46941,7 +47962,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -47065,7 +48085,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -47376,6 +48395,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/Deck1_Cargo_Corridor3)
+"oxa" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftStar1_Corridor2)
 "oxc" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
@@ -47407,7 +48436,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -47474,6 +48502,19 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/echidna)
+"oya" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock5)
 "oyj" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -47658,8 +48699,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -48517,6 +49556,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Research_Ship_Bay)
+"oOi" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/rnd/Xenobotany_Isolation_Chamber)
 "oOk" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable{
@@ -49055,13 +50109,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -49364,6 +50414,19 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarChamber2)
+"pdY" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Fueling_Post)
 "pej" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -49426,6 +50489,19 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/echidna)
+"peQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Aft_1_Deck_Stairwell)
 "peU" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -50044,13 +51120,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -50223,13 +51295,9 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
 	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 1
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4
@@ -50429,50 +51497,18 @@
 	},
 /area/maintenance/ab_Kitchen)
 "psu" = (
-/obj/item/stack/material/phoron{
-	amount = 25;
-	pixel_x = 9;
-	pixel_y = -9
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
 	},
-/obj/item/clothing/glasses/meson{
-	pixel_x = -6;
-	pixel_y = -13
-	},
-/obj/item/clothing/glasses/welding{
-	pixel_x = -6;
-	pixel_y = -8
-	},
-/obj/item/stack/material/plasteel{
-	amount = 30;
-	pixel_y = 1;
-	pixel_x = -8
-	},
-/obj/item/stack/material/steel{
-	amount = 50;
-	pixel_y = 4;
-	pixel_x = -8
-	},
-/obj/item/stack/material/glass{
-	amount = 50;
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/item/t_scanner{
-	pixel_y = 3;
-	pixel_x = 11
-	},
-/obj/item/multitool{
-	pixel_x = 4
-	},
-/obj/structure/closet/crate/secure/large/nanotrasen{
-	req_access = list(10)
+/obj/structure/window/titanium{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/harbor/Dock3)
 "psG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -50493,7 +51529,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -50930,26 +51965,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Corridor2)
 "pBU" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows{
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/arrows{
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
 	dir = 4
 	},
-/obj/machinery/door/airlock/angled_bay/external/glass{
-	dir = 4
-	},
-/obj/machinery/access_button{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/effect/map_helper/airlock/button/int_button{
-	pixel_y = -14
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/harbor/Dock5)
+/turf/simulated/floor/plating,
+/area/engineering/GravGen_Room)
 "pCf" = (
 /obj/structure/closet/emcloset,
 /obj/structure/disposalpipe/segment{
@@ -51196,6 +52225,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor3)
+"pGQ" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad"
+	},
+/obj/machinery/mineral/input,
+/turf/simulated/floor/plating,
+/area/quartermaster/Mining_Ship_Bay)
 "pHp" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows,
@@ -51409,13 +52446,9 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
 	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 1
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4
@@ -51525,6 +52558,19 @@
 /obj/random/drinkbottle,
 /turf/simulated/floor/tiled/eris/steel/bar_dance,
 /area/maintenance/ab_StripBar)
+"pMm" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock4)
 "pMq" = (
 /obj/effect/floor_decal/industrial/loading/white{
 	dir = 8
@@ -51537,10 +52583,33 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
+"pMC" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock1)
 "pML" = (
 /obj/structure/closet/crate/mimic/closet/safe,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber3)
+"pNg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftStar_1_Deck_Observatory)
 "pNX" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -51689,7 +52758,6 @@
 	dir = 6
 	},
 /obj/structure/table/steel,
-/obj/item/lightreplacer,
 /obj/item/lightreplacer,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Custodial_Office)
@@ -52659,7 +53727,6 @@
 /area/maintenance/Deck1_AftPort_Chamber3)
 "qee" = (
 /obj/structure/mopbucket,
-/obj/item/mop/advanced,
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/light{
 	dir = 8
@@ -52670,6 +53737,7 @@
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 8
 	},
+/obj/item/mop,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Custodial_Office)
 "qev" = (
@@ -52851,7 +53919,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortCorridor1)
 "qhi" = (
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
@@ -53591,6 +54658,21 @@
 /obj/effect/floor_decal/corner/mauve/border,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Custodial_Office)
+"qvX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock5)
 "qwb" = (
 /obj/machinery/computer/general_air_control{
 	dir = 4;
@@ -53610,6 +54692,27 @@
 /obj/structure/frame/computer,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Chamber1)
+"qws" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/engineering/Telecomms_Foyer)
 "qwt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -53776,6 +54879,19 @@
 /obj/item/batterer,
 /turf/simulated/floor/tiled,
 /area/maintenance/ab_GeneralStore)
+"qAx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Port_1Deck_Central_Corridor_1)
 "qAD" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -54051,7 +55167,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -54215,7 +55330,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -54766,7 +55880,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Chamber1)
 "qSb" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -54774,6 +55887,7 @@
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 10
 	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "qSj" = (
@@ -55009,7 +56123,6 @@
 /turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
 "qUU" = (
-/obj/effect/floor_decal/arrivals/right,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 4;
@@ -55189,7 +56302,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -55217,7 +56329,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -55488,6 +56599,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock5)
+"rbq" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock1)
 "rbS" = (
 /obj/machinery/button/remote/blast_door{
 	id = "SC-BDxenobiopen4";
@@ -55514,10 +56640,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -55577,7 +56699,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -55705,14 +56826,12 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -55751,6 +56870,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Observation_Hall)
+"reX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock4)
 "rfe" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
@@ -56054,7 +57185,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -56090,6 +57220,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor2)
+"rlJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForPort_Corridor2)
 "rlK" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
@@ -56421,9 +57561,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor2)
 "rsk" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 4
 	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "rsp" = (
@@ -56857,6 +57998,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_4)
+"rxL" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Car Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Mining_Ship_Bay)
 "rxV" = (
 /obj/machinery/camera/network/security{
 	dir = 5;
@@ -57235,6 +58396,27 @@
 /obj/structure/salvageable/server,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber2)
+"rGY" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/rnd/PA_Chamber)
 "rHo" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -57597,6 +58779,27 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/rnd/Research_Ship_Bay)
+"rOz" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Planetside_Equipment)
 "rOG" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
@@ -57731,6 +58934,19 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor3)
+"rRx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftStar1_Corridor2)
 "rRz" = (
 /obj/item/reagent_containers/syringe/steroid,
 /obj/item/material/shard{
@@ -57827,6 +59043,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/alt/parquet/turfpack/station,
 /area/hallway/Cryostorage_Lounge)
+"rTR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForPort_1_Deck_Observatory)
 "rTV" = (
 /obj/machinery/door/firedoor/multi_tile/glass{
 	dir = 1
@@ -57945,16 +59171,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -58149,6 +59368,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Aft)
+"rZg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForStar_Corridor2)
 "rZA" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -58221,8 +59453,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/phoronreinforced/full,
-/obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
 	dir = 8
 	},
@@ -58313,6 +59543,19 @@
 /obj/effect/floor_decal/industrial/bot_outline/blue,
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Harbor)
+"sbw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForStar_1_Deck_Observatory)
 "sbE" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
@@ -58856,9 +60099,9 @@
 /area/maintenance/Deck1_Cargo_Corridor1)
 "skc" = (
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/portable_atmospherics/powered/scrubber/huge,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/orange/border,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "ske" = (
@@ -59182,6 +60425,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock2)
+"srW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Port_Docking_Foyer)
 "ssc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -59464,13 +60720,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -59523,6 +60775,19 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortCorridor1)
+"szo" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Cargo_Chamber1)
 "szt" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -59726,7 +60991,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -59810,11 +61074,14 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_For)
 "sEk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock5)
@@ -59879,6 +61146,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor3)
+"sFb" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/security/Exploration_Sling_Shuttle)
 "sFm" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/white/border,
@@ -59917,13 +61199,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -60354,6 +61632,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Market_Stall_1)
+"sMf" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock1)
 "sMy" = (
 /obj/random/maintenance/clean,
 /turf/simulated/floor/tiled/hydro,
@@ -60771,16 +62061,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -61451,7 +62737,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -61597,6 +62882,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay3)
+"tly" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/GravGen_Room)
 "tlH" = (
 /obj/machinery/door/firedoor/multi_tile/glass{
 	dir = 1
@@ -61617,7 +62912,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -62591,13 +63885,11 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape_pod2/station)
 "tCF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4;
 	color = "#989898"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "tCH" = (
@@ -62641,6 +63933,26 @@
 /obj/random/tech_supply/component,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor3)
+"tCY" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Xenobotany_Lab)
 "tDq" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -62990,6 +64302,18 @@
 /obj/random/maintenance/research,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor3)
+"tKu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock4)
 "tLd" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -63398,6 +64722,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Chamber3)
+"tSH" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Star_Docking_Foyer)
 "tSI" = (
 /obj/machinery/light{
 	dir = 4
@@ -63501,6 +64838,21 @@
 /obj/random/maintenance/morestuff,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber3)
+"tUj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Port_Docking_Foyer)
 "tUw" = (
 /obj/machinery/holoposter,
 /turf/simulated/wall/r_wall,
@@ -63531,16 +64883,12 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
 	},
 /obj/structure/window/basic{
 	dir = 1
-	},
-/obj/structure/window/basic{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/Planetside_Equipment)
@@ -63690,6 +65038,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_6)
+"tYY" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock4)
 "tZf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -65038,6 +66398,34 @@
 /obj/structure/sign/hangar/three,
 /turf/simulated/wall/r_wall,
 /area/hallway/Aft_1_Deck_Stairwell)
+"uwu" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "SC-BDxenobiolockdown";
+	name = "Containment Blast Doors";
+	opacity = 0;
+	layer = 3.5
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Xenobiology_Lab)
 "uwx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -65367,6 +66755,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock1)
+"uEG" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForPort_1_Deck_Observatory)
 "uEH" = (
 /turf/simulated/shuttle/floor,
 /area/shuttle/cryo/station)
@@ -65558,6 +66959,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Gateway)
+"uHQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Fueling_Storage)
 "uHY" = (
 /obj/structure/table/steel,
 /obj/item/storage/briefcase/inflatable{
@@ -66785,6 +68198,19 @@
 /obj/structure/closet/emcloset/legacy,
 /turf/simulated/shuttle/floor/darkred,
 /area/shuttle/expoutpost/station)
+"ver" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftStar1_Corridor1)
 "vet" = (
 /obj/structure/bed/chair/bay/comfy/purple{
 	dir = 1
@@ -67140,17 +68566,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Research_Ship_Bay)
 "viE" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/shuttle/blue{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/harbor/Dock5)
+/turf/simulated/floor/plating,
+/area/harbor/Dock4)
 "viJ" = (
 /obj/structure/table/standard,
 /obj/random/maintenance/cargo,
@@ -67165,12 +68589,6 @@
 /turf/simulated/wall/r_wall,
 /area/rnd/Xenobiology_Lab)
 "viW" = (
-/obj/item/holosign_creator,
-/obj/structure/table/steel,
-/obj/item/holosign_creator{
-	pixel_y = 5;
-	pixel_x = 2
-	},
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
 	pixel_x = 27
@@ -67180,6 +68598,9 @@
 	},
 /obj/effect/floor_decal/corner/mauve/border{
 	dir = 4
+	},
+/obj/machinery/computer/rdconsole/service{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Custodial_Office)
@@ -67348,6 +68769,16 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock4)
+"vkW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock3)
 "vlb" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 2
@@ -67403,6 +68834,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck1_AftStar1_Corridor3)
+"vmu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Star_1Deck_Central_Corridor_1)
 "vna" = (
 /obj/machinery/door/firedoor/multi_tile/glass,
 /obj/effect/floor_decal/industrial/arrows/blue,
@@ -67482,6 +68923,26 @@
 	},
 /turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Port_1Deck_Atrium)
+"vof" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Science_ForCorridor1)
 "voF" = (
 /obj/structure/shuttle/engine/heater,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
@@ -67558,7 +69019,6 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/rnd/Xenobiology_Lab)
 "vpW" = (
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
@@ -68143,13 +69603,9 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
 	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 1
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4
@@ -68352,6 +69808,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Telecomms_Foyer)
+"vBQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForPort_1_Deck_Observatory)
 "vBS" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/red{
@@ -68431,6 +69899,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/rnd/PA_Chamber)
+"vCE" = (
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 4;
+	color = "#989898"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock5)
 "vCF" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -68454,6 +69932,23 @@
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor1)
+"vCV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Supply_Ship_Bay)
 "vCX" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
@@ -69287,6 +70782,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
+"vSu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Cargo_Chamber1)
 "vSI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table,
@@ -69640,6 +71145,11 @@
 "vYi" = (
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor1)
+"vYl" = (
+/obj/machinery/conveyor,
+/obj/machinery/mineral/output,
+/turf/simulated/floor/plating,
+/area/quartermaster/Mining_Ship_Bay)
 "vYv" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 8
@@ -69670,13 +71180,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -69911,6 +71417,18 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor1)
+"wbE" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock1)
 "wbK" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
@@ -70087,14 +71605,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/GravGen_Room)
 "wga" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/harbor/Dock5)
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock3)
 "wgf" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 4
@@ -70356,13 +71878,15 @@
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance/int,
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
 	id = "Sci Lockdown";
 	name = "Lockdown Gate";
 	desc = "A heavily reinforced gate, sector lockdown!";
 	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance/rnd{
+	name = "Circuitry Access"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Star_1Deck_Atrium)
@@ -70540,12 +72064,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Cryostorage_Lounge)
 "wpV" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/structure/cable/white{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled,
 /area/harbor/Dock5)
 "wpY" = (
@@ -70575,11 +72102,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
-/obj/structure/window/basic{
-	dir = 8
-	},
 /obj/structure/window/basic{
 	dir = 1
 	},
@@ -70829,7 +72352,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -70934,7 +72456,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -71160,11 +72681,43 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor3)
 "wBR" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock2)
+"wBV" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/glass/reinforced,
-/area/hallway/Star_1Deck_Central_Corridor_1)
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "SC-BDxenobiopen5";
+	name = "Containment Blast Doors";
+	opacity = 0;
+	layer = 3.5
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Xenobiology_Lab)
 "wBX" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
@@ -71258,13 +72811,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_Transit_Lobby)
 "wEr" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+/obj/structure/window/titanium{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/plating,
 /area/harbor/Dock5)
 "wEw" = (
 /obj/structure/bed/chair/sofa/sif_ora{
@@ -71803,13 +73359,9 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
-/obj/structure/window/phoronreinforced/full,
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
 	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 1
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4
@@ -71998,7 +73550,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -72069,13 +73620,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -72209,6 +73755,42 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Mining_Ship_Bay)
+"wUy" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "SC-BDxenobiopen6";
+	name = "Containment Blast Doors";
+	opacity = 0;
+	layer = 3.5
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Xenobiology_Lab)
+"wUA" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForStar_Corridor2)
 "wVr" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/loading/white{
@@ -72228,13 +73810,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -72590,11 +74168,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -72741,6 +74315,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobiology_Lab)
+"xdA" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock1)
 "xdG" = (
 /obj/random/maintenance/security,
 /turf/simulated/floor/tiled,
@@ -73030,11 +74614,14 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/Star_1Deck_Atrium)
 "xiM" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
 	dir = 1
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/harbor/Dock5)
 "xiN" = (
 /obj/effect/floor_decal/borderfloorwhite/corner,
@@ -73082,7 +74669,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -73155,24 +74741,15 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
 	},
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
-/area/harbor/Dock5)
+/area/harbor/Dock4)
 "xli" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -73319,6 +74896,27 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock4)
+"xmS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Cargo_Corridor3)
 "xmY" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -73365,7 +74963,6 @@
 /turf/simulated/floor/glass,
 /area/hallway/Port_1Deck_Atrium)
 "xoF" = (
-/obj/effect/floor_decal/arrivals/right,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -74873,6 +76470,22 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor1)
+"xVo" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock2)
 "xVw" = (
 /obj/structure/table/glass,
 /obj/item/melee/baton/slime/loaded{
@@ -74891,6 +76504,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Xenobiology_Lab)
+"xVx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock1)
 "xVH" = (
 /turf/simulated/floor/tiled,
 /area/security/Quantum_Pad_Checkpoint)
@@ -75122,16 +76748,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75165,6 +76787,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
+"xZE" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Xenobotany_Isolation_Chamber)
 "xZL" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/window/brigdoor/eastleft{
@@ -75441,15 +77083,17 @@
 	},
 /area/security/Quantum_Pad_Checkpoint)
 "ydb" = (
-/obj/effect/shuttle_landmark{
-	base_area = /area/space;
-	base_turf = /turf/space;
-	docking_controller = "sc-D1_L5A3_airlock";
-	landmark_tag = "sc-D1_L5A3";
-	name = "Docking Lane 5 Airlock 3"
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/turf/space,
-/area/space)
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftStar_1_Deck_Observatory)
 "ydF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -75732,13 +77376,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -83483,10 +85123,10 @@ aaa
 aaa
 qVz
 qVz
-syL
+xmS
 syL
 qVz
-syL
+xmS
 syL
 qVz
 qVz
@@ -83988,8 +85628,8 @@ qVz
 qVz
 qVz
 qVz
-syL
-syL
+xmS
+eQv
 syL
 qVz
 qVz
@@ -84010,7 +85650,7 @@ hBK
 ohA
 qVz
 qVz
-syL
+dSZ
 qVz
 qVz
 aaa
@@ -85010,7 +86650,7 @@ aaa
 ixO
 aaa
 aaa
-lxF
+bXf
 acx
 acx
 kkV
@@ -85313,12 +86953,12 @@ aBf
 aBf
 rqS
 rqS
-aNX
-aNX
+dym
+mOq
 aNX
 rqS
-aNX
-aNX
+dym
+mOq
 aNX
 rqS
 gNJ
@@ -85784,7 +87424,7 @@ aaa
 ixO
 aaa
 aaa
-lxF
+bXf
 fLw
 fLw
 jmQ
@@ -86302,8 +87942,8 @@ cSw
 cSw
 cSw
 qsN
-anx
-anx
+cdn
+cpe
 anx
 qsN
 qtH
@@ -88196,17 +89836,17 @@ aaa
 aaa
 aaa
 szS
-aBe
+bMe
 gwU
 tWM
 tWM
-aBe
+bMe
 akd
 aaa
 aaa
-aBe
+bMe
 gwU
-aBe
+bMe
 aaa
 aaa
 aaf
@@ -88214,9 +89854,9 @@ iFw
 aaf
 aaa
 aaa
-aBe
+bMe
 gwU
-aBe
+bMe
 aaa
 aaa
 aaa
@@ -88224,9 +89864,9 @@ aaa
 aaa
 aaa
 aaa
-aBe
+bMe
 gwU
-aBe
+bMe
 aaa
 aaa
 aaa
@@ -89189,7 +90829,7 @@ eHa
 bMN
 dWG
 ddb
-aov
+vCV
 aaa
 aaa
 aaa
@@ -89225,41 +90865,41 @@ aaa
 aaa
 aaa
 cfp
-aBe
+khE
 sCH
 cfp
-aBe
+xVx
 hTg
 eDP
 eZA
-aBe
+xVx
 aaa
 aaa
-aBe
-aBe
+sMf
+pMC
 iZh
-aBe
-aBe
+wbE
+xdA
 aaa
 aaa
 cfp
 aaa
 aaa
-aBe
-aBe
+sMf
+pMC
 iZh
-aBe
-aBe
+wbE
+xdA
 aaa
 aaa
 cfp
 aaa
 aaa
-aBe
-aBe
+sMf
+pMC
 iZh
-aBe
-aBe
+wbE
+xdA
 aaa
 aaa
 aaa
@@ -89447,7 +91087,7 @@ dVZ
 aVn
 jWC
 gia
-aov
+iic
 aaa
 aaa
 aaa
@@ -89492,39 +91132,39 @@ aYG
 fWo
 tPO
 nCw
-aBe
-aBe
+rbq
+pMC
 fsK
 sll
 fsK
-aBe
-aBe
+wbE
+gOu
 cfp
 cfp
 cfp
-aBe
-aBe
+rbq
+pMC
 fsK
 sll
 fsK
-aBe
-aBe
+wbE
+gOu
 cfp
 cfp
 cfp
-aBe
-aBe
+rbq
+pMC
 fsK
 sll
 fsK
-aBe
-aBe
+wbE
+gOu
 cfp
 cfp
-aBe
-aBe
-sCH
-aBe
+rbq
+bAW
+bAW
+gOu
 aaa
 aaa
 aaa
@@ -89671,7 +91311,7 @@ caq
 top
 top
 vai
-jsH
+bvF
 xrX
 xoB
 lRw
@@ -89929,7 +91569,7 @@ nDe
 vBh
 ylm
 vCX
-jsH
+rxL
 xrX
 xoB
 hIf
@@ -89999,8 +91639,8 @@ aaa
 aaa
 aaa
 cfp
-aBe
-aBe
+khE
+khE
 cfp
 kwu
 aAX
@@ -90266,39 +91906,39 @@ aAX
 inz
 cfp
 cfp
-aBe
-aBe
-aBe
+rbq
+bAW
+gOu
 cfp
-aBe
-aBe
-aBe
+rbq
+bAW
+gOu
 cfp
-aBe
+bMe
 hTg
 eDP
-aBe
+bMe
 aCV
 mLv
 aAY
-aBe
+bMe
 eDP
 vgS
-aBe
+bMe
 cfp
 cfp
-aBe
-aBe
-aBe
+rbq
+bAW
+gOu
 cfp
-aBe
-aBe
-aBe
+rbq
+bAW
+gOu
 cfp
-aBe
-aBe
-aBe
-aBe
+rbq
+bAW
+bAW
+gOu
 aaa
 aaa
 aaa
@@ -90514,7 +92154,7 @@ aaa
 aaa
 aaa
 aaa
-aBe
+bMe
 aAY
 eJf
 ais
@@ -90523,7 +92163,7 @@ aAX
 aAX
 wqR
 hww
-aBe
+bMe
 aaa
 aaa
 aaa
@@ -90960,8 +92600,8 @@ qHw
 iuh
 eUo
 jzz
-wsf
-jsH
+lGW
+rxL
 xrX
 xrX
 aaM
@@ -91196,7 +92836,7 @@ aaa
 ixO
 aaa
 aaa
-gZx
+vSu
 tkl
 wcD
 eao
@@ -91288,7 +92928,7 @@ aaa
 aaa
 aaa
 aaa
-aBe
+xVx
 aAY
 gID
 eZD
@@ -91297,7 +92937,7 @@ aAX
 aAX
 wqR
 aAY
-aBe
+xVx
 aaa
 aaa
 aaa
@@ -91306,17 +92946,17 @@ aaa
 aaa
 aaa
 aaa
-aBe
+xVx
 gwU
 tWM
-aBe
+xVx
 aaa
 aaa
 aaa
-aBe
+xVx
 tWM
 edM
-aBe
+xVx
 aaa
 aaa
 aaa
@@ -91454,7 +93094,7 @@ aaa
 ixO
 aaa
 aaa
-gZx
+szo
 fwc
 tkl
 nnV
@@ -91473,11 +93113,11 @@ iXQ
 iXQ
 fKK
 saW
+vYl
 iXQ
 iXQ
-iXQ
-wsf
-jsH
+pGQ
+fQW
 xrX
 xrX
 aaM
@@ -91563,23 +93203,23 @@ aaa
 aaa
 aaa
 aaa
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91817,27 +93457,27 @@ cfp
 aaa
 aaa
 aaa
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-vXj
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92062,7 +93702,7 @@ aaa
 aaa
 aaa
 aaa
-aBe
+bMe
 aAY
 rCP
 oBC
@@ -92071,31 +93711,31 @@ aAX
 aAX
 wqR
 aAY
-aBe
+bMe
 aaa
 aaa
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92332,29 +93972,29 @@ aAY
 aBe
 aaa
 aaa
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92590,29 +94230,29 @@ aAY
 aBe
 aaa
 aaa
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92836,7 +94476,7 @@ aaa
 aaa
 aaa
 aaa
-aBe
+xVx
 afV
 eJf
 jFz
@@ -92845,32 +94485,32 @@ aAX
 aAX
 wqR
 hww
-aBe
+xVx
 aaa
 aaa
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-jHx
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93106,29 +94746,29 @@ cfp
 cfp
 aaa
 aaa
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93262,7 +94902,7 @@ ixO
 aaa
 aaa
 aaa
-gZx
+vSu
 pZd
 fwc
 fwc
@@ -93364,29 +95004,29 @@ cfp
 aaa
 aaa
 aaa
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93520,7 +95160,7 @@ ixO
 aaa
 aaa
 aaa
-gZx
+szo
 mWL
 fwc
 fwc
@@ -93575,7 +95215,7 @@ jrU
 tvS
 arR
 lcQ
-eaO
+hXv
 aaa
 aaa
 ixO
@@ -93622,28 +95262,28 @@ aiO
 aaa
 aaa
 aaa
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93833,7 +95473,7 @@ wub
 eYA
 arR
 bOY
-eaO
+faU
 aaa
 aaa
 ixO
@@ -93881,27 +95521,27 @@ aaa
 aaa
 aaa
 aaa
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94018,11 +95658,11 @@ aaa
 aaa
 aaa
 aaa
-bWN
-bWN
-bWN
-bWN
-bWN
+vBQ
+myO
+myO
+myO
+uEG
 wiX
 wiX
 aaa
@@ -94104,11 +95744,11 @@ aaa
 aaa
 gSQ
 gSQ
-dQF
-dQF
-dQF
-dQF
-dQF
+fGh
+iuJ
+iuJ
+iuJ
+nyc
 aaa
 aaa
 aaa
@@ -94143,23 +95783,23 @@ aaa
 aaa
 aaa
 aaa
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
-pFU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94276,7 +95916,7 @@ aaa
 aaa
 aaa
 aaa
-bWN
+rTR
 iEp
 iEp
 iEp
@@ -94366,7 +96006,7 @@ hak
 hak
 hak
 hak
-dQF
+fVP
 aaa
 aaa
 aaa
@@ -94384,7 +96024,7 @@ aaa
 aaa
 aaa
 aaa
-act
+mOX
 nwU
 dxC
 cTv
@@ -94393,7 +96033,7 @@ xlE
 xlE
 ijD
 ack
-act
+mOX
 aaa
 aaa
 aaa
@@ -94402,17 +96042,17 @@ aaa
 aaa
 aaa
 aaa
-act
+mOX
 acF
 lbO
-act
+mOX
 aaa
 aaa
 aaa
-act
+mOX
 lbO
 kxP
-act
+mOX
 aaa
 aaa
 aaa
@@ -94534,7 +96174,7 @@ aaa
 aaa
 aaa
 aaa
-bWN
+rTR
 quc
 eni
 iEp
@@ -94624,7 +96264,7 @@ dht
 ihk
 jhG
 eHg
-dQF
+fVP
 aaa
 aaa
 aaa
@@ -94642,7 +96282,7 @@ aaa
 aaa
 aaa
 aaa
-act
+wBR
 nwU
 dxC
 cTv
@@ -94651,7 +96291,7 @@ xlE
 xlE
 ijD
 nwU
-act
+wBR
 aaa
 aaa
 aaa
@@ -94660,17 +96300,17 @@ aaa
 aaa
 aaa
 aaa
-act
+wBR
 vQS
 aKj
-act
+wBR
 aaa
 aaa
 aaa
-act
+wBR
 aNx
 aGt
-act
+wBR
 aaa
 aaa
 aaa
@@ -94792,7 +96432,7 @@ aaa
 aaa
 aaa
 aaa
-bWN
+rTR
 iEp
 rKK
 iEp
@@ -94882,7 +96522,7 @@ lom
 hmU
 pwU
 hak
-dQF
+fVP
 aaa
 aaa
 aaa
@@ -94900,7 +96540,7 @@ aaa
 aaa
 aaa
 aaa
-act
+wBR
 kRj
 dxC
 cTv
@@ -94909,7 +96549,7 @@ xlE
 xlE
 ijD
 nwU
-act
+wBR
 aaa
 aaa
 aaa
@@ -94918,17 +96558,17 @@ aaa
 aaa
 aaa
 aaa
-act
+wBR
 eEX
 bMw
-act
+wBR
 aaa
 aaa
 aaa
-act
+wBR
 cZl
 bCH
-act
+wBR
 aaa
 aaa
 aaa
@@ -95062,12 +96702,12 @@ wiX
 wiX
 fGi
 ary
-ary
-ary
+khu
+aUv
 fGi
 ary
-ary
-ary
+khu
+aUv
 fGi
 fGi
 fGi
@@ -95124,13 +96764,13 @@ aVS
 aVS
 aVS
 xYR
+eyi
 dSs
-dSs
-dSs
+nkG
 aNF
+eyi
 dSs
-dSs
-dSs
+nkG
 gSQ
 gSQ
 gSQ
@@ -95158,7 +96798,7 @@ aaa
 aaa
 aaa
 aaa
-act
+dfv
 nwU
 lbL
 awo
@@ -95167,7 +96807,7 @@ xlE
 xlE
 ijD
 ack
-act
+dfv
 aaa
 aaa
 aaa
@@ -95176,17 +96816,17 @@ aaa
 aaa
 aaa
 aaa
-act
+wBR
 lkw
 qRr
-act
+wBR
 aiO
 aiO
 aiO
-act
+wBR
 pJV
 rlK
-act
+wBR
 aaa
 aaa
 aaa
@@ -95426,37 +97066,37 @@ xlE
 dvj
 ggA
 dCC
-act
-act
-act
-aiO
-act
-act
+lUx
+lgu
 act
 aiO
+lUx
+lgu
 act
+aiO
+dfv
 aND
 nIg
-act
+dfv
 mrC
 dfh
 nwU
-act
+dfv
 nIg
 gXp
-act
+dfv
 aiO
 aiO
-act
-act
-act
-aiO
-act
-act
+lUx
+lgu
 act
 aiO
+lUx
+lgu
 act
-act
+aiO
+lUx
+lgu
 wSw
 act
 aaa
@@ -95932,7 +97572,7 @@ aaa
 aaa
 aaa
 aaa
-act
+mOX
 nwU
 vuh
 rUQ
@@ -95940,7 +97580,7 @@ umz
 xlE
 xlE
 lYo
-act
+xVo
 sHW
 aBK
 dXq
@@ -96190,7 +97830,7 @@ aaa
 aaa
 aaa
 aaa
-act
+wBR
 nwU
 dxC
 cTv
@@ -96376,7 +98016,7 @@ rrc
 aaM
 aaM
 aaM
-alh
+cUC
 alh
 qgA
 aaM
@@ -96448,7 +98088,7 @@ aaa
 aaa
 aaa
 aaa
-act
+wBR
 nwU
 dxC
 cTv
@@ -96458,37 +98098,37 @@ xlE
 qAp
 btl
 aiO
-act
-act
+lUx
+lgu
 act
 aiO
 nwU
 nwU
 nwU
 aiO
-act
-act
+lUx
+lgu
 act
 aiO
 ack
 ett
 ack
 aiO
-act
-act
+lUx
+lgu
 act
 aiO
 nwU
 nwU
 nwU
 aiO
-act
-act
+lUx
+lgu
 act
 aiO
-act
-act
-act
+lUx
+lgu
+lgu
 wSw
 act
 aaa
@@ -96602,7 +98242,7 @@ aaa
 ixO
 aaa
 aaa
-awR
+fQz
 ajg
 ske
 cHS
@@ -96706,7 +98346,7 @@ aaa
 aaa
 aaa
 aaa
-act
+dfv
 kRj
 dxC
 cTv
@@ -96720,24 +98360,24 @@ aaa
 aaa
 aaa
 aiO
-act
-act
-act
-aiO
-aaa
-aaa
-aaa
-aiO
-act
-act
+lUx
+lgu
 act
 aiO
 aaa
 aaa
 aaa
 aiO
+lUx
+lgu
 act
-act
+aiO
+aaa
+aaa
+aaa
+aiO
+lUx
+lgu
 act
 aiO
 aaa
@@ -96860,7 +98500,7 @@ aaa
 ixO
 aaa
 aaa
-awR
+rlJ
 tij
 wMB
 tij
@@ -96897,7 +98537,7 @@ bVF
 map
 aSf
 sFQ
-aaX
+qAx
 xAc
 xAc
 xAc
@@ -96972,7 +98612,7 @@ nFh
 xlE
 xlE
 ijD
-act
+mOX
 aaa
 aaa
 aaa
@@ -97155,7 +98795,7 @@ uJo
 aTE
 xXL
 ybW
-aaX
+gHS
 xAc
 xAc
 xAc
@@ -97230,7 +98870,7 @@ akk
 vDr
 aMv
 lQq
-act
+mBn
 aaa
 aaa
 aaa
@@ -97634,7 +99274,7 @@ aaa
 ixO
 aaa
 aaa
-awR
+fQz
 tij
 wMB
 tij
@@ -97740,7 +99380,7 @@ aDi
 aDi
 aDi
 aDi
-yjc
+bSy
 aDi
 hOT
 slX
@@ -98387,7 +100027,7 @@ aaa
 aaa
 oZJ
 hLC
-hLC
+kZQ
 eSR
 phf
 aQG
@@ -98520,7 +100160,7 @@ saP
 kaI
 bEm
 gll
-yjc
+ips
 aaa
 aaa
 aaa
@@ -98641,8 +100281,8 @@ aaa
 aaa
 oZJ
 hLC
-hLC
-hLC
+djp
+kZQ
 oZJ
 afm
 ncr
@@ -98778,7 +100418,7 @@ ilO
 cuX
 bEm
 hoU
-yjc
+srW
 aaa
 aaa
 aaa
@@ -98896,7 +100536,7 @@ aaa
 aaa
 oZJ
 hLC
-hLC
+kZQ
 oZJ
 afm
 ncr
@@ -99291,8 +100931,8 @@ jod
 esZ
 mrr
 aDi
-yjc
-yjc
+tUj
+hfM
 yjc
 aDi
 uDE
@@ -99407,7 +101047,7 @@ aaa
 aaa
 aaa
 oZJ
-hLC
+hoE
 oZJ
 exY
 afm
@@ -99477,7 +101117,7 @@ aTE
 aTE
 aSf
 ybW
-aaX
+qAx
 lun
 xAc
 ovz
@@ -99735,7 +101375,7 @@ hBp
 lmf
 sFQ
 sFQ
-aaX
+gHS
 xAc
 xAc
 ovz
@@ -100059,7 +101699,7 @@ fFD
 fFD
 fFD
 aDi
-yjc
+tUj
 yjc
 hne
 jCD
@@ -101006,10 +102646,10 @@ gLY
 nAs
 pjh
 hqB
-hqB
+iex
 lCS
 hqB
-hqB
+iex
 lCS
 lCS
 abs
@@ -101386,23 +103026,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
 aaa
 aaa
 aaa
@@ -101640,27 +103280,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+vXj
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
 aaa
 aaa
 aaa
@@ -101897,28 +103537,28 @@ iKg
 aaa
 vuJ
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
 aaa
 aaa
 aaa
@@ -102155,29 +103795,29 @@ iKg
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
 aaa
 aaa
 aaa
@@ -102301,7 +103941,7 @@ aaa
 aaa
 aaa
 aaa
-cRu
+dCQ
 cIr
 nJj
 asV
@@ -102309,7 +103949,7 @@ asV
 asV
 ovF
 hhx
-pKZ
+pBU
 pKZ
 cIR
 bsY
@@ -102413,29 +104053,29 @@ iKg
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
 aaa
 aaa
 aaa
@@ -102559,7 +104199,7 @@ vuJ
 aaa
 aaa
 aaa
-cRu
+tly
 cIr
 pAv
 iTC
@@ -102582,7 +104222,7 @@ qls
 tqY
 epy
 fDx
-aqG
+bXn
 uKF
 anO
 ddh
@@ -102671,29 +104311,29 @@ iKg
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+jHx
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
 aaa
 aaa
 aaa
@@ -102817,7 +104457,7 @@ aaa
 aaa
 aaa
 aaa
-cRu
+tly
 aCp
 pAv
 iTC
@@ -102840,7 +104480,7 @@ qls
 sJC
 epy
 oXp
-aqG
+kzO
 uKF
 avP
 tpZ
@@ -102929,29 +104569,29 @@ iKg
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
 aaa
 aaa
 aaa
@@ -103075,7 +104715,7 @@ aaa
 aaa
 aaa
 aaa
-cRu
+tly
 cIr
 pAv
 iTC
@@ -103187,29 +104827,29 @@ iKg
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
 aaa
 aaa
 aaa
@@ -103341,7 +104981,7 @@ cOl
 cOl
 ipW
 hmG
-pKZ
+pBU
 pKZ
 lax
 aiY
@@ -103445,28 +105085,28 @@ iKg
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
 aaa
 aaa
 aaa
@@ -103704,27 +105344,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-khE
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
 aaa
 aaa
 aaa
@@ -103942,8 +105582,8 @@ dgJ
 aTj
 aKi
 bLA
-bLA
-bLA
+uHQ
+ffT
 aKi
 aKi
 aKi
@@ -103959,7 +105599,6 @@ chQ
 ekA
 iKg
 aaa
-psu
 aaa
 aaa
 aaa
@@ -103967,22 +105606,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
+pFU
 aaa
 aaa
 aaa
@@ -104182,8 +105822,8 @@ gqi
 lcw
 lcw
 dYn
-dYn
-dYn
+cQa
+peQ
 lcw
 aRU
 eMu
@@ -104225,12 +105865,12 @@ aaa
 aaa
 aaa
 szS
-agL
-wXp
+oya
 wXp
 jEb
-agL
+oya
 akd
+aaa
 aaa
 aaa
 aaa
@@ -104333,12 +105973,12 @@ tpj
 aQY
 blz
 aQY
-aOv
+rOz
 qZw
 fVs
 njm
 xRw
-tUU
+lqN
 jKH
 cVF
 kZC
@@ -104473,24 +106113,24 @@ ibt
 wgO
 rcs
 kSE
-agL
-agL
-agL
-agL
-kSE
-agL
-agL
-agL
+qvX
+wEr
+wEr
 agL
 kSE
+qvX
+wEr
+wEr
 agL
+kSE
+xiM
 iDD
-jLb
 wHM
-agL
+xiM
 iFw
 iFw
 aaf
+aaa
 aaa
 aaa
 aaa
@@ -104632,7 +106272,7 @@ dHq
 dVW
 qkX
 vxR
-aFf
+qws
 aWf
 rFW
 ivU
@@ -104741,14 +106381,14 @@ mdY
 mdY
 bCp
 bap
-agL
+xiM
 cOQ
 rsk
 xiM
-agL
 jlA
 fZW
 iFw
+aaa
 aaa
 aaa
 aaa
@@ -104890,8 +106530,8 @@ ije
 dVX
 qkX
 skH
-aFf
-aFf
+fIl
+fIl
 xde
 bmu
 cPd
@@ -104999,14 +106639,14 @@ sQR
 sQR
 gjp
 dVV
-agL
-oSV
+mZW
+baS
 buZ
-oSV
-agL
+mZW
 jlA
 lGZ
 oRK
+aaa
 aaa
 aaa
 aaa
@@ -105148,8 +106788,8 @@ dIq
 cZt
 qkX
 dFO
-aFf
-aFf
+fIl
+fIl
 rFW
 mdg
 cPd
@@ -105260,11 +106900,11 @@ aJT
 elp
 dXe
 jEu
-mOX
 kSE
+qvX
+wEr
 agL
-xkT
-agL
+aaa
 aaa
 aaa
 aaa
@@ -105518,11 +107158,11 @@ dNN
 bBx
 dhx
 nBS
-wga
 pHp
 rdk
 dgp
 bot
+aaa
 aaa
 aaa
 aaa
@@ -105776,13 +107416,13 @@ fIm
 bry
 sPh
 wpV
-ojM
 buo
 pyv
 bFI
 bot
 aaa
 kAW
+aaa
 aaa
 aaa
 aaa
@@ -105922,7 +107562,7 @@ cjG
 cjG
 fCA
 cCj
-aFf
+qws
 aWf
 rFW
 mdg
@@ -106034,11 +107674,11 @@ dNN
 bBx
 mWi
 sEk
-wEr
 gvO
 sRF
 lFn
 mPv
+aaa
 aaa
 aaa
 aaa
@@ -106180,8 +107820,8 @@ jBl
 dVU
 fCA
 dFO
-aFf
-aFf
+fIl
+fIl
 rFW
 mdg
 oJF
@@ -106291,12 +107931,12 @@ ntT
 aJT
 mmk
 dXe
-jEu
-pBU
+lZN
 kSE
+qvX
+wEr
 agL
-xkT
-agL
+aaa
 aaa
 aaa
 aaa
@@ -106438,8 +108078,8 @@ fXc
 aBh
 fCA
 cjG
-aFf
-aFf
+fIl
+fIl
 gmR
 fSV
 ull
@@ -106547,14 +108187,14 @@ fOX
 fOX
 tcF
 dVV
-agL
-wHM
+oya
+vCE
 tCF
-wHM
-agL
+oya
 jlA
 lGZ
 dLR
+aaa
 aaa
 aaa
 aaa
@@ -106805,14 +108445,14 @@ fHt
 fHt
 pCF
 lvp
-agL
+xiM
 abh
 bBM
 xiM
-agL
 jlA
 deu
 iFw
+aaa
 aaa
 aaa
 aaa
@@ -107053,24 +108693,24 @@ eLq
 mQo
 cAM
 kSE
-agL
-agL
-agL
-agL
-kSE
-agL
-agL
-agL
+qvX
+wEr
+wEr
 agL
 kSE
+qvX
+wEr
+wEr
 agL
+kSE
+xiM
 mkx
-viE
 oSV
-agL
+xiM
 iFw
 iFw
 aaf
+aaa
 aaa
 aaa
 aaa
@@ -107278,8 +108918,8 @@ gqi
 lcw
 lcw
 dYn
-dYn
-dYn
+cQa
+peQ
 lcw
 aEZ
 eMu
@@ -107321,12 +108961,12 @@ aaa
 aaa
 aaa
 szS
-agL
-wXp
+mZW
 wXp
 mlW
-agL
+mZW
 akd
+aaa
 aaa
 aaa
 aaa
@@ -107553,13 +109193,13 @@ nVk
 lYS
 vtD
 aVW
+jLb
 aEU
-aEU
-aEU
+pdY
 aVW
+jLb
 aEU
-aEU
-aEU
+pdY
 aVW
 aVW
 aVW
@@ -107578,20 +109218,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
 aaa
 aaa
 aaa
@@ -107720,7 +109360,7 @@ aaa
 aaa
 aaa
 aaa
-bdG
+dXT
 cpH
 doD
 ilo
@@ -107834,22 +109474,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-ydb
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afo
+afo
+afo
+afo
+gXl
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
 aaa
 aaa
 aaa
@@ -107978,7 +109618,7 @@ aaa
 aaa
 aaa
 aaa
-bdG
+lWV
 hDo
 liJ
 uOn
@@ -108091,24 +109731,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
 aaa
 aaa
 aaa
@@ -108236,7 +109876,7 @@ aaa
 aaa
 aaa
 aaa
-bdG
+lWV
 tLI
 dZQ
 bzz
@@ -108349,24 +109989,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
 aaa
 aaa
 aaa
@@ -108607,24 +110247,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+qpp
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
 aaa
 aaa
 aaa
@@ -108865,24 +110505,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
 aaa
 aaa
 aaa
@@ -109123,24 +110763,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
 aaa
 aaa
 aaa
@@ -109268,7 +110908,7 @@ aaa
 aaa
 aaa
 aaa
-bdG
+dXT
 pVQ
 lXb
 pFS
@@ -109382,22 +111022,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
 aaa
 aaa
 aaa
@@ -109526,7 +111166,7 @@ aaa
 aaa
 aaa
 aaa
-bdG
+lWV
 ajD
 dZQ
 dDc
@@ -109642,20 +111282,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
+afo
 aaa
 aaa
 aaa
@@ -110577,8 +112217,8 @@ adX
 hAP
 sOr
 adX
-wBR
-wBR
+adX
+adX
 rtQ
 vQi
 ygP
@@ -111291,10 +112931,10 @@ aJl
 qYB
 aJl
 obx
-oYt
+sFb
 oYt
 kJg
-oYt
+sFb
 oYt
 siv
 uUf
@@ -111411,8 +113051,8 @@ xGs
 xGs
 xGs
 cof
-ptP
-ptP
+cMu
+tSH
 hXO
 jDD
 xgm
@@ -111603,7 +113243,7 @@ eav
 eau
 wal
 wal
-aGk
+vmu
 adX
 adX
 ajE
@@ -111861,7 +113501,7 @@ eaw
 eaw
 dgH
 oIG
-aGk
+afC
 mOg
 adX
 ajE
@@ -112191,9 +113831,9 @@ aLS
 aaD
 brr
 cof
-ptP
-ptP
-ptP
+cMu
+iQE
+tSH
 cof
 eab
 eab
@@ -112309,7 +113949,7 @@ aaa
 aaa
 aaa
 aaa
-fXM
+nwQ
 vYL
 aJl
 aJl
@@ -113085,13 +114725,13 @@ aaa
 aaa
 pdh
 pdh
-pmK
-pmK
-pdh
-pmK
+dCH
 pmK
 pdh
+dCH
 pmK
+pdh
+dCH
 pmK
 pdh
 pdh
@@ -113372,7 +115012,7 @@ aaa
 aaa
 aaa
 aaa
-gdk
+hcm
 feH
 tEO
 feH
@@ -114146,7 +115786,7 @@ aaa
 aaa
 aaa
 aaa
-gdk
+aOK
 feH
 tEO
 bGw
@@ -114183,7 +115823,7 @@ eCS
 eaw
 mzf
 oIG
-aGk
+vmu
 adX
 adX
 adX
@@ -114228,7 +115868,7 @@ vUq
 gDq
 oVU
 tyW
-axa
+oxa
 aaa
 aaa
 ixO
@@ -114258,7 +115898,7 @@ hEH
 ghn
 qfh
 tiD
-aqv
+psu
 aaa
 aaa
 aaa
@@ -114404,7 +116044,7 @@ aaa
 aaa
 aaa
 aaa
-gdk
+hcm
 feH
 tEO
 tEO
@@ -114441,7 +116081,7 @@ cit
 qhk
 dgH
 wal
-aGk
+afC
 adX
 adX
 adX
@@ -114486,7 +116126,7 @@ oVU
 oVU
 oVU
 vOL
-axa
+rRx
 aaa
 aaa
 ixO
@@ -114516,7 +116156,7 @@ ahi
 gnl
 gnl
 fST
-aqv
+wga
 aaa
 aaa
 aaa
@@ -114700,13 +116340,13 @@ dkj
 gCn
 dXp
 fjY
-bMe
-bMe
+adX
+adX
 adX
 kEq
 bOT
-bMe
-bMe
+adX
+adX
 ugh
 pQL
 vgc
@@ -114766,7 +116406,7 @@ aaa
 aaa
 aaa
 aaa
-aqv
+psu
 vpF
 fcH
 kXy
@@ -114780,25 +116420,25 @@ aaa
 aaa
 aaa
 pmj
+bef
 aqv
-aqv
-aqv
+aLV
 pmj
 aaa
 aaa
 aaa
 pmj
+bef
 aqv
-aqv
-aqv
+aLV
 pmj
 aaa
 aaa
 aaa
 pmj
+bef
 aqv
-aqv
-aqv
+aLV
 pmj
 aaa
 aaa
@@ -114952,7 +116592,7 @@ ijM
 qFn
 qFn
 qFn
-wVF
+cXL
 wVF
 plz
 qFn
@@ -115024,7 +116664,7 @@ aaa
 aaa
 aaa
 aaa
-aqv
+vkW
 vpF
 fcH
 kXy
@@ -115034,39 +116674,39 @@ gnl
 vBd
 hQV
 pmj
+bef
 aqv
-aqv
-aqv
+aLV
 pmj
 vpF
 vpF
 vpF
 pmj
+bef
 aqv
-aqv
-aqv
+aLV
 pmj
 cJw
 hPd
 cJw
 pmj
+bef
 aqv
-aqv
-aqv
+aLV
 pmj
 vpF
 vpF
 vpF
 pmj
+bef
 aqv
-aqv
-aqv
+aLV
 pmj
+bef
 aqv
 aqv
 aqv
-htm
-aqv
+aLV
 aaa
 aaa
 aaa
@@ -115282,7 +116922,7 @@ aaa
 aaa
 aaa
 aaa
-aqv
+vkW
 aQW
 fcH
 kXy
@@ -115540,7 +117180,7 @@ aaa
 aaa
 aaa
 aaa
-aqv
+wga
 vpF
 kEl
 qeQ
@@ -115548,7 +117188,7 @@ hFI
 gnl
 gnl
 dSy
-aqv
+aNg
 ozZ
 asO
 hmu
@@ -116066,39 +117706,39 @@ gnl
 leN
 oKL
 edb
+bef
 aqv
-aqv
-aqv
+aLV
 pmj
+bef
 aqv
-aqv
-aqv
+aLV
 pmj
-aqv
+psu
 oKx
 oul
-aqv
+psu
 ors
 pYg
 vpF
-aqv
+psu
 oul
 iZU
-aqv
+psu
 pmj
 pmj
+bef
 aqv
-aqv
-aqv
+aLV
 pmj
+bef
 aqv
-aqv
-aqv
+aLV
 pmj
-aqv
+bef
 aqv
 htm
-aqv
+aLV
 aaa
 aaa
 aaa
@@ -116206,7 +117846,7 @@ aaa
 aaa
 aaa
 aaa
-fUe
+sbw
 aNJ
 jVq
 aNJ
@@ -116217,13 +117857,13 @@ aPe
 aPe
 aPe
 tqK
-xbG
-xbG
-xbG
+hSg
+hrJ
+rZg
 tqK
-xbG
-xbG
-xbG
+hSg
+hrJ
+rZg
 tqK
 tqK
 tqK
@@ -116280,12 +117920,12 @@ oIK
 rYm
 rYm
 dYc
-dYc
-dYc
+jAb
+ver
 rYm
 dYc
-dYc
-dYc
+jAb
+ver
 rYm
 apD
 apD
@@ -116296,7 +117936,7 @@ ajZ
 xFV
 wvD
 cUK
-mUs
+pNg
 aaa
 aaa
 aaa
@@ -116314,7 +117954,7 @@ aaa
 aaa
 aaa
 aaa
-aqv
+psu
 vpF
 dgC
 pAh
@@ -116323,7 +117963,7 @@ gnl
 gnl
 fST
 cJw
-aqv
+psu
 aaa
 aaa
 aaa
@@ -116332,17 +117972,17 @@ aaa
 aaa
 aaa
 aaa
-aqv
+vkW
 bYk
 uWK
-aqv
+vkW
 pmj
 pmj
 pmj
-aqv
+vkW
 atP
 ets
-aqv
+vkW
 aaa
 aaa
 aaa
@@ -116572,7 +118212,7 @@ aaa
 aaa
 aaa
 aaa
-aqv
+vkW
 vpF
 fcH
 kXy
@@ -116581,7 +118221,7 @@ gnl
 gnl
 fST
 vpF
-aqv
+vkW
 aaa
 aaa
 aaa
@@ -116590,17 +118230,17 @@ aaa
 aaa
 aaa
 aaa
-aqv
+vkW
 afw
 qtB
-aqv
+vkW
 aaa
 aaa
 aaa
-aqv
+vkW
 eyT
 ksQ
-aqv
+vkW
 aaa
 aaa
 aaa
@@ -116830,7 +118470,7 @@ aaa
 aaa
 aaa
 aaa
-aqv
+vkW
 vpF
 fcH
 kXy
@@ -116839,7 +118479,7 @@ gnl
 gnl
 fST
 vpF
-aqv
+vkW
 aaa
 aaa
 aaa
@@ -116848,17 +118488,17 @@ aaa
 aaa
 aaa
 aaa
-aqv
+vkW
 hPn
 jrj
-aqv
+vkW
 aaa
 aaa
 aaa
-aqv
+vkW
 aVH
 aTA
-aqv
+vkW
 aaa
 aaa
 aaa
@@ -117088,7 +118728,7 @@ aaa
 aaa
 aaa
 aaa
-aqv
+wga
 aQW
 fcH
 kXy
@@ -117097,7 +118737,7 @@ gnl
 gnl
 fST
 cJw
-aqv
+wga
 aaa
 aaa
 aaa
@@ -117106,17 +118746,17 @@ aaa
 aaa
 aaa
 aaa
-aqv
+wga
 bMq
 tNm
-aqv
+wga
 aaa
 aaa
 aaa
-aqv
+wga
 tNm
 vnC
-aqv
+wga
 aaa
 aaa
 aaa
@@ -117238,11 +118878,11 @@ aaa
 aaa
 aaa
 aaa
-fUe
-fUe
-fUe
-fUe
-fUe
+mJQ
+nFc
+nFc
+nFc
+lIl
 aPe
 aPe
 aaa
@@ -117324,11 +118964,11 @@ aaa
 aaa
 apD
 apD
-mUs
-mUs
-mUs
-mUs
-mUs
+lxl
+ydb
+ydb
+ydb
+nLf
 aaa
 aaa
 aaa
@@ -117363,20 +119003,20 @@ aaa
 aaa
 aaa
 aaa
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117619,22 +119259,22 @@ aaa
 aaa
 aaa
 aaa
-afo
-afo
-afo
-afo
-gXl
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117876,24 +119516,24 @@ aaa
 aaa
 aaa
 aaa
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118030,7 +119670,7 @@ aaa
 ixO
 aaa
 aaa
-xbG
+wUA
 gPH
 itq
 uah
@@ -118134,24 +119774,24 @@ aaa
 aaa
 aaa
 aaa
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118288,7 +119928,7 @@ aaa
 ixO
 aaa
 aaa
-xbG
+jSB
 rYx
 itq
 uah
@@ -118392,24 +120032,24 @@ aaa
 aaa
 aaa
 aaa
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-qpp
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118636,7 +120276,7 @@ aaa
 aaa
 aaa
 aaa
-oAw
+xkT
 aLz
 nME
 mle
@@ -118645,29 +120285,29 @@ okm
 okm
 ozr
 hdW
-oAw
+xkT
 aaa
 aaa
 aaa
 aaa
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118894,7 +120534,7 @@ aaa
 aaa
 aaa
 aaa
-oAw
+viE
 aLz
 nME
 mle
@@ -118903,29 +120543,29 @@ okm
 okm
 ozr
 aLz
-oAw
+viE
 aaa
 aaa
 aaa
 aaa
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -119152,7 +120792,7 @@ aaa
 aaa
 aaa
 aaa
-oAw
+viE
 aNY
 nME
 mle
@@ -119161,28 +120801,28 @@ okm
 okm
 ozr
 aLz
-oAw
+viE
 aaa
 aaa
 aaa
 aaa
 aaa
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -119410,7 +121050,7 @@ aaa
 aaa
 aaa
 aaa
-oAw
+pMm
 aLz
 aUK
 hRp
@@ -119419,7 +121059,7 @@ okm
 okm
 ozr
 aLz
-oAw
+pMm
 aaa
 aaa
 aaa
@@ -119427,20 +121067,20 @@ aaa
 aaa
 aaa
 aaa
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
-afo
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -119596,8 +121236,8 @@ ukY
 tKn
 hWv
 ugP
-wBA
-wBA
+vuB
+kpf
 wBA
 ijM
 aMh
@@ -119834,7 +121474,7 @@ aaa
 ixO
 aaa
 aaa
-sVt
+vof
 dMr
 dMr
 fqf
@@ -119854,7 +121494,7 @@ dpG
 wBA
 wVY
 rpo
-kpf
+vuB
 wBA
 xFY
 ijM
@@ -120184,7 +121824,7 @@ aaa
 aaa
 aaa
 aaa
-oAw
+xkT
 aLz
 jVT
 jFN
@@ -120193,7 +121833,7 @@ okm
 okm
 ozr
 aLz
-oAw
+xkT
 aaa
 aaa
 aaa
@@ -120202,17 +121842,17 @@ aaa
 aaa
 aaa
 aaa
-oAw
+xkT
 vkS
 tdE
-oAw
+xkT
 aaa
 aaa
 aaa
-oAw
+xkT
 tdE
 ajy
-oAw
+xkT
 aaa
 aaa
 aaa
@@ -120442,7 +122082,7 @@ aaa
 aaa
 aaa
 aaa
-oAw
+viE
 aLz
 nME
 dwh
@@ -120451,7 +122091,7 @@ okm
 okm
 ozr
 aLz
-oAw
+viE
 aaa
 aaa
 aaa
@@ -120460,17 +122100,17 @@ aaa
 aaa
 aaa
 aaa
-oAw
+viE
 dZR
 cDF
-oAw
+viE
 aaa
 aaa
 aaa
-oAw
+viE
 wBw
 iRS
-oAw
+viE
 aaa
 aaa
 aaa
@@ -120608,7 +122248,7 @@ aaa
 ixO
 aaa
 aaa
-sVt
+vof
 dMr
 dMr
 fqf
@@ -120700,7 +122340,7 @@ aaa
 aaa
 aaa
 aaa
-oAw
+viE
 aLz
 nME
 dwh
@@ -120709,7 +122349,7 @@ okm
 okm
 ozr
 aLz
-oAw
+viE
 aaa
 aaa
 aaa
@@ -120718,17 +122358,17 @@ aaa
 aaa
 aaa
 aaa
-oAw
+viE
 eVQ
 ogJ
-oAw
+viE
 aaa
 aaa
 aaa
-oAw
+viE
 gUZ
 eVQ
-oAw
+viE
 aaa
 aaa
 aaa
@@ -120958,7 +122598,7 @@ aaa
 aaa
 aaa
 aaa
-oAw
+pMm
 aNY
 nME
 dwh
@@ -120967,7 +122607,7 @@ okm
 okm
 ozr
 hdW
-oAw
+pMm
 aaa
 aaa
 aaa
@@ -120976,17 +122616,17 @@ aaa
 aaa
 aaa
 aaa
-oAw
+viE
 xEE
 fqr
-oAw
+viE
 wOk
 wOk
 wOk
-oAw
+viE
 nSe
 xmv
-oAw
+viE
 aaa
 aaa
 aaa
@@ -121227,37 +122867,37 @@ paZ
 wOk
 wOk
 oAw
-oAw
-oAw
+reX
+gaP
 wOk
 oAw
-oAw
-oAw
+reX
+gaP
 wOk
-oAw
+pMm
 gzH
 tGZ
-oAw
+pMm
 moV
 eCo
 aLz
-oAw
+pMm
 tGZ
 mcn
-oAw
+pMm
 wOk
 wOk
 oAw
-oAw
-oAw
+reX
+gaP
 wOk
 oAw
-oAw
-oAw
+reX
+gaP
 wOk
 wOk
 oAw
-oAw
+gaP
 wOk
 aaa
 aaa
@@ -121476,7 +123116,7 @@ aaa
 aaa
 wOk
 oAw
-oAw
+gaP
 wOk
 raD
 okm
@@ -122001,32 +123641,32 @@ kpI
 eJe
 hxK
 oAw
-oAw
+hxj
 vHb
 cIs
 vHb
-oAw
-oAw
+xkT
+nQn
 wOk
 wOk
 wOk
-oAw
-oAw
+nQn
+nQn
 vHb
 cIs
 vHb
-oAw
-oAw
+tYY
+gaP
 wOk
 wOk
 wOk
-oAw
-oAw
+nQn
+nQn
 vHb
 cIs
 vHb
-oAw
-oAw
+tYY
+gaP
 wOk
 wOk
 wOk
@@ -122207,8 +123847,8 @@ taP
 eXA
 iBK
 xhV
-poW
-poW
+igl
+itl
 poW
 jMx
 iBK
@@ -122250,40 +123890,40 @@ aaa
 aaa
 wOk
 oAw
-sGn
+gaP
 wOk
-oAw
+xkT
 gzH
 tGZ
 cHa
-oAw
+xkT
 aaa
 aaa
-oAw
-oAw
+tKu
+hxj
 ikZ
-oAw
-oAw
+tYY
+mrM
 aaa
 aaa
 wOk
 aaa
 aaa
-oAw
-oAw
+tKu
+hxj
 ikZ
-oAw
-oAw
+tYY
+mrM
 aaa
 aaa
 wOk
 aaa
 aaa
-oAw
-oAw
+tKu
+hxj
 ikZ
-oAw
-oAw
+tYY
+mrM
 aaa
 aaa
 aaa
@@ -122510,17 +124150,17 @@ sLG
 iFw
 qIQ
 aaf
-oAw
+viE
 dZR
 hIE
 iRS
-oAw
+viE
 aaa
 aaa
 aaa
-oAw
+viE
 dGJ
-oAw
+viE
 aaa
 aaa
 aaa
@@ -122528,9 +124168,9 @@ wOk
 aaa
 aaa
 aaa
-oAw
+viE
 dGJ
-oAw
+viE
 aaa
 aaa
 aaa
@@ -122538,9 +124178,9 @@ wOk
 aaa
 aaa
 aaa
-oAw
+viE
 dGJ
-oAw
+viE
 aaa
 aaa
 aaa
@@ -122728,7 +124368,7 @@ nXY
 juH
 sHx
 oWj
-bhn
+dFU
 aaa
 aaa
 ixO
@@ -122768,17 +124408,17 @@ aaa
 iFw
 htS
 aaf
-oAw
+viE
 aFG
 cMm
 eVQ
-oAw
+viE
 aaa
 aaa
 aaa
-oAw
+viE
 aFG
-oAw
+viE
 aaa
 aaa
 aaf
@@ -122786,9 +124426,9 @@ bQW
 aaf
 aaa
 aaa
-oAw
+viE
 aFG
-oAw
+viE
 aaa
 aaa
 aaa
@@ -122796,9 +124436,9 @@ ajS
 aaa
 aaa
 aaa
-oAw
+viE
 aFG
-oAw
+viE
 aaa
 aaa
 aaa
@@ -123026,17 +124666,17 @@ aaa
 aaf
 iFw
 iFw
-oAw
+viE
 nMG
 oAe
 ocn
-oAw
+viE
 aaa
 aaa
 aaa
-oAw
+viE
 dml
-oAw
+viE
 aaa
 aaa
 iFw
@@ -123044,9 +124684,9 @@ din
 iFw
 aaa
 aaa
-oAw
+viE
 bCs
-oAw
+viE
 aaa
 aaa
 aaa
@@ -123054,9 +124694,9 @@ aaa
 aaa
 aaa
 aaa
-oAw
+viE
 ooS
-oAw
+viE
 aaa
 aaa
 aaa
@@ -123244,7 +124884,7 @@ xsD
 mUt
 sHx
 jlt
-bhn
+ojM
 aaa
 aaa
 ixO
@@ -123284,17 +124924,17 @@ aaa
 aaa
 aaa
 szS
-oAw
+pMm
 vkS
 tdE
 tdE
-oAw
+pMm
 akd
 aaa
 aaa
-oAw
+pMm
 vkS
-oAw
+pMm
 aaa
 aaa
 aaf
@@ -123302,9 +124942,9 @@ iFw
 aaf
 aaa
 aaa
-oAw
+pMm
 vkS
-oAw
+pMm
 aaa
 aaa
 aaa
@@ -123312,9 +124952,9 @@ aaa
 aaa
 aaa
 aaa
-oAw
+pMm
 vkS
-oAw
+pMm
 aaa
 aaa
 aaa
@@ -123450,7 +125090,7 @@ aaa
 aaa
 ixO
 sVC
-rWq
+tCY
 tqn
 dDV
 aHn
@@ -124018,7 +125658,7 @@ beG
 oTb
 sHx
 uXM
-bhn
+dFU
 aaa
 aaa
 ixO
@@ -124227,25 +125867,25 @@ aaa
 dWC
 fYe
 qCx
-hRQ
+oOi
 hRQ
 qCx
 ieW
 cOF
 qCx
-hRQ
+oOi
 hRQ
 yhx
 tPr
+uwu
 lvu
-lvu
-lvu
+eLg
 tPr
 tPr
 tPr
+uwu
 lvu
-lvu
-lvu
+eLg
 tPr
 ljU
 odG
@@ -124259,9 +125899,9 @@ wFw
 cTd
 tPr
 tPr
+uwu
 lvu
-lvu
-lvu
+eLg
 tPr
 bJq
 hGe
@@ -124534,7 +126174,7 @@ aJn
 oTb
 sHx
 vZY
-bhn
+ojM
 aaa
 aaa
 ixO
@@ -124741,7 +126381,7 @@ aaa
 ixO
 aaa
 aaa
-xZg
+bHa
 tUz
 odX
 oSB
@@ -125306,7 +126946,7 @@ aaF
 wPo
 uXL
 uXL
-vZk
+rGY
 vZk
 iPw
 aaa
@@ -125773,7 +127413,7 @@ aaa
 ixO
 aaa
 aaa
-xZg
+bHa
 kEe
 aaC
 jPG
@@ -126042,7 +127682,7 @@ gBk
 ifA
 uIn
 rxk
-dWV
+hPz
 dWV
 dXP
 dZp
@@ -126068,7 +127708,7 @@ viL
 jPJ
 dkw
 reo
-reo
+wUy
 viY
 qDr
 nXY
@@ -126305,7 +127945,7 @@ mwp
 gXO
 okX
 hGk
-dWY
+okI
 dWY
 gXH
 orU
@@ -126320,7 +127960,7 @@ uau
 viL
 wRN
 xZL
-rca
+wBV
 rca
 lAk
 okX
@@ -126553,7 +128193,7 @@ kQH
 kQH
 kQH
 guf
-guf
+xZE
 kQH
 kQH
 kQH
@@ -126845,7 +128485,7 @@ mwp
 aVf
 eaY
 uXL
-vZk
+rGY
 vZk
 uXL
 iPw

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
@@ -244,7 +244,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -407,7 +406,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -1433,16 +1431,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -1499,11 +1490,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -1772,13 +1759,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -1877,8 +1860,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -2448,14 +2429,10 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = 4
 	},
@@ -4098,13 +4075,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -4306,14 +4279,10 @@
 	pixel_y = -2
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_y = 2;
 	pixel_x = 9
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -1
 	},
@@ -4751,6 +4720,19 @@
 "alh" = (
 /turf/simulated/floor/carpet/bcarpet,
 /area/security/HoS_Office)
+"alj" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/rnd/Mech_Bay)
 "all" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/item/radio/headset,
@@ -5182,13 +5164,9 @@
 "anq" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5376,7 +5354,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -5715,7 +5692,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -5907,7 +5883,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -6183,8 +6158,6 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
@@ -6239,16 +6212,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -6535,6 +6501,19 @@
 	},
 /turf/simulated/wall,
 /area/security/Equipment_Storage)
+"asB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Aft_2_Deck_Airlock_Access)
 "asG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -6964,11 +6943,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -8137,6 +8112,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/medical/CMO_Office)
 "axJ" = (
@@ -8186,8 +8167,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -8690,8 +8669,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
-/obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
 	},
@@ -9355,7 +9332,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -9578,13 +9554,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -9983,6 +9955,19 @@
 "aEb" = (
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_1)
+"aEg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftPort_2_Deck_Observatory)
 "aEi" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -10511,8 +10496,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -10763,8 +10746,6 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
@@ -11046,14 +11027,10 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = 4
 	},
@@ -11210,11 +11187,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -11615,16 +11588,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -11942,7 +11911,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -12190,14 +12158,10 @@
 	pixel_y = -2
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_y = 2;
 	pixel_x = 9
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -1
 	},
@@ -12447,11 +12411,22 @@
 /obj/structure/table/bench/sifwooden/padded,
 /turf/simulated/floor/plating,
 /area/maintenance/ab_Theater)
+"aLV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Distro_Civilian)
 "aLX" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -12734,6 +12709,21 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/Midnight_Bar)
+"aMG" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Cargo_AftStarCorridor1)
 "aMH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12977,7 +12967,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -14177,8 +14166,6 @@
 "aRw" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -14554,8 +14541,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -14868,7 +14853,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -15465,7 +15449,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -16466,7 +16449,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -17317,6 +17299,10 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 6
 	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Recycling)
 "bbM" = (
@@ -17402,16 +17388,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -17764,7 +17746,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -17993,23 +17974,37 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Wardens_Office)
+"bdI" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Star_2_Deck_Corridor_2)
 "bdK" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck2_Security_StarCorridor1)
 "bdN" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 1;
 	id = "SC-Recycle"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/Recycling)
 "bdO" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/machinery/light,
 /obj/machinery/conveyor{
 	dir = 8;
@@ -18937,7 +18932,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -19351,7 +19345,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -19534,16 +19527,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -19814,13 +19803,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -20249,7 +20234,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -20640,14 +20624,10 @@
 	pixel_y = -2
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_y = 2;
 	pixel_x = 9
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -1
 	},
@@ -20987,7 +20967,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -21262,6 +21241,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engineering_Workshop)
+"bok" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/item/tape/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "bon" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/button/remote/driver{
@@ -22109,16 +22105,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/hallway/ForPort_2_Deck_Observatory)
@@ -23828,6 +23817,19 @@
 /obj/machinery/photocopier,
 /turf/simulated/floor/carpet/green,
 /area/medical/CMO_Office)
+"bxk" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Mech_Bay)
 "bxl" = (
 /obj/machinery/light{
 	dir = 4
@@ -24046,16 +24048,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/structure/cable/white{
 	d1 = 1;
@@ -24258,7 +24256,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -24996,13 +24993,9 @@
 "bAw" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -25155,16 +25148,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -25276,16 +25265,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -25405,14 +25390,10 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = 4
 	},
@@ -25490,16 +25471,28 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Engineering_PortChamber1)
-"bCK" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "SC-Recycle";
-	name = "Recycling Process";
-	pixel_y = 2
+"bCJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
 	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForStar_2_Deck_Observatory)
+"bCK" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/effect/floor_decal/steeldecal/steel_decals_central4,
+/obj/machinery/recycling/sorter{
+	color = "#BDBCA9"
+	},
+/obj/machinery/conveyor{
+	id = "SC-Recycle"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Recycling)
 "bCM" = (
@@ -26191,12 +26184,13 @@
 	pixel_x = -1;
 	pixel_y = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/railing/grey,
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/Recycling)
 "bGn" = (
@@ -26290,13 +26284,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -26569,6 +26558,26 @@
 /obj/structure/window/reinforced/tinted/frosted,
 /turf/simulated/floor/tiled/kafel_full,
 /area/security/Restroom)
+"bHB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Waste_Disposals)
 "bHC" = (
 /obj/structure/sink{
 	pixel_y = 16;
@@ -26590,16 +26599,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
-	dir = 8
-	},
-/obj/structure/window/basic{
 	dir = 1
-	},
-/obj/structure/window/basic{
-	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/medical/Dressing_Room)
@@ -26752,7 +26754,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -27654,16 +27655,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -27825,16 +27822,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -27866,11 +27859,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -28170,7 +28159,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -28240,16 +28228,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -28257,6 +28238,9 @@
 	name = "Lockdown Gate";
 	desc = "A heavily reinforced gate, sector lockdown!";
 	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Deck2_1_Corridor)
@@ -28497,13 +28481,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -28514,16 +28493,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/Library)
@@ -29048,7 +29020,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -29124,7 +29095,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -29132,9 +29102,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/Emergency_EVA)
 "bRt" = (
@@ -29254,11 +29221,12 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/For_Tool_Storage)
 "bRO" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "SC-Recycle"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Recycling)
 "bRQ" = (
@@ -29651,6 +29619,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/Reception)
+"bTq" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Gym_Sauna)
 "bTu" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/dark,
@@ -30573,7 +30557,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -30971,8 +30954,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -31010,7 +30991,7 @@
 /area/security/Wardens_Office)
 "bXM" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/powered/pump/huge,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Toxins_Storage)
 "bXN" = (
@@ -31333,7 +31314,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -31882,6 +31862,19 @@
 	},
 /turf/simulated/floor/boxing/gym,
 /area/security/Prison_Wing)
+"cbf" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_StarChamber1)
 "cbj" = (
 /obj/structure/closet/toolcloset,
 /obj/item/storage/box/lights/mixed,
@@ -31928,16 +31921,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -32437,7 +32426,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -32589,7 +32577,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/Vault)
 "cdz" = (
-/obj/machinery/recycling/stamper,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "SC-Recycle"
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/Recycling)
 "cdA" = (
@@ -32692,7 +32683,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -32756,7 +32746,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -33223,13 +33212,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -33456,13 +33441,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -34236,7 +34216,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -34290,7 +34269,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -34572,6 +34550,26 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape_pod11/station)
+"ciY" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Warehouse)
 "cja" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -34872,7 +34870,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -34880,9 +34877,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/security/Visitation_Room)
 "cjU" = (
@@ -35523,7 +35517,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -36098,7 +36091,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -36200,6 +36192,21 @@
 "cpi" = (
 /turf/simulated/wall,
 /area/engineering/CE_Office)
+"cpj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftStar_2_Deck_Observatory)
 "cpl" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -36646,11 +36653,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -37113,7 +37116,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -37897,7 +37899,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -38292,7 +38293,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -38300,9 +38300,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/security/Boardroom)
 "cwb" = (
@@ -38547,13 +38544,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -38711,25 +38703,17 @@
 /area/harbor/Star_2_Deck_Airlock_Access)
 "cxM" = (
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
-	dir = 1
-	},
-/obj/structure/window/titanium{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/cable/white{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
-/area/bridge/Vault)
+/area/maintenance/Deck2_Cargo_AftStarCorridor1)
 "cxN" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -38909,7 +38893,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -38969,7 +38952,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -39313,16 +39295,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/Chomp_Dinner_2)
@@ -39912,7 +39887,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -40198,7 +40172,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -40544,7 +40517,6 @@
 "cDX" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40732,7 +40704,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -40997,11 +40968,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -41294,8 +41261,6 @@
 "cFO" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -41312,13 +41277,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -41351,13 +41312,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -41509,16 +41466,9 @@
 "cGw" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
@@ -41921,6 +41871,33 @@
 /obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/carpet/purcarpet,
 /area/hallway/Star_Transit_Foyer)
+"cMP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Eng Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Storage)
 "cMU" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
@@ -41989,6 +41966,16 @@
 /obj/machinery/door/window/northright,
 /turf/simulated/floor/tiled/kafel_full,
 /area/crew_quarters/Gym)
+"cNF" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Port_2_Deck_Central_Corridor_1)
 "cNV" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -42848,7 +42835,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -43453,7 +43439,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -43909,6 +43894,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/ForPort_2_Deck_Observatory)
+"dnD" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Reception)
 "dnF" = (
 /obj/structure/bed/chair/bay/chair/padded/red/bignest,
 /turf/simulated/floor/carpet/oracarpet,
@@ -43940,6 +43938,23 @@
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Midnight_Bar)
+"doi" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/Armory)
 "doj" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
@@ -44155,12 +44170,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -44652,6 +44663,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Equipment_Storage)
+"dxA" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/Locker_Room)
 "dxM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -44777,6 +44801,24 @@
 	icon_state = "orange"
 	},
 /area/shuttle/large_escape_pod4/station)
+"dzw" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/crew_quarters/Emergency_EVA)
 "dzF" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -45623,6 +45665,21 @@
 	},
 /turf/simulated/wall,
 /area/medical/Treatment_Hall)
+"dJx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Distro_Civilian)
 "dJH" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -45903,13 +45960,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -46168,7 +46221,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -46243,16 +46295,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/structure/cable/white{
 	d1 = 1;
@@ -46279,6 +46324,19 @@
 /obj/structure/reagent_dispensers/fueltank/high,
 /turf/simulated/floor/plating,
 /area/maintenance/Security_Substation)
+"dRG" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftPort_2_Deck_Observatory)
 "dRH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -46721,6 +46779,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Corridor_1)
+"dWA" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Star_2_Deck_Central_Corridor_1)
 "dWG" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/figure/detective{
@@ -47351,6 +47422,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/engineering/Breakroom)
+"efy" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/item/tape/engineering,
+/turf/space,
+/area/maintenance/ab_TeshDen)
 "efB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -47457,6 +47541,21 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Lobby)
+"eha" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_AftStar_Corridor)
 "ehd" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -47950,8 +48049,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -48887,6 +48984,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Aft_2_Deck_Airlock_Access)
+"eBy" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_StarChamber2)
 "eBL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -48931,6 +49038,16 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/Library)
+"eCF" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_StarChamber1)
 "eCI" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -49814,6 +49931,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/Equipment_Storage)
+"eLS" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/industrial/danger,
+/obj/structure/railing/grey,
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/Recycling)
 "eMf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49936,7 +50059,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -50120,7 +50242,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -50865,7 +50986,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -51198,13 +51318,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -51723,13 +51839,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -52608,6 +52720,28 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Breakroom)
+"fuh" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/ab_Theater)
 "fuk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -52790,6 +52924,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Star_Tool_Storage)
+"fvs" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_PortChamber1)
 "fvE" = (
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 1
@@ -53375,6 +53524,19 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/Storage)
+"fCN" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Science_ForPort_Corridor)
 "fDf" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack/corner{
@@ -53474,6 +53636,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Corridor_1)
+"fEX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/For_2_Deck_Central_Corridor_1)
 "fFj" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -53646,6 +53823,23 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Toxins_Viewing_Port)
+"fGS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Surgery_Room_1)
 "fGW" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /obj/effect/catwalk_plated,
@@ -53974,6 +54168,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Prison_Wing)
+"fKO" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/rnd/Toxins_Storage)
 "fLb" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/tool/crowbar/red,
@@ -54238,7 +54445,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -54609,6 +54815,19 @@
 	},
 /turf/simulated/wall,
 /area/rnd/Testing_Lab)
+"fRg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Chomp_Dinner_1)
 "fRz" = (
 /obj/structure/bed/chair/wood/wings{
 	color = "#004b9a"
@@ -55791,16 +56010,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -56212,11 +56427,28 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Circuitry_Den)
+"gje" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/security/Visitation_Room)
 "gjf" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -56452,6 +56684,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_Transit_Foyer)
+"gky" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_StarChamber2)
 "gkJ" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -57011,6 +57256,22 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/Armory)
+"gtf" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftPort_2_Deck_Observatory)
 "gtm" = (
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -57049,6 +57310,26 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Robotics_Lab)
+"gtX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Star_2_Deck_Airlock_Access)
 "gud" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57125,6 +57406,16 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_2)
+"gvp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "gvF" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -57208,7 +57499,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -57247,6 +57537,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/AftStar_2_Deck_Observatory)
+"gxR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Aft_2_Deck_Airlock_Access)
 "gxS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -57456,6 +57761,26 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Central_2_Deck_Hall)
+"gzL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Breakroom)
 "gzQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -57947,6 +58272,58 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Domicile_Substation)
+"gFq" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Toxins_Viewing_Port)
+"gFu" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Emergency_EVA)
+"gFx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_StarChamber2)
 "gFB" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
 	dir = 4
@@ -58112,13 +58489,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -58163,6 +58536,26 @@
 /obj/structure/curtain/open/privacy,
 /turf/simulated/floor/tiled/techmaint,
 /area/medical/Treatment_Hall)
+"gIg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Toxins_Mixing_Room)
 "gIA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -58239,6 +58632,21 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/hallway/Port_Transit_Foyer)
+"gJv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Science_ForPort_Corridor)
 "gJB" = (
 /obj/effect/floor_decal/steeldecal/steel_decals7,
 /obj/effect/floor_decal/steeldecal/steel_decals7{
@@ -58271,7 +58679,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -58705,7 +59112,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -58951,6 +59357,25 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Engineering_PortChamber1)
+"gSm" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Science_ForPort_Chamber)
 "gSn" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/nifsofts_medical{
@@ -59167,10 +59592,24 @@
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/Chomp_Kitchen)
 "gVw" = (
-/obj/machinery/portable_atmospherics/powered/pump/huge,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/rnd/Toxins_Storage)
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Security_ForStar_Chamber)
 "gVx" = (
 /obj/effect/graffitispawner,
 /turf/simulated/floor/plating,
@@ -59230,6 +59669,18 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Robotics_Lab)
+"gWn" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_AftPort_Corridor)
 "gWp" = (
 /obj/machinery/shield_diffuser,
 /obj/structure/lattice,
@@ -59405,6 +59856,19 @@
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Midnight_Bar)
+"gYV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Library)
 "gYY" = (
 /obj/structure/girder/reinforced,
 /obj/random/trash,
@@ -59723,6 +60187,25 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/medical/Port_Medical_Post)
+"hde" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Toxins_Viewing_Port)
 "hdn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -59769,6 +60252,19 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10,
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Central_Corridor_1)
+"hdD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_ForPortCorridor1)
 "hdI" = (
 /obj/effect/floor_decal/industrial/loading/blue{
 	dir = 4
@@ -59927,6 +60423,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_Transit_Foyer)
+"hfN" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Science_StarChamber1)
 "hfR" = (
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
@@ -59994,7 +60509,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -60496,7 +61010,6 @@
 "hlX" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -60564,6 +61077,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/Locker_Room)
+"hms" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Gym_Sauna)
 "hmv" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -60571,6 +61097,18 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/rnd/Toxins_Mixing_Room)
+"hmx" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/industrial/danger,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/Recycling)
 "hmF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60834,36 +61372,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Robotics_Lab)
 "hqD" = (
-/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
-	},
-/obj/structure/window/titanium{
+/obj/structure/window/basic,
+/obj/structure/window/basic{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/door/blast/regular/open{
-	layer = 3.5;
-	id = "For Lockdown";
-	name = "Lockdown Gate";
-	desc = "A heavily reinforced gate, sector lockdown!"
-	},
-/obj/structure/cable/white{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable/white{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/window/basic{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/bridge/Vault)
+/area/engineering/Engineering_Workshop)
 "hqF" = (
 /obj/structure/girder/reinforced,
 /obj/machinery/alarm{
@@ -61113,6 +61633,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Corridor_1)
+"htS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Aft_2_Deck_Central_Corridor_1)
 "hua" = (
 /obj/structure/table/glass,
 /obj/item/roller/adv,
@@ -61189,6 +61724,30 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Corridor_2)
+"huH" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Eng Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Storage)
 "hva" = (
 /obj/structure/table/steel,
 /obj/random/maintenance/security,
@@ -61198,13 +61757,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
-/obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
-	},
-/obj/structure/window/basic{
-	dir = 1
 	},
 /obj/structure/window/basic{
 	dir = 4
@@ -61368,14 +61922,10 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = 4
 	},
@@ -61542,6 +62092,23 @@
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Robotics_Lab)
+"hAo" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/bridge/Vault_Reception)
 "hAu" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -61651,6 +62218,19 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/Deck2_Medical_AftStarChamber1)
+"hCp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForPort_2_Deck_Observatory)
 "hCx" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -61683,11 +62263,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -62065,23 +62641,26 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Security_Substation)
 "hJz" = (
+/obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/structure/window/titanium{
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/window/titanium{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/cable/white,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/bridge/Vault)
+/area/security/Brig)
 "hJC" = (
 /obj/machinery/status_display,
 /turf/simulated/wall/r_wall,
@@ -62269,6 +62848,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Stairwell)
+"hNw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Library)
 "hNJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -62359,14 +62954,12 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -62417,13 +63010,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
-	},
-/obj/structure/window/basic{
-	dir = 1
 	},
 /obj/structure/window/basic{
 	dir = 4
@@ -62818,7 +63407,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -63178,6 +63766,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Research_Lab)
+"hYE" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_PortChamber1)
 "hYG" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -63559,6 +64160,19 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/Storage)
+"icO" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/Dressing_Room)
 "icP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -64017,6 +64631,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/For_Medical_Post)
+"iiP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_PortChamber2)
 "iiR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -64341,6 +64967,19 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /area/hallway/Central_2_Deck_Hall)
+"ilJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftStar_2_Deck_Observatory)
 "ilQ" = (
 /obj/machinery/door/window/westright{
 	name = "Test Chamber";
@@ -64844,16 +65483,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_StarChamber1)
@@ -64941,6 +65576,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/For_2_Deck_Central_Corridor_2)
+"iuB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Port_2_Deck_Central_Corridor_1)
 "iuD" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/lights/bulbs{
@@ -65498,6 +66146,24 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Midnight_Kitchen)
+"iAH" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/security/Prison_Wing)
 "iAP" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -65912,6 +66578,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_2)
+"iGR" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/Brig)
 "iHh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65975,7 +66661,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -66207,13 +66892,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -66506,6 +67186,22 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/harbor/Aft_2_Deck_Airlock_Access)
+"iNd" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Technical_Storage)
 "iNk" = (
 /obj/item/universal_translator{
 	pixel_x = 3
@@ -66777,11 +67473,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -67783,7 +68475,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -68102,6 +68793,19 @@
 /obj/effect/floor_decal/corner/purple/bordercorner,
 /turf/simulated/floor/tiled,
 /area/rnd/Testing_Lab)
+"jiU" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_StarChamber2)
 "jjb" = (
 /obj/machinery/doorbell_chime{
 	id_tag = "sc-ChimeCar"
@@ -68446,6 +69150,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftStarCorridor1)
+"jnk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "jnn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -68551,6 +69268,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Medical_AftStarChamber1)
+"joJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForStar_2_Deck_Observatory)
 "jpd" = (
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -69953,7 +70683,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -70194,25 +70923,14 @@
 /area/hallway/For_2_Deck_Central_Corridor_1)
 "jMR" = (
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/structure/cable/white{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/plating,
-/area/bridge/Vault)
+/area/maintenance/Deck2_Civilian_PortChamber1)
 "jMS" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -70450,6 +71168,17 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Research_Lab)
+"jRu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/item/tape/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "jRN" = (
 /obj/effect/floor_decal/industrial/warning{
 	layer = 3
@@ -71090,6 +71819,16 @@
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/Midnight_Kitchen)
+"jZR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftStar_2_Deck_Observatory)
 "kam" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -71135,6 +71874,21 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_1)
+"kaH" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Mech_Bay)
 "kaM" = (
 /obj/item/radio/beacon,
 /obj/machinery/light/spot{
@@ -72362,6 +73116,19 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/rnd/Testing_Lab)
+"kqb" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/rnd/Toxins_Storage)
 "kqn" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -72426,8 +73193,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
-/obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
 	},
@@ -72440,6 +73205,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/crew_quarters/Chomp_Kitchen)
+"kqV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/medical/EMT_Bay)
 "krj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72597,6 +73381,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Recycling)
@@ -73230,6 +74017,19 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
 /turf/simulated/floor/tiled/white,
 /area/medical/For_Medical_Post)
+"kDU" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForPort_2_Deck_Observatory)
 "kEp" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -73453,6 +74253,21 @@
 	},
 /turf/simulated/wall,
 /area/security/Processing_Room)
+"kHg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_AftPort_Corridor)
 "kHj" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -73990,7 +74805,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -74060,6 +74874,21 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/Midnight_Bar)
+"kOx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_ForStarCorridor2)
 "kOA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -74463,6 +75292,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Star_Transit_Foyer)
+"kUj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Star_2_Deck_Airlock_Access)
 "kUm" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/random/tool,
@@ -74829,7 +75671,6 @@
 "kZg" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -75018,8 +75859,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -75038,9 +75877,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/Breakroom)
 "lbI" = (
-/obj/structure/ladder/updown{
-	pixel_y = 3
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/door/blast/angled/open{
 	dir = 4;
@@ -75057,6 +75893,9 @@
 /obj/structure/sign/small/warning/emerg_only{
 	desc = "Ladder for emergency use only";
 	pixel_y = -32
+	},
+/obj/structure/ladder{
+	pixel_y = 3
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/Research_Substation)
@@ -75749,7 +76588,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -76071,11 +76909,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -76325,8 +77159,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -76794,6 +77626,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/warning/moving_parts,
 /turf/simulated/wall,
 /area/quartermaster/Recycling)
 "lBG" = (
@@ -76801,14 +77634,10 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = 4
 	},
@@ -77055,8 +77884,6 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
@@ -77384,6 +78211,18 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/Warehouse)
+"lIZ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/For_2_Deck_Central_Corridor_1)
 "lJh" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -77416,6 +78255,20 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Chomp_Dinner_2)
+"lJu" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/crew_quarters/Chomp_Kitchen)
 "lJw" = (
 /obj/random/junk,
 /obj/random/trash,
@@ -77427,6 +78280,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
+"lJQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Medical_AftPortCorridor1)
 "lKa" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -77681,11 +78549,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -78117,6 +78981,30 @@
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Cargo_AftPortCorridor1)
+"lTS" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Emergency_EVA)
 "lTW" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -78176,6 +79064,19 @@
 	color = "#8bbbd5"
 	},
 /area/medical/Locker_Room)
+"lUF" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Port_Shuttlebay)
 "lUL" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -78344,35 +79245,17 @@
 /area/crew_quarters/Chomp_Kitchen)
 "lVS" = (
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
-	dir = 1
-	},
-/obj/structure/window/titanium{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/door/blast/regular/open{
-	layer = 3.5;
-	id = "For Lockdown";
-	name = "Lockdown Gate";
-	desc = "A heavily reinforced gate, sector lockdown!"
-	},
-/obj/structure/cable/white{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable/white{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/plating,
-/area/bridge/Vault)
+/area/maintenance/Deck2_Civilian_PortChamber2)
 "lVT" = (
 /obj/structure/table/steel,
 /obj/item/storage/briefcase/inflatable{
@@ -78623,7 +79506,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -78746,7 +79628,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -79177,7 +80058,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -79235,6 +80115,16 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/Chomp_Kitchen)
+"mhW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Chomp_Dinner_1)
 "mic" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -79370,16 +80260,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/structure/cable/white{
 	d1 = 1;
@@ -80155,20 +81041,29 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Warehouse)
+"myB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Chapel_Morgue)
 "myK" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_PortChamber1)
@@ -80220,14 +81115,10 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = 4
 	},
@@ -80238,6 +81129,21 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/maintenance/Security_Substation)
+"mzi" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_StarChamber1)
 "mzl" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -80384,8 +81290,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -80770,12 +81674,28 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/Armory)
 "mGd" = (
-/obj/structure/sign/warning/moving_parts,
-/turf/simulated/wall,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/quartermaster/Recycling)
 "mGr" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "SC-Recycle";
+	name = "Recycling Process";
+	pixel_y = 2
+	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/steeldecal/steel_decals_central4,
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Recycling)
 "mGs" = (
@@ -80881,6 +81801,19 @@
 	},
 /turf/simulated/floor/airless,
 /area/rnd/Testing_Chamber)
+"mIh" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_ForPort_Corridor)
 "mIi" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -81020,16 +81953,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
@@ -81752,6 +82678,26 @@
 /obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/carpet/bcarpet,
 /area/security/Lobby)
+"mRl" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Canister_Storage)
 "mRM" = (
 /obj/structure/table/bench/wooden,
 /obj/effect/floor_decal/spline/fancy{
@@ -82004,6 +82950,26 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Treatment_Hall)
+"mVw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Toxins_Mixing_Room)
 "mVG" = (
 /obj/structure/sign/warning/caution{
 	name = "\improper CAUTION: FIRING RANGE"
@@ -82325,7 +83291,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -82563,6 +83528,23 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Aft_2_Deck_Shuttlebay_Corridor)
+"ndg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Canister_Storage)
 "nds" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8;
@@ -82696,6 +83678,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck2_1_Corridor)
+"ngO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_StarChamber1)
 "ngT" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -82715,8 +83709,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -82816,6 +83808,24 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/crew_quarters/Library_Cafe)
+"nhY" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/Armory)
 "nia" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/door/blast/angled/open{
@@ -83000,6 +84010,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_2)
+"nnr" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/rnd/Mech_Bay)
 "nns" = (
 /obj/item/paper_bin{
 	pixel_x = 5
@@ -83043,6 +84066,19 @@
 "nnG" = (
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Midnight_Bar)
+"nnM" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Storage)
 "nnN" = (
 /obj/machinery/light{
 	dir = 8;
@@ -83085,7 +84121,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -83243,11 +84278,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
-/obj/structure/window/basic{
-	dir = 8
-	},
 /obj/structure/window/basic{
 	dir = 1
 	},
@@ -83589,7 +84620,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -83820,6 +84850,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_Transit_Foyer)
+"nAv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForStar_2_Deck_Observatory)
 "nAI" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -84367,6 +85407,19 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Chomp_Dinner_1)
+"nJy" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftStar_2_Deck_Observatory)
 "nJA" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/light/small,
@@ -84683,6 +85736,18 @@
 	},
 /turf/simulated/floor/tiled/old_tile/yellow,
 /area/crew_quarters/Library_Cafe)
+"nOW" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/industrial/danger,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/quartermaster/Recycling)
 "nPc" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -84912,6 +85977,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Corridor_2)
+"nSi" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Security_ForCorridor2)
 "nSu" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck2_Engineering_PortChamber2)
@@ -84954,7 +86039,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -85407,8 +86491,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -85706,6 +86788,19 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/Star_Tool_Storage)
+"obe" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Reception)
 "obf" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/machinery/alarm{
@@ -85909,6 +87004,29 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Boardroom)
+"odK" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/security/Visitation_Room)
 "odO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -86241,6 +87359,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/RD_Office)
 "ohK" = (
@@ -86331,6 +87455,31 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftStarCorridor1)
+"ojb" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftStar_2_Deck_Observatory)
+"oji" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_ForStarCorridor1)
 "ojk" = (
 /turf/simulated/floor/carpet/purple,
 /area/rnd/RD_Office)
@@ -86678,6 +87827,16 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/airless,
 /area/harbor/For_Shuttlebay)
+"opl" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/Locker_Room)
 "opo" = (
 /obj/structure/ladder{
 	pixel_y = 3
@@ -87093,6 +88252,25 @@
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/Chapel_Lobby)
+"ows" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Waste_Disposals)
 "owt" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -87173,6 +88351,19 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/crew_quarters/Gym)
+"oxk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftStar_2_Deck_Observatory)
 "oxp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -87621,13 +88812,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -87731,8 +88918,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -88173,6 +89358,27 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled,
 /area/hallway/AftStar_2_Deck_Observatory)
+"oLt" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Mail_Room)
 "oLw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -88527,6 +89733,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftStarCorridor1)
+"oQW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftPort_2_Deck_Observatory)
 "oRn" = (
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/techmaint,
@@ -88585,7 +89801,6 @@
 "oSs" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -88938,13 +90153,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -89332,7 +90542,6 @@
 "pbi" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -90574,7 +91783,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -90677,13 +91885,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -91161,7 +92365,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -91874,14 +93077,10 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = 4
 	},
@@ -92258,6 +93457,19 @@
 	},
 /turf/simulated/floor/carpet,
 /area/security/Forensics_Office)
+"pOw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_ForPortCorridor2)
 "pOQ" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -92709,11 +93921,31 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Medical_AftStarChamber1)
+"pTm" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Cargo_AftStarChamber1)
 "pTu" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -92890,6 +94122,32 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Locker_Room)
+"pVw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_For_Corridor)
+"pVR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Aft_2_Deck_Central_Corridor_1)
 "pVS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -93009,6 +94267,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central4,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/railing/grey{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Recycling)
 "pWZ" = (
@@ -93386,9 +94647,42 @@
 	},
 /turf/simulated/floor/boxing/gym,
 /area/crew_quarters/Gym)
+"qcp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/item/tape/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "qcZ" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck2_Civilian_StarChamber2)
+"qdl" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Warehouse)
 "qdI" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply,
@@ -93422,6 +94716,27 @@
 	},
 /turf/simulated/open,
 /area/maintenance/Deck2_Star_Corridor)
+"qdP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/security/Prison_Wing)
 "qdU" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -94100,6 +95415,21 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/harbor/Star_2_Deck_Airlock_Access)
+"qlE" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Technical_Storage)
 "qlL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -94150,11 +95480,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/ab_TeshDen)
 "qmn" = (
-/obj/machinery/recycling/crusher{
-	color = "#BDBCA9"
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/quartermaster/Recycling)
+/area/maintenance/Deck2_Civilian_PortChamber2)
 "qmo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/cable{
@@ -94559,7 +95896,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -94704,6 +96040,19 @@
 "qtf" = (
 /turf/simulated/wall,
 /area/hallway/Stairwell_Port)
+"qtl" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Chomp_Dinner_2)
 "qtn" = (
 /obj/item/reagent_containers/dropper{
 	pixel_y = -5
@@ -95081,15 +96430,20 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/Armory)
 "qyj" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "SC-Recycle"
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/obj/structure/railing{
+/obj/structure/window/titanium{
 	dir = 1
 	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
-/area/quartermaster/Recycling)
+/area/hallway/ForPort_2_Deck_Observatory)
 "qyu" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -95098,6 +96452,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_StarCorridor1)
+"qyy" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftCorridor1)
 "qyH" = (
 /obj/machinery/flasher/portable,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -95449,10 +96816,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -95466,16 +96829,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -95559,6 +96918,19 @@
 	},
 /obj/structure/simple_door/wood,
 /turf/simulated/floor/tiled/techmaint,
+/area/maintenance/ab_TeshDen)
+"qGQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/ab_TeshDen)
 "qGS" = (
 /obj/machinery/camera/network/research{
@@ -95682,11 +97054,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -95762,7 +97130,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -97014,6 +98381,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_ForCorridor3)
+"raK" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Chapel_Morgue)
 "raN" = (
 /obj/effect/floor_decal/milspec/cargo_arrow{
 	dir = 4
@@ -97289,14 +98671,10 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = 4
 	},
@@ -97374,6 +98752,31 @@
 	color = "#8bbbd5"
 	},
 /area/medical/Patient_Ward)
+"reV" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/Visitation_Room)
 "rfd" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -97625,16 +99028,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Star_2_Deck_Airlock_Access)
@@ -98074,14 +99473,10 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = 4
 	},
@@ -98159,6 +99554,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Patient_Ward)
+"rpp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForStar_2_Deck_Observatory)
 "rpV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/borderfloorblack{
@@ -98182,6 +99590,19 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/turfpack/station,
 /area/security/Prison_Wing)
+"rqc" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/maintenance/Engineering_Substation)
 "rqe" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/purple/border,
@@ -98219,6 +99640,21 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/plating,
 /area/harbor/Aft_2_Deck_Airlock_Access)
+"rrk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "rrl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -98387,7 +99823,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -98480,13 +99915,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -98646,6 +100076,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Stairwell)
+"rvH" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Chapel_Lobby)
 "rvV" = (
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -98662,6 +100107,26 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/FirstAid_Storage)
+"rwg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Port_2_Deck_Corridor_1)
 "rwk" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -98674,7 +100139,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -98728,6 +100192,19 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/Aft_Restroom)
+"rxg" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Dressing_Room)
 "rxm" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8
@@ -98913,16 +100390,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -99357,6 +100830,16 @@
 	color = "#8bbbd5"
 	},
 /area/medical/Dressing_Room)
+"rCD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_PortChamber2)
 "rCN" = (
 /obj/machinery/mech_recharger,
 /obj/effect/floor_decal/milspec/box,
@@ -99472,6 +100955,18 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftPortCorridor1)
+"rEe" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_ForStarCorridor2)
 "rEl" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/simulated/floor/tiled/white{
@@ -99589,7 +101084,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -99672,7 +101166,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -99680,9 +101173,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
 	id = "For Lockdown";
@@ -99783,7 +101273,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -99841,7 +101330,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -100010,6 +101498,19 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Science_StarCorridor2)
+"rJJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_PortChamber1)
 "rKl" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -100524,6 +102025,27 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_AftPortCorridor1)
+"rTc" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/medical/Deck2_Evac_Corridor)
 "rTn" = (
 /obj/structure/railing,
 /obj/effect/floor_decal/spline/plain,
@@ -100621,6 +102143,38 @@
 	},
 /turf/simulated/floor/tiled/kafel_full,
 /area/crew_quarters/Gym)
+"rUL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Gym)
+"rUO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Breakroom)
 "rUP" = (
 /obj/machinery/meter,
 /obj/machinery/camera/network/security{
@@ -100967,6 +102521,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/Deck2_1_Corridor)
+"rZf" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Deck2_Evac_Corridor)
 "rZn" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -101079,8 +102653,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -101311,6 +102883,19 @@
 "sdq" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck2_Port_Corridor)
+"sdt" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Rec_Lounge)
 "sdv" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -101446,7 +103031,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -101631,6 +103215,34 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_AftPortCorridor1)
+"shv" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/Visitation_Room)
 "shx" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled,
@@ -101881,7 +103493,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -102282,6 +103893,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Star_Tool_Storage)
+"sqF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/quartermaster/Recycling)
 "sqI" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 6
@@ -102520,6 +104143,26 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/Vault_Reception)
+"ssW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Drone_Fab)
 "stu" = (
 /obj/structure/closet/wardrobe/chemistry_white,
 /turf/simulated/floor/tiled/white{
@@ -102836,6 +104479,19 @@
 /obj/effect/floor_decal/industrial/arrows/blue,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Port_2_Deck_Corridor_2)
+"sxD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Chomp_Dinner_2)
 "sxF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -102992,6 +104648,21 @@
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/dark,
 /area/security/Evidence_Storage)
+"szH" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_ForStar_Corridor)
 "sAd" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -103039,6 +104710,16 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Chomp_Dinner_2)
+"sAw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_ForPortCorridor2)
 "sAF" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -103202,6 +104883,22 @@
 /obj/structure/railing,
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Port)
+"sBL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftCorridor1)
 "sBS" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -103672,6 +105369,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Cargo_StarChamber1)
+"sHq" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Surgery_Room_1)
 "sHr" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
@@ -103762,11 +105479,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -103985,6 +105698,26 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_StarCorridor1)
+"sLB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Security_ForCorridor1)
 "sMa" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -104367,11 +106100,11 @@
 /turf/simulated/floor,
 /area/engineering/Technical_Storage)
 "sQm" = (
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/recycling/crusher{
+	color = "#BDBCA9"
 	},
 /obj/machinery/conveyor{
-	id = "SC-RecyclingSort"
+	id = "SC-Recycle"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/Recycling)
@@ -104387,6 +106120,18 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/airless,
 /area/harbor/Aft_Shuttlebay)
+"sQx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftPort_2_Deck_Observatory)
 "sQG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -104680,6 +106425,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
+"sWf" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/ab_Theater)
 "sWi" = (
 /obj/machinery/pointdefense{
 	id_tag = "PD Primary"
@@ -104760,7 +106524,6 @@
 "sXf" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -104880,6 +106643,39 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Stairwell)
+"sYL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Circuitry_Den)
+"sYT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForPort_2_Deck_Observatory)
 "sYU" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -105621,6 +107417,18 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/Chapel_Office)
+"tiJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_PortChamber1)
 "tiT" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/reagent_dispensers/watertank,
@@ -105632,6 +107440,26 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Corridor_1)
+"tjg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Deck2_1_Corridor)
 "tjD" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -105790,6 +107618,19 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Civilian)
+"tmD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Library)
 "tmF" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -105798,6 +107639,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_StarChamber1)
+"tmI" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Circuitry_Den)
 "tna" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows{
@@ -106300,6 +108158,26 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Security_Substation)
+"tuv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/rnd/Toxins_Storage)
 "tuw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -106466,7 +108344,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -106747,6 +108624,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Patient_Ward)
+"tAR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_PortChamber2)
 "tBa" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 2;
@@ -106793,7 +108683,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -107108,6 +108997,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Lobby)
+"tFp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_For_Corridor)
 "tFJ" = (
 /obj/structure/bed/chair/sofa/corner/blue{
 	dir = 4
@@ -107142,6 +109046,23 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck2_Cargo_AftPortCorridor1)
+"tGA" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Drone_Fab)
 "tGD" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
@@ -107486,6 +109407,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Warehouse)
+"tKS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_StarChamber2)
 "tLm" = (
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -107554,11 +109487,7 @@
 "tNh" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -108275,8 +110204,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
-/obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
 	},
@@ -108351,6 +110278,26 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_ForPortChamber1)
+"tXm" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Security_ForPortChamber1)
 "tXq" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used to monitor the engine room.";
@@ -108661,12 +110608,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/railing/grey,
 /turf/simulated/floor/tiled,
 /area/quartermaster/Recycling)
 "tZQ" = (
@@ -108688,16 +110633,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -109189,6 +111130,27 @@
 	icon_state = "orange"
 	},
 /area/shuttle/escape_pod11/station)
+"uhk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Security_AftStarCorridor1)
 "uhs" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -109656,6 +111618,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Dressing_Room)
+"uno" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/medical/EMT_Bay)
 "unr" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -110036,11 +112019,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Robotics_Lab)
 "uqJ" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/industrial/danger,
+/obj/machinery/recycling/stamper,
+/obj/machinery/conveyor{
+	id = "SC-Recycle"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Recycling)
 "uqP" = (
@@ -110146,6 +112130,27 @@
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftStarCorridor1)
+"usy" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/security/Storage_Room)
 "usz" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
@@ -110507,6 +112512,23 @@
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/maintenance/ab_Theater)
+"uBp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Surgery_Room_2)
 "uBs" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightorange/border,
@@ -110601,6 +112623,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Engineering_PortChamber1)
+"uCY" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Gym_Sauna)
 "uDk" = (
 /obj/structure/lattice,
 /obj/structure/cable/white{
@@ -111105,6 +113137,18 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/maintenance/Medical_Substation)
+"uMA" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Medical_AftPortCorridor1)
 "uMC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -111116,16 +113160,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_ForStarCorridor1)
@@ -111437,6 +113477,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/AftPort_2_Deck_Observatory)
+"uQJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/AftPort_2_Deck_Observatory)
 "uQK" = (
 /obj/random/toolbox,
 /turf/simulated/floor/wood/broken,
@@ -111536,7 +113589,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -111908,6 +113960,19 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Science_ForPort_Corridor)
+"uVW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Star_2_Deck_Central_Corridor_1)
 "uVY" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -112098,6 +114163,19 @@
 	color = "#989898"
 	},
 /area/crew_quarters/Emergency_EVA)
+"uYn" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "uYT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -112156,7 +114234,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -112493,8 +114570,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -112514,33 +114589,17 @@
 /area/maintenance/Deck2_Science_StarChamber1)
 "veO" = (
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/door/blast/regular/open{
-	layer = 3.5;
-	id = "For Lockdown";
-	name = "Lockdown Gate";
-	desc = "A heavily reinforced gate, sector lockdown!";
-	dir = 4
-	},
-/obj/structure/cable/white,
-/obj/structure/cable/white{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor/plating,
-/area/bridge/Vault)
+/area/maintenance/Deck2_Civilian_StarChamber1)
 "vfb" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightorange/border,
@@ -113217,11 +115276,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -113759,6 +115814,27 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Gallery)
+"vwd" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/Boardroom)
 "vwr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -114014,8 +116090,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -115257,11 +117331,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -115324,16 +117394,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/hallway/Port_2_Deck_Central_Corridor_1)
@@ -115578,16 +117644,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -116003,11 +118065,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -116056,7 +118114,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -116064,10 +118121,6 @@
 /obj/structure/window/titanium{
 	dir = 1
 	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
-/obj/item/tape/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/ab_TeshDen)
 "wfl" = (
@@ -116571,6 +118624,25 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/ab_TeshDen)
+"wkD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Engineering_PortChamber2)
 "wkF" = (
 /obj/item/stool/padded{
 	dir = 4
@@ -116706,13 +118778,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -116724,6 +118791,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_StarChamber2)
+"wlT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "wlZ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -116929,6 +119009,21 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/Chapel_Office)
+"wog" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/rnd/Toxins_Storage)
 "woi" = (
 /obj/structure/closet/gmcloset,
 /obj/item/glass_jar,
@@ -116969,6 +119064,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Vault_Reception)
+"wov" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/Breakroom)
 "woz" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -117235,6 +119350,18 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Corridor_1)
+"wrQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Rec_Lounge)
 "wsg" = (
 /turf/simulated/wall,
 /area/security/Equipment_Storage)
@@ -117252,14 +119379,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
-	},
 /obj/structure/window/titanium{
 	dir = 8
 	},
@@ -117907,16 +120027,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -117931,13 +120047,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -118001,6 +120113,26 @@
 "wCI" = (
 /turf/simulated/wall,
 /area/maintenance/Deck2_Cargo_AftCorridor1)
+"wCK" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Surgery_Room_2)
 "wCM" = (
 /obj/structure/table/bench/padded,
 /obj/effect/floor_decal/spline/plain/cee{
@@ -118474,6 +120606,19 @@
 /obj/structure/table/rack/shelf,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_StarChamber2)
+"wIR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Aft_2_Deck_Airlock_Access)
 "wIY" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -118947,6 +121092,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Treatment_Hall)
+"wOz" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/Visitation_Room)
 "wPa" = (
 /obj/machinery/camera/network/security{
 	dir = 1;
@@ -119015,6 +121181,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/Medical_Substation)
+"wQj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/bridge/Vault_Reception)
 "wQu" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -119864,14 +122050,10 @@
 	pixel_y = 11
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -3
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = 4
 	},
@@ -120678,6 +122860,19 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_For_Corridor)
+"xnk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Aft_2_Deck_Airlock_Access)
 "xnp" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -121080,6 +123275,18 @@
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Testing_Lab)
+"xsU" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForStar_2_Deck_Observatory)
 "xsZ" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/camera/network/security{
@@ -121356,6 +123563,23 @@
 	},
 /turf/simulated/wall,
 /area/security/Wardens_Office)
+"xwU" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/barricade,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "xxw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -121567,13 +123791,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/Locker_Room)
 "xAQ" = (
-/obj/machinery/recycling/sorter{
-	color = "#BDBCA9"
-	},
 /obj/machinery/camera/network/security{
 	dir = 1;
 	c_tag = "D2-Car-Recycling1";
 	network = list("Cargo")
+	},
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "SC-Recycle"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/Recycling)
@@ -121857,8 +124082,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -122446,6 +124669,18 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/hallway/Port_Transit_Foyer)
+"xNY" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/ForPort_2_Deck_Observatory)
 "xOn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -123257,13 +125492,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -123312,6 +125542,27 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Science_StarChamber1)
+"xYv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/ab_Theater)
 "xYy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -123844,14 +126095,10 @@
 	pixel_y = -2
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_y = 2;
 	pixel_x = 9
 	},
 /obj/item/cell/high{
-	charge = 100;
-	maxcharge = 15000;
 	pixel_x = 6;
 	pixel_y = -1
 	},
@@ -124324,6 +126571,23 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Midnight_Kitchen)
+"yju" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/security/Brig)
 "yjF" = (
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/brown,
@@ -131015,10 +133279,10 @@ aaa
 nSu
 nSu
 xEv
-xEv
+wkD
 nSu
 xEv
-xEv
+wkD
 nSu
 nSu
 aaa
@@ -131258,11 +133522,11 @@ aaa
 aaa
 gYZ
 lbH
-lbH
+rUO
 gYZ
 gYZ
 lbH
-lbH
+rUO
 bov
 bov
 bov
@@ -131281,9 +133545,9 @@ pfK
 cwk
 cwk
 cwk
+xYv
 iJG
-iJG
-iJG
+sWf
 cwk
 cwk
 aaa
@@ -131772,7 +134036,7 @@ bUz
 bUz
 hoa
 aaa
-qIV
+gzL
 kPs
 ceN
 khw
@@ -131806,8 +134070,8 @@ rzs
 rlI
 wcj
 cwk
-iJG
-iJG
+xYv
+sWf
 cwk
 aaa
 aaa
@@ -132587,7 +134851,7 @@ kDy
 kDy
 kDy
 cwk
-iJG
+fuh
 xyF
 aaa
 aaa
@@ -135370,7 +137634,7 @@ aaa
 aaa
 aaa
 aaa
-bMl
+mRl
 nul
 bDk
 jPx
@@ -135434,7 +137698,7 @@ azj
 azj
 azj
 nhc
-nhc
+ows
 bvu
 aaa
 aaa
@@ -135628,7 +137892,7 @@ aaa
 aaa
 aaa
 aaa
-bMl
+ndg
 nul
 jPx
 bDk
@@ -135951,7 +138215,7 @@ bOB
 lTp
 chm
 bhg
-crf
+bHB
 aaa
 aaa
 aaa
@@ -136154,20 +138418,20 @@ txI
 cdJ
 xjG
 xjG
+kaH
 hvb
-hvb
-hvb
+bxk
 xjG
 qWS
 sIV
 aiQ
 cDt
 cDt
-anq
+iNd
 cDt
 pex
 cDt
-anq
+qlE
 anq
 cDt
 pGs
@@ -136725,7 +138989,7 @@ chm
 sKi
 brl
 cbA
-crf
+bHB
 aaa
 aaa
 aaa
@@ -136918,7 +139182,7 @@ aaa
 aaa
 aaa
 aaa
-bMl
+mRl
 bJH
 jPx
 qmX
@@ -136931,16 +139195,16 @@ esJ
 aim
 hZV
 tVu
-tVu
+nnM
 aim
 tVu
-tVu
+nnM
 aim
 aim
 ahz
 ahz
 aRw
-aRw
+rqc
 aJa
 qkE
 ahz
@@ -137019,8 +139283,8 @@ onO
 aaa
 cCw
 mAT
-mAT
-mAT
+iiP
+lVS
 cCw
 aaa
 aaa
@@ -137176,7 +139440,7 @@ aaa
 aaa
 aaa
 aaa
-bMl
+ndg
 bJH
 qmX
 qmX
@@ -138045,7 +140309,7 @@ aaa
 aaa
 aaa
 aaa
-mAT
+qmn
 vZd
 fsb
 oht
@@ -138059,7 +140323,7 @@ cCw
 cCw
 mAT
 rtD
-mAT
+lVS
 cCw
 cCw
 cCw
@@ -138068,8 +140332,8 @@ cCw
 cCw
 cCw
 mAT
-mAT
-mAT
+iiP
+lVS
 cCw
 cCw
 cCw
@@ -138079,7 +140343,7 @@ cCw
 cCw
 mAT
 rtD
-mAT
+lVS
 cCw
 cCw
 cCw
@@ -138303,7 +140567,7 @@ aaa
 aaa
 aaa
 aaa
-mAT
+rCD
 ocV
 oht
 oht
@@ -138345,7 +140609,7 @@ nCr
 oht
 hPY
 feR
-mAT
+qmn
 aaf
 gWp
 aaf
@@ -138465,7 +140729,7 @@ bhp
 bhp
 aop
 vAp
-vAp
+lUF
 aop
 bcB
 klj
@@ -138473,7 +140737,7 @@ yeN
 klj
 klj
 apd
-aJo
+cMP
 amH
 bNU
 aoj
@@ -138561,7 +140825,7 @@ aaa
 aaa
 aaa
 aaa
-mAT
+tAR
 jbZ
 wLS
 wLS
@@ -138731,7 +140995,7 @@ foi
 foi
 klj
 ohV
-aJo
+huH
 cel
 oZp
 hPC
@@ -138839,14 +141103,14 @@ cCw
 cCw
 cCw
 mAT
-mAT
+lVS
 cCw
 cCw
 cCw
 cCw
 cCw
 mAT
-mAT
+lVS
 cCw
 cCw
 cCw
@@ -138858,7 +141122,7 @@ cCw
 cCw
 cCw
 mAT
-mAT
+lVS
 cCw
 cCw
 cCw
@@ -139047,7 +141311,7 @@ gOX
 wjc
 daD
 syX
-gdJ
+wov
 aaa
 aaa
 aaa
@@ -139505,7 +141769,7 @@ bwu
 fBz
 umh
 aSU
-aJo
+cMP
 amH
 rTs
 cri
@@ -139763,7 +142027,7 @@ blB
 ljE
 wFO
 aXX
-aJo
+huH
 amH
 bNU
 kLg
@@ -139821,7 +142085,7 @@ oEG
 xIe
 aPb
 aPb
-gdJ
+wov
 aaa
 aaa
 aaa
@@ -140529,7 +142793,7 @@ bhp
 bhp
 aop
 vAp
-vAp
+lUF
 aop
 aop
 aop
@@ -140543,10 +142807,10 @@ kLA
 aim
 rml
 tVu
-tVu
+nnM
 aim
 tVu
-tVu
+nnM
 aim
 aim
 ahz
@@ -140634,7 +142898,7 @@ bQG
 cbV
 vPX
 vPX
-mAT
+qmn
 aaa
 aaa
 aaa
@@ -140883,7 +143147,7 @@ aaa
 aaa
 aaa
 aaa
-mAT
+qmn
 rcx
 bub
 cbV
@@ -140892,7 +143156,7 @@ xKX
 cbV
 vPX
 vPX
-mAT
+rCD
 aaa
 aaa
 aaa
@@ -141046,7 +143310,7 @@ aaa
 aaa
 aaa
 aaa
-bNW
+tjg
 nZs
 nZs
 fLS
@@ -141110,7 +143374,7 @@ bbu
 rJh
 qbq
 qbq
-acL
+ciY
 aaa
 aaa
 aaa
@@ -141141,7 +143405,7 @@ aaa
 aaa
 aaa
 aaa
-mAT
+rCD
 rcx
 bub
 cbV
@@ -141150,7 +143414,7 @@ xKX
 cbV
 vPX
 vPX
-mAT
+tAR
 aaa
 aaa
 aaa
@@ -141321,7 +143585,7 @@ cDH
 lYO
 bCy
 azN
-azN
+hqD
 avx
 eWt
 fHh
@@ -141399,7 +143663,7 @@ aaa
 aaa
 aaa
 aaa
-mAT
+tAR
 fjT
 bub
 bfJ
@@ -141820,7 +144084,7 @@ aaa
 aaa
 aaa
 aaa
-vpU
+tGA
 dIm
 bZb
 mYL
@@ -141884,7 +144148,7 @@ bzb
 vtp
 fDD
 fDD
-acL
+qdl
 aaa
 aaa
 aaa
@@ -142065,11 +144329,11 @@ aaa
 aaa
 bvO
 bvO
-bry
-bry
-bry
-bry
-bry
+qyj
+xNY
+xNY
+sYT
+sYT
 bvO
 bvO
 aaa
@@ -142078,7 +144342,7 @@ aaa
 aaa
 aaa
 aaa
-vpU
+ssW
 chg
 mYL
 qlt
@@ -142152,10 +144416,10 @@ aHO
 bAi
 bAi
 luQ
-luQ
-luQ
-luQ
-luQ
+sQx
+sQx
+sQx
+uQJ
 bAi
 bAi
 aHO
@@ -142579,7 +144843,7 @@ aaa
 aaa
 aaa
 aaa
-bry
+hCp
 aKS
 bad
 bad
@@ -142587,7 +144851,7 @@ bad
 bad
 bad
 bad
-bry
+hCp
 aaa
 aaa
 aaa
@@ -142657,7 +144921,7 @@ cjC
 rWs
 vtp
 bzd
-acL
+ciY
 aaa
 aaa
 aaa
@@ -142665,7 +144929,7 @@ aaa
 ajt
 aHO
 aHO
-luQ
+aEg
 kDg
 kDg
 kDg
@@ -142673,7 +144937,7 @@ kDg
 vqW
 aUP
 aUP
-luQ
+aEg
 aHO
 aHO
 aKr
@@ -142845,7 +145109,7 @@ wJS
 wJS
 dld
 wJS
-bry
+kDU
 aaa
 aaa
 aaa
@@ -142903,8 +145167,8 @@ bYc
 ozL
 ccb
 keJ
-mGr
-bdN
+eLS
+cdz
 xVd
 dcC
 xOn
@@ -142923,7 +145187,7 @@ aaa
 ajt
 aHO
 aHO
-luQ
+dRG
 pFH
 msX
 fdE
@@ -142931,7 +145195,7 @@ jmL
 fVt
 aUP
 bgf
-luQ
+oQW
 aHO
 aHO
 aKr
@@ -142947,7 +145211,7 @@ aaa
 aaa
 aaa
 aaa
-myK
+rJJ
 brp
 pAW
 dUM
@@ -143158,11 +145422,11 @@ atb
 vmk
 vcR
 bKf
-aLX
+dnD
 bxn
-keJ
-mGr
-bdN
+sqF
+nOW
+cdz
 xVd
 uvq
 alw
@@ -143173,7 +145437,7 @@ lIY
 qWA
 iyJ
 aEK
-acL
+qdl
 aaa
 aaa
 aaa
@@ -143189,7 +145453,7 @@ uPF
 fVt
 aUP
 mwn
-luQ
+oQW
 aHO
 aHO
 aKr
@@ -143205,7 +145469,7 @@ aaa
 aaa
 aaa
 aaa
-myK
+jMR
 nDk
 pAW
 jBe
@@ -143214,7 +145478,7 @@ gDe
 jBe
 nDk
 aRu
-myK
+rJJ
 aaa
 aaa
 aaa
@@ -143362,8 +145626,8 @@ bvO
 blu
 qjZ
 bvO
-bry
-bry
+qyj
+sYT
 bvO
 acU
 acU
@@ -143416,7 +145680,7 @@ vcR
 nex
 vcR
 aDL
-aLX
+obe
 aBD
 tZL
 uqJ
@@ -143438,16 +145702,16 @@ bQq
 bQq
 bAi
 luQ
-luQ
+uQJ
 bAi
 bAi
-luQ
+gtf
 bAi
 mWi
 fVt
 aUP
 bpH
-luQ
+oQW
 aHO
 aHO
 aKr
@@ -143611,7 +145875,7 @@ aaa
 aaa
 aaa
 aaa
-bry
+kDU
 ami
 vuC
 cBw
@@ -143676,8 +145940,8 @@ tsu
 jfp
 xpv
 dyX
-sxc
-mGr
+tZL
+bRO
 bdN
 bhs
 otj
@@ -143705,7 +145969,7 @@ vTx
 fVt
 aUP
 aUP
-luQ
+dRG
 aHO
 aHO
 aKr
@@ -143998,15 +146262,15 @@ bFD
 bFD
 bFD
 bFD
-myK
-myK
+fvs
+hYE
 bFD
 bFD
 bFD
 bFD
 bFD
-myK
-myK
+fvs
+hYE
 bFD
 bFD
 bFD
@@ -144017,8 +146281,8 @@ bFD
 bFD
 bFD
 bFD
-myK
-myK
+fvs
+hYE
 bFD
 bFD
 bFD
@@ -144128,8 +146392,8 @@ aaa
 aaa
 aaa
 bvO
-bry
-bry
+qyj
+sYT
 bvO
 bvO
 bvO
@@ -144192,7 +146456,7 @@ iQF
 rHm
 hPV
 eva
-sxc
+tZL
 bCK
 xAQ
 xVd
@@ -144219,7 +146483,7 @@ niK
 bAi
 bAi
 bAi
-luQ
+gtf
 bAi
 bAi
 aHO
@@ -144537,7 +146801,7 @@ vGJ
 wFm
 izi
 jrp
-myK
+jMR
 aaf
 gWp
 aaf
@@ -144709,8 +146973,8 @@ aQI
 nqt
 kVa
 ktG
-mGr
-qyj
+hmx
+cdz
 bhs
 ssD
 bHQ
@@ -144732,7 +146996,7 @@ jUU
 bPV
 jlU
 jQa
-luQ
+dRG
 aHO
 aHO
 aHO
@@ -144753,7 +147017,7 @@ aaa
 aaa
 aaa
 aaa
-myK
+rJJ
 nDk
 pAW
 jBe
@@ -144968,7 +147232,7 @@ lBF
 mGd
 pWU
 bbK
-qmn
+cdz
 xVd
 ssD
 hBF
@@ -144979,9 +147243,9 @@ bLj
 vdS
 vdS
 vdS
+aMG
 cwS
-cwS
-cwS
+cxM
 vdS
 vdS
 bAi
@@ -145011,7 +147275,7 @@ onO
 aaa
 aaa
 vbD
-myK
+jMR
 nDk
 pAW
 jBe
@@ -145025,25 +147289,25 @@ bFD
 bFD
 bFD
 bFD
-myK
-myK
-myK
+fvs
+tiJ
+hYE
 bFD
 bFD
 bFD
 bFD
 bFD
-myK
-myK
-myK
+fvs
+tiJ
+hYE
 bFD
 bFD
 bFD
 bFD
 bFD
-myK
-myK
-myK
+fvs
+tiJ
+hYE
 bFD
 bFD
 bFD
@@ -145224,9 +147488,9 @@ wGl
 xVd
 pog
 qKC
-sQm
-sQm
 bvx
+sQm
+cdz
 xVd
 ssD
 txC
@@ -145656,24 +147920,24 @@ ane
 ane
 ane
 beB
-ajm
-ajm
-ane
-ajm
+qdP
 ajm
 ane
-beB
-ane
-ajm
-ajm
-ane
-ajm
+qdP
 ajm
 ane
 beB
+ane
+qdP
 ajm
+ane
+qdP
 ajm
-ajm
+ane
+beB
+qdP
+iAH
+iAH
 ajm
 ane
 ane
@@ -145746,7 +148010,7 @@ xVd
 xVd
 dvR
 gmg
-bMS
+rwg
 bLj
 tCR
 bLj
@@ -146016,7 +148280,7 @@ mAg
 ctj
 ctj
 ctj
-aHP
+hdD
 hKb
 yaa
 rOO
@@ -146029,9 +148293,9 @@ iqT
 hoN
 afF
 afF
+gxR
 cfR
-cfR
-cfR
+wIR
 afF
 afF
 mYK
@@ -146284,7 +148548,7 @@ uTu
 rWc
 cUH
 lpj
-cfR
+xnk
 cnI
 tDn
 eJf
@@ -146455,7 +148719,7 @@ bwC
 yfZ
 iKh
 fpz
-dqy
+odK
 uap
 aIZ
 jKf
@@ -146542,7 +148806,7 @@ uTu
 cUH
 cUH
 lpj
-cfR
+asB
 cdG
 cdG
 cdG
@@ -146570,7 +148834,7 @@ xDR
 xDR
 wZn
 oEW
-oEW
+jnk
 wZn
 aaa
 aaa
@@ -147253,7 +149517,7 @@ ctj
 ctj
 ctj
 dJJ
-aCK
+oLt
 aCK
 dJJ
 agu
@@ -147286,7 +149550,7 @@ hqU
 jsm
 bEJ
 jsm
-fcH
+pTm
 fcH
 jsm
 ctj
@@ -147352,7 +149616,7 @@ xDR
 wZn
 wZn
 oEW
-oEW
+jnk
 wZn
 wZn
 aaa
@@ -147482,8 +149746,8 @@ lvO
 pAR
 lvO
 oJi
-cjR
-rGo
+gje
+reV
 fYw
 brD
 xxw
@@ -147740,8 +150004,8 @@ qQR
 pBP
 lwg
 hVT
-cjR
-rGo
+wOz
+shv
 nbk
 bcu
 rWh
@@ -147773,11 +150037,11 @@ ctj
 ctj
 dJJ
 dJJ
-aCK
+oLt
 aCK
 dJJ
 dJJ
-aCK
+oLt
 aCK
 dJJ
 dJJ
@@ -147870,7 +150134,7 @@ kkc
 xDR
 wRf
 rSV
-oEW
+uYn
 ctj
 ctj
 ctj
@@ -148128,7 +150392,7 @@ mga
 mga
 xDR
 rSV
-oEW
+wlT
 ctj
 ctj
 ctj
@@ -148240,20 +150504,20 @@ fkU
 aPA
 myX
 jLI
-qEG
+hJz
 aFm
-qEG
+hJz
 gbB
-qEG
+hJz
 aHy
-qEG
+hJz
 acN
 gqm
 sIk
 nFF
-qEG
-qEG
-qEG
+iGR
+yju
+yju
 qEG
 gbB
 atB
@@ -148297,7 +150561,7 @@ ctj
 ctj
 ctj
 ctj
-vVP
+iuB
 chy
 cuq
 cuq
@@ -148307,7 +150571,7 @@ fZj
 cuq
 cuq
 lGq
-vVP
+iuB
 ctj
 ctj
 ctj
@@ -148509,9 +150773,9 @@ awA
 ata
 caN
 bvz
-qEG
-qEG
-qEG
+iGR
+yju
+yju
 qEG
 jLI
 mvb
@@ -148555,7 +150819,7 @@ ctj
 ctj
 ctj
 ctj
-vVP
+cNF
 chy
 aSh
 aSh
@@ -148565,7 +150829,7 @@ tlY
 aSh
 aSh
 lGq
-vVP
+cNF
 ctj
 ctj
 ctj
@@ -149014,13 +151278,13 @@ fkU
 bTu
 pDs
 aPn
-qEG
+hJz
 axp
-qEG
+hJz
 gbB
-qEG
+hJz
 pwV
-qEG
+hJz
 pMR
 acx
 ctP
@@ -149038,7 +151302,7 @@ biQ
 aMB
 cXd
 wQP
-bRs
+lTS
 eHa
 ctZ
 bIZ
@@ -149341,11 +151605,11 @@ aSh
 wnR
 iis
 bQz
-bjC
-bjC
+kHg
+gWn
 bjC
 bQz
-bjC
+kHg
 bjC
 bQz
 bQz
@@ -149577,7 +151841,7 @@ ctj
 ctj
 aFt
 axP
-axP
+mIh
 aFt
 rVE
 mMp
@@ -149607,7 +151871,7 @@ ooV
 aYe
 dlD
 bQz
-bjC
+kHg
 bjC
 bQz
 ctj
@@ -149763,7 +152027,7 @@ cFG
 aaa
 aaa
 aaa
-vZw
+tXm
 jRi
 jRi
 uHU
@@ -149812,7 +152076,7 @@ biQ
 gPA
 aLY
 cyT
-bRs
+lTS
 bfo
 dIf
 aCD
@@ -150586,7 +152850,7 @@ biQ
 rlr
 cFY
 rlr
-bRs
+lTS
 gDA
 dIf
 xjY
@@ -150849,7 +153113,7 @@ uYj
 ceR
 giE
 bAj
-bRs
+gFu
 fPi
 aBd
 sfI
@@ -150908,7 +153172,7 @@ ctj
 ctj
 ctj
 ctj
-bNb
+sAw
 fGB
 snr
 oqz
@@ -151121,7 +153385,7 @@ aaa
 aaa
 aaa
 aaa
-atX
+mhW
 auP
 kaC
 aEb
@@ -151166,7 +153430,7 @@ ctj
 ctj
 ctj
 ctj
-bNb
+pOw
 bBv
 gDQ
 arN
@@ -151379,7 +153643,7 @@ aaa
 alW
 aaa
 aaa
-atX
+fRg
 hGy
 kaC
 aEb
@@ -151881,7 +154145,7 @@ fDI
 bDg
 aCD
 bOr
-bRs
+dzw
 fPi
 iWL
 csF
@@ -152139,7 +154403,7 @@ fDI
 jwO
 lZh
 bOr
-bRs
+gFu
 kgh
 enO
 caS
@@ -152153,7 +154417,7 @@ aaa
 aaa
 aaa
 aaa
-atX
+mhW
 pFy
 fuv
 aEb
@@ -152261,7 +154525,7 @@ eKH
 eKH
 eKH
 cBU
-cEI
+qyy
 aaa
 aaa
 aaa
@@ -152411,7 +154675,7 @@ aaa
 aaa
 aaa
 aaa
-atX
+fRg
 aeJ
 cpB
 uAw
@@ -152680,7 +154944,7 @@ sFM
 aEF
 rol
 kqM
-kqM
+lJu
 apU
 kqt
 hff
@@ -152789,8 +155053,8 @@ aaa
 aaa
 aaa
 bHD
-ptE
-wff
+rrk
+qcp
 ptE
 bHD
 aaa
@@ -152923,9 +155187,9 @@ cmj
 cmj
 cBN
 cBN
+tFp
 xYn
-xYn
-xYn
+pVw
 cBN
 cBN
 aae
@@ -152967,9 +155231,9 @@ aVU
 bQz
 sjZ
 qTR
+htS
 bGL
-bGL
-bGL
+pVR
 oTZ
 dmt
 bTh
@@ -153042,15 +155306,15 @@ bHD
 bHD
 bHD
 bHD
-wff
-ptE
+rrk
+qcp
 wsr
 bHD
 bHD
 mic
 dWN
 tHG
-ptE
+qGQ
 aaa
 aaa
 aaa
@@ -153308,7 +155572,7 @@ bHD
 hOJ
 pNb
 dWN
-wff
+jRu
 aaa
 aaa
 aaa
@@ -153381,12 +155645,12 @@ aRi
 avf
 boR
 hOu
-hOu
-hOu
+doi
+nhY
 aDA
 hOu
-hOu
-hOu
+doi
+nhY
 ccw
 aRi
 aRi
@@ -153566,7 +155830,7 @@ bHD
 peA
 dzV
 cqv
-ptE
+wff
 aaa
 aaa
 aaa
@@ -153888,7 +156152,7 @@ aaa
 cFG
 aaa
 aaa
-lNY
+sLB
 oCS
 oCS
 cvz
@@ -154085,7 +156349,7 @@ bHD
 cqv
 woz
 piv
-ptE
+qGQ
 aaf
 gWp
 aaf
@@ -154662,7 +156926,7 @@ aaa
 cFG
 aaa
 aaa
-lNY
+sLB
 oCS
 oCS
 cvz
@@ -154929,12 +157193,12 @@ aRi
 avf
 hDz
 hOu
-hOu
-hOu
+doi
+nhY
 aDA
 hOu
-hOu
-hOu
+doi
+nhY
 aRi
 aRi
 rMh
@@ -155114,7 +157378,7 @@ bHD
 lUy
 auv
 dzV
-ptE
+qGQ
 aaa
 aaa
 aaa
@@ -155372,7 +157636,7 @@ bHD
 vmI
 kAe
 rAI
-ptE
+gvp
 aaa
 aaa
 aaa
@@ -155503,8 +157767,8 @@ bYZ
 bYU
 mMv
 ael
-adJ
-adJ
+fEX
+lIZ
 adJ
 ael
 ael
@@ -155547,8 +157811,8 @@ men
 jsb
 jsb
 fhn
-cFW
-cFW
+dJx
+aLV
 cFW
 fhn
 fhn
@@ -155622,15 +157886,15 @@ bHD
 bHD
 bHD
 bHD
-wff
+efy
 ptE
-wsr
+xwU
 bHD
 bHD
 anu
 rAI
 vaa
-ptE
+wff
 aaa
 aaa
 aaa
@@ -155839,12 +158103,12 @@ cme
 cmE
 mbG
 cnD
-hPl
+rvH
 hPl
 eEU
 slk
 eEU
-hPl
+rvH
 hPl
 cnD
 tIV
@@ -155885,9 +158149,9 @@ aaa
 aaa
 aaa
 bHD
+rrk
 ptE
-ptE
-wff
+bok
 bHD
 aaa
 aaa
@@ -156023,7 +158287,7 @@ aaa
 aaa
 aaa
 aaa
-czO
+qtl
 hHW
 mXe
 vxj
@@ -156067,7 +158331,7 @@ ctj
 ctj
 ctj
 ctj
-bPd
+gYV
 bwK
 cPg
 sIQ
@@ -156131,7 +158395,7 @@ tQg
 tQg
 ctW
 tQg
-cEI
+sBL
 aaa
 aaa
 aaa
@@ -156539,7 +158803,7 @@ aaa
 aaa
 aaa
 aaa
-czO
+sxD
 cCa
 riM
 lEj
@@ -156583,7 +158847,7 @@ ctj
 ctj
 ctj
 ctj
-bPd
+tmD
 bwK
 bPj
 xdp
@@ -156647,7 +158911,7 @@ svD
 svD
 tQg
 iOC
-cEI
+sBL
 aaa
 aaa
 aaa
@@ -157055,7 +159319,7 @@ aaa
 aaa
 aaa
 aaa
-czO
+qtl
 cBX
 rXL
 rWt
@@ -157571,7 +159835,7 @@ aaa
 aaa
 aaa
 aaa
-czO
+sxD
 cCa
 cDB
 vfI
@@ -158076,7 +160340,7 @@ bOL
 cCC
 xVq
 bZK
-cbs
+wQj
 ctj
 ctj
 ctj
@@ -158277,7 +160541,7 @@ cFG
 aaa
 aaa
 aaa
-biL
+nSi
 cum
 hou
 xXQ
@@ -158334,7 +160598,7 @@ bOL
 cCC
 xVq
 bZl
-cbs
+hAo
 ctj
 ctj
 ctj
@@ -158391,7 +160655,7 @@ ctj
 ctj
 ctj
 ctj
-bPd
+hNw
 kgw
 kgw
 kgw
@@ -158449,7 +160713,7 @@ kxM
 kxM
 xXo
 nYj
-nYj
+rUL
 gWZ
 bKO
 ctj
@@ -158592,13 +160856,13 @@ bPU
 hfX
 xVq
 bZL
-cbs
+hAo
 ctj
 ctj
 ctj
 ctj
 bZU
-jMR
+bZU
 bZU
 aaa
 aaa
@@ -158649,7 +160913,7 @@ ctj
 ctj
 ctj
 ctj
-bPd
+hNw
 pux
 pux
 pux
@@ -158856,7 +161120,7 @@ ctj
 bZU
 bZU
 bZU
-lVS
+bZU
 bZU
 bZU
 bZU
@@ -158864,7 +161128,7 @@ ctj
 ctj
 ctj
 kLW
-cFP
+szH
 cFP
 kLW
 mQi
@@ -158895,7 +161159,7 @@ azP
 gXf
 kax
 jsb
-wBI
+eha
 wBI
 jsb
 ctj
@@ -159071,7 +161335,7 @@ bSh
 fSv
 srH
 dPi
-cwa
+vwd
 dRO
 gPb
 apZ
@@ -159146,8 +161410,8 @@ qQq
 bzM
 bzM
 aFJ
-aFJ
-aFJ
+wrQ
+sdt
 bzM
 jsb
 jsb
@@ -159479,7 +161743,7 @@ olH
 olH
 olH
 olH
-hCW
+uCY
 ctj
 ctj
 ctj
@@ -159649,7 +161913,7 @@ ctj
 ctj
 ctj
 ctj
-mKm
+dWA
 wjt
 aZE
 aZE
@@ -159659,7 +161923,7 @@ muk
 aZE
 aZE
 tto
-mKm
+dWA
 ctj
 ctj
 ctj
@@ -159737,7 +162001,7 @@ olH
 olH
 olH
 cdO
-hCW
+uCY
 ctj
 ctj
 ctj
@@ -159892,8 +162156,8 @@ vhB
 lAI
 csA
 cwp
-veO
-hJz
+bZU
+bZU
 ctj
 ctj
 ctj
@@ -159995,7 +162259,7 @@ olH
 olH
 olH
 olH
-hCW
+hms
 ctj
 ctj
 ctj
@@ -160165,7 +162429,7 @@ ctj
 ctj
 ctj
 ctj
-mKm
+uVW
 iQE
 qDS
 qDS
@@ -160175,7 +162439,7 @@ gAe
 qDS
 qDS
 nID
-mKm
+uVW
 ctj
 ctj
 ctj
@@ -160694,8 +162958,8 @@ lKg
 bsU
 bsU
 bsU
-bgR
-bgR
+uno
+kqV
 bsU
 bsU
 bsU
@@ -160920,7 +163184,7 @@ bZU
 bZU
 bZU
 bZU
-hqD
+bZU
 bZU
 bZU
 bZU
@@ -161178,7 +163442,7 @@ ctj
 ctj
 ctj
 bZU
-cxM
+bZU
 bZU
 ctj
 ctj
@@ -161186,7 +163450,7 @@ ctj
 ctj
 cDd
 aSL
-aSL
+gSm
 cDd
 ogR
 asV
@@ -161282,7 +163546,7 @@ kxM
 xXo
 xXo
 xXo
-hCW
+bTq
 xXo
 aaa
 aaa
@@ -161903,7 +164167,7 @@ aaa
 aaa
 xUg
 bXK
-bXK
+gVw
 xUg
 iIv
 qYX
@@ -162049,7 +164313,7 @@ gWZ
 gWZ
 gWZ
 nYj
-nYj
+rUL
 gWZ
 gWZ
 aaa
@@ -162426,10 +164690,10 @@ aaa
 aaa
 xUg
 caj
-gHy
+usy
 gHy
 caj
-gHy
+usy
 gHy
 adU
 lhA
@@ -162441,10 +164705,10 @@ cDW
 lhA
 adU
 aTd
-fiG
+uhk
 fiG
 aTd
-fiG
+uhk
 fiG
 aTd
 aaa
@@ -162468,7 +164732,7 @@ tSV
 abK
 abK
 abK
-bBN
+bdI
 csN
 ydh
 gdr
@@ -162528,7 +164792,7 @@ mAg
 ctj
 ctj
 ctj
-uMN
+oji
 qgb
 wDP
 njG
@@ -162541,8 +164805,8 @@ aaa
 voL
 voL
 voL
-oDE
-oDE
+kOx
+rEe
 oDE
 voL
 gbW
@@ -162804,9 +165068,9 @@ aaa
 aaa
 aaa
 gbW
+raK
 oXt
-oXt
-oXt
+myB
 gbW
 poL
 gbW
@@ -163329,7 +165593,7 @@ aaa
 aaa
 aaa
 aaa
-itt
+veO
 tyQ
 oMZ
 wLq
@@ -163491,9 +165755,9 @@ bvd
 bFM
 tSV
 tSV
+gJv
 bOY
-bOY
-bOY
+fCN
 tSV
 tSV
 tSV
@@ -163555,8 +165819,8 @@ bLN
 vPa
 vPa
 vPa
-cfh
-cfh
+lJQ
+uMA
 cfh
 vPa
 vPa
@@ -163587,7 +165851,7 @@ aaa
 aaa
 aaa
 aaa
-itt
+eCF
 hWI
 oMZ
 nST
@@ -163601,25 +165865,25 @@ uhD
 uhD
 uhD
 uhD
-itt
-itt
-itt
+mzi
+ngO
+cbf
 uhD
 uhD
 uhD
 uhD
 uhD
-itt
-itt
-itt
+mzi
+ngO
+cbf
 uhD
 uhD
 uhD
 uhD
 uhD
-itt
-itt
-itt
+mzi
+ngO
+cbf
 uhD
 uhD
 uhD
@@ -163824,7 +166088,7 @@ eip
 sdb
 upe
 oKS
-uZI
+nJy
 aaa
 aaa
 aaa
@@ -163887,7 +166151,7 @@ mbj
 irh
 qUu
 vwX
-itt
+veO
 aaa
 aaa
 aaa
@@ -164145,7 +166409,7 @@ uDk
 qSt
 uKc
 dHd
-itt
+eCF
 aaf
 gWp
 aaf
@@ -164253,7 +166517,7 @@ aHO
 aHO
 bFM
 adV
-adV
+bCJ
 bFM
 bFM
 bFM
@@ -164638,15 +166902,15 @@ uhD
 uhD
 uhD
 uhD
-itt
-itt
+mzi
+cbf
 uhD
 uhD
 uhD
 uhD
 uhD
-itt
-itt
+mzi
+cbf
 uhD
 uhD
 uhD
@@ -164657,8 +166921,8 @@ uhD
 uhD
 uhD
 uhD
-itt
-itt
+mzi
+cbf
 uhD
 uhD
 uhD
@@ -164767,7 +167031,7 @@ aaa
 ajt
 aHO
 aHO
-adV
+joJ
 ccQ
 xPz
 acM
@@ -164861,7 +167125,7 @@ pGX
 mXA
 cgL
 cgL
-uZI
+nJy
 aaa
 aaa
 aaa
@@ -165025,7 +167289,7 @@ aaa
 ajt
 aHO
 aHO
-adV
+nAv
 mVe
 xPz
 bta
@@ -165035,7 +167299,7 @@ ijW
 akH
 bFM
 adV
-adV
+bCJ
 bFM
 crJ
 crJ
@@ -165109,8 +167373,8 @@ juu
 bkE
 bkE
 bXg
-uZI
-uZI
+cpj
+oxk
 bXg
 bXg
 uZI
@@ -165119,7 +167383,7 @@ aOa
 mXA
 cgL
 dfc
-uZI
+jZR
 aaa
 aaa
 aaa
@@ -165135,7 +167399,7 @@ aaa
 aaa
 aaa
 aaa
-itt
+veO
 hWI
 oMZ
 nST
@@ -165144,7 +167408,7 @@ evu
 nST
 hWI
 iqu
-itt
+veO
 aaa
 aaa
 aaa
@@ -165283,7 +167547,7 @@ aaa
 ajt
 aHO
 aHO
-adV
+nAv
 ikk
 jIb
 mDS
@@ -165314,7 +167578,7 @@ esV
 cCM
 cCJ
 afq
-cGw
+alj
 eGp
 geE
 rzH
@@ -165377,7 +167641,7 @@ gUt
 mXA
 cgL
 iQt
-uZI
+jZR
 aaa
 aaa
 aaa
@@ -165393,7 +167657,7 @@ aaa
 aaa
 aaa
 aaa
-itt
+eCF
 hWI
 oMZ
 nST
@@ -165541,7 +167805,7 @@ aaa
 ajt
 aHO
 aHO
-adV
+nAv
 mVe
 fIW
 eDZ
@@ -165549,7 +167813,7 @@ eDZ
 eDZ
 gda
 eDZ
-adV
+joJ
 aHO
 aHO
 aHO
@@ -165627,7 +167891,7 @@ aaa
 aaa
 aaa
 aaa
-uZI
+nJy
 cdr
 aWe
 tTo
@@ -165635,7 +167899,7 @@ cEm
 mXA
 cgL
 ccC
-uZI
+jZR
 aaa
 aaa
 aaa
@@ -165799,7 +168063,7 @@ aaa
 ajt
 aHO
 aHO
-adV
+rpp
 aSj
 iTU
 iTU
@@ -165807,7 +168071,7 @@ iTU
 iTU
 iTU
 iTU
-adV
+rpp
 aHO
 aHO
 uiI
@@ -165830,7 +168094,7 @@ cyi
 aqx
 fHc
 cEh
-cGw
+nnr
 hKo
 geE
 lUR
@@ -165879,13 +168143,13 @@ bTz
 bfI
 wnu
 awq
-acV
+fGS
 aaa
 aaa
 aaa
 aaa
 aaa
-uZI
+ilJ
 ewD
 ewD
 ewD
@@ -165893,7 +168157,7 @@ ewD
 yau
 cgL
 cgL
-uZI
+ilJ
 aaa
 aaa
 aaa
@@ -166072,7 +168336,7 @@ aKr
 aaa
 aaa
 aaa
-riG
+kUj
 aon
 qlA
 vDn
@@ -166137,7 +168401,7 @@ rBe
 rBe
 jxZ
 cpN
-acV
+sHq
 aaa
 aaa
 aaa
@@ -166318,10 +168582,10 @@ aHO
 bFM
 bFM
 adV
-adV
-adV
-adV
-adV
+xsU
+xsU
+xsU
+bCJ
 bFM
 bFM
 aHO
@@ -166403,11 +168667,11 @@ aaa
 aaa
 bXg
 bXg
-uZI
-uZI
-uZI
-uZI
-uZI
+cpj
+ojb
+ojb
+ojb
+oxk
 bXg
 bXg
 aaa
@@ -167104,7 +169368,7 @@ aaa
 aaa
 aaa
 aaa
-uai
+gtX
 cna
 wFz
 wfz
@@ -167169,7 +169433,7 @@ oBT
 oBT
 itA
 bWm
-ryI
+wCK
 aaa
 aaa
 aaa
@@ -167199,7 +169463,7 @@ aaa
 aaa
 aaa
 aaa
-sbk
+jiU
 vor
 dKd
 wQZ
@@ -167427,7 +169691,7 @@ bSq
 bTJ
 ijP
 bWn
-ryI
+uBp
 aaa
 aaa
 aaa
@@ -167457,7 +169721,7 @@ aaa
 aaa
 aaa
 aaa
-sbk
+eBy
 xzT
 dKd
 tBD
@@ -167466,7 +169730,7 @@ oHb
 tBD
 toM
 toM
-sbk
+jiU
 aaa
 aaa
 aaa
@@ -167715,7 +169979,7 @@ aaa
 aaa
 aaa
 aaa
-sbk
+gFx
 xzT
 dKd
 tBD
@@ -167724,7 +169988,7 @@ oHb
 tBD
 toM
 toM
-sbk
+eBy
 aaa
 aaa
 aaa
@@ -167982,7 +170246,7 @@ oHb
 tBD
 toM
 toM
-sbk
+gFx
 aaa
 aaa
 aaa
@@ -168399,7 +170663,7 @@ pxs
 hmH
 aWJ
 lSj
-bcb
+sYL
 bOz
 owy
 cth
@@ -168657,7 +170921,7 @@ pxs
 bOa
 aWJ
 lSj
-bcb
+tmI
 aXa
 uVT
 gjb
@@ -168970,7 +171234,7 @@ bVb
 bNV
 qXU
 lvX
-bHE
+icO
 bSx
 eej
 uiJ
@@ -169744,7 +172008,7 @@ bVb
 btH
 fCx
 bSu
-bHE
+rxg
 xTW
 wEW
 nZr
@@ -169779,7 +172043,7 @@ aaa
 aaa
 aaa
 aaa
-sbk
+jiU
 sQq
 kfm
 sQq
@@ -169799,14 +172063,14 @@ qcZ
 qcZ
 qcZ
 sbk
-sbk
+gky
 qcZ
 qcZ
 qcZ
 qcZ
 qcZ
 sbk
-sbk
+gky
 qcZ
 qcZ
 qcZ
@@ -169818,7 +172082,7 @@ qcZ
 qcZ
 qcZ
 sbk
-sbk
+gky
 qcZ
 qcZ
 qcZ
@@ -170037,7 +172301,7 @@ aaa
 aaa
 aaa
 aaa
-sbk
+eBy
 pin
 pwn
 gjv
@@ -170295,7 +172559,7 @@ aaa
 aaa
 aaa
 aaa
-sbk
+gFx
 kfm
 sQq
 bFw
@@ -170337,7 +172601,7 @@ xTR
 sQq
 fVB
 pQm
-sbk
+gFx
 aaf
 gWp
 aaf
@@ -170567,7 +172831,7 @@ qcZ
 qcZ
 sbk
 wlP
-sbk
+gky
 qcZ
 qcZ
 qcZ
@@ -170576,8 +172840,8 @@ qcZ
 qcZ
 qcZ
 sbk
-sbk
-sbk
+tKS
+gky
 qcZ
 qcZ
 qcZ
@@ -170587,7 +172851,7 @@ qcZ
 qcZ
 sbk
 wlP
-sbk
+gky
 qcZ
 qcZ
 qcZ
@@ -171292,7 +173556,7 @@ iJP
 rUQ
 bLO
 gWq
-nqY
+dxA
 pKf
 sUE
 jVN
@@ -171550,7 +173814,7 @@ iJP
 pQo
 dsV
 fek
-nqY
+opl
 eym
 gBb
 usz
@@ -171591,8 +173855,8 @@ onO
 aaa
 qcZ
 sbk
-sbk
-sbk
+tKS
+gky
 qcZ
 aaa
 aaa
@@ -171759,8 +174023,8 @@ cBe
 aWC
 fJy
 bGI
-tNh
-tNh
+wog
+fKO
 cgM
 bvI
 cEB
@@ -172264,14 +174528,14 @@ aaa
 aaa
 aaa
 aaa
-weK
-gVw
+tuv
+bXM
 bXM
 idI
 idI
 idI
 aez
-tNh
+kqb
 aXR
 mOj
 sub
@@ -172780,7 +175044,7 @@ aaa
 aaa
 aaa
 aaa
-arv
+mVw
 gQv
 bMW
 blw
@@ -173296,7 +175560,7 @@ aaa
 aaa
 aaa
 aaa
-arv
+gIg
 cvO
 hgv
 dWe
@@ -175417,7 +177681,7 @@ rGf
 fZU
 bju
 tri
-wBE
+rZf
 bJG
 sUz
 jwC
@@ -175931,7 +178195,7 @@ pjG
 pjG
 pjG
 wUp
-dMp
+rTc
 dMp
 wUp
 abK
@@ -176403,8 +178667,8 @@ ckC
 sYg
 wWX
 enC
-enC
-enC
+gFq
+hde
 wWX
 wWX
 bih
@@ -176699,7 +178963,7 @@ sgw
 nCE
 pho
 veJ
-veJ
+hfN
 mmv
 aaa
 aaa
@@ -177455,10 +179719,10 @@ aaa
 pho
 pho
 veJ
-veJ
+hfN
 pho
 veJ
-veJ
+hfN
 pho
 pho
 aaa

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
@@ -394,7 +394,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -558,7 +557,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance/common,
+/obj/machinery/door/airlock/maintenance/medical{
+	id_tag = "Med Lockdown"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck3_Medical_AftCorridor1)
 "agy" = (
@@ -759,19 +760,24 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Chomp_Lounge)
+"akN" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
-/area/crew_quarters/Chomp_Lounge)
+/area/crew_quarters/Observation_Atrium)
 "akR" = (
 /obj/structure/table/rack,
 /obj/random/flashlight,
@@ -983,6 +989,27 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled,
 /area/medical/Lounge)
+"aqh" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/harbor/For_3_Deck_Airlock_Access_1)
 "aqj" = (
 /obj/structure/lattice,
 /turf/space,
@@ -1331,13 +1358,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -1522,13 +1544,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -1703,6 +1720,19 @@
 /obj/machinery/portable_atmospherics/canister/air/airlock,
 /turf/simulated/floor/plating,
 /area/harbor/Port_3_Deck_Airlock_Access)
+"aCu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Atrium)
 "aCV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -1778,7 +1808,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -2670,6 +2699,19 @@
 	color = "#8bbbd5"
 	},
 /area/medical/Aft_Medical_Post)
+"aVA" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Lounge)
 "aVB" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -2902,8 +2944,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -2960,9 +3000,6 @@
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 1
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 4
 	},
 /obj/machinery/door/blast/regular{
 	dir = 8;
@@ -3057,6 +3094,12 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
+"bcY" = (
+/obj/machinery/holoposter{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/Aft_3_Deck_Central_Corridor_1)
 "bdd" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/drinks/cans/waterbottle{
@@ -3371,6 +3414,21 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/Engine_Tech_Storage)
+"bju" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_AftPortChamber1)
 "bjy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3521,6 +3579,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Star_Breakroom)
+"blO" = (
+/obj/structure/sign/poster/nanotrasen{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/Aft_3_Deck_Central_Corridor_1)
 "blQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -3806,6 +3870,19 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Center_Star)
+"brE" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_AftPort)
 "brI" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/power/smes/buildable{
@@ -3843,13 +3920,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -3917,11 +3990,7 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
-/obj/structure/window/basic{
-	dir = 8
-	},
 /obj/structure/window/basic{
 	dir = 1
 	},
@@ -4370,14 +4439,9 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -4626,7 +4690,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -4889,13 +4952,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -5398,13 +5457,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -5604,8 +5659,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -5736,8 +5789,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -5852,6 +5903,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Genetics_Lab)
+"ccX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_StarCorridor2)
 "cdc" = (
 /obj/machinery/door/window/brigdoor/southright{
 	req_access = list(19)
@@ -6025,6 +6089,27 @@
 /obj/structure/bed/chair/comfy/purp,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_AftStarChamber1)
+"cgW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Star_3_Deck_Airlock_Access)
 "cho" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -6217,13 +6302,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -6762,11 +6843,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -6810,7 +6887,6 @@
 "cuz" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -6877,13 +6953,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -7307,7 +7379,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/structure/grille,
 /obj/structure/window/phoronreinforced/full,
-/obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
 	dir = 8
 	},
@@ -7718,6 +7789,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/alt,
 /area/bridge/Embassy)
+"cJG" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Substation)
 "cJI" = (
 /obj/random/trash_pile,
 /obj/random/junk,
@@ -7951,11 +8041,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 1
-	},
 /obj/structure/window/titanium{
 	dir = 8
 	},
@@ -8076,13 +8161,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -8240,7 +8321,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -8485,11 +8565,11 @@
 /turf/space,
 /area/space)
 "cXl" = (
-/obj/machinery/portable_atmospherics/powered/pump/huge,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "cXn" = (
@@ -8712,6 +8792,24 @@
 	},
 /turf/simulated/floor/reinforced/phoron,
 /area/engineering/Atmospherics_Chamber)
+"daZ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Construction_Area)
 "dbc" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
@@ -8745,11 +8843,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -8812,6 +8906,18 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Center_Star)
+"dcX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Lounge)
 "ddi" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -8858,11 +8964,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 1
-	},
 /obj/structure/window/titanium{
 	dir = 8
 	},
@@ -9127,24 +9229,10 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/crew_quarters/Observation_Atrium)
 "djT" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/industrial/hatch/blue,
-/obj/structure/grille,
-/obj/structure/window/basic/full,
-/obj/structure/window/basic,
-/obj/structure/window/basic{
-	dir = 8
-	},
-/obj/structure/window/basic{
-	dir = 1
-	},
-/obj/structure/window/basic{
-	dir = 4
-	},
 /obj/structure/sign/hydro{
 	layer = 3.5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/hallway/Central_3_Deck_Hall)
 "djU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9187,6 +9275,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/Surgery_Storage)
+"dkk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Engineering_ForStarChamber2)
 "dkv" = (
 /obj/structure/sign/levels/engineering/solars{
 	dir = 1;
@@ -9210,6 +9317,23 @@
 	dir = 1
 	},
 /turf/simulated/floor/glass/reinforced,
+/area/maintenance/Deck3_Medical_ForPortChamber1)
+"dkM" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_ForPortChamber1)
 "dkU" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -9376,6 +9500,36 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Bridge_Substation)
+"dnu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/harbor/For_3_Deck_Airlock_Access_1)
+"dnE" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_ForPort)
 "dog" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -9589,6 +9743,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Aft_3_Deck_Airlock_Access)
+"dtR" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Virology)
 "dvc" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10035,12 +10204,26 @@
 /turf/simulated/floor/grass,
 /area/crew_quarters/Public_Garden)
 "dBo" = (
-/obj/structure/railing/grey{
-	color = "yellow";
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
 	dir = 1
 	},
-/turf/simulated/open,
-/area/maintenance/Deck3_Medical_ForChamber2)
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Bridge_ForPort_Corridor2)
 "dBt" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -10641,6 +10824,19 @@
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
+"dLW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_ForPort_Corridor1)
 "dMf" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/borderfloor/corner2{
@@ -10687,6 +10883,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Solar_Control_ForPort)
+"dMH" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/bridge/Control_Atrium)
 "dMY" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -11071,16 +11291,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
@@ -11088,11 +11301,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -11139,16 +11348,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
@@ -11576,8 +11778,6 @@
 "dYy" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -11758,11 +11958,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -11994,6 +12190,19 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/Aft_3_Deck_Stairwell)
+"ecG" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Airlock_Access)
 "ecR" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -12054,11 +12263,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -12459,11 +12664,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -12476,16 +12677,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 6
@@ -12851,12 +13045,12 @@
 "esF" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/white,
-/obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 1
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
 	},
+/obj/structure/grille,
+/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 8
 	},
@@ -13284,11 +13478,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -13384,6 +13574,21 @@
 	},
 /turf/simulated/floor/airless,
 /area/engineering/Solar_Array_ForPort)
+"eAU" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Aft_3_Deck_Central_Corridor_1)
 "eBa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14392,7 +14597,6 @@
 "eOx" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 1
@@ -14531,16 +14735,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -14565,11 +14762,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -15017,7 +15210,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -15082,16 +15274,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -15106,7 +15294,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -15356,6 +15543,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/Captain_Office)
+"eZw" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Central_3_Deck_Hall)
 "eZO" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/button/remote/emitter{
@@ -15488,6 +15688,18 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"faL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_AftPort)
 "faZ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28;
@@ -15675,13 +15887,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -15983,6 +16191,19 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/crew_quarters/Chomp_Dinner_2)
+"fgu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_PortChamber1)
 "fgI" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -16041,13 +16262,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -16395,6 +16612,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Foyer)
+"fmr" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Central_3_Deck_Hall)
 "fmx" = (
 /obj/structure/table/sifwoodentable,
 /obj/machinery/computer/security/telescreen/entertainment{
@@ -16478,6 +16710,27 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_AftStarChamber1)
+"fng" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/bridge/AI_Core_Chamber)
 "fnj" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16737,7 +16990,7 @@
 	health = 1e+006
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "fqG" = (
@@ -17132,6 +17385,27 @@
 	},
 /turf/simulated/floor/airless,
 /area/engineering/Solar_Control_AftStar)
+"fxb" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_ForPortChamber1)
 "fxe" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -17297,7 +17571,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -17348,6 +17621,24 @@
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Aft_3_Deck_Stairwell)
+"fAd" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/medical/Virology)
 "fAn" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -17546,6 +17837,32 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Genetics_Lab)
+"fCM" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Chamber)
 "fCX" = (
 /obj/machinery/light{
 	dir = 1
@@ -17850,11 +18167,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -17890,6 +18203,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Virology)
+"fHt" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Waste_Handling)
 "fHB" = (
 /obj/machinery/power/smes/buildable{
 	RCon_tag = "Solar - ForStar";
@@ -17911,8 +18236,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -17993,6 +18316,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_2)
+"fIL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/harbor/For_3_Deck_Airlock_Access_2)
 "fIV" = (
 /obj/machinery/camera/network/security{
 	c_tag = "D3-Dmc-Dorms Foyer2";
@@ -18083,7 +18424,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -18374,6 +18714,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/medical/Autoresleeving)
+"fOY" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Central_3_Deck_Hall)
 "fPi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -18623,6 +18976,22 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
+"fTs" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Atrium)
 "fTw" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -18850,6 +19219,24 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/brown,
 /area/crew_quarters/Chomp_Dinner_2)
+"fXu" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/bridge/Control_Atrium)
 "fXS" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/light/small{
@@ -19024,6 +19411,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_ForStarChamber1)
+"gau" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Aft_3_Deck_Central_Corridor_1)
 "gaI" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -19757,6 +20156,13 @@
 	},
 /turf/simulated/floor/airless,
 /area/engineering/Solar_Control_AftPort)
+"gmL" = (
+/obj/machinery/holoposter{
+	pixel_y = 32;
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/Aft_3_Deck_Central_Corridor_1)
 "gnf" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19978,6 +20384,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_ForStarChamber2)
+"gqc" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/radproof/open{
+	dir = 4;
+	id = "SC-GCengineroom";
+	layer = 3.5
+	},
+/obj/structure/girder/reinforced{
+	default_material = "lead"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Substation)
 "gqe" = (
 /obj/structure/table/rack/holorack,
 /obj/machinery/door/window/brigdoor/northleft,
@@ -20159,6 +20584,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_AftCorridor2)
+"gto" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Engineering_AftStarChamber3)
 "gtC" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -20500,16 +20944,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 4
@@ -20603,13 +21040,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -20842,17 +21274,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
-"gGh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/engineering/Atmospherics_Chamber)
-"gGj" = (
+"gGf" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -20862,10 +21287,23 @@
 /obj/structure/window/titanium{
 	dir = 8
 	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_AftPort)
+"gGh" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Chamber)
+"gGj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -21174,8 +21612,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -21595,6 +22031,18 @@
 "gSg" = (
 /turf/simulated/wall,
 /area/maintenance/Deck3_Medical_AftPortChamber2)
+"gSs" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Center_Port)
 "gSU" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -21811,6 +22259,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/medical/Morgue)
+"gVq" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Chomp_Lounge)
 "gVw" = (
 /obj/machinery/camera/network/security{
 	dir = 8;
@@ -22268,6 +22729,23 @@
 "hge" = (
 /turf/simulated/wall/r_wall,
 /area/medical/Deck3_Corridor)
+"hgi" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_ForStarChamber1)
 "hgl" = (
 /obj/structure/table/bench/sifwooden,
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -22343,6 +22821,19 @@
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_AftPortChamber1)
+"hhT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Center_Port)
 "hig" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -23023,6 +23514,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_AftPortChamber2)
+"hvE" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/bridge/Control_Atrium)
 "hvR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23236,6 +23747,23 @@
 "hzi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Chamber)
+"hzu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -23874,7 +24402,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -23904,16 +24431,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -23928,7 +24451,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -24004,6 +24526,24 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/engineering/Engine3_Control_Room)
+"hLK" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/bridge/AI_Core_Chamber)
 "hLS" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -24075,6 +24615,19 @@
 /obj/structure/bed/chair/comfy/beige,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_AftStarChamber1)
+"hMz" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Engine1_Control_Room)
 "hMC" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -24239,6 +24792,19 @@
 /obj/effect/floor_decal/corner/lightorange/border,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine_Tech_Storage)
+"hPO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Waste_Handling)
 "hQu" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -24347,8 +24913,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -24686,7 +25250,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -25108,6 +25671,43 @@
 	color = "#8bbbd5"
 	},
 /area/medical/Virology)
+"idg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_AftStarChamber1)
+"ids" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	dir = 8;
+	id = "SC-GCreactor";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Chamber)
 "idA" = (
 /obj/structure/cable/white{
 	d1 = 1;
@@ -25271,6 +25871,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Leisure_Room)
+"ifh" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_ForStar)
 "ifx" = (
 /obj/effect/catwalk_plated/techfloor,
 /obj/item/toy/mistletoe{
@@ -25345,6 +25958,27 @@
 /obj/machinery/appliance/cooker/oven,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/sleep/Dormitory_06)
+"ihf" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Construction_Area)
 "ihl" = (
 /obj/structure/table/standard,
 /obj/item/measuring_tape,
@@ -25729,9 +26363,6 @@
 /obj/structure/window/phoronreinforced{
 	dir = 1
 	},
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
 /obj/machinery/door/blast/radproof/open{
 	dir = 4;
 	id = "SC-GCengineroom";
@@ -25847,11 +26478,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -26151,6 +26778,19 @@
 	},
 /turf/simulated/open,
 /area/maintenance/Deck3_Center_Star)
+"ivB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Public_Hydroponics)
 "ivH" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -26346,8 +26986,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -26795,6 +27433,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/clothing/suit/storage/apron/overalls,
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
 "iFs" = (
@@ -26819,6 +27458,27 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_06)
+"iFS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/harbor/For_3_Deck_Airlock_Access_2)
 "iGr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -26867,6 +27527,7 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/item/clothing/head/greenbandana,
 /obj/item/clothing/head/greenbandana,
+/obj/item/clothing/suit/storage/apron/overalls,
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
 "iHY" = (
@@ -27288,10 +27949,15 @@
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "iOb" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/engineering/Atmospherics_Chamber)
+/area/engineering/Solar_Control_ForPort)
 "iOf" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/red{
@@ -27746,16 +28412,9 @@
 "iVU" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/plating,
@@ -28010,7 +28669,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -28321,7 +28979,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -28398,45 +29055,34 @@
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleep/Dormitory_10)
 "jhC" = (
-/obj/item/gun/energy/locked/frontier/rifle{
-	pixel_y = 9
-	},
 /obj/item/cell/device/weapon{
-	pixel_y = 4
-	},
-/obj/item/cell/device/weapon{
-	pixel_y = 2
-	},
-/obj/item/cell/device/weapon,
-/obj/structure/closet/secure_closet/guncabinet{
-	req_one_access = list(1,19)
-	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
-	pixel_x = 5
-	},
-/obj/item/gun/energy/locked/frontier/rifle{
 	pixel_y = 6
 	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
-	pixel_x = 2
+/obj/item/cell/device/weapon{
+	pixel_y = 3
 	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
-	pixel_x = -1
-	},
-/obj/item/gun/projectile/shotgun/pump/rifle{
-	pixel_y = -2
-	},
-/obj/item/gun/projectile/shotgun/pump/rifle{
-	pixel_y = -5
+/obj/structure/closet/secure_closet/guncabinet{
+	req_one_access = list(1,19)
 	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 5
+	},
+/obj/item/gun/energy/gun/taser{
+	pixel_y = -4
+	},
+/obj/item/flash{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/flash{
+	pixel_y = 9;
+	pixel_x = 4
+	},
+/obj/item/gun/energy/gun/rifle{
+	pixel_y = -7
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/Control_Atrium)
@@ -28925,6 +29571,26 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/Observation_Lounge)
+"jqe" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Resleeving)
 "jqk" = (
 /obj/item/autopsy_scanner,
 /obj/item/surgical/scalpel,
@@ -29065,6 +29731,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Central_3_Deck_Hall)
+"jtr" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Engine1_Control_Room)
 "jtv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 8
@@ -29108,12 +29786,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -29217,11 +29891,20 @@
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForPort_Corridor2)
+"jvd" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Atrium)
 "jve" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -29800,12 +30483,8 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -30213,11 +30892,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -30235,7 +30910,6 @@
 /area/medical/Resleeving)
 "jKo" = (
 /obj/machinery/smartfridge/drying_rack,
-/obj/item/clothing/suit/storage/apron/overalls,
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
 "jKE" = (
@@ -30614,16 +31288,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
@@ -30888,12 +31555,31 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Virology)
+"jXj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Port_3_Deck_Airlock_Access)
 "jXl" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -31540,16 +32226,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/door/blast/regular/open{
@@ -31609,6 +32288,25 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/engineering/Construction_Area)
+"kjc" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/medical/Virology)
 "kjD" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows{
@@ -31680,16 +32378,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 8
@@ -31894,6 +32585,19 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Stage)
+"kpB" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Virology)
 "kpC" = (
 /obj/machinery/honey_extractor,
 /turf/simulated/floor/tiled/hydro,
@@ -32292,6 +32996,21 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck3_Dorms_AftPortChamber2)
+"kud" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_AftStar)
 "kuq" = (
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -32817,6 +33536,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
+"kDY" = (
+/obj/structure/sign/poster/nanotrasen{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/Aft_3_Deck_Central_Corridor_1)
 "kEc" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/steel_ridged{
@@ -32936,6 +33661,16 @@
 	},
 /turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
+"kGc" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Control_Room)
 "kGh" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
@@ -33128,6 +33863,27 @@
 /obj/structure/sign/warning/lethal_turrets,
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck3_Bridge_ForPort_Chamber1)
+"kKL" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating,
+/area/bridge/AI_Core_Chamber)
 "kKO" = (
 /obj/structure/bed/chair/backed_grey{
 	color = "grey";
@@ -33604,6 +34360,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
+"kSt" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Center_Star)
 "kSx" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -33745,6 +34516,18 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_StarCorridor1)
+"kUm" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Construction_Area)
 "kUz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -34095,8 +34878,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -34207,13 +34988,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -34395,6 +35172,28 @@
 "len" = (
 /turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
+"lev" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/radproof/open{
+	dir = 4;
+	id = "SC-GCengineroom";
+	layer = 3.5
+	},
+/obj/structure/girder/reinforced{
+	default_material = "lead"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Substation)
 "leC" = (
 /obj/structure/bed/chair/sofa/blue,
 /obj/machinery/firealarm{
@@ -34437,12 +35236,12 @@
 /turf/simulated/wall,
 /area/engineering/Atmospherics_Chamber)
 "lfV" = (
-/obj/machinery/portable_atmospherics/powered/pump/huge,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "lfY" = (
@@ -34542,7 +35341,7 @@
 "lhX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "lib" = (
@@ -34705,6 +35504,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck3_Dorms_AftCorridor2)
+"ljS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Atrium)
 "lke" = (
 /obj/structure/window/plastitanium{
 	dir = 8
@@ -34798,6 +35607,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Chomp_Lounge)
+"lmc" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Control_Room)
 "lmd" = (
 /obj/structure/transit_tube{
 	icon_state = "D-SE"
@@ -34808,15 +35630,11 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck3_Engineering_AftStarChamber2)
 "lmF" = (
-/obj/structure/ladder{
-	pixel_y = 3
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/sign/small/warning/emerg_only{
 	desc = "Ladder for emergency use only";
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_ForChamber2)
 "lmQ" = (
 /obj/structure/cable/cyan{
@@ -35002,6 +35820,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Hydroponics)
+"lps" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_AftStar)
 "lpN" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/red{
@@ -35961,13 +36792,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -36062,6 +36889,28 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
+"lGy" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Bridge_AftStarCorridor1)
 "lGz" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 6
@@ -36075,8 +36924,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -36207,13 +37054,38 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_08)
 "lIN" = (
-/obj/machinery/atmospherics/portables_connector{
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/powered/pump/huge,
-/obj/effect/floor_decal/industrial/outline/blue,
+/obj/structure/window/basic{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/engineering/Atmospherics_Chamber)
+/area/hallway/Central_3_Deck_Hall)
+"lIT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_ForStarChamber1)
 "lJd" = (
 /obj/structure/table/standard,
 /obj/item/towel/random,
@@ -36369,6 +37241,24 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_StarCorridor1)
+"lLx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_ForPortChamber1)
 "lLA" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -36434,6 +37324,37 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"lMR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 6
+	},
+/obj/machinery/door/blast/multi_tile/three_tile_hor{
+	icon_state = "open";
+	layer = 3.5;
+	id = "SC-BDatmoslockdown";
+	opacity = 0;
+	density = 0;
+	name = "Atmospherics Lockdown"
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Chamber)
 "lMS" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass2,
@@ -36861,6 +37782,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/Port_3_Deck_Stairwell)
+"lSv" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	dir = 8;
+	id = "SC-GCreactor";
+	layer = 3.3;
+	name = "Reactor Blast Door"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Chamber)
 "lSN" = (
 /turf/simulated/wall/r_wall,
 /area/harbor/For_3_Deck_Airlock_Access_2)
@@ -37285,7 +38226,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -37293,9 +38233,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/door/blast/multi_tile/two_tile_hor{
 	icon_state = "open";
 	layer = 3.5;
@@ -37345,6 +38282,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_2)
+"lXJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_AftStar)
 "lXZ" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 8
@@ -37407,6 +38357,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/bridge/Firstaid_Post)
+"lZl" = (
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/bridge/AI_Core_Chamber)
 "lZm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37652,8 +38615,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -37950,7 +38911,6 @@
 /obj/effect/floor_decal/industrial/arrows/yellow{
 	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance/common,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -37967,6 +38927,9 @@
 	id = "Med Lockdown";
 	name = "Lockdown Gate";
 	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/obj/machinery/door/airlock/maintenance/medical{
+	id_tag = "Med Lockdown"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Star_Breakroom)
@@ -38975,6 +39938,26 @@
 	},
 /turf/simulated/open,
 /area/maintenance/Deck3_Center_Port)
+"mtv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_ForPortChamber2)
 "mtz" = (
 /obj/structure/ladder{
 	pixel_y = 3
@@ -39456,8 +40439,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -39648,7 +40629,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -39656,11 +40636,26 @@
 /obj/structure/window/titanium{
 	dir = 1
 	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/Public_Hydroponics)
+"mHg" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/bridge/Control_Atrium)
 "mHK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -39885,6 +40880,19 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/medical/Restrooms)
+"mLu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Center_Port)
 "mLA" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck3_Dorms_StarCorridor2)
@@ -40167,6 +41175,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Substation)
+"mRA" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/radproof/open{
+	dir = 4;
+	id = "SC-GCengineroom";
+	layer = 3.5
+	},
+/obj/structure/girder/reinforced{
+	default_material = "lead"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine3_Control_Room)
 "mRC" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -40826,6 +41853,19 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck3_Dorms_StarCorridor2)
+"ncC" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_ForStar)
 "ncF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40873,8 +41913,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -41293,7 +42331,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -41505,6 +42542,16 @@
 /obj/random/maintenance/morestuff,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_AftStarChamber3)
+"noO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_AftStar)
 "noT" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck3_Medical_AftPortChamber2)
@@ -41577,6 +42624,19 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Center_Star)
+"nqc" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_ForPort)
 "nqg" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -41870,9 +42930,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/portable_atmospherics/powered/scrubber/huge{
-	scrub_id = "SC_Atmos"
-	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "nvI" = (
@@ -42155,6 +43213,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/Control_Atrium)
+"nzS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_ForPortChamber2)
 "nzU" = (
 /obj/machinery/vending/loadout/uniform,
 /obj/machinery/light{
@@ -42403,13 +43478,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -42675,11 +43746,7 @@
 "nHx" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -42770,6 +43837,19 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/Atmospherics_Substation)
+"nHZ" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Engine1_Control_Room)
 "nIc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
@@ -42818,11 +43898,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -42851,13 +43927,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -43004,6 +44075,22 @@
 	color = "#8bbbd5"
 	},
 /area/medical/Genetics_Lab)
+"nMp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Center_Port)
 "nMq" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
@@ -43340,8 +44427,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -43373,11 +44458,23 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
 "nTh" = (
-/obj/machinery/computer/area_atmos/tag{
-	scrub_id = "SC_Atmos"
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
 	},
 /turf/simulated/floor/plating,
-/area/engineering/Atmospherics_Chamber)
+/area/harbor/Star_3_Deck_Airlock_Access)
 "nTk" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -43437,13 +44534,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -43591,8 +44683,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -43835,6 +44925,22 @@
 	},
 /turf/simulated/open,
 /area/maintenance/Deck3_Center_Star)
+"oaY" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_AftPortChamber1)
 "obc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44493,7 +45599,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -44996,10 +46101,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -45098,6 +46199,29 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/open,
 /area/maintenance/Deck3_Dorms_PortCorridor1)
+"oti" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced{
+	dir = 8
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/radproof/open{
+	id = "SC-GCengineroom";
+	layer = 3.5
+	},
+/obj/structure/girder/reinforced{
+	default_material = "lead"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Chamber)
 "ott" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	external_pressure_bound = 0;
@@ -45412,6 +46536,19 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
+"oxA" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Aft_3_Deck_Airlock_Access)
 "oxB" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -45532,11 +46669,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -45571,6 +46704,27 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/crew_quarters/sleep/Dormitory_05)
+"oAu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Bridge_ForStarCorridor2)
 "oAF" = (
 /turf/simulated/wall,
 /area/maintenance/Deck3_Engineering_StarChamber1)
@@ -45585,16 +46739,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -45808,8 +46958,6 @@
 "oGh" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -45870,16 +47018,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/meter,
@@ -46047,16 +47191,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
@@ -46289,16 +47429,12 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
 	},
 /obj/structure/window/basic{
 	dir = 1
-	},
-/obj/structure/window/basic{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -46511,14 +47647,13 @@
 "oQl" = (
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "oQM" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -46531,6 +47666,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_ForPort_Chamber1)
+"oQQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Engineering_AftStarChamber1)
 "oQZ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -46695,6 +47850,19 @@
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/bridge/sleep/CMO_Quarters)
+"oUw" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Construction_Area)
 "oUA" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 4
@@ -46786,6 +47954,41 @@
 	},
 /turf/simulated/floor/plating,
 /area/bridge/AI_Upload_Hall)
+"oVS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/multi_tile/three_tile_ver{
+	icon_state = "open";
+	layer = 3.5;
+	density = 0;
+	id = "SC-GCengineviewport";
+	name = "Engine Radiator Viewport";
+	opacity = 0
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Chamber)
 "oWj" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -47305,8 +48508,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -47405,6 +48606,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Waste_Handling)
+"pgi" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_ForChamber3)
 "pgC" = (
 /obj/effect/floor_decal/industrial/hatch,
 /obj/machinery/atmospheric_field_generator/perma/underdoors{
@@ -47669,6 +48890,26 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_AftPortChamber1)
+"plT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_ForChamber3)
 "pmk" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -47684,11 +48925,7 @@
 "pmm" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -48028,7 +49265,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -48654,6 +49890,19 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/bridge/Conference_Room)
+"pAv" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Center_Port)
 "pAw" = (
 /obj/structure/table/rack/steel,
 /obj/random/maintenance/medical,
@@ -48768,39 +50017,14 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "pDm" = (
-/obj/item/gun/energy/locked/frontier/rifle{
-	pixel_y = 9
-	},
 /obj/item/cell/device/weapon{
-	pixel_y = 4
-	},
-/obj/item/cell/device/weapon{
-	pixel_y = 2
-	},
-/obj/item/cell/device/weapon,
-/obj/structure/closet/secure_closet/guncabinet{
-	req_one_access = list(1,19)
-	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
-	pixel_x = 5
-	},
-/obj/item/gun/energy/locked/frontier/rifle{
 	pixel_y = 6
 	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
-	pixel_x = 2
+/obj/item/cell/device/weapon{
+	pixel_y = 3
 	},
-/obj/item/ammo_magazine/clip/c762{
-	pixel_y = -7;
-	pixel_x = -1
-	},
-/obj/item/gun/projectile/shotgun/pump/rifle{
-	pixel_y = -2
-	},
-/obj/item/gun/projectile/shotgun/pump/rifle{
-	pixel_y = -5
+/obj/structure/closet/secure_closet/guncabinet{
+	req_one_access = list(1,19)
 	},
 /obj/machinery/light{
 	dir = 1
@@ -48821,6 +50045,20 @@
 	},
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 1
+	},
+/obj/item/gun/energy/gun/taser{
+	pixel_y = -4
+	},
+/obj/item/flash{
+	pixel_y = 9;
+	pixel_x = 8
+	},
+/obj/item/flash{
+	pixel_y = 9;
+	pixel_x = 4
+	},
+/obj/item/gun/energy/gun/rifle{
+	pixel_y = -7
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/bridge/Control_Atrium)
@@ -49094,6 +50332,19 @@
 	},
 /turf/simulated/open,
 /area/hallway/Star_Breakroom)
+"pHA" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_ForPort)
 "pHF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -49335,16 +50586,22 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/sleep/Dormitory_10)
 "pMu" = (
-/obj/structure/railing/grey{
-	color = "yellow";
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
 	dir = 1
 	},
-/obj/structure/railing/grey{
-	color = "yellow";
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
 	dir = 4
 	},
-/turf/simulated/open,
-/area/maintenance/Deck3_Medical_ForChamber2)
+/turf/simulated/floor/plating,
+/area/medical/Resleeving)
 "pMy" = (
 /obj/structure/sign/levels/engineering/solars{
 	dir = 4;
@@ -49434,7 +50691,7 @@
 /area/hallway/Port_Breakroom)
 "pOf" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "pOt" = (
@@ -49574,7 +50831,6 @@
 "pQQ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 1
@@ -49716,6 +50972,18 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_1)
+"pSW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Atrium)
 "pTg" = (
 /obj/structure/loot_pile/maint/technical,
 /obj/random/trash,
@@ -49974,8 +51242,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -50186,6 +51452,33 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_2)
+"qbf" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Chamber)
 "qbh" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	frequency = 1441;
@@ -50234,6 +51527,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_For)
+"qcg" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_ForStar)
 "qcQ" = (
 /obj/machinery/light_construct/small{
 	dir = 1
@@ -50431,16 +51734,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/meter,
@@ -50865,6 +52164,23 @@
 /obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_PortCorridor1)
+"qlz" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Engineering_AftStarChamber1)
 "qlI" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -50882,8 +52198,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -51600,16 +52914,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -51933,7 +53240,6 @@
 "qCU" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -52098,6 +53404,24 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Aft)
+"qGP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Engineering_AftStarChamber3)
 "qHj" = (
 /obj/structure/undies_wardrobe,
 /obj/item/reagent_containers/food/drinks/cans/waterbottle{
@@ -52181,7 +53505,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -52616,9 +53939,7 @@
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/portable_atmospherics/powered/scrubber/huge{
-	scrub_id = "SC_Atmos"
-	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "qMY" = (
@@ -52635,6 +53956,19 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/Observation_Lounge)
+"qNw" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/medical/Virology)
 "qNG" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -53284,6 +54618,18 @@
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/medical/Patient_4)
+"raX" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Center_Star)
 "rbj" = (
 /obj/machinery/computer/transhuman/resleeving{
 	dir = 1
@@ -53497,13 +54843,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -54331,13 +55673,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -54556,7 +55893,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -54632,7 +55968,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -55038,13 +56373,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -55069,7 +56400,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -55201,7 +56531,7 @@
 	layer = 3
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "rFQ" = (
@@ -55246,13 +56576,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -55298,6 +56624,26 @@
 	color = "#8bbbd5"
 	},
 /area/medical/Resleeving)
+"rHI" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_ForPortChamber1)
 "rHJ" = (
 /obj/machinery/camera/network/security{
 	c_tag = "D3-Eng-Atmos Phoron";
@@ -55367,11 +56713,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -55432,13 +56774,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -55556,6 +56894,24 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/Atmospherics_Chamber)
+"rLP" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/white{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/bridge/Embassy)
 "rMh" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -55695,6 +57051,26 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/sleep/Captain_Quarters)
+"rPk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Lounge)
 "rPo" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -55976,11 +57352,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -56436,16 +57808,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/machinery/door/blast/regular/open{
@@ -56470,7 +57838,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -56560,6 +57927,27 @@
 "seR" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/Atmospherics_Substation)
+"seZ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black,
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Chamber)
 "sfe" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -56614,11 +58002,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -57731,6 +59115,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Star_Breakroom)
+"sxp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_ForStar)
 "sxw" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/techfloor/corner{
@@ -58397,13 +59793,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -58456,7 +59848,6 @@
 "sJF" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -58483,11 +59874,23 @@
 /turf/simulated/floor/tiled,
 /area/medical/Lounge)
 "sJN" = (
-/obj/machinery/atmospherics/pipe/simple/visible/purple,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
 /turf/simulated/floor/plating,
-/area/engineering/Atmospherics_Chamber)
+/area/engineering/Engine1_Chamber)
 "sJT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
@@ -59042,6 +60445,27 @@
 /obj/item/frame,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForStarChamber1)
+"sTj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Lounge)
 "sTq" = (
 /obj/effect/floor_decal/industrial/warning/color{
 	dir = 9
@@ -59069,16 +60493,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/structure/cable/white{
 	d1 = 1;
@@ -59103,16 +60523,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/Observation_Atrium)
@@ -59478,13 +60894,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -59811,13 +61223,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -59846,7 +61254,6 @@
 "tfH" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 1
@@ -59877,11 +61284,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -60392,6 +61795,28 @@
 /obj/structure/reflector/single,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/Engine_Tech_Storage)
+"tmA" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/door/firedoor/glass,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced/full,
+/obj/structure/window/phoronreinforced,
+/obj/structure/window/phoronreinforced{
+	dir = 1
+	},
+/obj/structure/window/phoronreinforced{
+	dir = 4
+	},
+/obj/machinery/door/blast/radproof/open{
+	dir = 4;
+	id = "SC-GCengineroom";
+	layer = 3.5
+	},
+/obj/structure/girder/reinforced{
+	default_material = "lead"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine3_Control_Room)
 "tmF" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 1
@@ -60406,7 +61831,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -60464,16 +61888,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/meter,
@@ -60619,6 +62039,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
+"tqs" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Medical_AftPortChamber2)
 "trw" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -60706,6 +62145,24 @@
 	},
 /turf/simulated/floor/glass,
 /area/bridge/Control_Atrium)
+"ttV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Engineering_ForStarChamber2)
 "tvd" = (
 /obj/structure/bed/chair/bay/chair/padded/red/smallnest,
 /obj/item/digestion_remains/skull/teshari,
@@ -60896,8 +62353,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -60920,6 +62375,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Virology)
+"tzU" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Chamber)
 "tAb" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -61188,7 +62653,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/purple,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "tFp" = (
@@ -61382,8 +62847,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -61440,6 +62903,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Foyer)
+"tJA" = (
+/turf/simulated/wall,
+/area/hallway/Aft_3_Deck_Central_Corridor_1)
 "tJB" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -61640,6 +63106,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
+"tLZ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_AftPortChamber2)
 "tMc" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/arrows/blue{
@@ -61718,6 +63197,19 @@
 "tNr" = (
 /turf/simulated/wall,
 /area/maintenance/Deck3_Engineering_AftStarCorridor2)
+"tNF" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Solar_Control_AftPort)
 "tNV" = (
 /obj/structure/undies_wardrobe,
 /obj/machinery/alarm{
@@ -61947,6 +63439,34 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Dorm_Foyer)
+"tSm" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/multi_tile/two_tile_hor{
+	icon_state = "open";
+	layer = 3.5;
+	density = 0;
+	opacity = 0;
+	name = "Atmospherics Lockdown";
+	id = "SC-BDatmoslockdown"
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Chamber)
 "tSn" = (
 /obj/random/cargopod,
 /turf/simulated/floor/plating,
@@ -62058,6 +63578,27 @@
 	},
 /turf/simulated/open,
 /area/maintenance/Deck3_Engineering_StarChamber1)
+"tUQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Bridge_AftStarCorridor1)
 "tUX" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop{
@@ -62324,6 +63865,16 @@
 	},
 /turf/simulated/floor/plating/turfpack/airless,
 /area/space)
+"tYp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Atrium)
 "tYr" = (
 /obj/item/toy/plushie/teshari/w_yw,
 /turf/simulated/floor/wood/alt,
@@ -62386,7 +63937,6 @@
 /turf/simulated/open,
 /area/maintenance/Deck3_Engineering_ForStarChamber1)
 "tZj" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
@@ -62401,6 +63951,7 @@
 	pixel_y = -27
 	},
 /obj/structure/cable/green,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "tZq" = (
@@ -62628,16 +64179,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -62832,6 +64376,25 @@
 	},
 /turf/simulated/floor/carpet/geo,
 /area/crew_quarters/sleep/Dormitory_10)
+"ugI" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Port_3_Deck_Airlock_Access)
 "ugN" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -63021,7 +64584,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
@@ -63077,6 +64639,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
+"ulu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Lounge)
 "ulv" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/plating,
@@ -63351,8 +64931,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -63695,6 +65273,26 @@
 	color = "#8bbbd5"
 	},
 /area/medical/Genetics_Lab)
+"uuG" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Patient_4)
 "uuP" = (
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -64111,16 +65709,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -64305,7 +65899,6 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 1
@@ -64448,16 +66041,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/meter,
@@ -64586,16 +66175,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/door/blast/multi_tile/three_tile_hor{
@@ -64682,6 +66264,19 @@
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/bridge/AI_Core_Chamber)
+"uLR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Center_Star)
 "uMh" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -64999,11 +66594,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -65770,9 +67361,6 @@
 /obj/structure/window/phoronreinforced{
 	dir = 1
 	},
-/obj/structure/window/phoronreinforced{
-	dir = 4
-	},
 /obj/machinery/door/blast/radproof/open{
 	dir = 4;
 	id = "SC-GCengineroom";
@@ -65948,6 +67536,19 @@
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/bridge/sleep/CMO_Quarters)
+"vcV" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Virology)
 "vdi" = (
 /obj/machinery/power/rad_collector,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -66178,7 +67779,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -66186,9 +67786,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/door/blast/multi_tile/three_tile_hor{
 	icon_state = "open";
 	layer = 3.5;
@@ -66805,6 +68402,19 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/crew_quarters/sleep/Dormitory_05)
+"vrk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_ForPort_Corridor1)
 "vrt" = (
 /obj/structure/table/standard,
 /obj/random/coin/sometimes,
@@ -67323,16 +68933,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 10
@@ -67956,6 +69559,27 @@
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleep/Dormitory_04)
+"vIZ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Chamber)
 "vJa" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -68116,6 +69740,19 @@
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Chomp_Lounge)
+"vKA" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Chamber)
 "vKL" = (
 /obj/structure/table/steel,
 /obj/random/cash,
@@ -68488,6 +70125,21 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/harbor/Aft_3_Deck_Airlock_Access)
+"vRj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_StarChamber1)
 "vRq" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -68973,7 +70625,6 @@
 "vZr" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -69127,11 +70778,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -69279,7 +70926,6 @@
 "weB" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 1
@@ -69543,6 +71189,26 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_01)
+"whR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable/white,
+/obj/structure/cable/white{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/plating,
+/area/bridge/AI_Core_Chamber)
 "wik" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
@@ -69559,6 +71225,19 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
+"wiI" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Control_Room)
 "wiR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -69922,13 +71601,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -69985,6 +71660,23 @@
 	},
 /turf/space,
 /area/space)
+"wqH" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Chamber)
 "wqU" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows{
@@ -70161,6 +71853,24 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/Engine1_Chamber)
+"wsP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Chamber)
 "wsV" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -70390,16 +72100,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/regular/open{
 	layer = 3.5;
@@ -71357,16 +73063,12 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
 /obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 8
@@ -71640,11 +73342,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -71926,7 +73624,6 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
@@ -71980,6 +73677,26 @@
 	},
 /turf/simulated/floor/airless,
 /area/engineering/Solar_Array_ForStar)
+"wUO" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Star Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Patient_3)
 "wUP" = (
 /turf/simulated/wall,
 /area/bridge/Leisure_Room)
@@ -72122,6 +73839,26 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Stairwell_Port)
+"wWq" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Atmospherics_Chamber)
 "wWP" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
@@ -72150,6 +73887,19 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_AftStarChamber3)
+"wYC" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_AftPortChamber1)
 "wYH" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/arrows/blue{
@@ -72338,9 +74088,6 @@
 /obj/structure/window/phoronreinforced,
 /obj/structure/window/phoronreinforced{
 	dir = 8
-	},
-/obj/structure/window/phoronreinforced{
-	dir = 1
 	},
 /obj/structure/window/phoronreinforced{
 	dir = 4
@@ -72641,7 +74388,6 @@
 "xeQ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -72831,6 +74577,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/Lounge)
+"xis" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Bridge_ForPort_Corridor2)
 "xiD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -73070,6 +74835,19 @@
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/crew_quarters/Chomp_Lounge)
+"xlU" = (
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/plating,
+/area/engineering/Airlock_Access)
 "xlY" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -73320,14 +75098,12 @@
 	icon_state = "0-2"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -73749,6 +75525,19 @@
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /turf/simulated/floor/plating,
 /area/harbor/For_3_Deck_Airlock_Access_1)
+"xvJ" = (
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/bridge/AI_Core_Chamber)
 "xvN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -73831,6 +75620,21 @@
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleep/Dormitory_07)
+"xxm" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Dorm_Corridor_1)
 "xxD" = (
 /obj/structure/sink{
 	dir = 8;
@@ -73860,13 +75664,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic/full,
-/obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
-	},
-/obj/structure/window/basic{
-	dir = 1
 	},
 /obj/structure/window/basic{
 	dir = 4
@@ -73904,16 +75703,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Solar_Control_AftPort)
@@ -74132,13 +75924,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
 	},
 /obj/structure/window/titanium{
 	dir = 8
@@ -74193,8 +75981,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -74244,6 +76030,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/bridge/sleep/Secretary_Quarters)
+"xEe" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/hallway/Central_3_Deck_Hall)
 "xEs" = (
 /obj/structure/railing{
 	dir = 1
@@ -74265,8 +76066,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -74445,11 +76244,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
@@ -74699,7 +76494,6 @@
 	icon_state = "0-8"
 	},
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -74707,9 +76501,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/machinery/door/blast/multi_tile/three_tile_hor{
 	icon_state = "open";
 	layer = 3.5;
@@ -75037,6 +76828,24 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_3_Deck_Central_Corridor_1)
+"xOT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "For Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Bridge_ForStarCorridor2)
 "xPg" = (
 /obj/effect/floor_decal/corner/blue/full{
 	dir = 8
@@ -75056,6 +76865,21 @@
 /obj/effect/floor_decal/corner/beige/border,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Foyer)
+"xPm" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Dorm_Corridor_2)
 "xPx" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -75162,6 +76986,28 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Dorm_Foyer)
+"xQP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine2_Waste_Handling)
 "xQQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -75795,16 +77641,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/multi_tile/two_tile_hor{
 	icon_state = "open";
@@ -75871,16 +77710,9 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium/full,
 /obj/structure/window/titanium,
 /obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
 	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
 	},
 /obj/machinery/door/blast/multi_tile/three_tile_hor{
 	icon_state = "open";
@@ -76066,11 +77898,7 @@
 "yfm" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
-/obj/structure/window/reinforced/full,
 /obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -76141,6 +77969,22 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_AftStarChamber1)
+"ygW" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/medical/Virology)
 "yhb" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -76322,6 +78166,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Construction_Area)
+"yjT" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Public_Hydroponics)
 "yjU" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -83827,19 +85681,19 @@ hjD
 ava
 dHa
 mYj
-nSN
-nSN
+jXl
+sJN
 gGj
 tct
 nSN
-nSN
-nSN
-nSN
-nSN
+sJN
+sJN
+sJN
+gGj
 tct
 jXl
-nSN
-nSN
+sJN
+gGj
 mYj
 dHa
 dHa
@@ -84362,16 +86216,16 @@ gxz
 tXX
 ngU
 vTE
-fcB
-fcB
-fcB
-vTE
-fcB
-fcB
+ihf
+daZ
 fcB
 vTE
+ihf
+daZ
 fcB
-fcB
+vTE
+ihf
+daZ
 fcB
 vTE
 vTE
@@ -84618,7 +86472,7 @@ yfm
 yen
 mEf
 qVX
-iVU
+xlU
 sUf
 aGi
 aGi
@@ -84872,11 +86726,11 @@ xJY
 qjI
 vLY
 lJP
-iVU
+ecG
 aZg
 gHy
 sSl
-iVU
+ecG
 yaQ
 eaW
 aGi
@@ -84897,15 +86751,15 @@ jve
 jve
 hLJ
 udG
-nUr
-nUr
-cko
+qbf
+qbf
+oVS
 jyp
 djK
 vUL
 djK
 jyp
-nUr
+fCM
 nUr
 cko
 bYL
@@ -85416,11 +87270,11 @@ inP
 uOh
 eDk
 vfw
-baT
+ids
 bjg
 aFq
 bjg
-baT
+ids
 hHH
 psW
 jXK
@@ -85670,19 +87524,19 @@ pkC
 rKA
 eZO
 aMZ
-inP
+mRA
 uOh
 eDk
 tjF
-baT
+ids
 bjg
 uZQ
 bjg
-baT
+ids
 mjB
 psW
 jXK
-uBR
+wqH
 dHa
 nbo
 bde
@@ -85928,15 +87782,15 @@ iRi
 gXh
 wjn
 kxk
-inP
+tmA
 uOh
 eDk
 vfw
-baT
+lSv
 bjg
 bjg
 bjg
-baT
+lSv
 hHH
 psW
 jXK
@@ -86154,10 +88008,10 @@ iYl
 eNb
 njv
 dYy
-dYy
-dYy
-dYy
-dYy
+jtr
+jtr
+jtr
+hMz
 njv
 xgf
 rZF
@@ -86682,7 +88536,7 @@ mCr
 odR
 sER
 pja
-iVU
+xlU
 wLz
 aGi
 pGG
@@ -86926,13 +88780,13 @@ opA
 jGz
 bJT
 mmh
-dYy
+nHZ
 eHT
 wPS
 bFI
 uHu
 hAE
-dYy
+nHZ
 uFP
 txS
 cxj
@@ -86960,7 +88814,7 @@ dQn
 lWB
 eSB
 nOi
-vao
+gqc
 uOh
 vex
 ocL
@@ -86972,7 +88826,7 @@ puR
 ocL
 puR
 jXK
-uBR
+wqH
 dHa
 dHa
 dHa
@@ -87198,7 +89052,7 @@ mCr
 rUr
 vCP
 aYS
-iVU
+ecG
 stF
 aGi
 xcU
@@ -87218,7 +89072,7 @@ jQQ
 gZM
 nrZ
 kbV
-vao
+lev
 uOh
 aqS
 wHW
@@ -87743,7 +89597,7 @@ gbH
 uDx
 tbQ
 ciH
-xbg
+oti
 xbg
 ciH
 ciH
@@ -87958,7 +89812,7 @@ uSU
 jgV
 dOd
 tEU
-sJN
+lhX
 lhX
 rFL
 wiE
@@ -87979,8 +89833,8 @@ eaR
 mmB
 mmB
 oGh
-oGh
-oGh
+kUm
+oUw
 mmB
 eVh
 uWT
@@ -88006,7 +89860,7 @@ puR
 lHE
 ciH
 tIU
-tIU
+wsP
 tfz
 ciH
 ciH
@@ -88209,14 +90063,14 @@ oRH
 dHa
 dHa
 dHa
-elx
+lMR
 kwH
 fjD
 rfS
 xJQ
 xJQ
 fqE
-iOb
+pOf
 pOf
 oQl
 jme
@@ -90028,7 +91882,7 @@ rfS
 gZF
 xkb
 nfF
-pmm
+tzU
 tYv
 lCs
 aFn
@@ -90286,7 +92140,7 @@ nZG
 jme
 wBQ
 lVv
-pmm
+vKA
 tbl
 rmO
 sJF
@@ -91056,7 +92910,7 @@ woS
 gxe
 aBx
 mUo
-qCU
+lmc
 jgo
 gJe
 frh
@@ -91105,7 +92959,7 @@ puR
 puR
 puR
 vSq
-eQx
+seZ
 oRh
 iHm
 bFR
@@ -91314,11 +93168,11 @@ tgT
 rfS
 rpO
 qrB
-qCU
+kGc
 uLx
 gUn
 aku
-qCU
+lmc
 tbl
 tkK
 aFn
@@ -91572,11 +93426,11 @@ vLO
 vAz
 aBx
 mme
-qCU
+kGc
 eRi
 gpX
 kah
-qCU
+kGc
 ozz
 ksx
 aFn
@@ -91611,16 +93465,16 @@ mqI
 mqI
 nFH
 peV
-peV
+hPO
 hdM
 peV
-peV
+hPO
 mqI
 mqI
 peV
-peV
-peV
-peV
+fHt
+fHt
+hPO
 rfg
 dHa
 dHa
@@ -91830,11 +93684,11 @@ mqy
 rfS
 wqg
 mUo
-qCU
+kGc
 uTY
 pmu
 mqf
-qCU
+wiI
 tbl
 tkK
 gDe
@@ -92088,7 +93942,7 @@ tqh
 gxe
 aBx
 mUo
-qCU
+wiI
 wKi
 kMc
 nkg
@@ -92594,7 +94448,7 @@ pgJ
 oGv
 wPR
 wPR
-kix
+vIZ
 lRm
 kNr
 uoG
@@ -92863,7 +94717,7 @@ rfS
 ycN
 nRD
 rSq
-nTh
+rfS
 ciB
 pAf
 rLN
@@ -92910,7 +94764,7 @@ mqI
 gKC
 axI
 axI
-gKC
+xQP
 mqI
 dHa
 nTW
@@ -93369,7 +95223,7 @@ cpp
 aff
 aff
 aff
-wMX
+wWq
 sbH
 eBy
 gNg
@@ -94128,8 +95982,8 @@ dHa
 clB
 clB
 hRf
-elu
-elu
+dnE
+pHA
 clB
 clB
 dHa
@@ -94143,7 +95997,7 @@ oRH
 dHa
 dHa
 dHa
-oAW
+hzu
 rfS
 vid
 kNr
@@ -94196,7 +96050,7 @@ ecu
 kvb
 kvb
 dAr
-eQM
+qlz
 dHa
 dHa
 dHa
@@ -94213,8 +96067,8 @@ apc
 dHa
 qRA
 qRA
-xyE
-xyE
+gGf
+faL
 bsD
 qRA
 qRA
@@ -94454,7 +96308,7 @@ ecu
 uzx
 kvb
 cgU
-eQM
+oQQ
 dHa
 dHa
 dHa
@@ -94733,7 +96587,7 @@ vBV
 nVM
 heQ
 rKO
-xyE
+tNF
 dHa
 apc
 apc
@@ -94899,7 +96753,7 @@ apc
 apc
 apc
 dHa
-elu
+iOb
 lLJ
 cik
 pOt
@@ -95157,7 +97011,7 @@ apc
 apc
 apc
 dHa
-elu
+nqc
 hNx
 ocO
 wxB
@@ -95187,7 +97041,7 @@ taH
 rpO
 njr
 nLX
-lIN
+cXl
 jux
 jen
 jkp
@@ -95249,7 +97103,7 @@ otX
 dRW
 liY
 oKg
-xyE
+brE
 dHa
 apc
 apc
@@ -95433,7 +97287,7 @@ kaL
 nza
 elF
 elF
-ybA
+tSm
 ppf
 rfS
 qpo
@@ -95676,8 +97530,8 @@ dHa
 clB
 clB
 mcs
-elu
-elu
+dnE
+pHA
 clB
 cpE
 dHa
@@ -95761,8 +97615,8 @@ dHa
 dHa
 aMV
 qRA
-xyE
-xyE
+gGf
+faL
 rem
 qRA
 qRA
@@ -98023,7 +99877,7 @@ dHa
 seR
 seR
 nWq
-nWq
+cJG
 seR
 seR
 seR
@@ -98566,8 +100420,8 @@ mBU
 mhM
 tev
 mDF
-mDF
-mDF
+qGP
+gto
 tev
 tev
 tev
@@ -98756,13 +100610,13 @@ dHa
 dHa
 wnQ
 wnQ
+dBo
 nJo
-nJo
-nJo
+xis
 wnQ
 nxf
-cOS
-cOS
+aqh
+dnu
 cOS
 iom
 iJM
@@ -98803,13 +100657,13 @@ dHa
 tgc
 tgc
 lap
-lap
-lap
+ttV
+dkk
 tgc
 tgc
 lap
-lap
-lap
+ttV
+dkk
 tgc
 mBU
 dVR
@@ -98872,10 +100726,10 @@ dHa
 oBG
 oBG
 xEB
-xEB
+tLZ
 dzJ
 xEB
-xEB
+tLZ
 oBG
 lPX
 dHa
@@ -99070,9 +100924,9 @@ dHa
 dHa
 dHa
 mBU
+jXj
 rpL
-rpL
-rpL
+ugI
 mBU
 mBU
 jFT
@@ -99264,9 +101118,9 @@ dHa
 dHa
 dHa
 wnQ
+dBo
 nJo
-nJo
-nJo
+xis
 wnQ
 ykC
 ykC
@@ -99380,7 +101234,7 @@ dHa
 lTq
 lTq
 tzJ
-tzJ
+fgu
 lTq
 kzz
 kzz
@@ -99396,9 +101250,9 @@ xRV
 jTu
 hUm
 lPX
+bju
 gCl
-gCl
-gCl
+wYC
 lPX
 dHa
 dHa
@@ -99519,8 +101373,8 @@ dHa
 dHa
 dHa
 wnQ
-nJo
-nJo
+dBo
+xis
 wnQ
 ykC
 ykC
@@ -99631,7 +101485,7 @@ dHa
 dHa
 dHa
 bOE
-nDs
+xxm
 nDs
 bOE
 lTq
@@ -100179,7 +102033,7 @@ wVX
 lyw
 jTu
 lPX
-gCl
+oaY
 lPX
 dHa
 dHa
@@ -100958,7 +102812,7 @@ muw
 gcI
 muw
 rnE
-gCl
+oaY
 dHa
 dHa
 dHa
@@ -101397,8 +103251,8 @@ jlC
 cfe
 hbN
 upr
-upr
-upr
+gSs
+hhT
 hbN
 dHa
 dHa
@@ -101641,8 +103495,8 @@ hbN
 hbN
 hbN
 hbN
-upr
-upr
+nMp
+nMp
 hbN
 hbN
 hbN
@@ -101658,15 +103512,15 @@ ubi
 ubi
 ubi
 hbN
-upr
+nMp
 hbN
 hbN
 hbN
 hbN
 hbN
 upr
-upr
-upr
+gSs
+hhT
 hbN
 hbN
 hbN
@@ -102187,7 +104041,7 @@ rhw
 mqp
 ddt
 ddt
-upr
+pAv
 apc
 apc
 apc
@@ -102445,7 +104299,7 @@ kUR
 ddt
 cFL
 ddt
-upr
+mLu
 jub
 apc
 apc
@@ -102961,7 +104815,7 @@ prX
 len
 ijw
 mdT
-mGO
+ivB
 nbo
 hXb
 apc
@@ -102971,7 +104825,7 @@ apc
 qpl
 oRH
 dHa
-ujW
+vrk
 iDM
 pfx
 reP
@@ -103174,7 +105028,7 @@ rgj
 rDW
 leS
 nDi
-jEU
+rLP
 dHa
 hjD
 akK
@@ -103219,7 +105073,7 @@ kFY
 lcC
 len
 mcQ
-mGO
+yjT
 nbo
 hXb
 apc
@@ -103229,7 +105083,7 @@ apc
 poc
 oRH
 dHa
-ujW
+dLW
 koN
 ori
 iKS
@@ -103435,7 +105289,7 @@ wGW
 jEU
 dHa
 dHa
-akK
+gVq
 gqT
 koz
 koz
@@ -103477,7 +105331,7 @@ kGh
 len
 lME
 mgL
-mGO
+yjT
 nbo
 hXb
 apc
@@ -104005,7 +105859,7 @@ dHa
 dHa
 dHa
 dHa
-ujW
+vrk
 hfE
 uqk
 tQo
@@ -104146,8 +106000,8 @@ hjD
 bUf
 mJP
 oaL
-oaL
-cNm
+hag
+whR
 cNm
 cNm
 ddu
@@ -104198,9 +106052,9 @@ hlx
 pAs
 rtU
 vFj
-rtU
+hvE
 bDk
-rtU
+fXu
 fuk
 nxM
 fuk
@@ -104251,7 +106105,7 @@ kII
 len
 lcC
 mcQ
-mGO
+ivB
 nbo
 hXb
 apc
@@ -104263,7 +106117,7 @@ dHa
 dHa
 dHa
 dHa
-ujW
+dLW
 krt
 bge
 tQo
@@ -104404,8 +106258,8 @@ hjD
 hjD
 mJP
 oaL
-hag
-cNm
+xvJ
+whR
 cNm
 cNm
 esF
@@ -104509,7 +106363,7 @@ joM
 cgg
 len
 mgL
-mGO
+yjT
 nbo
 hXb
 apc
@@ -104578,7 +106432,7 @@ jhg
 ptq
 ptq
 fHI
-fHI
+aVA
 ptq
 nev
 hXb
@@ -104725,7 +106579,7 @@ bUZ
 jtL
 dHa
 dHa
-akK
+gVq
 mmp
 xkW
 koz
@@ -104767,7 +106621,7 @@ jKo
 kLY
 len
 mcQ
-mGO
+yjT
 nbo
 bde
 jub
@@ -104849,14 +106703,14 @@ apc
 apc
 apc
 apc
-sUk
-sUk
-sUk
-sUk
-sUk
-sUk
-sUk
-sUk
+aCu
+pSW
+pSW
+pSW
+pSW
+pSW
+pSW
+tYp
 apc
 apc
 apc
@@ -105014,7 +106868,7 @@ vJr
 gkF
 eiV
 uZq
-hKr
+lIN
 ieB
 mAN
 jkH
@@ -105107,14 +106961,14 @@ dHa
 dHa
 dHa
 dHa
-sUk
+jvd
 jIk
 fWz
 gyU
 mXZ
 nMy
 scL
-sUk
+jvd
 apc
 apc
 apc
@@ -105285,13 +107139,13 @@ lTW
 mep
 mDE
 onG
-xCQ
-xCQ
+eAU
+gau
 xCQ
 onG
 onG
-xCQ
-xCQ
+eAU
+gau
 xCQ
 onG
 ddj
@@ -105365,14 +107219,14 @@ dHa
 dHa
 dHa
 dHa
-sUk
+jvd
 vSi
 djL
 gyU
 tls
 nwj
 sNB
-sUk
+jvd
 apc
 apc
 apc
@@ -105630,7 +107484,7 @@ gyU
 ixC
 mly
 akk
-sUk
+jvd
 apc
 apc
 apc
@@ -105754,7 +107608,7 @@ xGI
 bYz
 gBw
 cem
-jtL
+mHg
 dHa
 dHa
 akK
@@ -105872,15 +107726,15 @@ peP
 ojz
 ioT
 fHI
-fHI
-fHI
+dcX
+aVA
 ptq
 fHI
-fHI
+aVA
 ptq
 fHI
-fHI
-fHI
+dcX
+aVA
 fjG
 rvv
 cDk
@@ -105888,7 +107742,7 @@ nxF
 fjG
 tLl
 kQJ
-sUk
+jvd
 apc
 apc
 apc
@@ -105950,7 +107804,7 @@ qpl
 hjD
 hjD
 weB
-eOx
+fng
 cLD
 tTr
 tTr
@@ -106015,7 +107869,7 @@ fzQ
 jtL
 dHa
 dHa
-akK
+gVq
 hcx
 kHn
 aMh
@@ -106062,7 +107916,7 @@ qIy
 eac
 eac
 eac
-eac
+kDY
 eac
 eac
 eac
@@ -106146,7 +108000,7 @@ gyU
 oDY
 atl
 wwd
-sUk
+jvd
 apc
 apc
 apc
@@ -106208,7 +108062,7 @@ qpl
 hjD
 hjD
 eOx
-eOx
+hLK
 fhv
 tTr
 fcW
@@ -106259,7 +108113,7 @@ fLj
 fLj
 fLj
 jSS
-jtL
+dMH
 iSF
 eup
 hYl
@@ -106318,11 +108172,11 @@ jkH
 aXg
 gsu
 eac
-eac
-eac
-eac
-eac
-eac
+bcY
+tJA
+tJA
+tJA
+gmL
 eac
 jHF
 mWq
@@ -106386,7 +108240,7 @@ tGH
 iJQ
 peP
 vUb
-ezB
+sTj
 myX
 myX
 lWh
@@ -106397,14 +108251,14 @@ myX
 bYS
 myX
 myX
-sUk
+fTs
 vqw
 gyU
 hAe
 tls
 dEn
 jEb
-sUk
+jvd
 apc
 apc
 apc
@@ -106466,7 +108320,7 @@ qpl
 hjD
 hjD
 eOx
-eOx
+kKL
 cLD
 tTr
 tTr
@@ -106578,7 +108432,7 @@ eac
 eac
 eac
 eac
-eac
+blO
 eac
 eac
 eac
@@ -106662,7 +108516,7 @@ oPO
 dqY
 utP
 osL
-sUk
+jvd
 apc
 apc
 apc
@@ -106786,7 +108640,7 @@ bHJ
 bYz
 yis
 rVR
-jtL
+mHg
 dHa
 dHa
 akK
@@ -106904,15 +108758,15 @@ kDg
 xet
 ioT
 fHI
-fHI
-fHI
+dcX
+aVA
 ptq
 fHI
-fHI
+aVA
 ptq
 fHI
-fHI
-fHI
+dcX
+aVA
 fjG
 xLL
 dYB
@@ -106920,7 +108774,7 @@ nxF
 fjG
 uYD
 qCI
-sUk
+jvd
 apc
 apc
 apc
@@ -107047,7 +108901,7 @@ cRD
 jtL
 dHa
 dHa
-akK
+gVq
 aGs
 kHn
 aMh
@@ -107171,14 +109025,14 @@ dHa
 dHa
 dHa
 dHa
-sUk
+aCu
 vSi
 djL
 gyU
 jfv
 xOc
 akk
-sUk
+jvd
 apc
 apc
 apc
@@ -107349,13 +109203,13 @@ eUC
 jzA
 mDE
 onG
-xCQ
-xCQ
+eAU
+gau
 xCQ
 onG
 onG
-xCQ
-xCQ
+eAU
+gau
 xCQ
 onG
 lmX
@@ -107418,7 +109272,7 @@ qNj
 iJQ
 vLE
 dRN
-ezB
+ulu
 dHa
 dHa
 dHa
@@ -107429,14 +109283,14 @@ dHa
 dHa
 dHa
 dHa
-sUk
+jvd
 vSi
 djL
 gyU
 tls
 ocu
 sNB
-sUk
+jvd
 apc
 apc
 apc
@@ -107594,7 +109448,7 @@ fSz
 hnK
 qhq
 uZq
-hKr
+eZw
 xrz
 pqg
 mAN
@@ -107605,7 +109459,7 @@ urV
 loI
 kNg
 mgF
-mGO
+ivB
 rpR
 sra
 sra
@@ -107687,14 +109541,14 @@ dHa
 dHa
 dHa
 dHa
-sUk
+jvd
 bWm
 kAS
 gyU
 uWU
 pUa
 ixc
-sUk
+jvd
 apc
 apc
 apc
@@ -107852,7 +109706,7 @@ opy
 mXc
 cwt
 rPK
-oMt
+xEe
 ihl
 fZH
 ylH
@@ -107863,7 +109717,7 @@ kRw
 len
 lMS
 len
-mGO
+yjT
 nbo
 uOo
 nhz
@@ -107945,14 +109799,14 @@ apc
 apc
 apc
 apc
-sUk
-sUk
-sUk
-sUk
-sUk
-sUk
-sUk
-sUk
+akN
+pSW
+pSW
+pSW
+pSW
+pSW
+pSW
+ljS
 apc
 apc
 apc
@@ -108016,8 +109870,8 @@ hjD
 hjD
 mJP
 oaL
-vfq
-cNm
+lZl
+whR
 cNm
 cNm
 esF
@@ -108102,8 +109956,8 @@ dHF
 laA
 hJj
 hJj
-hKr
-hKr
+fmr
+fOY
 hJj
 hJj
 fTw
@@ -108121,7 +109975,7 @@ cPJ
 mhC
 lcC
 mgL
-mGO
+yjT
 nbo
 hXb
 apc
@@ -108190,7 +110044,7 @@ jhg
 ptq
 ptq
 fHI
-fHI
+aVA
 ptq
 nev
 hXb
@@ -108274,8 +110128,8 @@ hjD
 hjD
 mJP
 oaL
-oaL
-cNm
+vfq
+whR
 cNm
 cNm
 ddu
@@ -108337,7 +110191,7 @@ fuk
 oLa
 dHa
 dHa
-akK
+gVq
 hAc
 vKr
 koz
@@ -108895,7 +110749,7 @@ eLV
 len
 lMS
 mhC
-mGO
+ivB
 nbo
 hXb
 apc
@@ -109153,7 +111007,7 @@ ibb
 mhC
 lME
 miH
-mGO
+yjT
 nbo
 hXb
 apc
@@ -109411,7 +111265,7 @@ kTs
 lcC
 len
 mjR
-mGO
+yjT
 nbo
 hXb
 apc
@@ -109627,7 +111481,7 @@ gXK
 jgw
 hjD
 hjD
-akK
+gVq
 aTo
 yhy
 abK
@@ -110929,8 +112783,8 @@ eXY
 eXY
 eXY
 eXY
-eUS
-eUS
+kSt
+uLR
 eXY
 eXY
 eXY
@@ -111196,23 +113050,23 @@ dHa
 dHa
 dHa
 eXY
-eUS
-eUS
-eUS
+kSt
+raX
+uLR
 eXY
 pAd
 hqk
 npS
 eXY
-eUS
-eUS
+kSt
+uLR
 eXY
-eUS
-eUS
-eUS
+kSt
+raX
+uLR
 eXY
-eUS
-eUS
+kSt
+uLR
 eXY
 hjD
 hjD
@@ -111937,7 +113791,7 @@ hWs
 dLf
 eTa
 rul
-cwa
+lGy
 rul
 dHa
 dHa
@@ -112193,7 +114047,7 @@ gVl
 dTD
 uaG
 rul
-cwa
+lGy
 dkv
 dHa
 dHa
@@ -112449,7 +114303,7 @@ cSS
 vDg
 gVl
 rul
-cwa
+lGy
 rul
 dHa
 dHa
@@ -112935,7 +114789,7 @@ dHa
 dHa
 dHa
 avY
-lby
+oAu
 lby
 avY
 eEJ
@@ -112960,7 +114814,7 @@ tLB
 lSN
 lSN
 rul
-cwa
+tUQ
 cwa
 rul
 dHa
@@ -113047,7 +114901,7 @@ dHa
 dHa
 dHa
 ueI
-rKc
+xPm
 rKc
 ueI
 mLA
@@ -113074,7 +114928,7 @@ tZq
 lPm
 pJW
 mau
-fhw
+vRj
 fhw
 mau
 dHa
@@ -113458,7 +115312,7 @@ dHa
 dHa
 dHa
 avY
-lby
+oAu
 lby
 avY
 pzH
@@ -113522,8 +115376,8 @@ uWI
 eCv
 eSu
 eSu
-taY
-taY
+cgW
+nTh
 taY
 eSu
 dHa
@@ -113573,7 +115427,7 @@ dHa
 dHa
 ncv
 bYU
-bYU
+ccX
 tfl
 cIB
 rfp
@@ -113720,13 +115574,13 @@ dHa
 dHa
 avY
 avY
-lby
-lby
+oAu
+xOT
 lby
 avY
 lSN
-lFi
-lFi
+iFS
+fIL
 lFi
 rQi
 pmD
@@ -114047,7 +115901,7 @@ bke
 uPL
 noT
 izb
-izb
+tqs
 noT
 dHa
 dHa
@@ -114096,7 +115950,7 @@ mKo
 gSY
 xFT
 xDw
-xDw
+oxA
 xFT
 xFT
 dHa
@@ -114790,8 +116644,8 @@ dHa
 dHa
 lJz
 aan
-bMd
-bMd
+fxb
+lLx
 bMd
 aan
 aan
@@ -115562,7 +117416,7 @@ dHa
 dHa
 dHa
 dHa
-eaE
+dkM
 pei
 rPo
 kcG
@@ -115820,7 +117674,7 @@ dHa
 dHa
 dHa
 dHa
-eaE
+rHI
 uNb
 kfL
 pyK
@@ -116832,8 +118686,8 @@ dHa
 bDN
 bDN
 ndB
-dbu
-dbu
+sxp
+ifh
 bDN
 uVF
 dHa
@@ -116917,7 +118771,7 @@ dHa
 dHa
 fYV
 nQB
-aAy
+kud
 aAy
 bUQ
 nQB
@@ -117437,7 +119291,7 @@ hKn
 lwv
 hOa
 coA
-aAy
+lps
 dHa
 apc
 apc
@@ -117603,7 +119457,7 @@ apc
 apc
 apc
 dHa
-dbu
+qcg
 wpa
 wBF
 kfl
@@ -117675,7 +119529,7 @@ lZq
 lZq
 bUc
 rbj
-jJZ
+jqe
 dHa
 dHa
 dHa
@@ -117695,7 +119549,7 @@ jIY
 jIY
 kSX
 kgC
-aAy
+noO
 dHa
 apc
 apc
@@ -117861,7 +119715,7 @@ apc
 apc
 apc
 dHa
-dbu
+ncC
 xoy
 oML
 kfl
@@ -117953,7 +119807,7 @@ jIY
 jIY
 tXb
 maJ
-aAy
+lXJ
 dHa
 apc
 apc
@@ -118380,8 +120234,8 @@ dHa
 bDN
 bDN
 cbe
-dbu
-dbu
+sxp
+ifh
 bDN
 bDN
 dHa
@@ -118465,7 +120319,7 @@ apc
 dHa
 nQB
 nQB
-aAy
+kud
 aAy
 rGW
 nQB
@@ -118654,7 +120508,7 @@ dHa
 dHa
 dHa
 dHa
-wRF
+nzS
 rjA
 rjA
 wDV
@@ -118708,7 +120562,7 @@ lZq
 tdX
 iGt
 xXQ
-jJZ
+pMu
 dHa
 dHa
 dHa
@@ -118912,7 +120766,7 @@ dHa
 dHa
 dHa
 dHa
-wRF
+mtv
 rjA
 rjA
 wDV
@@ -118966,7 +120820,7 @@ gnK
 dUj
 rHG
 qyx
-jJZ
+jqe
 dHa
 dHa
 dHa
@@ -120458,7 +122312,7 @@ oRH
 dHa
 dHa
 dHa
-qyD
+plT
 sFo
 bYh
 ssq
@@ -120517,7 +122371,7 @@ nbG
 jgF
 iDD
 xzq
-wwM
+rPk
 dHa
 dHa
 nbo
@@ -121291,7 +123145,7 @@ bzX
 qVo
 oBv
 asa
-wwM
+rPk
 dHa
 dHa
 nbo
@@ -121490,7 +123344,7 @@ oRH
 dHa
 dHa
 dHa
-qyD
+pgi
 sFo
 bYh
 sFo
@@ -121769,8 +123623,8 @@ xrZ
 xgk
 xRu
 xRu
+xRu
 cbr
-dBo
 lOH
 iSQ
 iYC
@@ -122027,8 +123881,8 @@ ouJ
 xgk
 xRu
 xVM
+xRu
 cbr
-pMu
 lOH
 gnf
 moL
@@ -123040,7 +124894,7 @@ dHa
 dHa
 dHa
 dHa
-eVn
+lIT
 vrt
 pTg
 dgI
@@ -123298,7 +125152,7 @@ dHa
 dHa
 dHa
 dHa
-eVn
+hgi
 nfD
 fTg
 uFE
@@ -123867,7 +125721,7 @@ hLW
 tUX
 fSs
 lrg
-rJr
+wUO
 dHa
 dHa
 dHa
@@ -124641,7 +126495,7 @@ keW
 wJg
 wyV
 cmv
-ipL
+uuG
 dHa
 dHa
 dHa
@@ -125673,7 +127527,7 @@ oxB
 swg
 lPs
 mKK
-ipL
+uuG
 dHa
 dHa
 dHa
@@ -126443,7 +128297,7 @@ suU
 rjW
 asY
 qFG
-ozU
+idg
 dHa
 dHa
 dHa
@@ -127185,9 +129039,9 @@ isJ
 csA
 wBn
 nJi
+dtR
 xyc
-xyc
-xyc
+kpB
 fUI
 eta
 uyp
@@ -127203,9 +129057,9 @@ wai
 nJi
 eta
 xBS
+dtR
 xyc
-xyc
-xyc
+kpB
 nJi
 eLu
 jvK
@@ -127448,7 +129302,7 @@ fCi
 vAI
 rRU
 oTl
-buC
+ygW
 cju
 ljJ
 oTl
@@ -127458,7 +129312,7 @@ xyN
 nZm
 iCX
 lVx
-xyc
+qNw
 nZm
 rRU
 vJW
@@ -127716,7 +129570,7 @@ opZ
 nZm
 iCX
 udn
-xyc
+vcV
 mht
 uNy
 pHF
@@ -128476,10 +130330,10 @@ dHa
 dHa
 nJi
 qlN
-qlN
+kjc
 nJi
 qlN
-qlN
+kjc
 ncF
 nJi
 oWv
@@ -128492,10 +130346,10 @@ oWv
 nJi
 nJi
 qlN
-qlN
+kjc
 nJi
 qlN
-qlN
+kjc
 nJi
 dHa
 dHa
@@ -128741,12 +130595,12 @@ dHa
 aqs
 nJi
 qlN
-qlN
-qlN
+fAd
+kjc
 nJi
 qlN
-qlN
-qlN
+fAd
+kjc
 nJi
 dHa
 dHa


### PR DESCRIPTION
-Replaced large air pumps with regular air pumps.
-Removed windows inside the vault.
-Arrivals & Departure shuttle moved to dock 5. Make for a straight walk into the station. 
-Tcoms, freezer starts on.
-Science Substation is now access locked.
-Cargo recycling machines can now recycle.
-Cargo mining can now process materials.
-Bridge, replaced guns with tasers and flashers.
-Engineering, powercells in smes rooms now start charged. 
-Medical, reduced the amount of flashes and pepperspray. 
-Janitor, replaced adv-mops with regular mops. Placed Service autholate. 
-Fixed all windows on the station.

