### PR TITLE
Medical QoL Updates and Chem Rebalance

### DIFF
--- a/modular_chomp/maps/southern_cross/southern_cross-2.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-2.dmm
@@ -14441,9 +14441,21 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/chemical_dispenser/full{
-	density = 1
+/obj/item/reagent_containers/glass/bottle/diethylamine{
+	pixel_x = 5
 	},
+/obj/item/reagent_containers/glass/bottle/diethylamine{
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/glass/bottle/mutagen{
+	pixel_y = 10;
+	pixel_x = -5
+	},
+/obj/item/reagent_containers/glass/bottle/mutagen{
+	pixel_x = 5;
+	pixel_y = 10
+	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/hydro,
 /area/rnd/xenobiology/xenoflora)
 "dZe" = (
@@ -26119,9 +26131,6 @@
 /area/rnd/xenobiology)
 "pPP" = (
 /obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/full{
-	density = 1
-	},
 /obj/machinery/camera/network/research{
 	c_tag = "SCI - Xenobiology Fore Port"
 	},
@@ -33196,7 +33205,7 @@
 	dir = 8
 	},
 /obj/item/stack/material/phoron{
-	amount = 10
+	amount = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -75206,10 +75206,14 @@
 	dir = 1
 	},
 /obj/structure/table/standard,
-/obj/machinery/chemical_dispenser/full{
-	pixel_y = 18
+/obj/item/storage/pill_bottle/adranol{
+	pixel_y = 1;
+	pixel_x = -6
 	},
-/obj/item/reagent_containers/chem_disp_cartridge/milk,
+/obj/item/reagent_containers/glass/bottle/mutagen{
+	pixel_y = 9;
+	pixel_x = 7
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "tKB" = (

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -63835,6 +63835,10 @@
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/syringe/antiviral,
 /obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper{
+	pixel_y = -4
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "nhc" = (

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -20354,6 +20354,9 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 5
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "bkm" = (
@@ -22529,7 +22532,10 @@
 	dir = 4
 	},
 /obj/item/tool/screwdriver,
-/obj/item/organ/internal/lungs/erikLungs,
+/obj/item/organ/internal/lungs/erikLungs{
+	pixel_x = -4;
+	pixel_y = 14
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/reception)
 "brd" = (
@@ -23095,6 +23101,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lime/bordercorner{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
@@ -44520,7 +44529,9 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/sortjunction/flipped{
-	name = "Genetics"
+	name = "Genetics";
+	sortType = "Genetics";
+	dir = 2
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
@@ -44862,6 +44873,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
+	},
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -48522,6 +48536,7 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "fdO" = (
@@ -50229,6 +50244,16 @@
 /obj/machinery/vending/wallmed1{
 	dir = 4;
 	pixel_x = -25
+	},
+/obj/structure/table/standard,
+/obj/machinery/reagentgrinder{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/obj/item/stack/material/phoron{
+	amount = 5;
+	pixel_x = -3;
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -54557,7 +54582,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
-/obj/structure/table/standard,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "iej" = (
@@ -67471,9 +67496,7 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/library)
 "pjG" = (
-/obj/structure/table/marble{
-	color = "grey"
-	},
+/obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
 	pixel_y = 10;
 	pixel_x = -10
@@ -69675,6 +69698,11 @@
 /obj/item/storage/box/monkeycubes{
 	pixel_x = -7;
 	pixel_y = -3
+	},
+/obj/machinery/requests_console{
+	department = "Virology";
+	name = "Virology Requests Console";
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -73213,9 +73241,8 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
+/obj/structure/sign/deathsposal{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -74437,26 +74464,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry/D3)
-"tlx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/medbay)
 "tmd" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light{
@@ -75194,12 +75201,11 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
 	},
-/obj/item/radio/intercom/department/medbay{
-	dir = 1;
-	pixel_y = 21
-	},
 /obj/structure/table/standard,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/chemical_dispenser/full{
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/chem_disp_cartridge/milk,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "tKB" = (
@@ -79794,6 +79800,9 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "wMO" = (
@@ -80288,6 +80297,10 @@
 	pixel_x = -7;
 	pixel_y = -3
 	},
+/obj/item/radio/intercom/department/medbay{
+	dir = 4;
+	pixel_x = 21
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "wZn" = (
@@ -80713,6 +80726,7 @@
 	pixel_x = 1;
 	pixel_y = 8
 	},
+/obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
 "xiE" = (
@@ -82178,6 +82192,11 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	layer = 3.3;
+	pixel_x = 26
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/virology)
@@ -127360,7 +127379,7 @@ rHH
 rHH
 cUx
 qDw
-tlx
+oZU
 vyg
 wum
 vqv

--- a/modular_chomp/maps/southern_cross/southern_cross-4.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-4.dmm
@@ -7803,6 +7803,10 @@
 /obj/item/surgical/FixOVein,
 /obj/item/surgical/retractor,
 /obj/item/reagent_containers/glass/bottle/culture/cold,
+/obj/item/reagent_containers/glass/bottle/culture/flu{
+	pixel_x = 10;
+	pixel_y = 10
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/dormsstarboard)
 "fFq" = (

--- a/modular_chomp/maps/southern_cross/southern_cross-6.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-6.dmm
@@ -3833,6 +3833,9 @@
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},
+/obj/structure/reagent_dispensers/acid{
+	pixel_x = -30
+	},
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology/analysis)
 "hI" = (

--- a/modular_chomp/maps/southern_cross/southern_cross-6.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-6.dmm
@@ -1664,7 +1664,6 @@
 /turf/simulated/shuttle/floor/voidcraft/external,
 /area/surface/outpost/wall/checkpoint)
 "du" = (
-/obj/structure/bed/chair/office/light,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -1866,14 +1865,13 @@
 	},
 /area/surface/outpost/mining_main/cave)
 "dK" = (
-/obj/machinery/computer/crew{
-	dir = 1
-	},
+/obj/structure/table/glass,
 /obj/item/radio/intercom{
 	dir = 8;
 	name = "Station Intercom (General)";
 	pixel_x = -21
 	},
+/obj/item/defib_kit/loaded,
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology/medical)
 "dL" = (
@@ -1882,7 +1880,6 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/recharger,
-/obj/item/defib_kit/loaded,
 /obj/item/radio{
 	frequency = 1487;
 	icon_state = "med_walkietalkie";

--- a/modular_chomp/maps/southern_cross/southern_cross-6.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-6.dmm
@@ -3643,7 +3643,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/research/xenoarcheology/restroom)
 "ho" = (
-/obj/machinery/chemical_dispenser/full,
 /obj/structure/sign/warning/nosmoking_2{
 	pixel_x = -32
 	},
@@ -3831,7 +3830,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/research/xenoarcheology/restroom)
 "hH" = (
-/obj/machinery/chem_master,
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
 	},

--- a/modular_chomp/maps/southern_cross/southern_cross-7.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-7.dmm
@@ -5311,7 +5311,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/midsternhallway)
 "etp" = (
-/obj/machinery/chem_master,
+/obj/machinery/computer/rdconsole/core,
 /obj/effect/floor_decal/milspec/color/purple,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
@@ -31472,10 +31472,7 @@
 /turf/simulated/floor,
 /area/expoutpost/reactoraccess)
 "xZQ" = (
-/obj/machinery/chemical_dispenser/full{
-	pixel_y = 5
-	},
-/obj/structure/table/darkglass,
+/obj/machinery/r_n_d/destructive_analyzer,
 /obj/effect/floor_decal/milspec/color/purple,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)


### PR DESCRIPTION
## About The Pull Request

Just a few adjustments to medical and virology for Southern Cross.

## Changelog
:cl:
maptweak: Added some lights in darker areas of medical
maptweak: Fixed the genetics sorter so the lab is no longer a dumping ground and deliveries will now work
maptweak: Added a bottle of Adranol pills and a bottle of Mutagen to give some starting chems and hints for viro. Also added some phoron and a grinder for same reason.
maptweak: Added the sign by viro disposals reminding people that it goes into space
maptweak: Added the viro requests console back into viro
maptweak: Fixed the chemistry tables
maptweak: Finally moved Erik's Lungs out of the way
maptweak: Added a flu culture to the maints loot with the cold culture
maptweak: Adds droppers to viro
maptweak: Replaced the chem dispenser in xenobotany with 2 bottles of Diethylamine and 2 bottles of Mutagen
maptweak: Removed xenobiology's chem dispenser and halved the starting phoron stacks
maptweak: Removed the chem master and dispenser from the science ship and replaced it with an RnD console and Destructive analyser
maptweak: Removed the chemistry lab in xenoarch - the lab already has a massive coolant supply. Added a sulphuric acid dispenser in its place
maptweak: Removes the crew monitor from xenoarch
/:cl:
