### PR TITLE
Item TF interactions with mob cubes and cigarettes

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -205,6 +205,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 				to_chat(M, span_notice("Your [name] goes out."))
 			M.remove_from_mob(src) //un-equip it so the overlays can update
 			M.update_inv_wear_mask(0)
+		//CHOMPAdd Start - Turn mind bound cigs into butts
+		if(src.possessed_voice && src.possessed_voice.len)
+			var/mob/living/voice/V = src.possessed_voice[1]
+			butt.inhabit_item(V, null, V.tf_mob_holder, TRUE)
+			qdel(V)
+		//CHOMPAdd End
 		qdel(src)
 	else
 		new /obj/effect/decal/cleanable/ash(T)

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -62,6 +62,12 @@ var/global/list/ashtray_cache = list()
 				STOP_PROCESSING(SSobj, cig)
 				var/obj/item/butt = new cig.type_butt(src)
 				cig.transfer_fingerprints_to(butt)
+				//CHOMPAdd Start - Turn mind bound cigs into butts
+				if(cig.possessed_voice && cig.possessed_voice.len)
+					var/mob/living/voice/V = src.possessed_voice[1]
+					butt.inhabit_item(V, null, V.tf_mob_holder, TRUE)
+					qdel(V)
+				//CHOMPAdd End
 				qdel(cig)
 				W = butt
 				//spawn(1)
@@ -86,7 +92,7 @@ var/global/list/ashtray_cache = list()
 		health = max(0,health - 3)
 		if (contents.len)
 			src.visible_message(span_danger("\The [src] slams into [hit_atom], spilling its contents!"))
-		for (var/obj/item/clothing/mask/smokable/cigarette/O in contents)
+		for (var/obj/item/O in contents) //CHOMPEdit - Dump all items out, so it ejects butts too
 			O.loc = src.loc
 		if (health < 1)
 			shatter()

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -2002,7 +2002,7 @@
 		qdel(V)
 	//CHOMPAdd End
 	qdel(src)
-	return H
+	return H //CHOMPEdit - Return expanded mob for use in On_Consume
 
 /obj/item/reagent_containers/food/snacks/monkeycube/proc/Unwrap(mob/user as mob)
 	icon_state = "monkeycube"

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -1994,8 +1994,15 @@
 	if(ismob(loc))
 		var/mob/M = loc
 		M.unEquip(src)
+	//CHOMPAdd Start - Delete Mind Binder voices and transfer to resulting mob
+	if(src.possessed_voice && src.possessed_voice.len)
+		var/mob/living/voice/V = src.possessed_voice[1]
+		V.mind.transfer_to(H)
+		H.tf_mob_holder = V.tf_mob_holder
+		qdel(V)
+	//CHOMPAdd End
 	qdel(src)
-	return 1
+	return H
 
 /obj/item/reagent_containers/food/snacks/monkeycube/proc/Unwrap(mob/user as mob)
 	icon_state = "monkeycube"
@@ -2006,12 +2013,22 @@
 	return
 
 /obj/item/reagent_containers/food/snacks/monkeycube/On_Consume(var/mob/M)
+	/*CHOMPEdit Start - Remove chest bursting, add vore
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.visible_message(span_warning("A screeching creature bursts out of [M]'s chest!"))
 		var/obj/item/organ/external/organ = H.get_organ(BP_TORSO)
 		organ.take_damage(50, 0, 0, "Animal escaping the ribcage")
-	Expand()
+	*/
+	var/mob/living/Prey = Expand()
+
+	if(!isliving(M))
+		return
+
+	var/mob/living/Pred = M
+	if(Pred.can_be_drop_pred && Pred.food_vore && Pred.vore_selected)
+		Prey.forceMove(Pred.vore_selected)
+	//CHOMPEdit End
 
 /obj/item/reagent_containers/food/snacks/monkeycube/on_reagent_change()
 	if(reagents.has_reagent("water"))


### PR DESCRIPTION

## About The Pull Request
Some extra interactions with mind-bound items. Possessed mob cubes gain control of the mob when it expands on water addition. Eating mob cubes can vore the spawned mob if prefs align, otherwise still pops out on the floor. Possessed cigs and cigars now get transferred to the resulting butt on burn out or crushing. Also works with ashtrays.
## Changelog
:cl:
add: Mind binded monkey/mob cubes gain control of the rehydrated mob
add: Monkey/mob cubes when eaten can vore the rehydrated mob if spont pred and food vore are enabled
add: Mind binded cigs/cigars correctly turn into cig butts when burnt out or used in an ashtray
/:cl:
