### PR TITLE
exclude JOB_VR from mail recipients

### DIFF
--- a/code/controllers/subsystems/mail_ch.dm
+++ b/code/controllers/subsystems/mail_ch.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(mail)
 	// Collect recipients
 	var/list/mail_recipients = list()
 	for(var/mob/living/carbon/human/player_human in player_list)
-		if(player_human.stat != DEAD && player_human.client && player_human.client.inactivity <= 10 MINUTES && player_human.job != JOB_OUTSIDER && player_human.job != JOB_ANOMALY && !player_is_antag(player_human.mind)) // Only alive, active and NT employeers should be getting mail.
+		if(player_human.stat != DEAD && player_human.client && player_human.client.inactivity <= 10 MINUTES && player_human.job != JOB_OUTSIDER && player_human.job != JOB_ANOMALY && player_human.job != JOB_VR && !player_is_antag(player_human.mind)) // Only alive, active and NT employeers should be getting mail.
 			mail_recipients += player_human
 
 	// Creates mail for all the mail waiting to arrive, if there's nobody to receive it, it will be a chance of junk mail.


### PR DESCRIPTION
## About The Pull Request

Include JOB_VR from the excluded mail recipients. No more mail for VR avatars.

## Changelog

:cl:
fix: VR avatars no longer get mail from cargo
/:cl:
