### PR TITLE
Food TF interactions

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -85,9 +85,33 @@
 
 		usr.drop_from_inventory(src) // Drop food from inventory so it doesn't end up staying on the hud after qdel, and so inhands go away
 
+		//CHOMPAdd Start - Consume item TF mobs as raw nutrition if prefs align
+		if(possessed_voice && possessed_voice.len && M.can_be_drop_pred && M.food_vore && M.vore_selected)
+			var/obj/item/reagent_containers/food/rawnutrition/NR = new /obj/item/reagent_containers/food/rawnutrition(usr)
+			NR.name = "piece of food"
+			NR.stored_nutrition = 1
+			for(var/mob/living/voice/V in possessed_voice)
+				NR.inhabit_item(V, null, V.tf_mob_holder, TRUE)
+				possessed_voice -= V
+				qdel(V)
+			NR.forceMove(M.vore_selected)
+		//CHOMPAdd End
 		if(trash)
 			var/obj/item/TrashItem = new trash(usr)
 			usr.put_in_hands(TrashItem)
+			//CHOMPAdd Start - Transfer item TF mobs to the trash if able
+			if(possessed_voice && possessed_voice.len)
+				for(var/mob/living/voice/V in possessed_voice)
+					TrashItem.inhabit_item(V, null, V.tf_mob_holder, TRUE)
+					possessed_voice -= V
+					qdel(V)
+			//CHOMPAdd End
+		//CHOMPAdd Start - Clean up any remaining item TF mobs
+		if(possessed_voice && possessed_voice.len)
+			for(var/mob/living/voice/V in possessed_voice)
+				possessed_voice -= V
+				qdel(V)
+		//CHOMPAdd End
 		qdel(src)
 
 /obj/item/reagent_containers/food/snacks/attack_self(mob/user as mob)


### PR DESCRIPTION

## About The Pull Request
Firstly, fixes #9522 so that item TF for food items on consumption doesn't make an astral projection of the prey. Additionally, added interactions where if the consumer has spont pred and food vore enabled they can catch the eaten piece of food in their selected belly as a raw nutrition item. Which will give the prey vore FX before quickly being absorbed, unless the belly has Storing mode enabled for nutrition. In which case the pred can keep or move them within their vore bellies as an eaten piece of food. If the pred is not setup for spont pred or food vore, then if able to the prey will be transferred to the resulting trash item instead.
## Changelog
:cl:
add: Eating someone bound to a food item can spont pred them as nutrition with food vore enabled
add: Eating someone bound to a food item will retain them as the trash item if eaten with spont pred/food vore disabled
fix: Eating someone bound to a food item no longer makes them astral project as a ghost in the world
/:cl:
