### PR TITLE
Soluna Nexus map fix 1.6

### DIFF
--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
@@ -232,17 +232,12 @@
 /turf/simulated/floor/glass,
 /area/hallway/Port_1Deck_Atrium)
 "abh" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
+/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	frequency = 1380;
-	id_tag = "sc-D1_L5A3_airlock";
-	pixel_y = 24
+	id_tag = "arrivals_dock_north_airlock";
+	master_tag = "arrivals_dock";
+	pixel_y = 27;
+	req_one_access = list(13)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
@@ -1022,10 +1017,9 @@
 "afw" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	frequency = 1380;
-	id_tag = "arrivals_dock_north_airlock";
-	master_tag = "arrivals_dock";
 	pixel_y = 27;
-	req_one_access = list(13)
+	req_one_access = list(13);
+	id_tag = "SC-docklane31"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock3)
@@ -1418,8 +1412,39 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Custodial_Office)
 "aht" = (
-/obj/machinery/autolathe,
-/obj/effect/floor_decal/milspec/color/purple,
+/obj/machinery/chemical_dispenser/full{
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/carbon{
+	pixel_y = 9;
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/oxygen{
+	pixel_y = 9;
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/sugar{
+	pixel_y = 9;
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/water{
+	pixel_y = 9;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/nitrogen{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/iron{
+	pixel_x = -4
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/silicon{
+	pixel_x = 1
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/potassium{
+	pixel_x = 5
+	},
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/milspec/color/white,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "ahx" = (
@@ -4742,6 +4767,11 @@
 "aCL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /obj/structure/reagent_dispensers/watertank/high,
+/obj/machinery/light/spot{
+	dir = 4;
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
+	},
 /turf/simulated/floor/tiled/hydro,
 /area/rnd/Xenobotany_Lab)
 "aCO" = (
@@ -6079,16 +6109,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/PA_Chamber)
 "aMP" = (
-/obj/structure/closet/secure_closet/guncabinet/phase{
-	req_one_access = list(7,47)
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 5
 	},
-/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/mineral/equipment_vendor/survey,
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Research_Ship_Bay)
 "aMU" = (
@@ -6961,9 +6988,7 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobotany_Lab)
 "aSU" = (
-/obj/machinery/mineral/unloading_machine{
-	icon_state = "unloader-corner"
-	},
+/obj/machinery/mineral/unloading_machine,
 /turf/simulated/floor/plating,
 /area/quartermaster/Mining_Ship_Bay)
 "aTg" = (
@@ -7638,6 +7663,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/For_Transit_Foyer)
+"aXg" = (
+/obj/machinery/camera/network/security{
+	c_tag = "D1-Har-5th Dock3";
+	network = list("Harbor");
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white/bordercorner{
+	dir = 4
+	},
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
 "aXm" = (
 /obj/machinery/ai_status_display,
 /obj/structure/disposalpipe/segment{
@@ -7875,12 +7917,13 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck1_Security_PortCorridor2)
 "baS" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 4;
+	color = "#989898"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
@@ -7962,6 +8005,24 @@
 "bci" = (
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortCorridor1)
+"bck" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock5)
 "bco" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -8627,15 +8688,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck1_AftStar1_Corridor1)
 "bot" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows,
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
 	},
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/tiled/techmaint,
+/obj/machinery/airlock_sensor{
+	pixel_y = 24
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 4;
+	color = "#989898"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "boC" = (
 /obj/structure/disposalpipe/segment{
@@ -8965,20 +9029,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor2)
 "buo" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows,
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
+/obj/structure/bed/chair{
+	dir = 4
 	},
-/obj/machinery/door/airlock/angled_bay/external/glass,
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "buw" = (
 /obj/effect/floor_decal/rust,
@@ -9013,11 +9067,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/ForStar_1_Deck_Observatory)
 "buZ" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8;
 	color = "#989898"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "bvd" = (
@@ -9408,10 +9462,13 @@
 /turf/simulated/wall/r_wall,
 /area/rnd/Xenobotany_Isolation_Chamber)
 "bBM" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 8;
+	color = "#989898"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "bBQ" = (
@@ -9531,10 +9588,9 @@
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	dir = 1;
 	frequency = 1380;
-	id_tag = "escape_dock_ssouth_airlock";
-	master_tag = "escape_dock";
 	pixel_y = -27;
-	req_one_access = list(13)
+	req_one_access = list(13);
+	id_tag = "SC-docklane22"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock2)
@@ -9704,27 +9760,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck1_AftStar1_Corridor2)
 "bFI" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/shuttle/blue{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1;
-	color = "#989898"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/harbor/Dock5)
+/obj/effect/gibspawner/robot,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftPort_Chamber3)
 "bFJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
@@ -9818,8 +9856,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Harbor Substation";
-	req_one_access = null
+	name = "Harbor Substation"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Harbor_Substation)
@@ -13154,17 +13191,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Xenobotany_Isolation_Chamber)
 "cOQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
+/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	frequency = 1380;
-	id_tag = "sc-D1_L5A1_airlock";
-	pixel_y = 24
+	id_tag = "escape_dock_snorth_airlock";
+	master_tag = "escape_dock";
+	pixel_y = 27;
+	req_one_access = list(13)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
@@ -14324,21 +14356,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber2)
 "dgp" = (
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
-	},
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1;
-	color = "#989898"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Dock5)
+/obj/structure/sign/warning/vacuum,
+/turf/simulated/wall/r_wall,
+/area/harbor/Ship_Bay2)
 "dgA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
@@ -14395,13 +14415,25 @@
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/AftPort_1_Deck_Observatory)
 "dhx" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/arrows{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/machinery/door/airlock/angled_bay/external/glass{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/access_button{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/map_helper/airlock/button/int_button{
+	pixel_y = -14
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock5)
 "dhy" = (
 /obj/structure/table/rack/shelf/steel,
@@ -14849,8 +14881,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Science_AftCorridor1)
 "dpe" = (
-/obj/machinery/chem_master,
-/obj/effect/floor_decal/milspec/color/purple,
+/obj/effect/floor_decal/milspec/color/white,
+/obj/machinery/sleeper{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "dpD" = (
@@ -16252,13 +16286,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor2)
 "dLR" = (
-/obj/machinery/light/small/emergency{
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
 	dir = 8
 	},
-/obj/structure/lattice,
-/obj/machinery/shield_diffuser,
-/turf/space,
-/area/space)
+/obj/structure/window/titanium,
+/turf/simulated/floor/plating,
+/area/harbor/Dock5)
 "dLV" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/red{
@@ -18454,21 +18493,9 @@
 	pixel_y = -2;
 	pixel_x = -6
 	},
-/obj/item/stock_parts/manipulator/nano{
-	pixel_y = 2;
-	pixel_x = 4
-	},
 /obj/item/stock_parts/matter_bin/adv{
 	pixel_y = -7;
 	pixel_x = -6
-	},
-/obj/item/stock_parts/scanning_module/omni{
-	pixel_y = -4;
-	pixel_x = 6
-	},
-/obj/item/stock_parts/scanning_module/omni{
-	pixel_y = -6;
-	pixel_x = 2
 	},
 /obj/structure/closet/crate/nanotrasen{
 	dir = 2;
@@ -18477,6 +18504,14 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/stock_parts/scanning_module/adv{
+	pixel_y = -9
+	},
+/obj/item/stock_parts/scanning_module/adv{
+	pixel_y = -6;
+	pixel_x = 4
+	},
+/obj/item/stock_parts/manipulator/hyper,
 /turf/simulated/floor,
 /area/maintenance/Telecomms_Substation)
 "eaQ" = (
@@ -19515,6 +19550,15 @@
 "ett" = (
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock2)
+"etu" = (
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/sign/warning/vacuum,
+/turf/simulated/wall/r_wall,
+/area/quartermaster/Mining_Ship_Bay)
 "etG" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -19821,6 +19865,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Depot2)
+"ezN" = (
+/obj/effect/gibspawner/human,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftPort_Chamber3)
 "eAa" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor/glass,
@@ -20096,10 +20144,9 @@
 "eEX" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	frequency = 1380;
-	id_tag = "escape_dock_snorth_airlock";
-	master_tag = "escape_dock";
 	pixel_y = 27;
-	req_one_access = list(13)
+	req_one_access = list(13);
+	id_tag = "SC-docklane21"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock2)
@@ -22927,6 +22974,14 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
+"fEw" = (
+/obj/machinery/light/spot{
+	dir = 8;
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/rnd/Xenobotany_Lab)
 "fEB" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -25164,6 +25219,10 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/rnd/Xenobotany_Lab)
+"gnx" = (
+/obj/structure/sign/warning/vacuum,
+/turf/simulated/wall/r_wall,
+/area/rnd/Research_Ship_Bay)
 "gnM" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/structure/sign/securearea{
@@ -25522,26 +25581,26 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/engineering/Telecomms_Foyer)
+"gvf" = (
+/obj/machinery/light/small/emergency{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/airless,
+/area/harbor/Dock5)
 "gvu" = (
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/ab_Hydroponics)
 "gvO" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows,
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/machinery/door/airlock/angled_bay/external/glass,
-/obj/machinery/access_button{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/effect/map_helper/airlock/button/int_button{
-	pixel_y = -14
-	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/white/bordercorner,
+/turf/simulated/floor/tiled,
 /area/harbor/Dock5)
 "gwS" = (
 /obj/structure/disposalpipe/segment,
@@ -25583,6 +25642,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortCorridor2)
+"gxb" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock5)
 "gxg" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows,
@@ -27338,14 +27415,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/Supply_Ship_Bay)
 "hcU" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows/yellow,
-/obj/effect/floor_decal/industrial/arrows/yellow{
-	dir = 1
-	},
-/obj/structure/closet/crate/mimic/airlock/safe,
-/turf/simulated/floor/tiled/techmaint,
-/area/maintenance/Deck1_AftPort_Chamber3)
+/obj/structure/sign/warning/vacuum,
+/turf/simulated/wall/r_wall,
+/area/harbor/Ship_Bay1)
 "hdB" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/empty,
@@ -28729,10 +28801,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/mineral/equipment_vendor{
-	dir = 8;
-	pixel_x = 4
-	},
+/obj/machinery/mineral/equipment_vendor,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "hDJ" = (
@@ -29918,6 +29987,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Locker_Room)
+"icj" = (
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/r_wall,
+/area/harbor/Dock5)
 "icl" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -30944,6 +31021,17 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck1_ForStar_Chamber2)
+"iro" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
+	dir = 1;
+	frequency = 1380;
+	id_tag = "escape_dock_ssouth_airlock";
+	master_tag = "escape_dock";
+	pixel_y = -27;
+	req_one_access = list(13)
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock5)
 "irz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -30986,7 +31074,14 @@
 /obj/effect/floor_decal/corner/purple/diagonal{
 	dir = 4
 	},
-/obj/item/toy/toy_xeno,
+/obj/item/toy/toy_xeno{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/storage/box/syringes{
+	pixel_y = -1;
+	pixel_x = -5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Xenobiology_Lab)
 "isE" = (
@@ -31233,6 +31328,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/harbor/Ship_Bay4)
+"iwp" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 4;
+	color = "#989898"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock5)
 "iwx" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/plating,
@@ -31538,15 +31643,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Mining_Ship_Bay)
 "iDD" = (
-/obj/machinery/airlock_sensor{
-	pixel_y = 24
-	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/lattice,
+/turf/space,
 /area/harbor/Dock5)
 "iDI" = (
 /obj/machinery/door/firedoor/border_only,
@@ -32951,6 +33049,10 @@
 "jiG" = (
 /obj/random/contraband,
 /obj/random/junk,
+/obj/structure/closet/crate/mimic/safe,
+/obj/random/maintenance/cargo,
+/obj/item/bone/ribs,
+/obj/item/bone/skull/tajaran,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber3)
 "jje" = (
@@ -33037,8 +33139,19 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/PA_Chamber)
 "jlA" = (
-/obj/structure/lattice,
-/turf/simulated/floor/airless,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/harbor/Dock5)
 "jlD" = (
 /obj/machinery/power/apc/super/critical{
@@ -33678,6 +33791,17 @@
 "jww" = (
 /turf/simulated/floor/glass,
 /area/hallway/Star_1Deck_Atrium)
+"jwO" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 8;
+	color = "#989898"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock5)
 "jxi" = (
 /obj/structure/closet/cabinet,
 /obj/item/storage/box/donkpockets,
@@ -34048,28 +34172,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Harbor_Substation)
 "jEu" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 4
-	},
-/obj/machinery/door/airlock/angled_bay/external/glass{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/door/int_door,
-/obj/machinery/access_button{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/map_helper/airlock/button/int_button{
-	pixel_y = -14
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/lattice,
+/obj/machinery/shield_diffuser,
+/turf/space,
 /area/harbor/Dock5)
 "jEw" = (
 /obj/structure/closet/walllocker_double/kitchen/east{
@@ -36237,10 +36342,9 @@
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	dir = 1;
 	frequency = 1380;
-	id_tag = "arrivals_dock_south_airlock";
-	master_tag = "arrivals_dock";
 	pixel_y = -27;
-	req_one_access = list(13)
+	req_one_access = list(13);
+	id_tag = "SC-docklane32"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock3)
@@ -36407,7 +36511,7 @@
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
 "kwE" = (
-/obj/effect/floor_decal/milspec/color/purple,
+/obj/effect/floor_decal/milspec/color/white,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "kwI" = (
@@ -36629,15 +36733,14 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/Supply_Ship_Bay)
 "kAW" = (
-/obj/effect/shuttle_landmark{
-	base_area = /area/space;
-	base_turf = /turf/space;
-	docking_controller = "sc-D1_L5A2_airlock";
-	landmark_tag = "sc-D1_L5A2";
-	name = "Docking Lane 5 Airlock 2"
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/space,
-/area/space)
+/obj/machinery/atmospherics/pipe/manifold/hidden,
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
 "kBb" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -36786,6 +36889,18 @@
 "kEx" = (
 /turf/simulated/floor/water/indoors,
 /area/hallway/Star_1Deck_Atrium)
+"kED" = (
+/obj/machinery/light/small/emergency{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/airless,
+/area/harbor/Dock5)
 "kEE" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/random/trash,
@@ -39560,6 +39675,20 @@
 	},
 /turf/simulated/floor,
 /area/maintenance/Deck1_Cargo_Chamber1)
+"lBW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/machinery/airlock_sensor{
+	pixel_y = 24
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 8;
+	color = "#989898"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock5)
 "lBY" = (
 /obj/structure/table,
 /obj/random/maintenance/morestuff,
@@ -39732,16 +39861,24 @@
 	},
 /area/maintenance/ab_Kitchen)
 "lFn" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
 /obj/structure/cable/white{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1;
-	color = "#989898"
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/harbor/Dock5)
 "lFr" = (
 /obj/structure/cable{
@@ -39813,12 +39950,12 @@
 /area/quartermaster/Mining_Ship_Bay)
 "lGZ" = (
 /obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor/airless,
+/obj/structure/table/bench/sifwooden/padded,
+/turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "lHc" = (
 /obj/machinery/hologram/holopad,
@@ -40184,8 +40321,10 @@
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/light/spot{
+	dir = 1;
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobotany_Lab)
@@ -41088,16 +41227,16 @@
 /obj/machinery/door/airlock/angled_bay/external/glass{
 	dir = 4
 	},
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
 /obj/machinery/access_button{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/map_helper/airlock/door/int_door,
 /obj/effect/map_helper/airlock/button/int_button{
 	pixel_y = -14
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock5)
@@ -41595,10 +41734,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Chamber1)
 "mkx" = (
-/obj/machinery/airlock_sensor{
-	pixel_y = 24
-	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8;
 	color = "#989898"
@@ -41651,26 +41788,16 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/Depot2)
 "mlW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 8
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 4
+/obj/effect/floor_decal/corner/white/bordercorner{
+	dir = 1
 	},
-/obj/machinery/door/airlock/angled_bay/external/glass{
-	dir = 4
+/obj/machinery/ai_status_display{
+	pixel_x = -32
 	},
-/obj/machinery/access_button{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/effect/map_helper/airlock/button/ext_button{
-	pixel_y = -14
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled,
 /area/harbor/Dock5)
 "mma" = (
 /obj/structure/cable/green{
@@ -41689,6 +41816,17 @@
 "mmk" = (
 /obj/structure/sign/warning/nosmoking_2,
 /turf/simulated/wall/r_wall,
+/area/harbor/Dock5)
+"mmB" = (
+/obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
+	dir = 1;
+	frequency = 1380;
+	id_tag = "arrivals_dock_south_airlock";
+	master_tag = "arrivals_dock";
+	pixel_y = -27;
+	req_one_access = list(13)
+	},
+/turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "mmI" = (
 /obj/structure/table/standard,
@@ -43657,23 +43795,9 @@
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/ursula)
 "mPv" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows,
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/machinery/door/airlock/angled_bay/external/glass/red,
-/obj/machinery/access_button{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/map_helper/airlock/door/ext_door,
-/obj/effect/map_helper/airlock/button/ext_button{
-	pixel_y = -14
-	},
-/obj/machinery/shield_diffuser,
-/turf/simulated/floor/tiled/techmaint,
-/area/harbor/Dock5)
+/obj/structure/sign/warning/vacuum,
+/turf/simulated/wall/r_wall,
+/area/quartermaster/Supply_Ship_Bay)
 "mPC" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -43967,11 +44091,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/ab_StripBar)
 "mVX" = (
-/obj/machinery/chemical_dispenser/full{
-	pixel_y = 5
-	},
-/obj/structure/table/darkglass,
-/obj/effect/floor_decal/milspec/color/purple,
+/obj/effect/floor_decal/milspec/color/white,
+/obj/machinery/sleep_console,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "mWc" = (
@@ -43996,9 +44117,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
 "mWi" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central5{
 	dir = 1
 	},
@@ -45485,17 +45603,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Corridor1)
 "nBS" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/harbor/Dock5)
+/obj/structure/sign/warning/vacuum,
+/turf/simulated/wall/r_wall,
+/area/rnd/Research_Ship_Bay)
 "nBU" = (
 /obj/structure/table/rack{
 	dir = 8;
@@ -48695,6 +48810,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock4)
+"oAk" = (
+/obj/structure/sign/warning/vacuum,
+/turf/simulated/wall/r_wall,
+/area/quartermaster/Mining_Ship_Bay)
 "oAw" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -49713,13 +49832,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber2)
 "oRK" = (
-/obj/machinery/light/small/emergency{
-	dir = 4
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/lattice,
-/obj/machinery/shield_diffuser,
-/turf/space,
-/area/space)
+/obj/structure/sign/warning/vacuum,
+/turf/simulated/wall/r_wall,
+/area/security/Exploration_Ship_Bay)
 "oSc" = (
 /obj/structure/table/woodentable,
 /obj/item/deck/wizoff{
@@ -49768,6 +49888,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Depot1)
 "oSV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/obj/machinery/airlock_sensor{
+	pixel_y = -24;
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 8;
 	color = "#989898"
@@ -50622,6 +50750,12 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor3)
+"pgE" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock5)
 "pgI" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -51818,16 +51952,30 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck1_AftPort_Corridor3)
 "pyv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/structure/cable/white{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	color = "#989898"
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
+"pyD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
+/obj/machinery/door/airlock/angled_bay/external/glass{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/door/int_door,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock5)
 "pzk" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -52234,14 +52382,8 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/Mining_Ship_Bay)
 "pHp" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows,
-/obj/effect/floor_decal/industrial/arrows{
-	dir = 1
-	},
-/obj/machinery/door/airlock/angled_bay/external/glass,
-/obj/effect/map_helper/airlock/door/int_door,
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/table/bench/sifwooden/padded,
+/turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "pHw" = (
 /obj/machinery/light/small{
@@ -52594,9 +52736,13 @@
 /turf/simulated/floor/plating,
 /area/harbor/Dock1)
 "pML" = (
-/obj/structure/closet/crate/mimic/closet/safe,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck1_AftPort_Chamber3)
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
 "pNg" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -56238,6 +56384,16 @@
 /obj/machinery/vending/weeb,
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/Market_Stall_6)
+"qWw" = (
+/obj/machinery/shield_diffuser,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/airless,
+/area/harbor/Dock5)
 "qWy" = (
 /obj/structure/table/rack/shelf/steel,
 /obj/fiftyspawner/steel,
@@ -56751,19 +56907,17 @@
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "rdk" = (
-/obj/machinery/airlock_sensor{
-	pixel_x = -24;
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 4
-	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	color = "#989898"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/plating,
 /area/harbor/Dock5)
 "rdl" = (
 /obj/structure/cable{
@@ -57561,10 +57715,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor2)
 "rsk" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "rsp" = (
@@ -59775,7 +59929,7 @@
 /obj/structure/closet/walllocker_double/hydrant/south,
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/regular,
-/obj/effect/floor_decal/milspec/color/purple,
+/obj/effect/floor_decal/milspec/color/white,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "sdO" = (
@@ -60181,8 +60335,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock1)
 "slm" = (
-/obj/machinery/mineral/equipment_vendor/survey,
-/obj/effect/floor_decal/milspec/color/purple,
+/obj/machinery/chem_master,
+/obj/effect/floor_decal/milspec/color/white,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "slH" = (
@@ -60456,6 +60610,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber1)
+"ssn" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
+/obj/machinery/door/airlock/angled_bay/external/glass{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/access_button{
+	pixel_y = 24
+	},
+/obj/effect/map_helper/airlock/button/ext_button{
+	pixel_y = -14
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/tiled/techmaint,
+/area/harbor/Dock5)
 "ssD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -60540,10 +60715,9 @@
 "suH" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	frequency = 1380;
-	id_tag = "escape_dock_north_airlock";
-	master_tag = "escape_dock";
 	pixel_y = 27;
-	req_one_access = list(13)
+	req_one_access = list(13);
+	id_tag = "SC-docklane11"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock1)
@@ -61074,12 +61248,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_For)
 "sEk" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -61799,10 +61967,6 @@
 /area/hallway/Stairwell_Port)
 "sPh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/camera/network/security{
-	c_tag = "D1-Har-5th Dock3";
-	network = list("Harbor")
-	},
 /obj/structure/cable/white{
 	d1 = 1;
 	d2 = 2;
@@ -61896,18 +62060,11 @@
 /turf/simulated/floor/plating,
 /area/harbor/Ship_Bay3)
 "sRF" = (
-/obj/machinery/atmospherics/unary/vent_pump/high_volume{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
 	},
-/obj/effect/map_helper/airlock/atmos/chamber_pump,
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
-	id_tag = "sc-D1_L5A2_airlock";
-	pixel_x = 24;
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	color = "#989898"
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
@@ -63746,6 +63903,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock2)
+"tAl" = (
+/obj/machinery/shield_diffuser,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/airless,
+/area/harbor/Dock5)
 "tAq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -63885,11 +64052,11 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape_pod2/station)
 "tCF" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4;
 	color = "#989898"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
 "tCH" = (
@@ -64431,7 +64598,7 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
-/obj/effect/floor_decal/milspec/color/purple,
+/obj/effect/floor_decal/milspec/color/white,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "tNb" = (
@@ -65794,7 +65961,14 @@
 /turf/simulated/floor/tiled,
 /area/engineering/GravGen_Room)
 "ulv" = (
-/obj/structure/closet/crate/mimic/safe,
+/obj/structure/closet/crate/mimic/closet/safe,
+/obj/random/contraband,
+/obj/random/contraband/nofail,
+/obj/random/junk,
+/obj/random/junk,
+/obj/random/maintenance/clean,
+/obj/item/bone,
+/obj/item/bone/skull,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber3)
 "ulX" = (
@@ -66495,6 +66669,16 @@
 /obj/machinery/door/airlock/maintenance/common,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck1_ForStar_Corridor2)
+"uyD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows/yellow,
+/obj/effect/floor_decal/industrial/arrows/yellow{
+	dir = 1
+	},
+/obj/structure/closet/crate/mimic/airlock/safe,
+/obj/item/tape/police,
+/turf/simulated/floor/tiled/techmaint,
+/area/maintenance/Deck1_AftPort_Chamber3)
 "uyN" = (
 /obj/effect/floor_decal/corner/brown/diagonal{
 	dir = 4
@@ -67095,10 +67279,9 @@
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi{
 	dir = 1;
 	frequency = 1380;
-	id_tag = "escape_dock_south_airlock";
-	master_tag = "escape_dock";
 	pixel_y = -27;
-	req_one_access = list(13)
+	req_one_access = list(13);
+	id_tag = "SC-docklane12"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock1)
@@ -67241,8 +67424,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Harbor Substation";
-	req_one_access = null
+	name = "Harbor Substation"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -68212,14 +68394,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor1)
 "vet" = (
+/obj/effect/floor_decal/milspec/color/white,
 /obj/structure/bed/chair/bay/comfy/purple{
-	dir = 1
+	dir = 4
 	},
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_x = 24;
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/milspec/color/purple,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "vew" = (
@@ -68588,6 +68766,16 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/rnd/Xenobiology_Lab)
+"viM" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#DDFFD3"
+	},
+/turf/simulated/floor/tiled/steel_ridged{
+	color = "#989898"
+	},
+/area/harbor/Dock5)
 "viW" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 8;
@@ -69156,6 +69344,16 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay2)
+"vrz" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 6
+	},
+/turf/simulated/floor/tiled/steel_ridged{
+	color = "#989898"
+	},
+/area/harbor/Dock5)
 "vrX" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -69900,12 +70098,11 @@
 /turf/simulated/floor/plating,
 /area/rnd/PA_Chamber)
 "vCE" = (
+/obj/machinery/atmospherics/unary/vent_pump/high_volume,
+/obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4;
 	color = "#989898"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock5)
@@ -70148,6 +70345,7 @@
 /obj/random/maintenance/engineering,
 /obj/random/trash,
 /obj/random/junk,
+/obj/effect/gibspawner/human,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber3)
 "vFJ" = (
@@ -70323,6 +70521,20 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/rnd/Xenobotany_Isolation_Chamber)
+"vJG" = (
+/obj/machinery/atmospheric_field_generator/perma/underdoors{
+	color = "Yellow"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/angled{
+	id = "sc-GCtransitgate2";
+	name = "Primary Docking Gate"
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay2)
 "vJS" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -70899,7 +71111,12 @@
 	},
 /obj/item/tank/phoron,
 /obj/item/tank/phoron,
-/obj/effect/floor_decal/milspec/color/purple,
+/obj/item/roller{
+	pixel_y = 7
+	},
+/obj/item/roller{
+	pixel_y = 3
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "vTY" = (
@@ -70954,7 +71171,7 @@
 /obj/machinery/atmospherics/binary/passive_gate{
 	regulate_mode = 0;
 	unlocked = 1;
-	dir = 8
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
@@ -71671,6 +71888,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Public_EVA)
+"wgr" = (
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 1
+	},
+/obj/machinery/light/spot{
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
+	},
+/turf/simulated/floor/tiled/white,
+/area/rnd/Xenobotany_Lab)
 "wgs" = (
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled,
@@ -72068,9 +72298,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden,
 /turf/simulated/floor/tiled,
@@ -72974,6 +73201,14 @@
 /turf/simulated/floor/reinforced/airless,
 /area/maintenance/Deck1_Security_StarCorridor3)
 "wHM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5
+	},
+/obj/machinery/airlock_sensor{
+	pixel_y = -24;
+	dir = 1
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4;
 	color = "#989898"
@@ -75313,6 +75548,15 @@
 /obj/machinery/light_construct,
 /turf/simulated/floor/plating,
 /area/maintenance/ab_CardTrading)
+"xvj" = (
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/sign/warning/vacuum,
+/turf/simulated/wall/r_wall,
+/area/quartermaster/Supply_Ship_Bay)
 "xvs" = (
 /obj/effect/floor_decal/industrial/stand_clear/blue,
 /turf/simulated/floor/tiled/monotile{
@@ -75512,6 +75756,10 @@
 "xAc" = (
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/Port_1Deck_Central_Corridor_1)
+"xAL" = (
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/airless,
+/area/harbor/Dock5)
 "xBj" = (
 /obj/effect/floor_decal/industrial/loading/blue{
 	dir = 8
@@ -76288,6 +76536,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
+"xSj" = (
+/obj/machinery/atmospheric_field_generator/perma/underdoors{
+	color = "Yellow"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/blast/angled{
+	id = "sc-GCtransitgate1";
+	name = "Primary Docking Gate"
+	},
+/obj/structure/sign/warning/vacuum{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay1)
 "xSm" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/space;
@@ -77418,9 +77680,6 @@
 "yjP" = (
 /obj/structure/table/glass,
 /obj/item/clipboard,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -86960,7 +87219,7 @@ rqS
 dym
 mOq
 aNX
-rqS
+xvj
 gNJ
 myq
 iFw
@@ -87933,7 +88192,7 @@ aaa
 iFw
 yhq
 tdK
-cSw
+etu
 cSw
 cSw
 cSw
@@ -90056,7 +90315,7 @@ bMN
 aDR
 ani
 agF
-agF
+mPv
 agF
 akd
 aaa
@@ -92061,7 +92320,7 @@ aaa
 aaa
 szS
 sZQ
-sZQ
+oAk
 sZQ
 aiB
 aiB
@@ -100951,7 +101210,7 @@ uDE
 uDE
 uDE
 uDE
-uDE
+hcU
 uDE
 akd
 aaa
@@ -103721,11 +103980,11 @@ bGi
 auk
 lZZ
 lZZ
+lZZ
+lZZ
+lZZ
+lZZ
 rne
-lZZ
-lZZ
-lZZ
-lZZ
 lZZ
 lZZ
 lZZ
@@ -103982,7 +104241,7 @@ ulv
 neE
 neE
 lZZ
-pML
+neE
 neE
 wyq
 lZZ
@@ -104237,9 +104496,9 @@ bGi
 auk
 lZZ
 eJN
-neE
+ezN
 kai
-rne
+lZZ
 neE
 kUS
 tUi
@@ -104753,11 +105012,11 @@ htL
 auk
 lZZ
 lZZ
+uyD
+lZZ
+lZZ
+lZZ
 rne
-lZZ
-lZZ
-lZZ
-lZZ
 lZZ
 lZZ
 lZZ
@@ -105162,7 +105421,7 @@ iFw
 aCB
 eLm
 dKC
-dKC
+oRK
 tag
 ebf
 ebf
@@ -105269,9 +105528,9 @@ fiB
 auk
 lZZ
 mLC
-neE
+bFI
 kai
-rZA
+lZZ
 neE
 kai
 neE
@@ -105595,7 +105854,7 @@ aKi
 aKi
 pUe
 lzJ
-chQ
+xSj
 ekA
 iKg
 aaa
@@ -105786,7 +106045,7 @@ auk
 lZZ
 lZZ
 lZZ
-hcU
+rne
 lZZ
 lZZ
 lZZ
@@ -105866,16 +106125,16 @@ aaa
 aaa
 szS
 oya
+ssn
+wXp
+oya
+aaa
+aaa
+aaa
+oya
 wXp
 jEb
 oya
-akd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -106124,19 +106383,19 @@ wEr
 agL
 kSE
 xiM
-iDD
+vCE
 wHM
 xiM
-iFw
-iFw
-aaf
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+xiM
+bot
+baS
+xiM
+jEu
+jEu
+iDD
 aaa
 aaa
 aaa
@@ -106384,17 +106643,17 @@ bap
 xiM
 cOQ
 rsk
+rdk
+aaa
+aaa
+aaa
+rdk
+sRF
+iro
 xiM
-jlA
+xAL
 fZW
-iFw
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jEu
 aaa
 aaa
 aaa
@@ -106639,20 +106898,20 @@ sQR
 sQR
 gjp
 dVV
-mZW
-baS
+xiM
+mkx
 buZ
-mZW
+kSE
 jlA
-lGZ
-oRK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+wEr
+dLR
+kSE
+bBM
+jwO
+xiM
+gvf
+qWw
+jEu
 aaa
 aaa
 aaa
@@ -106899,16 +107158,16 @@ ebd
 aJT
 elp
 dXe
-jEu
+lZN
 kSE
-qvX
-wEr
-agL
-aaa
-aaa
-aaa
-aaa
-aaa
+buo
+vrz
+buo
+kSE
+pyD
+dhx
+kSE
+icj
 aaa
 aaa
 aaa
@@ -107156,17 +107415,17 @@ bKR
 pdf
 dNN
 bBx
-dhx
-nBS
+mWi
+sEk
+ebd
+mdY
+mdY
+mdY
+mlW
+sEk
+pdf
 pHp
-rdk
-dgp
-bot
-aaa
-aaa
-aaa
-aaa
-aaa
+gxb
 aaa
 aaa
 aaa
@@ -107416,15 +107675,15 @@ fIm
 bry
 sPh
 wpV
-buo
 pyv
-bFI
-bot
-aaa
+pyv
+pyv
+pyv
+pyv
 kAW
-aaa
-aaa
-aaa
+pML
+lGZ
+lFn
 aaa
 aaa
 aaa
@@ -107675,14 +107934,14 @@ bBx
 mWi
 sEk
 gvO
-sRF
-lFn
-mPv
-aaa
-aaa
-aaa
-aaa
-aaa
+fHt
+fHt
+fHt
+aXg
+sEk
+pdf
+pHp
+bck
 aaa
 aaa
 aaa
@@ -107933,14 +108192,14 @@ mmk
 dXe
 lZN
 kSE
-qvX
-wEr
-agL
-aaa
-aaa
-aaa
-aaa
-aaa
+pgE
+viM
+pgE
+kSE
+pyD
+dhx
+kSE
+icj
 aaa
 aaa
 aaa
@@ -108187,20 +108446,20 @@ fOX
 fOX
 tcF
 dVV
-oya
+xiM
 vCE
 tCF
-oya
+kSE
 jlA
-lGZ
+wEr
 dLR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kSE
+iwp
+baS
+xiM
+kED
+tAl
+jEu
 aaa
 aaa
 aaa
@@ -108447,18 +108706,18 @@ pCF
 lvp
 xiM
 abh
-bBM
+rsk
+oya
+aaa
+aaa
+aaa
+oya
+sRF
+mmB
 xiM
-jlA
+xAL
 deu
-iFw
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jEu
 aaa
 aaa
 aaa
@@ -108707,16 +108966,16 @@ xiM
 mkx
 oSV
 xiM
-iFw
-iFw
-aaf
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+xiM
+lBW
+jwO
+xiM
+jEu
+jEu
+iDD
 aaa
 aaa
 aaa
@@ -108962,16 +109221,16 @@ aaa
 aaa
 szS
 mZW
+ssn
 wXp
-mlW
 mZW
-akd
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+mZW
+wXp
+jEb
+mZW
 aaa
 aaa
 aaa
@@ -109207,7 +109466,7 @@ aVW
 aVW
 jot
 noM
-adk
+vJG
 rXy
 iKg
 aaa
@@ -109290,7 +109549,7 @@ iFw
 aCB
 eLm
 dKC
-dKC
+oRK
 jLi
 ebf
 ebf
@@ -113851,7 +114110,7 @@ eab
 eab
 eab
 eab
-eab
+dgp
 eab
 akd
 aaa
@@ -119211,7 +119470,7 @@ mMe
 asJ
 asJ
 asJ
-asJ
+gnx
 asJ
 akd
 aaa
@@ -121999,8 +122258,8 @@ eyJ
 gKh
 gnw
 aLh
-aLh
 hSi
+fEw
 cgH
 aLh
 xfQ
@@ -122257,9 +122516,9 @@ eyJ
 dDV
 aLh
 ams
-aSb
 sgQ
-aSb
+sgQ
+sgQ
 iTK
 kuY
 cCp
@@ -123339,7 +123598,7 @@ wLZ
 wLZ
 bHO
 dWb
-dWT
+nBS
 dHz
 jbn
 iFw
@@ -123810,7 +124069,7 @@ aMF
 aSb
 dDV
 vFg
-aPE
+wgr
 duN
 wqU
 rPJ
@@ -124063,9 +124322,9 @@ dYZ
 eyu
 aHn
 uSq
-aSb
 cVw
-aSb
+cVw
+cVw
 adn
 imW
 tGc

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
@@ -324,28 +324,10 @@
 	pixel_y = 7;
 	pixel_x = -8
 	},
-/obj/item/ammo_magazine/m9mm/compact{
-	pixel_y = 1;
-	pixel_x = 8
-	},
-/obj/item/ammo_magazine/m9mm/compact{
-	pixel_y = 1;
-	pixel_x = 4
-	},
-/obj/item/ammo_magazine/m9mm/compact{
-	pixel_y = 1
-	},
-/obj/item/ammo_magazine/m9mm/compact{
-	pixel_y = 1;
-	pixel_x = -4
-	},
-/obj/item/ammo_magazine/m9mm/compact{
-	pixel_y = 1;
-	pixel_x = -8
-	},
 /obj/machinery/door/window/brigdoor/southleft{
 	layer = 2.9
 	},
+/obj/structure/table/rack,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/Equipment_Storage)
 "aaB" = (
@@ -4917,6 +4899,10 @@
 	dir = 1;
 	pixel_y = -13
 	},
+/obj/item/reagent_containers/food/drinks/shaker{
+	pixel_y = 6;
+	pixel_x = 6
+	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Midnight_Kitchen)
 "alV" = (
@@ -6460,10 +6446,10 @@
 /turf/simulated/wall,
 /area/hallway/Port_2_Deck_Corridor_2)
 "asn" = (
-/obj/structure/closet/secure_closet/bar,
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/machinery/vending/wardrobe/bardrobe,
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/Midnight_Kitchen)
 "aso" = (
@@ -12545,26 +12531,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Rec_Lounge)
 "aMm" = (
-/obj/structure/table/glass,
-/obj/item/stack/material/plastic{
-	max_amount = 25;
-	amount = 20;
-	pixel_y = 1;
-	pixel_x = -4
-	},
-/obj/item/stack/material/phoron{
-	amount = 5;
-	pixel_x = 3
-	},
-/obj/item/stack/material/phoron{
-	amount = 5;
-	pixel_y = 8;
-	pixel_x = 3
-	},
-/obj/machinery/light{
+/obj/structure/sink{
 	dir = 8;
-	layer = 3
+	pixel_x = -12;
+	pixel_y = 2
 	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -17185,13 +17157,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Cargo_AftPortCorridor1)
 "baY" = (
-/obj/structure/table/woodentable,
 /obj/machinery/light,
-/obj/item/clothing/accessory/permit/gun/bar,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/table/woodentable,
+/obj/item/toy/figure/bartender{
+	pixel_y = 1
+	},
+/obj/item/ammo_magazine/ammo_box/b12g/stunshell{
+	pixel_x = -9
+	},
+/obj/item/ammo_magazine/ammo_box/b12g/beanbag{
+	pixel_y = 4;
+	pixel_x = -9
+	},
+/obj/item/ammo_magazine/ammo_box/b12g{
+	pixel_y = 9;
+	pixel_x = -9
+	},
+/obj/item/gun/projectile/shotgun/doublebarrel{
+	pixel_y = 9;
+	pixel_x = 7
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/Midnight_Kitchen)
@@ -18049,6 +18038,11 @@
 "bec" = (
 /obj/structure/bed/chair/sofa/corner/brown{
 	dir = 8
+	},
+/obj/machinery/light/small/neon/booze1{
+	dir = 1;
+	pixel_x = -1;
+	pixel_y = -29
 	},
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/Midnight_Bar)
@@ -20087,6 +20081,9 @@
 /obj/item/reagent_containers/glass/beaker/large{
 	pixel_x = 2
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -20560,6 +20557,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 2
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
@@ -21242,21 +21242,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engineering_Workshop)
 "bok" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/hatch,
-/obj/structure/grille,
-/obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/titanium{
-	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
-/obj/item/tape/engineering,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/wood/broken,
 /area/maintenance/ab_TeshDen)
 "bon" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -21471,15 +21462,11 @@
 /turf/simulated/floor/carpet,
 /area/security/Forensics_Office)
 "bpf" = (
-/obj/structure/sink/countertop{
-	pixel_y = 35;
-	pixel_x = 16;
-	dir = 1
-	},
 /obj/structure/table/marble{
 	color = "grey"
 	},
 /obj/item/hand_labeler,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -21730,25 +21717,6 @@
 	},
 /obj/item/ammo_magazine/m45/flash{
 	pixel_y = 7;
-	pixel_x = -8
-	},
-/obj/item/ammo_magazine/m45/hp{
-	pixel_y = 1;
-	pixel_x = 8
-	},
-/obj/item/ammo_magazine/m45/hp{
-	pixel_y = 1;
-	pixel_x = 4
-	},
-/obj/item/ammo_magazine/m45/hp{
-	pixel_y = 1
-	},
-/obj/item/ammo_magazine/m45/hp{
-	pixel_y = 1;
-	pixel_x = -4
-	},
-/obj/item/ammo_magazine/m45/hp{
-	pixel_y = 1;
 	pixel_x = -8
 	},
 /obj/machinery/door/window/brigdoor/southright{
@@ -27772,11 +27740,6 @@
 /area/rnd/Robotics_Lab)
 "bMw" = (
 /obj/machinery/light,
-/obj/machinery/light/small/neon/booze1{
-	dir = 1;
-	pixel_x = -1;
-	pixel_y = -29
-	},
 /turf/simulated/floor/glass,
 /area/crew_quarters/Midnight_Bar)
 "bMy" = (
@@ -31037,28 +31000,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/CE_Office)
 "bYa" = (
-/obj/structure/table/woodentable,
-/obj/item/ammo_magazine/ammo_box/b12g/stunshell{
-	pixel_x = -9
+/obj/machinery/alarm{
+	pixel_y = 25
 	},
-/obj/item/ammo_magazine/ammo_box/b12g/beanbag{
-	pixel_y = 4;
-	pixel_x = -9
-	},
-/obj/item/ammo_magazine/ammo_box/b12g{
-	pixel_y = 9;
-	pixel_x = -9
-	},
-/obj/item/gun/projectile/shotgun/doublebarrel{
-	pixel_y = 10;
-	pixel_x = 10
-	},
-/obj/item/tool/screwdriver{
-	pixel_y = 4;
-	pixel_x = 8
-	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/crew_quarters/Midnight_Kitchen)
+/turf/simulated/floor/wood,
+/area/maintenance/ab_TeshDen)
 "bYc" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 4
@@ -31405,8 +31351,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Southern control room";
-	req_one_access = null
+	name = "Southern control room"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Aft_2_Deck_Stairwell)
@@ -32592,13 +32537,12 @@
 /area/medical/EMT_Bay)
 "cdC" = (
 /obj/structure/table/marble,
-/obj/machinery/cash_register/civilian,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/shutters{
 	id = "sc-GCmidnightbar";
 	layer = 3.1;
 	name = "Bar Shutters"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Midnight_Kitchen)
 "cdG" = (
@@ -32660,10 +32604,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 8
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/Midnight_Kitchen)
 "cdO" = (
@@ -38461,6 +38414,7 @@
 	dir = 4;
 	pixel_x = -25
 	},
+/obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Midnight_Kitchen)
 "cwF" = (
@@ -39311,6 +39265,20 @@
 /obj/structure/table/marble{
 	color = "grey"
 	},
+/obj/item/stack/material/phoron{
+	amount = 5;
+	pixel_y = 8;
+	pixel_x = 3
+	},
+/obj/item/stack/material/phoron{
+	amount = 5;
+	pixel_x = 3
+	},
+/obj/item/stack/material/plastic{
+	max_amount = 25;
+	amount = 20;
+	pixel_x = -14
+	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -39695,15 +39663,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Midnight_Kitchen)
@@ -40500,16 +40459,21 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/Engineering_Workshop)
 "cDS" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/obj/structure/reagent_dispensers/beerkeg,
-/obj/item/storage/box/mixedglasses{
-	pixel_y = 14
+/obj/structure/window/titanium{
+	dir = 1
 	},
-/turf/simulated/floor/wood/alt/tile,
-/area/crew_quarters/Midnight_Kitchen)
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/barricade,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "cDW" = (
 /obj/effect/catwalk_plated/white,
 /turf/space,
@@ -40895,28 +40859,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Testing_Lab)
 "cEC" = (
-/obj/item/stack/material/cardboard{
-	amount = 25
-	},
-/obj/item/packageWrap{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/item/packageWrap{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/hand_labeler{
-	pixel_y = 1;
-	pixel_x = 2
-	},
-/obj/item/tape_roll{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/purcarpet,
-/area/crew_quarters/Midnight_Kitchen)
+/obj/structure/table/standard,
+/obj/random/donkpocketbox,
+/turf/simulated/floor/wood,
+/area/maintenance/ab_TeshDen)
 "cED" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -42020,23 +41966,19 @@
 /turf/simulated/floor/plating,
 /area/harbor/Aft_2_Deck_Airlock_Access)
 "cOC" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/crew_quarters/Midnight_Kitchen)
+/obj/item/tape/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "cOH" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/sif,
@@ -46588,6 +46530,11 @@
 /area/hallway/Central_2_Deck_Hall)
 "dTH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/door/window/southleft{
+	layer = 2.8;
+	name = "Chemistry Desk";
+	req_access = list(33)
+	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -47433,7 +47380,7 @@
 	dir = 1
 	},
 /obj/item/tape/engineering,
-/turf/space,
+/turf/simulated/floor/plating,
 /area/maintenance/ab_TeshDen)
 "efB" = (
 /obj/structure/cable{
@@ -48195,19 +48142,8 @@
 /turf/space,
 /area/harbor/For_Shuttlebay)
 "epJ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows/yellow,
-/obj/effect/floor_decal/industrial/arrows/yellow{
-	dir = 1
-	},
-/obj/structure/simple_door/wood,
-/obj/item/tape/engineering,
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/random/trash,
+/turf/simulated/floor/wood/broken,
 /area/maintenance/ab_TeshDen)
 "eqi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -53495,29 +53431,6 @@
 /area/medical/Deck2_Corridor)
 "fCA" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/item/reagent_containers/chem_disp_cartridge/berry{
-	pixel_y = -4;
-	pixel_x = 8
-	},
-/obj/item/reagent_containers/chem_disp_cartridge/hot_coco{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/reagent_containers/chem_disp_cartridge/milk{
-	pixel_x = 8
-	},
-/obj/item/reagent_containers/chem_disp_cartridge/mint{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/chem_disp_cartridge/tea{
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/chem_disp_cartridge/coffee{
-	pixel_y = 6;
-	pixel_x = 8
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Midnight_Kitchen)
 "fCI" = (
@@ -63269,16 +63182,19 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Research_Lab)
 "hSQ" = (
-/obj/structure/window/basic{
-	dir = 1
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/radio/intercom/department/medbay{
-	dir = 8;
-	pixel_x = -22
+/obj/structure/window/titanium{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/Patient_Ward)
+/obj/item/tape/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "hSV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -63492,6 +63408,16 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/security/Prison_Wing)
+"hVX" = (
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "sc-GCmidnightbar";
+	name = "Bar Shutters Control";
+	pixel_x = 24;
+	req_access = list(28)
+	},
+/turf/simulated/floor/wood/alt/tile,
+/area/crew_quarters/Midnight_Kitchen)
 "hWe" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/light/small{
@@ -64377,6 +64303,22 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_ForPortChamber1)
+"ifV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/item/tape/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "igu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -68108,8 +68050,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Southern control room";
-	req_one_access = null
+	name = "Southern control room"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -69779,6 +69720,10 @@
 /area/shuttle/large_escape_pod4/station)
 "jwD" = (
 /obj/machinery/chemical_analyzer,
+/obj/machinery/light{
+	dir = 8;
+	layer = 3
+	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -71802,20 +71747,21 @@
 /turf/simulated/floor/carpet/green,
 /area/hallway/Aft_2_Deck_Lobby)
 "jZO" = (
-/obj/structure/table/woodentable,
 /obj/item/radio/intercom{
 	pixel_y = -22
-	},
-/obj/item/reagent_containers/food/drinks/shaker,
-/obj/item/packageWrap,
-/obj/item/toy/figure/bartender{
-	pixel_y = 1;
-	pixel_x = -7
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/table/woodentable,
+/obj/item/clothing/accessory/permit/gun/bar{
+	pixel_x = -9
+	},
+/obj/item/tool/screwdriver{
+	pixel_y = 4;
+	pixel_x = 8
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/Midnight_Kitchen)
@@ -77626,7 +77572,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/warning/moving_parts,
 /turf/simulated/wall,
 /area/quartermaster/Recycling)
 "lBG" = (
@@ -78776,13 +78721,13 @@
 	pixel_x = -32;
 	pixel_y = -4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/machinery/door/blast/shutters{
 	id = "sc-GCmidnightbar";
 	layer = 3.1;
 	name = "Bar Shutters"
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/crew_quarters/Midnight_Kitchen)
@@ -80605,6 +80550,13 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/CMO_Office)
+"mpC" = (
+/obj/structure/bed/pillowpilefront/teal,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/ab_TeshDen)
 "mpT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -81677,7 +81629,8 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/sign/warning/moving_parts,
+/turf/simulated/wall,
 /area/quartermaster/Recycling)
 "mGr" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -89926,10 +89879,17 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/Office_Lounge)
 "oUx" = (
-/obj/machinery/vending/wardrobe/bardrobe,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/closet/gmcloset,
+/obj/item/retail_scanner/civilian,
+/obj/item/retail_scanner/civilian,
+/obj/item/clothing/head/that{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/item/glass_jar,
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/Midnight_Kitchen)
 "oUC" = (
@@ -95128,6 +95088,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/Engineering_Workshop)
+"qhV" = (
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/structure/closet/secure_closet/bar,
+/turf/simulated/floor/wood/alt/tile,
+/area/crew_quarters/Midnight_Kitchen)
 "qip" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -102485,17 +102453,22 @@
 /turf/simulated/floor/tiled,
 /area/security/Prison_Wing)
 "rYB" = (
-/obj/structure/sign/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
-	pixel_x = -28;
-	pixel_y = 4
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
 	},
-/turf/simulated/floor/carpet/purcarpet,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Midnight_Kitchen)
 "rYF" = (
 /obj/machinery/alarm{
@@ -105788,12 +105761,15 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/EMT_Bay)
 "sMS" = (
-/obj/structure/table/glass,
-/obj/item/radio/intercom/department/medbay{
-	pixel_y = -22
+/obj/machinery/door/window/southright{
+	layer = 2.9;
+	name = "Chemistry Desk";
+	req_access = list(33)
 	},
-/turf/simulated/floor/tiled/dark,
-/area/medical/Patient_Ward)
+/turf/simulated/floor/tiled/white{
+	color = "#8bbbd5"
+	},
+/area/medical/Chemistry)
 "sNa" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -106263,13 +106239,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck2_Security_PortCorridor1)
 "sSl" = (
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "sc-GCmidnightbar";
-	name = "Bar Shutters Control";
-	pixel_x = 24;
-	req_access = list(28)
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -106317,6 +106286,37 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Reception)
+"sTT" = (
+/obj/structure/table/marble,
+/obj/item/packageWrap{
+	pixel_y = 5;
+	pixel_x = -9
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/berry{
+	pixel_y = -4;
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/hot_coco{
+	pixel_x = 8;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/milk{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/mint{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/tea{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/coffee{
+	pixel_y = 6;
+	pixel_x = 8
+	},
+/turf/simulated/floor/wood/alt/tile,
+/area/crew_quarters/Midnight_Kitchen)
 "sTX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -109796,10 +109796,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/carpet/purcarpet,
@@ -110706,6 +110706,7 @@
 	name = "Chemistry Cleaner";
 	pixel_x = 9
 	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -112200,6 +112201,15 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Corridor_2)
+"utI" = (
+/obj/machinery/chem_master,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white{
+	color = "#8bbbd5"
+	},
+/area/medical/Chemistry)
 "utJ" = (
 /obj/vehicle/train/engine{
 	dir = 2
@@ -116702,6 +116712,10 @@
 /area/crew_quarters/Chapel_Morgue)
 "vKy" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white{
 	color = "#8bbbd5"
 	},
@@ -116801,6 +116815,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Lobby)
+"vLL" = (
+/obj/structure/table/marble,
+/obj/machinery/cash_register/civilian,
+/obj/machinery/door/blast/shutters{
+	id = "sc-GCmidnightbar";
+	layer = 3.1;
+	name = "Bar Shutters"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/crew_quarters/Midnight_Kitchen)
 "vLQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -116918,10 +116942,6 @@
 /obj/item/gun/energy/ionrifle/pistol{
 	pixel_y = 7;
 	pixel_x = 5
-	},
-/obj/item/gun/energy/ionrifle/pistol{
-	pixel_y = 3;
-	pixel_x = 4
 	},
 /obj/item/gun/energy/ionrifle/pistol{
 	pixel_y = -1;
@@ -119025,16 +119045,10 @@
 /turf/simulated/floor/plating,
 /area/rnd/Toxins_Storage)
 "woi" = (
-/obj/structure/closet/gmcloset,
-/obj/item/glass_jar,
-/obj/item/retail_scanner/civilian,
-/obj/item/retail_scanner/civilian,
-/obj/item/clothing/head/that{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/turf/simulated/floor/carpet/purcarpet,
-/area/crew_quarters/Midnight_Kitchen)
+/obj/structure/disposalpipe/segment,
+/obj/item/stool/baystool/padded,
+/turf/simulated/floor/wood/sif,
+/area/crew_quarters/Midnight_Bar)
 "wop" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -119085,11 +119099,18 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/Breakroom)
 "woz" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/barricade,
+/turf/simulated/floor/plating,
 /area/maintenance/ab_TeshDen)
 "woF" = (
 /obj/machinery/light{
@@ -123034,6 +123055,16 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/sign/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = -28;
+	pixel_y = 4
 	},
 /turf/simulated/floor/carpet/purcarpet,
 /area/crew_quarters/Midnight_Kitchen)
@@ -155054,15 +155085,15 @@ aaa
 aaa
 bHD
 rrk
-qcp
-ptE
+hSQ
 bHD
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bHD
+ifV
+ptE
+bHD
 aaa
 aaa
 aaa
@@ -155311,16 +155342,16 @@ qcp
 wsr
 bHD
 bHD
+cqv
+cEC
+bHD
+aaa
+aaa
+aaa
+bHD
 mic
-dWN
 tHG
 qGQ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -155569,16 +155600,16 @@ lAc
 qKV
 uck
 bHD
+mpC
+fav
+bHD
+aaa
+aaa
+aaa
+bHD
 hOJ
-pNb
 dWN
 jRu
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -155808,7 +155839,7 @@ cyF
 plF
 lYV
 plF
-ciN
+sTT
 dgU
 bRu
 iAF
@@ -155827,16 +155858,16 @@ lHe
 nUC
 ybj
 bHD
-peA
+piv
 dzV
-cqv
+bHD
+aaa
+aaa
+aaa
+bHD
+peA
+auv
 wff
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -156061,7 +156092,7 @@ iwp
 uaB
 cOH
 cOH
-cOH
+woi
 cdC
 rue
 rWH
@@ -156092,10 +156123,10 @@ bHD
 bHD
 bHD
 bHD
-aaa
-aaa
-aaa
-aaa
+bHD
+qGP
+bHD
+bHD
 aaa
 aaa
 aaa
@@ -156320,11 +156351,11 @@ aMR
 aMR
 aMR
 aMR
-xDr
+vLL
 plF
 cBr
 sSl
-cDS
+ciN
 gPC
 shD
 eaY
@@ -156342,21 +156373,21 @@ dzV
 fav
 kAe
 rBs
+dzV
+dzV
+dzV
+dzV
+fav
+dzV
+dzV
 auv
+fav
 dzV
 dzV
-bHD
-cqv
 woz
-piv
-qGQ
 aaf
 gWp
 aaf
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -156578,11 +156609,11 @@ aMR
 aMR
 aMR
 bMw
-gPC
-imz
-atA
-gPC
-gPC
+xDr
+plF
+rYB
+hVX
+qhV
 gPC
 bRi
 pnz
@@ -156600,21 +156631,21 @@ kmP
 vrq
 qEx
 vrq
-ulC
-ulC
 gKQ
-epJ
 vrq
+vrq
+gKQ
+vrq
+bok
+gKQ
+ulC
 nOM
+gKQ
 vrq
 dQS
 bmS
 cVD
 onO
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -156837,10 +156868,10 @@ aMR
 aMR
 aMR
 brh
-cEC
-cOC
-rYB
-bYa
+imz
+atA
+gPC
+gPC
 gPC
 fON
 bYP
@@ -156858,21 +156889,21 @@ kAe
 dzV
 fav
 auv
+dzV
+auv
+dzV
+dzV
+dzV
+dzV
+dzV
 pNb
 pNb
 dzV
-bHD
-lZD
-oie
-lUy
-wff
+dzV
+cOC
 aaf
 gWp
 aaf
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -157118,16 +157149,16 @@ uJd
 uJd
 bHD
 bHD
+qGP
+bHD
+bHD
+bHD
+bHD
+bHD
+bHD
 xZV
 bHD
 bHD
-bHD
-bHD
-bHD
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -157353,7 +157384,7 @@ deb
 aLB
 aMC
 gPC
-woi
+opg
 trc
 bZx
 jZO
@@ -157376,15 +157407,15 @@ nUC
 sSs
 bHD
 lUy
-auv
+dzV
+bHD
+aaa
+aaa
+aaa
+bHD
+lUy
 dzV
 qGQ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -157633,16 +157664,16 @@ dnF
 pDj
 aJi
 bHD
+bYa
+epJ
+bHD
+aaa
+aaa
+aaa
+bHD
 vmI
-kAe
 rAI
 gvp
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -157891,16 +157922,16 @@ ptE
 xwU
 bHD
 bHD
+lZD
+oie
+bHD
+aaa
+aaa
+aaa
+bHD
 anu
-rAI
 vaa
 wff
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -158149,16 +158180,16 @@ aaa
 aaa
 aaa
 bHD
-rrk
+cDS
 ptE
-bok
 bHD
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bHD
+rrk
+hSQ
+bHD
 aaa
 aaa
 aaa
@@ -168122,7 +168153,7 @@ tQj
 bkf
 aIY
 aMn
-aMn
+sMS
 avP
 lEI
 crH
@@ -168378,7 +168409,7 @@ sXo
 aQu
 qip
 bkk
-fma
+utI
 blN
 vKy
 hWu
@@ -173545,7 +173576,7 @@ lQC
 qsK
 lhc
 lQC
-hSQ
+lUr
 lRG
 hnT
 reJ
@@ -175097,7 +175128,7 @@ sRL
 ePO
 aiA
 iXo
-sMS
+ksd
 fZU
 mkW
 xwB

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
@@ -16570,6 +16570,12 @@
 	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/Chapel_Office)
+"aZa" = (
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/ab_TeshDen)
 "aZf" = (
 /obj/structure/table/sifwoodentable,
 /obj/item/radio/subspace{
@@ -21242,13 +21248,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engineering_Workshop)
 "bok" = (
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22
 	},
-/turf/simulated/floor/wood/broken,
-/area/maintenance/ab_TeshDen)
+/obj/structure/closet/secure_closet/bar,
+/turf/simulated/floor/wood/alt/tile,
+/area/crew_quarters/Midnight_Kitchen)
 "bon" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/button/remote/driver{
@@ -31000,10 +31006,20 @@
 /turf/simulated/floor/plating,
 /area/engineering/CE_Office)
 "bYa" = (
-/obj/machinery/alarm{
-	pixel_y = 25
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/item/tape/engineering,
+/turf/simulated/floor/plating,
 /area/maintenance/ab_TeshDen)
 "bYc" = (
 /obj/structure/bed/chair/comfy/brown{
@@ -40459,21 +40475,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/Engineering_Workshop)
 "cDS" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/hatch,
-/obj/structure/grille,
-/obj/structure/window/titanium{
+/obj/machinery/chem_master,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/window/titanium{
-	dir = 1
+/turf/simulated/floor/tiled/white{
+	color = "#8bbbd5"
 	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
-/obj/structure/barricade,
-/turf/simulated/floor/plating,
-/area/maintenance/ab_TeshDen)
+/area/medical/Chemistry)
 "cDW" = (
 /obj/effect/catwalk_plated/white,
 /turf/space,
@@ -40859,10 +40868,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Testing_Lab)
 "cEC" = (
-/obj/structure/table/standard,
-/obj/random/donkpocketbox,
-/turf/simulated/floor/wood,
-/area/maintenance/ab_TeshDen)
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 6
+	},
+/obj/effect/floor_decal/borderfloor/corner2{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/wood/alt/tile,
+/area/crew_quarters/Midnight_Kitchen)
 "cED" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -41966,19 +41988,17 @@
 /turf/simulated/floor/plating,
 /area/harbor/Aft_2_Deck_Airlock_Access)
 "cOC" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/hatch,
-/obj/structure/grille,
-/obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
+/obj/structure/table/marble,
+/obj/item/packageWrap{
+	pixel_y = 5;
+	pixel_x = -9
 	},
-/obj/structure/window/titanium{
-	dir = 1
+/obj/machinery/chemical_dispenser/bar_coffee/full{
+	dir = 1;
+	pixel_y = -13
 	},
-/obj/item/tape/engineering,
-/turf/simulated/floor/plating,
-/area/maintenance/ab_TeshDen)
+/turf/simulated/floor/wood/alt/tile,
+/area/crew_quarters/Midnight_Kitchen)
 "cOH" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/sif,
@@ -47627,6 +47647,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_AftPort_Corridor)
+"eix" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/item/tape/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "eiy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -48142,9 +48176,15 @@
 /turf/space,
 /area/harbor/For_Shuttlebay)
 "epJ" = (
-/obj/random/trash,
-/turf/simulated/floor/wood/broken,
-/area/maintenance/ab_TeshDen)
+/obj/machinery/door/window/southright{
+	layer = 2.9;
+	name = "Chemistry Desk";
+	req_access = list(33)
+	},
+/turf/simulated/floor/tiled/white{
+	color = "#8bbbd5"
+	},
+/area/medical/Chemistry)
 "eqi" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -63182,19 +63222,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Research_Lab)
 "hSQ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/hatch,
-/obj/structure/grille,
-/obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
+/obj/structure/table/marble,
+/obj/machinery/cash_register/civilian,
+/obj/machinery/door/blast/shutters{
+	id = "sc-GCmidnightbar";
+	layer = 3.1;
+	name = "Bar Shutters"
 	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
-/obj/item/tape/engineering,
-/turf/simulated/floor/plating,
-/area/maintenance/ab_TeshDen)
+/turf/simulated/floor/tiled/steel_grid,
+/area/crew_quarters/Midnight_Kitchen)
 "hSV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -63408,16 +63444,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/security/Prison_Wing)
-"hVX" = (
-/obj/machinery/button/remote/blast_door{
-	dir = 8;
-	id = "sc-GCmidnightbar";
-	name = "Bar Shutters Control";
-	pixel_x = 24;
-	req_access = list(28)
-	},
-/turf/simulated/floor/wood/alt/tile,
-/area/crew_quarters/Midnight_Kitchen)
 "hWe" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/machinery/light/small{
@@ -64303,22 +64329,6 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_ForPortChamber1)
-"ifV" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/hatch,
-/obj/structure/grille,
-/obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
-/obj/item/tape/engineering,
-/turf/simulated/floor/plating,
-/area/maintenance/ab_TeshDen)
 "igu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -67654,6 +67664,20 @@
 /obj/machinery/light,
 /turf/simulated/floor/reinforced,
 /area/rnd/Testing_Lab)
+"iVr" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/item/tape/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "iVx" = (
 /obj/item/clothing/gloves/brown{
 	pixel_y = -1;
@@ -75611,6 +75635,11 @@
 "kYA" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/Star_Transit_Foyer)
+"kYI" = (
+/obj/structure/disposalpipe/segment,
+/obj/item/stool/baystool/padded,
+/turf/simulated/floor/wood/sif,
+/area/crew_quarters/Midnight_Bar)
 "kYN" = (
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_2)
@@ -80550,13 +80579,6 @@
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
 /area/medical/CMO_Office)
-"mpC" = (
-/obj/structure/bed/pillowpilefront/teal,
-/obj/machinery/alarm{
-	pixel_y = 25
-	},
-/turf/simulated/floor/wood,
-/area/maintenance/ab_TeshDen)
 "mpT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -95088,14 +95110,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/Engineering_Workshop)
-"qhV" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/structure/closet/secure_closet/bar,
-/turf/simulated/floor/wood/alt/tile,
-/area/crew_quarters/Midnight_Kitchen)
 "qip" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -102453,23 +102467,21 @@
 /turf/simulated/floor/tiled,
 /area/security/Prison_Wing)
 "rYB" = (
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
+/obj/structure/window/titanium{
+	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+/obj/structure/window/titanium{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/wood/alt/tile,
-/area/crew_quarters/Midnight_Kitchen)
+/obj/structure/barricade,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "rYF" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -105761,15 +105773,13 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/EMT_Bay)
 "sMS" = (
-/obj/machinery/door/window/southright{
-	layer = 2.9;
-	name = "Chemistry Desk";
-	req_access = list(33)
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white{
-	color = "#8bbbd5"
-	},
-/area/medical/Chemistry)
+/turf/simulated/floor/wood/broken,
+/area/maintenance/ab_TeshDen)
 "sNa" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -106286,37 +106296,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Reception)
-"sTT" = (
-/obj/structure/table/marble,
-/obj/item/packageWrap{
-	pixel_y = 5;
-	pixel_x = -9
-	},
-/obj/item/reagent_containers/chem_disp_cartridge/berry{
-	pixel_y = -4;
-	pixel_x = 8
-	},
-/obj/item/reagent_containers/chem_disp_cartridge/hot_coco{
-	pixel_x = 8;
-	pixel_y = -2
-	},
-/obj/item/reagent_containers/chem_disp_cartridge/milk{
-	pixel_x = 8
-	},
-/obj/item/reagent_containers/chem_disp_cartridge/mint{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/chem_disp_cartridge/tea{
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/chem_disp_cartridge/coffee{
-	pixel_y = 6;
-	pixel_x = 8
-	},
-/turf/simulated/floor/wood/alt/tile,
-/area/crew_quarters/Midnight_Kitchen)
 "sTX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -112201,15 +112180,6 @@
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Corridor_2)
-"utI" = (
-/obj/machinery/chem_master,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white{
-	color = "#8bbbd5"
-	},
-/area/medical/Chemistry)
 "utJ" = (
 /obj/vehicle/train/engine{
 	dir = 2
@@ -116815,16 +116785,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Lobby)
-"vLL" = (
-/obj/structure/table/marble,
-/obj/machinery/cash_register/civilian,
-/obj/machinery/door/blast/shutters{
-	id = "sc-GCmidnightbar";
-	layer = 3.1;
-	name = "Bar Shutters"
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/crew_quarters/Midnight_Kitchen)
 "vLQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -118059,6 +118019,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Star_Tool_Storage)
+"web" = (
+/obj/structure/bed/pillowpilefront/teal,
+/obj/machinery/alarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/wood,
+/area/maintenance/ab_TeshDen)
 "weu" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -119045,10 +119012,9 @@
 /turf/simulated/floor/plating,
 /area/rnd/Toxins_Storage)
 "woi" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/stool/baystool/padded,
-/turf/simulated/floor/wood/sif,
-/area/crew_quarters/Midnight_Bar)
+/obj/random/trash,
+/turf/simulated/floor/wood/broken,
+/area/maintenance/ab_TeshDen)
 "wop" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -119099,19 +119065,15 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/Breakroom)
 "woz" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/hatch,
-/obj/structure/grille,
-/obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 1
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "sc-GCmidnightbar";
+	name = "Bar Shutters Control";
+	pixel_x = 24;
+	req_access = list(28)
 	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
-/obj/structure/barricade,
-/turf/simulated/floor/plating,
-/area/maintenance/ab_TeshDen)
+/turf/simulated/floor/wood/alt/tile,
+/area/crew_quarters/Midnight_Kitchen)
 "woF" = (
 /obj/machinery/light{
 	dir = 1
@@ -119396,6 +119358,11 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Cargo_AftCorridor2)
+"wsl" = (
+/obj/structure/table/standard,
+/obj/random/donkpocketbox,
+/turf/simulated/floor/wood,
+/area/maintenance/ab_TeshDen)
 "wsr" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -120822,6 +120789,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Engineering_EVA)
+"wKZ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/barricade,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_TeshDen)
 "wLh" = (
 /obj/effect/floor_decal/carpet{
 	dir = 4
@@ -155085,13 +155066,13 @@ aaa
 aaa
 bHD
 rrk
-hSQ
+eix
 bHD
 aaa
 aaa
 aaa
 bHD
-ifV
+bYa
 ptE
 bHD
 aaa
@@ -155343,7 +155324,7 @@ wsr
 bHD
 bHD
 cqv
-cEC
+wsl
 bHD
 aaa
 aaa
@@ -155600,7 +155581,7 @@ lAc
 qKV
 uck
 bHD
-mpC
+web
 fav
 bHD
 aaa
@@ -155839,8 +155820,8 @@ cyF
 plF
 lYV
 plF
-sTT
-dgU
+cOC
+gPC
 bRu
 iAF
 eiA
@@ -156092,7 +156073,7 @@ iwp
 uaB
 cOH
 cOH
-woi
+kYI
 cdC
 rue
 rWH
@@ -156351,12 +156332,12 @@ aMR
 aMR
 aMR
 aMR
-vLL
+hSQ
 plF
 cBr
 sSl
 ciN
-gPC
+dgU
 shD
 eaY
 wMO
@@ -156384,7 +156365,7 @@ auv
 fav
 dzV
 dzV
-woz
+wKZ
 aaf
 gWp
 aaf
@@ -156611,9 +156592,9 @@ aMR
 bMw
 xDr
 plF
-rYB
-hVX
-qhV
+cEC
+woz
+bok
 gPC
 bRi
 pnz
@@ -156636,7 +156617,7 @@ vrq
 vrq
 gKQ
 vrq
-bok
+sMS
 gKQ
 ulC
 nOM
@@ -156900,7 +156881,7 @@ pNb
 pNb
 dzV
 dzV
-cOC
+iVr
 aaf
 gWp
 aaf
@@ -157664,8 +157645,8 @@ dnF
 pDj
 aJi
 bHD
-bYa
-epJ
+aZa
+woi
 bHD
 aaa
 aaa
@@ -158180,7 +158161,7 @@ aaa
 aaa
 aaa
 bHD
-cDS
+rYB
 ptE
 bHD
 aaa
@@ -158188,7 +158169,7 @@ aaa
 aaa
 bHD
 rrk
-hSQ
+eix
 bHD
 aaa
 aaa
@@ -168153,7 +168134,7 @@ tQj
 bkf
 aIY
 aMn
-sMS
+epJ
 avP
 lEI
 crH
@@ -168409,7 +168390,7 @@ sXo
 aQu
 qip
 bkk
-utI
+cDS
 blN
 vKy
 hWu

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
@@ -1262,17 +1262,8 @@
 /turf/simulated/open,
 /area/crew_quarters/Chomp_Dinner_2)
 "avr" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/effect/floor_decal/corner/green/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
+/obj/machinery/status_display,
+/turf/simulated/wall,
 /area/crew_quarters/Public_Hydroponics)
 "avF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2748,6 +2739,13 @@
 	},
 /turf/simulated/open,
 /area/maintenance/Deck3_Engineering_StarChamber1)
+"aWb" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
+	},
+/turf/simulated/floor/grass2,
+/area/crew_quarters/Public_Hydroponics)
 "aWg" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/floor_decal/borderfloorwhite{
@@ -3641,6 +3639,9 @@
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
@@ -4686,6 +4687,13 @@
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForStarCorridor1)
+"bIi" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/hydro,
+/area/crew_quarters/Public_Hydroponics)
 "bII" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -5172,10 +5180,11 @@
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/sleep/Captain_Quarters)
 "bQC" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/effect/floor_decal/spline/plain{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/kafel_full/green,
+/turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
 "bQD" = (
 /obj/machinery/power/tracker,
@@ -6055,10 +6064,11 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/Captain_Office)
 "cgg" = (
-/obj/effect/floor_decal/spline/plain/corner{
-	dir = 1
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/simulated/floor/grass2,
+/turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "cgr" = (
 /obj/effect/floor_decal/spline/fancy{
@@ -8859,6 +8869,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Hydroponics)
 "dbY" = (
@@ -10411,11 +10422,17 @@
 /turf/simulated/floor/wood/alt,
 /area/hallway/Star_Breakroom)
 "dEG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/hydro,
-/area/crew_quarters/Public_Hydroponics)
+/obj/effect/floor_decal/corner/green/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/Observation_Lounge)
 "dER" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -10680,9 +10697,6 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/bridge/sleep/CE_Quarters)
 "dJY" = (
-/obj/machinery/atmospherics/unary/freezer{
-	icon_state = "freezer"
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10698,6 +10712,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/unary/cryo_cell,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/medical/Resleeving)
 "dKj" = (
@@ -12430,6 +12445,7 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/white,
 /area/medical/Stairwell)
 "egN" = (
@@ -12572,27 +12588,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
 "ejh" = (
-/obj/structure/table/standard,
-/obj/item/clothing/gloves/botanic_leather{
-	pixel_y = -5
+/obj/machinery/door/firedoor/multi_tile/glass,
+/obj/effect/floor_decal/industrial/arrows/blue,
+/obj/effect/floor_decal/industrial/arrows/blue{
+	dir = 1
 	},
-/obj/item/toy/figure/gardener{
-	pixel_y = 2;
-	pixel_x = 1
+/obj/machinery/door/airlock/angled_bay/double/color{
+	name = "Hydroponic";
+	req_one_access = list(35,28)
 	},
-/obj/item/clothing/gloves/botanic_leather{
-	pixel_y = -1;
-	pixel_x = -1
-	},
-/obj/item/material/knife/machete/hatchet{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/material/knife/machete/hatchet{
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled/kafel_full/green,
+/turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Public_Hydroponics)
 "ejD" = (
 /obj/machinery/floodlight,
@@ -13597,6 +13602,11 @@
 /area/crew_quarters/Chomp_Dinner_2)
 "eBc" = (
 /obj/machinery/vending/hydronutrients,
+/obj/machinery/camera/network/security{
+	c_tag = "D3-Dmc-Hydroponics1";
+	network = list("Domicile");
+	dir = 8
+	},
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "eBi" = (
@@ -13925,6 +13935,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
 "eFF" = (
@@ -15112,7 +15123,9 @@
 	},
 /obj/machinery/door/airlock/angled_bay/double/glass/medical{
 	name = "Medical hallway";
-	dir = 8
+	dir = 8;
+	req_one_access = list(5,47);
+	req_access = null
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Star_3_Deck_Stairwell)
@@ -15163,13 +15176,8 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/sleep/Dormitory_09)
 "eUC" = (
-/obj/machinery/door/window/northright{
-	dir = 4;
-	name = "Animal Pen";
-	req_access = newlist();
-	req_one_access = list(35,28)
-	},
-/turf/simulated/floor/tiled/kafel_full/green,
+/obj/structure/sign/painting/public,
+/turf/simulated/wall,
 /area/crew_quarters/Public_Hydroponics)
 "eUH" = (
 /obj/structure/cable/green{
@@ -15546,13 +15554,8 @@
 "eZw" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/structure/grille,
-/obj/structure/window/basic,
-/obj/structure/window/basic{
-	dir = 8
-	},
-/obj/structure/window/basic{
-	dir = 1
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "sc-WTbotkitchen"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/Central_3_Deck_Hall)
@@ -17022,24 +17025,25 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_AftCorridor1)
 "frg" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/glass/bucket{
-	pixel_x = 6;
-	pixel_y = 7
-	},
-/obj/structure/sink/kitchen{
-	layer = 1;
-	pixel_y = 12
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 1
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 11;
+	pixel_y = 24;
+	on = 0
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
@@ -17104,20 +17108,17 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/Dormitory_12)
 "frG" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/arrows/blue{
+	dir = 1
 	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 11;
-	pixel_y = -27
+/obj/effect/floor_decal/industrial/arrows/blue,
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	req_access = newlist();
+	req_one_access = list(35,28)
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/hydro,
+/turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Public_Hydroponics)
 "frX" = (
 /obj/effect/catwalk_plated/techfloor,
@@ -19071,10 +19072,7 @@
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/Observation_Lounge)
 "fUH" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = 22
-	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "fUI" = (
@@ -19351,6 +19349,7 @@
 /obj/item/toy/figure/gardener,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/tool/crowbar,
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
 "fZO" = (
@@ -21147,8 +21146,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Dorms Substation";
-	req_one_access = null
+	name = "Dorms Substation"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -21390,43 +21388,15 @@
 /turf/simulated/floor/airless,
 /area/engineering/Solar_Array_ForPort)
 "gIn" = (
-/obj/structure/table/rack/shelf,
-/obj/item/honey_frame{
-	pixel_y = -9;
-	pixel_x = -4
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows/yellow,
+/obj/effect/floor_decal/industrial/arrows/yellow{
+	dir = 1
 	},
-/obj/item/honey_frame{
-	pixel_y = -6;
-	pixel_x = -4
+/obj/machinery/door/airlock/maintenance/int{
+	req_one_access = list(35,28)
 	},
-/obj/item/honey_frame{
-	pixel_y = -3;
-	pixel_x = -4
-	},
-/obj/item/honey_frame{
-	pixel_x = -4
-	},
-/obj/item/honey_frame{
-	pixel_y = 3;
-	pixel_x = -4
-	},
-/obj/item/honey_frame{
-	pixel_y = 6;
-	pixel_x = -4
-	},
-/obj/item/beehive_assembly{
-	pixel_y = -9;
-	pixel_x = 6
-	},
-/obj/item/beehive_assembly{
-	pixel_y = -4;
-	pixel_x = 6
-	},
-/obj/item/beehive_assembly{
-	pixel_y = 1;
-	pixel_x = 6
-	},
-/turf/simulated/floor/tiled/kafel_full/green,
+/turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Public_Hydroponics)
 "gIq" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -21707,6 +21677,7 @@
 /obj/item/clothing/head/hood_vr/hotdog_hood{
 	pixel_x = -4
 	},
+/obj/item/toy/chainsaw,
 /turf/simulated/floor/plating,
 /area/hallway/Central_3_Deck_Hall)
 "gLF" = (
@@ -21881,6 +21852,9 @@
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
@@ -22762,10 +22736,6 @@
 /area/maintenance/Deck3_Medical_PortChamber1)
 "hgw" = (
 /obj/structure/bed/chair/sofa/left/blue,
-/obj/item/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = 22
-	},
 /obj/item/toy/plushie/teppi/alt{
 	desc = "No teppis were harmed in the creation of this plushie. It looks tattered and old, with various sewn patches from different plushies.";
 	name = "tattered teppi plush";
@@ -22955,9 +22925,12 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/green/border{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Hydroponics)
@@ -23103,9 +23076,30 @@
 /turf/simulated/floor/carpet/tealcarpet,
 /area/bridge/sleep/Secretary_Quarters)
 "hml" = (
-/obj/structure/closet/emcloset,
-/obj/item/toy/chainsaw,
-/turf/simulated/floor/tiled/kafel_full/green,
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/botanic_leather{
+	pixel_y = -5
+	},
+/obj/item/toy/figure/gardener{
+	pixel_y = 2;
+	pixel_x = 1
+	},
+/obj/item/clothing/gloves/botanic_leather{
+	pixel_y = -1;
+	pixel_x = -1
+	},
+/obj/item/material/knife/machete/hatchet{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/material/knife/machete/hatchet{
+	pixel_x = 1;
+	pixel_y = 4
+	},
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
 "hmm" = (
 /obj/structure/cable{
@@ -23668,15 +23662,24 @@
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
 "hye" = (
-/obj/machinery/camera/network/security{
-	c_tag = "D3-Dmc-Hydroponics2";
-	network = list("Domicile")
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/structure/sink/kitchen{
+	layer = 1;
+	pixel_y = 12
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
@@ -23820,13 +23823,26 @@
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Chomp_Lounge)
 "hAe" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/shuttle/blue{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/crew_quarters/Observation_Atrium)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 21
+	},
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/Observation_Lounge)
 "hAo" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -23989,10 +24005,10 @@
 /area/crew_quarters/Chomp_Lounge)
 "hCW" = (
 /obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/industrial/arrows,
-/obj/effect/floor_decal/industrial/arrows{
+/obj/effect/floor_decal/industrial/arrows/blue{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/arrows/blue,
 /obj/machinery/door/airlock/sandstone{
 	name = "Botanical kitchen";
 	req_one_access = list(28)
@@ -24819,7 +24835,8 @@
 	id = "sc-WTbotkitchen";
 	name = "N-window tint control";
 	pixel_x = -11;
-	pixel_y = 26
+	pixel_y = 26;
+	range = 13
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "sc-botkitchen";
@@ -25743,7 +25760,6 @@
 /turf/simulated/floor/carpet/blue,
 /area/bridge/sleep/CMO_Quarters)
 "idM" = (
-/obj/machinery/vending/loadout/clothing,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -25758,6 +25774,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/vending/loadout/clothing,
 /turf/simulated/floor/tiled/dark,
 /area/medical/Resleeving)
 "iea" = (
@@ -26115,13 +26132,16 @@
 /turf/simulated/floor/carpet/purcarpet,
 /area/bridge/Captain_Office)
 "ijw" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/mob/living/simple_mob/animal/passive/pillbug{
-	name = "Conchambruda";
-	faction = "nanotrasen"
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/shuttle/blue{
+	pixel_x = -1;
+	pixel_y = 1
 	},
-/turf/simulated/floor/grass2,
-/area/crew_quarters/Public_Hydroponics)
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/crew_quarters/Observation_Atrium)
 "ijL" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -26435,7 +26455,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/int{
 	name = "Botanical Maintenance";
-	req_one_access = list(28)
+	req_one_access = list(35,28)
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Botanical_Shop)
@@ -26934,15 +26954,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
@@ -27370,50 +27389,36 @@
 /turf/simulated/floor/wood/alt/panel,
 /area/crew_quarters/sleep/Dormitory_06)
 "iEn" = (
-/obj/structure/table/rack/shelf,
-/obj/item/bee_smoker{
-	pixel_y = -7;
-	pixel_x = 6
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/bee_smoker{
-	pixel_y = -4;
-	pixel_x = 7
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
 	},
-/obj/item/bee_smoker{
-	pixel_y = -1;
-	pixel_x = 8
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
 	},
-/obj/item/bee_pack{
-	pixel_y = -6;
-	pixel_x = -6
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/obj/item/bee_pack{
-	pixel_y = 5;
-	pixel_x = -6
-	},
-/turf/simulated/floor/tiled/kafel_full/green,
-/area/crew_quarters/Public_Hydroponics)
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/Observation_Lounge)
 "iEp" = (
 /obj/structure/table/standard,
-/obj/item/uv_light{
-	pixel_y = -4;
-	pixel_x = 7
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 9;
+	pixel_y = 3
 	},
-/obj/item/uv_light{
-	pixel_y = 3;
-	pixel_x = 9
-	},
-/obj/item/storage/toolbox/hydro{
-	pixel_y = 8;
+/obj/item/analyzer/plant_analyzer{
+	pixel_y = 2;
 	pixel_x = -4
 	},
-/obj/item/storage/toolbox/hydro{
-	pixel_y = 15;
-	pixel_x = -4
-	},
-/obj/item/multitool{
-	pixel_y = -2;
-	pixel_x = -4
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 4;
+	pixel_y = -1
 	},
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
@@ -27427,13 +27432,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
 "iFp" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/item/clothing/head/greenbandana,
-/obj/item/clothing/head/greenbandana,
+/obj/machinery/smartfridge/drying_rack,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/clothing/suit/storage/apron/overalls,
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
 "iFs" = (
@@ -27524,10 +27526,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "iHL" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/item/clothing/head/greenbandana,
-/obj/item/clothing/head/greenbandana,
-/obj/item/clothing/suit/storage/apron/overalls,
+/obj/machinery/smartfridge/drying_rack,
+/obj/machinery/camera/network/security{
+	c_tag = "D3-Dmc-Hydroponics2";
+	network = list("Domicile")
+	},
 /turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
 "iHY" = (
@@ -28109,6 +28112,11 @@
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/sleep/Dormitory_03)
+"iRD" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/grass2,
+/area/crew_quarters/Public_Hydroponics)
 "iRJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28145,6 +28153,12 @@
 	},
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/green/bordercorner,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Hydroponics)
 "iSE" = (
@@ -29483,10 +29497,28 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_AftStarChamber1)
 "joM" = (
-/obj/effect/floor_decal/spline/plain{
-	dir = 5
+/obj/structure/table/rack/shelf,
+/obj/item/bee_smoker{
+	pixel_y = -7;
+	pixel_x = 6
 	},
-/turf/simulated/floor/grass2,
+/obj/item/bee_smoker{
+	pixel_y = -4;
+	pixel_x = 7
+	},
+/obj/item/bee_smoker{
+	pixel_y = -1;
+	pixel_x = 8
+	},
+/obj/item/bee_pack{
+	pixel_y = -6;
+	pixel_x = -6
+	},
+/obj/item/bee_pack{
+	pixel_y = 5;
+	pixel_x = -6
+	},
+/turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "joP" = (
 /obj/structure/bed/chair/office/light,
@@ -29959,8 +29991,11 @@
 /turf/simulated/floor/tiled,
 /area/engineering/Atmospherics_Control_Room)
 "jvp" = (
-/obj/machinery/atmospherics/unary/cryo_cell,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/atmospherics/unary/freezer{
+	icon_state = "freezer";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/medical/Resleeving)
 "jvv" = (
@@ -30157,14 +30192,12 @@
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "jzA" = (
-/obj/machinery/ai_status_display{
-	pixel_y = -32
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	health = 1e+006
-	},
-/turf/simulated/floor/tiled/kafel_full/green,
+/turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
 "jAg" = (
 /obj/structure/cable/white{
@@ -30235,24 +30268,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/Resleeving)
 "jAy" = (
-/obj/structure/table/standard,
-/obj/item/tool/wirecutters/clippers/trimmers{
-	pixel_y = -3;
-	pixel_x = -2
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "Animal Pen";
+	req_access = newlist();
+	req_one_access = list(35,28)
 	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_y = 8;
-	pixel_x = 1
-	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_y = 8;
-	pixel_x = 6
-	},
-/obj/item/reagent_containers/spray/plantbgone{
-	pixel_y = 5;
-	pixel_x = 5
-	},
-/turf/simulated/floor/tiled/hydro,
+/turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
 "jBk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
@@ -31119,10 +31141,8 @@
 /turf/simulated/floor/wood/alt,
 /area/bridge/Embassy)
 "jOD" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
@@ -31457,6 +31477,9 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "jWo" = (
@@ -32448,10 +32471,11 @@
 /turf/simulated/open,
 /area/maintenance/Deck3_Engineering_StarChamber1)
 "knK" = (
-/obj/machinery/smartfridge/drying_rack{
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/kafel_full/green,
+/turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
 "knU" = (
 /obj/machinery/alarm{
@@ -32947,24 +32971,11 @@
 /turf/simulated/floor/tiled/milspec/raised,
 /area/bridge/AI_Core_Chamber)
 "ktn" = (
-/obj/structure/table/standard,
-/obj/item/material/minihoe{
-	pixel_y = 1;
-	pixel_x = 4
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/effect/floor_decal/spline/plain{
+	dir = 5
 	},
-/obj/item/tool/wirecutters/clippers{
-	pixel_y = -3;
-	pixel_x = -5
-	},
-/obj/item/tool/wirecutters/clippers{
-	pixel_y = 2;
-	pixel_x = -5
-	},
-/obj/item/material/minihoe{
-	pixel_y = 6;
-	pixel_x = 4
-	},
-/turf/simulated/floor/tiled/kafel_full/green,
+/turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
 "ktq" = (
 /obj/structure/disposalpipe/segment{
@@ -33654,10 +33665,13 @@
 /turf/simulated/floor/tiled,
 /area/bridge/Leisure_Room)
 "kFY" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
@@ -33946,10 +33960,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
 "kLY" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
+/mob/living/simple_mob/animal/passive/chick,
 /turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
 "kMc" = (
@@ -33976,24 +33987,18 @@
 /turf/simulated/floor/tiled,
 /area/engineering/Atmospherics_Control_Room)
 "kMd" = (
-/obj/structure/table/standard,
-/obj/item/analyzer/plant_analyzer{
-	pixel_x = -4;
-	pixel_y = 3
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
 	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 9;
-	pixel_y = 3
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/item/analyzer/plant_analyzer{
-	pixel_y = -1;
-	pixel_x = -4
+/obj/effect/floor_decal/spline/plain{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 4;
-	pixel_y = -1
-	},
-/turf/simulated/floor/tiled/kafel_full/green,
+/turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
 "kMm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -34073,15 +34078,8 @@
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "kNF" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "D3-Dmc-Hydroponics1";
-	network = list("Domicile")
-	},
-/turf/simulated/floor/tiled/hydro,
+/obj/machinery/ai_status_display,
+/turf/simulated/wall,
 /area/crew_quarters/Public_Hydroponics)
 "kNG" = (
 /obj/item/clothing/under/medigown,
@@ -34440,29 +34438,21 @@
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Chomp_Dinner_2)
 "kTs" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
-	},
-/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/bot/farmbot,
 /obj/effect/floor_decal/spline/plain{
 	dir = 1
 	},
 /turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
 "kTz" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	health = 1e+006
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/hydro,
+/turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
 "kTD" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -35596,6 +35586,10 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
 "llp" = (
@@ -35771,9 +35765,25 @@
 /turf/simulated/floor/glass,
 /area/medical/Stairwell)
 "loI" = (
-/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/table/standard,
+/obj/item/material/minihoe{
+	pixel_y = 1;
+	pixel_x = 4
+	},
+/obj/item/tool/wirecutters/clippers{
+	pixel_y = -3;
+	pixel_x = -5
+	},
+/obj/item/tool/wirecutters/clippers{
+	pixel_y = 2;
+	pixel_x = -5
+	},
+/obj/item/material/minihoe{
+	pixel_y = 6;
+	pixel_x = 4
+	},
 /obj/effect/floor_decal/spline/plain{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
@@ -36144,6 +36154,17 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /area/crew_quarters/Public_Garden)
+"lwh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/green/border,
+/turf/simulated/floor/tiled/hydro,
+/area/crew_quarters/Public_Hydroponics)
 "lwr" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
@@ -38737,14 +38758,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_AftStarChamber2)
 "mep" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/effect/floor_decal/spline/plain{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/turf/simulated/floor/grass2,
+/turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
 "meq" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -38815,14 +38832,11 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "mgF" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/floor_decal/spline/plain{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
 "mgH" = (
@@ -38894,16 +38908,24 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/bridge/sleep/CMO_Quarters)
 "mhn" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_y = 8;
+	pixel_x = 1
 	},
-/obj/machinery/light/spot{
-	color = "#ccc9ff";
-	desc = "An extra bright lighting fixture."
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_y = 8;
+	pixel_x = 6
 	},
-/turf/simulated/floor/grass2,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/tool/wirecutters/clippers/trimmers{
+	pixel_y = -3;
+	pixel_x = -2
+	},
+/turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "mhr" = (
 /obj/machinery/door/firedoor/border_only,
@@ -39776,9 +39798,6 @@
 	},
 /area/medical/Virology)
 "mrm" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -39794,6 +39813,8 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/unary/cryo_cell,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/medical/Resleeving)
 "mrt" = (
@@ -40006,8 +40027,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/maintenance/engi{
-	name = "Dorms Substation";
-	req_one_access = null
+	name = "Dorms Substation"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Dorms_Substation)
@@ -40479,11 +40499,12 @@
 /turf/simulated/floor/plating,
 /area/engineering/Airlock_Access)
 "mEk" = (
-/obj/effect/floor_decal/industrial/arrows/blue,
-/obj/effect/floor_decal/industrial/arrows/blue{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Hydroponics)
 "mEm" = (
 /obj/effect/floor_decal/spline/plain{
@@ -40806,9 +40827,10 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/bridge/sleep/CE_Quarters)
 "mKx" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/clothing/head/greenbandana,
+/obj/item/clothing/head/greenbandana,
+/obj/item/clothing/suit/storage/apron/overalls,
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "mKF" = (
@@ -41831,16 +41853,31 @@
 /turf/simulated/floor/tiled,
 /area/medical/Deck3_Corridor)
 "nbY" = (
-/obj/effect/landmark{
-	name = "blobstart"
+/obj/structure/table/standard,
+/obj/item/uv_light{
+	pixel_y = -4;
+	pixel_x = 7
 	},
-/turf/simulated/floor/grass2,
+/obj/item/uv_light{
+	pixel_y = 3;
+	pixel_x = 9
+	},
+/obj/item/storage/toolbox/hydro{
+	pixel_y = 8;
+	pixel_x = -4
+	},
+/turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "nci" = (
-/obj/effect/landmark{
-	name = "lightsout"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/wall/r_wall,
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/green/border,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "ncv" = (
 /obj/structure/sign/directions/engineering/solars{
@@ -42297,8 +42334,12 @@
 /turf/simulated/wall,
 /area/medical/Lounge)
 "nkd" = (
-/obj/structure/sign/painting/public,
-/turf/simulated/wall/r_wall,
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "sc-WTbotkitchen"
+	},
+/turf/simulated/floor/plating,
 /area/crew_quarters/Public_Hydroponics)
 "nkg" = (
 /obj/machinery/power/apc{
@@ -45370,11 +45411,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/green/border,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "ogk" = (
@@ -45775,10 +45814,6 @@
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Chamber)
 "omS" = (
-/obj/item/radio/intercom/department/medbay{
-	dir = 4;
-	pixel_x = 22
-	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/tiled/white,
@@ -49084,8 +49119,41 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/Psych_Room_1)
 "ppV" = (
-/obj/item/radio/intercom{
-	pixel_y = -22
+/obj/structure/table/rack/shelf,
+/obj/item/honey_frame{
+	pixel_y = -9;
+	pixel_x = -4
+	},
+/obj/item/honey_frame{
+	pixel_y = -6;
+	pixel_x = -4
+	},
+/obj/item/honey_frame{
+	pixel_y = -3;
+	pixel_x = -4
+	},
+/obj/item/honey_frame{
+	pixel_x = -4
+	},
+/obj/item/honey_frame{
+	pixel_y = 3;
+	pixel_x = -4
+	},
+/obj/item/honey_frame{
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/obj/item/beehive_assembly{
+	pixel_y = -9;
+	pixel_x = 6
+	},
+/obj/item/beehive_assembly{
+	pixel_y = -4;
+	pixel_x = 6
+	},
+/obj/item/beehive_assembly{
+	pixel_y = 1;
+	pixel_x = 6
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
@@ -49204,14 +49272,17 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/Autoresleeving)
 "prX" = (
-/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/structure/window/reinforced{
+	dir = 1;
+	health = 1e+006
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 1
-	},
-/turf/simulated/floor/grass2,
+/turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "psc" = (
 /turf/simulated/wall,
@@ -50506,8 +50577,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_AftStarChamber1)
 "pKT" = (
-/mob/living/bot/farmbot,
-/turf/simulated/floor/tiled/kafel_full/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border,
+/turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
 "pLe" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -52900,7 +52978,10 @@
 /area/hallway/Central_3_Deck_Hall)
 "qyx" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/unary/cryo_cell,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/medical/Resleeving)
 "qyy" = (
@@ -53477,7 +53558,9 @@
 "qIe" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/atmospherics/binary/pump/high_power/on{
-	dir = 4
+	dir = 4;
+	name = "Air to Supply";
+	target_pressure = 301.325
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Substation)
@@ -56450,11 +56533,13 @@
 /turf/simulated/floor/wood/sif,
 /area/bridge/Breakroom)
 "rDw" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/effect/floor_decal/spline/plain{
-	dir = 5
+/obj/machinery/door/window/northright{
+	dir = 8;
+	name = "Animal Pen";
+	req_access = newlist();
+	req_one_access = list(35,28)
 	},
-/turf/simulated/floor/grass2,
+/turf/simulated/floor/tiled/kafel_full/green,
 /area/crew_quarters/Public_Hydroponics)
 "rDE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -58949,6 +59034,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Central_3_Deck_Hall)
 "suQ" = (
@@ -59334,22 +59420,18 @@
 	dir = 8;
 	pixel_x = -3
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Hydroponics)
 "sCU" = (
@@ -60368,6 +60450,18 @@
 /obj/item/starcaster_news,
 /turf/simulated/floor/wood/alt,
 /area/hallway/Port_Breakroom)
+"sRB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Atrium)
 "sRP" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -64912,6 +65006,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Dorm_Foyer)
+"upi" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/crew_quarters/Observation_Lounge)
 "upp" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -65041,14 +65151,22 @@
 /turf/simulated/floor/plating,
 /area/engineering/Airlock_Access)
 "urV" = (
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 1;
-	health = 1e+006
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/spline/plain{
-	dir = 9
-	},
-/turf/simulated/floor/grass2,
+/turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Hydroponics)
 "urW" = (
 /obj/structure/bed/chair/sofa/yellow{
@@ -65506,13 +65624,11 @@
 /turf/simulated/wall/r_wall,
 /area/medical/Virology)
 "uyw" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Animal Pen";
-	req_access = newlist();
-	req_one_access = list(35,28)
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/kafel_full/green,
+/turf/simulated/floor/grass2,
 /area/crew_quarters/Public_Hydroponics)
 "uyA" = (
 /obj/effect/floor_decal/industrial/arrows/blue,
@@ -68955,10 +69071,11 @@
 /obj/effect/floor_decal/industrial/arrows/blue{
 	dir = 1
 	},
-/obj/machinery/door/airlock/angled_bay/double/glass/common{
-	name = "Botanical garden"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/angled_bay/double/color{
+	name = "Hydroponic";
+	req_one_access = list(35,28)
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Central_3_Deck_Hall)
 "vAs" = (
@@ -70104,6 +70221,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/medical/Resleeving)
+"vQP" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Port Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine1_Chamber)
 "vQT" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 4
@@ -71025,6 +71166,17 @@
 /obj/structure/sign/nosmoking_2/burnt,
 /turf/simulated/wall,
 /area/medical/Morgue)
+"wfG" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/clothing/head/greenbandana,
+/obj/item/clothing/head/greenbandana,
+/obj/item/clothing/suit/storage/apron/overalls,
+/obj/item/multitool{
+	pixel_y = -2;
+	pixel_x = -4
+	},
+/turf/simulated/floor/tiled/hydro,
+/area/crew_quarters/Public_Hydroponics)
 "wfP" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin{
@@ -71144,6 +71296,13 @@
 /obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Center_Star)
+"wha" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/grass2,
+/area/crew_quarters/Public_Hydroponics)
 "whj" = (
 /obj/machinery/camera/network/security{
 	c_tag = "D3-Eng-Atmos1";
@@ -73185,18 +73344,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_StarCorridor1)
 "wPe" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -22
+/obj/machinery/portable_atmospherics/hydroponics/soil,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/spline/plain{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/green/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/crew_quarters/Observation_Lounge)
+/turf/simulated/floor/grass2,
+/area/crew_quarters/Public_Hydroponics)
 "wPn" = (
 /obj/structure/railing/grey{
 	color = "yellow";
@@ -76031,20 +76186,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/bridge/sleep/Secretary_Quarters)
 "xEe" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/industrial/hatch/blue,
-/obj/structure/grille,
-/obj/structure/window/basic,
-/obj/structure/window/basic{
-	dir = 1
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/spot{
+	color = "#ccc9ff";
+	desc = "An extra bright lighting fixture."
 	},
-/obj/structure/window/basic{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/hallway/Central_3_Deck_Hall)
+/turf/simulated/floor/grass2,
+/area/crew_quarters/Public_Hydroponics)
 "xEs" = (
 /obj/structure/railing{
 	dir = 1
@@ -77488,15 +77640,17 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/bridge/sleep/CMO_Quarters)
 "xXQ" = (
-/obj/item/tool/wrench,
-/obj/structure/table/glass,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -4;
-	pixel_y = -3
-	},
+/obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 7;
+	pixel_y = -3
+	},
+/obj/item/tool/wrench{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
 	pixel_y = -3
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -85683,7 +85837,7 @@ dHa
 mYj
 jXl
 sJN
-gGj
+vQP
 tct
 nSN
 sJN
@@ -104548,11 +104702,11 @@ hgN
 hgN
 hgN
 kUR
-hml
+jKo
 cEp
 kHC
 eTN
-klU
+knK
 kUR
 kUR
 kUR
@@ -104806,15 +104960,15 @@ tVT
 nZV
 gJu
 kUR
-gIn
+jKo
 mAN
 jkH
 vse
-klU
+knK
 prX
-len
-ijw
-mdT
+jkH
+jkH
+jOD
 ivB
 nbo
 hXb
@@ -105064,15 +105218,15 @@ hgN
 hgN
 hgN
 kUR
-iEn
+kol
 mAN
 jkH
-nVa
-klU
+lwh
+wPe
 kFY
-lcC
-len
-mcQ
+iRD
+mgF
+wha
 yjT
 nbo
 hXb
@@ -105325,12 +105479,12 @@ kUR
 iEp
 mAN
 jkH
-nVa
-kiZ
-kGh
+pKT
+knK
+kRw
 len
-lME
-mgL
+lMS
+mjR
 yjT
 nbo
 hXb
@@ -105583,12 +105737,12 @@ kUR
 iFp
 mAN
 jkH
-nVa
-klU
-kII
-nbY
-len
-lME
+nci
+loI
+cPJ
+mhC
+lcC
+mgL
 mGO
 nbo
 hXb
@@ -105842,11 +105996,11 @@ iHL
 mAN
 jkH
 jVW
-klU
-kIX
+hml
+ibb
 len
-lMS
-lZW
+len
+xEe
 mDE
 nbo
 hXb
@@ -106095,16 +106249,16 @@ gJm
 rZi
 hJj
 hJj
-kUR
 cLI
+kUR
 hye
 kTK
-nVa
-klU
-kII
+nci
+knK
+cPJ
+mgW
 len
-lcC
-mcQ
+len
 ivB
 nbo
 hXb
@@ -106357,12 +106511,12 @@ qOw
 oxp
 uBr
 jkH
-nVa
-pKT
-joM
-cgg
+nci
+knK
+eLV
 len
-mgL
+lMS
+mhC
 yjT
 nbo
 hXb
@@ -106617,10 +106771,10 @@ smi
 smi
 ogj
 knK
-jKo
+ibb
 kLY
-len
-mcQ
+lME
+miH
 yjT
 nbo
 bde
@@ -106703,7 +106857,11 @@ apc
 apc
 apc
 apc
-aCu
+apc
+apc
+apc
+apc
+sRB
 pSW
 pSW
 pSW
@@ -106711,10 +106869,6 @@ pSW
 pSW
 pSW
 tYp
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -106874,11 +107028,11 @@ mAN
 jkH
 jkH
 wrU
-kol
+ktn
 kMd
-kGh
-len
-mdT
+aWb
+lTW
+lTW
 mGO
 gXS
 kaL
@@ -106961,6 +107115,10 @@ dHa
 dHa
 dHa
 dHa
+dHa
+dHa
+dHa
+dHa
 jvd
 jIk
 fWz
@@ -106969,10 +107127,6 @@ mXZ
 nMy
 scL
 jvd
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -107132,10 +107286,10 @@ frg
 jkH
 jkH
 sVm
-knK
-jKo
+kiZ
+mep
 rDw
-lTW
+jAy
 mep
 mDE
 onG
@@ -107219,6 +107373,10 @@ dHa
 dHa
 dHa
 dHa
+dHa
+dHa
+dHa
+dHa
 jvd
 vSi
 djL
@@ -107227,10 +107385,6 @@ tls
 nwj
 sNB
 jvd
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -107386,7 +107540,7 @@ xVX
 hlY
 hNR
 vHG
-mgf
+mEk
 mgf
 mgf
 mgf
@@ -107477,6 +107631,10 @@ dHa
 dHa
 dHa
 dHa
+dHa
+dHa
+dHa
+dHa
 sUk
 vSi
 djL
@@ -107485,10 +107643,6 @@ ixC
 mly
 akk
 jvd
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -107646,7 +107800,7 @@ suJ
 dbX
 iSr
 sCL
-elR
+urV
 elR
 elR
 elR
@@ -107735,6 +107889,10 @@ ptq
 fHI
 dcX
 aVA
+ptq
+fHI
+dcX
+aVA
 fjG
 rvv
 cDk
@@ -107743,10 +107901,6 @@ fjG
 tLl
 kQJ
 jvd
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -107902,14 +108056,14 @@ bmj
 gnN
 ikH
 fUH
+nbY
 jkH
-jOD
+cgg
 rdD
 jLi
-kpC
 eBc
 jkH
-jkH
+mhn
 mgv
 mDE
 qIy
@@ -107989,7 +108143,11 @@ tfh
 jMX
 tfh
 tfh
-wPe
+tfh
+tfh
+tfh
+tfh
+dEG
 tfh
 ccR
 oNf
@@ -108001,10 +108159,6 @@ oDY
 atl
 wwd
 jvd
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -108159,16 +108313,16 @@ gnX
 gOc
 tVZ
 djT
-jkH
-jkH
+nkd
+eUC
 frG
-mDE
-nci
+avr
+nkd
 nkd
 kNF
-jkH
-jkH
-jkH
+frG
+eUC
+nkd
 aXg
 gsu
 eac
@@ -108245,8 +108399,12 @@ myX
 myX
 lWh
 myX
+bYS
 myX
 myX
+myX
+myX
+lWh
 myX
 bYS
 myX
@@ -108254,15 +108412,11 @@ myX
 fTs
 vqw
 gyU
-hAe
-tls
+gyU
+ijw
 dEn
 jEb
 jvd
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -108418,14 +108572,14 @@ bmj
 vOQ
 kOa
 mKx
+wfG
 jkH
-jkH
-jmf
+bIi
 cwv
-jAy
-dEG
+jmf
+kpC
 jkH
-jkH
+joM
 ppV
 xsr
 eac
@@ -108503,9 +108657,13 @@ xpo
 ank
 cuw
 eMQ
-uyo
+iEn
 uyo
 hOU
+upi
+uyo
+cuw
+hAe
 dxW
 bXz
 aSR
@@ -108517,10 +108675,6 @@ dqY
 utP
 osL
 jvd
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -108679,13 +108833,13 @@ qzC
 loX
 fdg
 hkm
-hkm
-hkm
-avr
+hvi
+hvi
+hvi
 hvi
 cZt
 qTV
-eSH
+ejh
 pTW
 har
 gyc
@@ -108767,6 +108921,10 @@ ptq
 fHI
 dcX
 aVA
+ptq
+fHI
+dcX
+aVA
 fjG
 xLL
 dYB
@@ -108775,10 +108933,6 @@ fjG
 uYD
 qCI
 jvd
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -108943,7 +109097,7 @@ mgf
 mgf
 mgf
 qTV
-mEk
+mDE
 pTW
 rfG
 rfG
@@ -109025,6 +109179,10 @@ dHa
 dHa
 dHa
 dHa
+dHa
+dHa
+dHa
+dHa
 aCu
 vSi
 djL
@@ -109033,10 +109191,6 @@ jfv
 xOc
 akk
 jvd
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -109196,10 +109350,10 @@ eJa
 mAN
 jkH
 sVm
-kiZ
+klU
 bQC
 uyw
-eUC
+kNg
 jzA
 mDE
 onG
@@ -109283,6 +109437,10 @@ dHa
 dHa
 dHa
 dHa
+dHa
+dHa
+dHa
+dHa
 jvd
 vSi
 djL
@@ -109291,10 +109449,6 @@ tls
 ocu
 sNB
 jvd
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -109455,10 +109609,10 @@ mAN
 jkH
 cXn
 klU
-urV
-loI
-kNg
-mgF
+kII
+len
+lME
+mcQ
 ivB
 rpR
 sra
@@ -109541,6 +109695,10 @@ dHa
 dHa
 dHa
 dHa
+dHa
+dHa
+dHa
+dHa
 jvd
 bWm
 kAS
@@ -109549,10 +109707,6 @@ uWU
 pUa
 ixc
 jvd
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -109706,17 +109860,17 @@ opy
 mXc
 cwt
 rPK
-xEe
+eZw
 ihl
 fZH
 ylH
 smi
 euw
 klU
-kRw
+kIX
 len
-lMS
-len
+lcC
+mgL
 yjT
 nbo
 uOo
@@ -109799,6 +109953,10 @@ apc
 apc
 apc
 apc
+apc
+apc
+apc
+apc
 akN
 pSW
 pSW
@@ -109807,10 +109965,6 @@ pSW
 pSW
 pSW
 ljS
-apc
-apc
-apc
-apc
 apc
 apc
 apc
@@ -109971,10 +110125,10 @@ eKW
 wFC
 nVa
 klU
-cPJ
-mhC
+kII
+lMS
+len
 lcC
-mgL
 yjT
 nbo
 hXb
@@ -110231,8 +110385,8 @@ nVa
 klU
 kTs
 len
-len
-mgW
+lME
+lcC
 mGO
 nbo
 hXb
@@ -110486,11 +110640,11 @@ iJc
 ers
 dVU
 nVa
-ktn
-cPJ
-mgW
+kiZ
+kGh
+lcC
 len
-mhn
+lZW
 mDE
 nbo
 hXb
@@ -110744,11 +110898,11 @@ iKs
 rhR
 mAN
 nVa
-ejh
-eLV
+klU
+kII
 len
-lMS
-mhC
+lME
+mcQ
 ivB
 nbo
 hXb
@@ -111003,10 +111157,10 @@ rhR
 mAN
 nVa
 klU
-ibb
-mhC
-lME
-miH
+kIX
+len
+lMS
+mgL
 yjT
 nbo
 hXb
@@ -111261,10 +111415,10 @@ lzK
 uBr
 nVa
 klU
-kTs
+kII
 lcC
-len
-mjR
+lcC
+mcQ
 yjT
 nbo
 hXb
@@ -111520,9 +111674,9 @@ jkH
 dLL
 klU
 kTz
-jkH
-jkH
-jkH
+len
+len
+mdT
 mGO
 nbo
 hXb
@@ -112033,7 +112187,7 @@ ipu
 ers
 ers
 kUR
-mFG
+gIn
 kUR
 kUR
 vjD


### PR DESCRIPTION
-Harbor, Fixed arrival and departure docks. Docks no longer vent themselves. Extended tesh den, extended observatory. 
-Reduced the amount of mimics, they are now in inaccessible rooms. 
-Xenoflora. Added stronger lights, reduced the amount of hydroponic trays. 
-Xenobio. Added syringe box.
-Hydroponics has a redesign. is now access locked, there is still a botanical garden to the public. 
-Midnight bar has a slight redesign. Added Coffee dispenser.
-Medical. Manual resleeving cryo pods are now piped correctly. 
-Medical. Chemistry, fixed the sink.
-Distro central. Fixed pressure regulator pumping wrong direction. 
-Atmos. Fixed pressure pump kpa to 301.325
-Engineering. Second engine, fixed missing wire.
-Fixed various space tiles under windows.
-Harbor & Dorms substation are engineering access locked. 
-Security. Removed lethal bullets in non-lethal armament. 
-Medical. Chemistry is now access locked to chemist. 
-Medical. Genetics now has science access.
-Medical. Removed medical intercoms in public areas. 
-Tcoms. Replaced omni capacitors with advanced.
-Ursula. replaced chemistry dispenser with a lesser one, removed autolathe, moved explo vendor outside the ship, placed a sleeper inside the ship.

