### PR TITLE
Binder/Snatcher OOC Escape

### DIFF
--- a/code/game/objects/items/devices/body_snatcher_vr.dm
+++ b/code/game/objects/items/devices/body_snatcher_vr.dm
@@ -92,8 +92,14 @@
 					user.ooc_notes_favs = target_favs
 					user.ooc_notes_maybes = target_maybes
 					user.ooc_notes_style = target_style
-					M.tf_mob_holder = user
-					user.tf_mob_holder = M
+					if(M.tf_mob_holder == user)
+						M.tf_mob_holder = null
+					else
+						M.tf_mob_holder = user
+					if(user.tf_mob_holder == M)
+						user.tf_mob_holder = null
+					else
+						user.tf_mob_holder = M
 					//CHOMPEdit End
 					user.ooc_notes = target_ooc_notes
 					user.ooc_notes_likes = target_likes

--- a/code/game/objects/items/devices/body_snatcher_vr.dm
+++ b/code/game/objects/items/devices/body_snatcher_vr.dm
@@ -92,6 +92,8 @@
 					user.ooc_notes_favs = target_favs
 					user.ooc_notes_maybes = target_maybes
 					user.ooc_notes_style = target_style
+					M.tf_mob_holder = user
+					user.tf_mob_holder = M
 					//CHOMPEdit End
 					user.ooc_notes = target_ooc_notes
 					user.ooc_notes_likes = target_likes

--- a/code/game/objects/items_vr.dm
+++ b/code/game/objects/items_vr.dm
@@ -15,6 +15,7 @@
 	new_voice.transfer_identity(candidate) 			//Now make the voice mob load from the ghost's active character in preferences.
 	new_voice.mind = candidate.mind					//Transfer the mind, if any.
 	new_voice.ckey = candidate.ckey					//Finally, bring the client over.
+	candidate.mind = null							//CHOMPAdd - Remove the mind from the mob to avoid issues with multi TF interactions
 	new_voice.tf_mob_holder = candidate_original_form //Save what mob they are! We'll need this for OOC escape and transformation back to their normal form.
 	if(candidate_name) 								//Were we given a candidate_name? Great! Name them that.
 		new_voice.name = "[candidate_name]"

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -662,6 +662,22 @@
 	//You've been turned into an item!
 	else if(tf_mob_holder && istype(src, /mob/living/voice) && istype(src.loc, /obj/item))
 		var/obj/item/item_to_destroy = src.loc //If so, let's destroy the item they just TF'd out of.
+		//CHOMPEdit Start - If tf_mob_holder is not located in src, then it's a Mind Binder OOC Escape
+		var/mob/living/ourmob = tf_mob_holder
+		if(ourmob.loc != src)
+			if(isnull(ourmob.loc))
+				to_chat(src,span_notice("You have no body."))
+				src.tf_mob_holder = null
+				return
+			if(ourmob.ckey)
+				to_chat(src,span_notice("Your body appears to be in someone else's control."))
+				return
+			src.mind.transfer_to(ourmob)
+			item_to_destroy.possessed_voice -= src
+			qdel(src)
+			log_and_message_admins("[key_name(src)] used the OOC escape button to revert back to their original form from being TFed into an object.")
+			return
+		//CHOMPEdit End
 		if(istype(src.loc, /obj/item/clothing)) //Are they in clothes? Delete the item then revert them.
 			qdel(item_to_destroy)
 			log_and_message_admins("[key_name(src)] used the OOC escape button to revert back to their original form from being TFed into an object.")

--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -93,7 +93,7 @@
 		if(!M.allow_spontaneous_tf && !tf_admin_pref_override)
 			return
 	M.drop_both_hands()	//CHOMPAdd - Drop items in hand before transformation
-	if(M.tf_mob_holder && M.tf_mob_holder.loc == M)
+	if(M.tf_mob_holder && M.tf_mob_holder.loc == M) //CHOMPEdit - Extra check to account for Mind Binder usage
 		new /obj/effect/effect/teleport_greyscale(M.loc) //CHOMPEdit Start
 		var/mob/living/ourmob = M.tf_mob_holder
 		if(ourmob.ai_holder)

--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -93,7 +93,7 @@
 		if(!M.allow_spontaneous_tf && !tf_admin_pref_override)
 			return
 	M.drop_both_hands()	//CHOMPAdd - Drop items in hand before transformation
-	if(M.tf_mob_holder)
+	if(M.tf_mob_holder && M.tf_mob_holder.loc == M)
 		new /obj/effect/effect/teleport_greyscale(M.loc) //CHOMPEdit Start
 		var/mob/living/ourmob = M.tf_mob_holder
 		if(ourmob.ai_holder)
@@ -203,8 +203,38 @@
 /mob/living/proc/revert_mob_tf()
 	if(!tf_mob_holder)
 		return
-	new /obj/effect/effect/teleport_greyscale(src.loc) //CHOMPEdit Start
+	//CHOMPEdit Start - OOC Escape functionality for Mind Binder and Body Snatcher
 	var/mob/living/ourmob = tf_mob_holder
+	if(ourmob.loc != src)
+		if(isnull(ourmob.loc))
+			to_chat(src,span_notice("You have no body."))
+			tf_mob_holder = null
+			return
+		if(ourmob.ckey)
+			if(ourmob.tf_mob_holder && ourmob.tf_mob_holder == src)
+				//Body Swap
+				var/datum/mind/ourmind = src.mind
+				var/datum/mind/theirmind = ourmob.mind
+				ourmob.ghostize()
+				src.ghostize()
+				ourmob.mind = null
+				src.mind = null
+				ourmind.current = null
+				theirmind.current = null
+				ourmind.active = TRUE
+				ourmind.transfer_to(ourmob)
+				theirmind.active = TRUE
+				theirmind.transfer_to(src)
+				ourmob.tf_mob_holder = null
+				src.tf_mob_holder = null
+			else
+				to_chat(src,span_notice("Your body appears to be in someone else's control."))
+			return
+		src.mind.transfer_to(ourmob)
+		tf_mob_holder = null
+		return
+	//CHOMPEdit End
+	new /obj/effect/effect/teleport_greyscale(src.loc) //CHOMPEdit Start
 	if(ourmob.ai_holder)
 		var/datum/ai_holder/our_AI = ourmob.ai_holder
 		our_AI.set_stance(STANCE_IDLE)

--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -210,6 +210,8 @@
 			to_chat(src,span_notice("You have no body."))
 			tf_mob_holder = null
 			return
+		if(istype(ourmob.loc, /mob/living)) //Check for if body was transformed
+			ourmob = ourmob.loc
 		if(ourmob.ckey)
 			if(ourmob.tf_mob_holder && ourmob.tf_mob_holder == src)
 				//Body Swap

--- a/modular_chomp/code/game/objects/items/devices/mind_binder.dm
+++ b/modular_chomp/code/game/objects/items/devices/mind_binder.dm
@@ -76,16 +76,16 @@
 	if(self_bind)
 		var/choice = tgui_alert(usr,"This will bind YOUR mind to the target! You may not be able to go back without help. Continue?","Confirmation",list("Continue","Cancel"))
 		if(!choice || choice == "Cancel") return
-		choice = tgui_alert(usr,"No really. You cannot OOC Escape this. Are you sure?","Confirmation",list("Yes I'm sure","Cancel"))
-		if(choice == "Yes I'm sure" && usr.get_active_hand() == src && usr.Adjacent(target))
-			usr.visible_message(span_warning("[usr] presses [src] against [target]. The device beginning to let out a series of beeps!"),span_notice("You begin to bind yourself into [target]!"))
-			log_and_message_admins("attempted to bind themselves to \an [target] with a Mind Binder.")
-			if(do_after(usr,30 SECONDS,target))
-				if(!target.ckey)
-					usr.mind.transfer_to(target)
-				self_bind = !self_bind
-				update_icon()
-				to_chat(usr,span_notice("Your mind as been bound to [target]."))
+		usr.visible_message(span_warning("[usr] presses [src] against [target]. The device beginning to let out a series of beeps!"),span_notice("You begin to bind yourself into [target]!"))
+		log_and_message_admins("attempted to bind themselves to \an [target] with a Mind Binder.")
+		if(do_after(usr,30 SECONDS,target))
+			if(!target.ckey)
+				usr.mind.transfer_to(target)
+			if(!target.tf_mob_holder)
+				target.tf_mob_holder = usr
+			self_bind = !self_bind
+			update_icon()
+			to_chat(usr,span_notice("Your mind as been bound to [target]."))
 		return
 
 	usr.visible_message(span_warning("[usr] presses [src] against [target]. The device beginning to let out a series of beeps!"),span_notice("You begin to bind someone's mind into [target]!"))
@@ -97,8 +97,10 @@
 		if(possessed_voice.len == 1 && !target.ckey)
 			var/mob/living/voice/V = possessed_voice[1]
 			V.mind.transfer_to(target)
-			V.Destroy()
-			possessed_voice = list()
+			if(!target.tf_mob_holder)
+				target.tf_mob_holder = V.tf_mob_holder
+			possessed_voice -= V
+			qdel(V)
 			to_chat(usr,span_notice("Mind bound to [target]."))
 
 	update_icon()
@@ -120,15 +122,13 @@
 	if(self_bind)
 		var/choice = tgui_alert(usr,"This will bind YOUR mind to the target! You will not be able to go back without help. Continue?","Confirmation",list("Continue","Cancel"))
 		if(!choice || choice == "Cancel") return
-		choice = tgui_alert(usr,"No really. You cannot OOC Escape this. Are you sure?","Confirmation",list("Yes I'm sure","Cancel"))
-		if(choice == "Yes I'm sure" && usr.get_active_hand() == src && usr.Adjacent(item))
-			log_and_message_admins("attempted to bind themselves to \an [item] with a Mind Binder.")
-			usr.visible_message(span_warning("[usr] presses [src] against [item]. The device beginning to let out a series of beeps!"),span_notice("You begin to bind yourself into [item]!"))
-			if(do_after(usr,30 SECONDS,item))
-				item.inhabit_item(usr, null, null, TRUE)
-				self_bind = !self_bind
-				update_icon()
-				to_chat(usr,span_notice("Your mind as been bound to [item]."))
+		log_and_message_admins("attempted to bind themselves to \an [item] with a Mind Binder.")
+		usr.visible_message(span_warning("[usr] presses [src] against [item]. The device beginning to let out a series of beeps!"),span_notice("You begin to bind yourself into [item]!"))
+		if(do_after(usr,30 SECONDS,item))
+			item.inhabit_item(usr, null, usr, TRUE)
+			self_bind = !self_bind
+			update_icon()
+			to_chat(usr,span_notice("Your mind as been bound to [item]."))
 		return
 
 	log_and_message_admins("attempted to bind [key_name(src.possessed_voice[1])] to \an [item] with a Mind Binder.")
@@ -137,8 +137,8 @@
 		if(possessed_voice.len == 1)
 			var/mob/living/voice/V = possessed_voice[1]
 			item.inhabit_item(V, null, V.tf_mob_holder, TRUE)
-			V.Destroy()
-			possessed_voice = list()
+			possessed_voice -= V
+			qdel(V)
 			to_chat(usr,span_notice("Mind bound to [item]."))
 
 	update_icon()
@@ -162,7 +162,7 @@
 		usr.visible_message(span_warning("[usr] presses [src] against [target]'s head. The device beginning to let out a series of beeps!"),span_notice("You begin to download [target]'s mind!"))
 		if(do_after(usr,30 SECONDS,target))
 			if(possessed_voice.len == 0 && target.mind)
-				inhabit_item(target, target.real_name, null)
+				inhabit_item(target, target.real_name, target)
 				to_chat(usr,span_notice("Mind successfully stored!"))
 
 	update_icon()
@@ -183,8 +183,8 @@
 	if(do_after(usr,5 SECONDS,item))
 		if(possessed_voice.len == 0 && item.possessed_voice.Find(target))
 			inhabit_item(target, target.real_name, target.tf_mob_holder)
-			target.Destroy()
-			item.possessed_voice.Remove(target)
+			item.possessed_voice -= target
+			qdel(target)
 			to_chat(usr,span_notice("Mind successfully stored!"))
 
 	update_icon()

--- a/modular_chomp/code/game/objects/items/devices/mind_binder.dm
+++ b/modular_chomp/code/game/objects/items/devices/mind_binder.dm
@@ -83,6 +83,8 @@
 				usr.mind.transfer_to(target)
 			if(!target.tf_mob_holder)
 				target.tf_mob_holder = usr
+			if(target.tf_mob_holder == target)
+				target.tf_mob_holder = null
 			self_bind = !self_bind
 			update_icon()
 			to_chat(usr,span_notice("Your mind as been bound to [target]."))
@@ -99,6 +101,8 @@
 			V.mind.transfer_to(target)
 			if(!target.tf_mob_holder)
 				target.tf_mob_holder = V.tf_mob_holder
+			if(target.tf_mob_holder == target)
+				target.tf_mob_holder = null
 			possessed_voice -= V
 			qdel(V)
 			to_chat(usr,span_notice("Mind bound to [target]."))


### PR DESCRIPTION
Adds OOC Escape functionality to item and mob TF via a Mind Binder or Body Snatcher.
## About The Pull Request
This should allow OOC Escape to work with 90% of scenarios involving the Mind Binder or Body Snatcher. It uses the existing tf_mob_holder from the mouse ray to reference the body you were taken out from. Provided your body still exists and that it's not controlled by another player then you will be returned to it. In the case of the Body Snatcher, each body will reference the other. If both references match then when one uses OOC Escape both will be un-swapped instantly. This is meant to prevent pref breaking scenarios, accidental usage, or needing to revert when not physically able to. It would still be best to manually swap back to ensure everything returns properly, but it's better than nothing.

Special cases involving the mouse ray are taken into account to avoid overwriting the value and making transformation back impossible. Various chain swapping situations were tested as well. If the referenced body no longer exists (digested or otherwise) you will be informed and the reference will be cleared. An ahelp would be needed at that point since you can't go back to a non-existent body.
## Changelog
:cl:
qol: OOC Escape now works for most Mind Binder and Body Snatcher interactions
/:cl:
