### PR TITLE
fixing reported scaling issue and renamed datum ending for future PR code redo.

### DIFF
--- a/modular_chomp/code/modules/mob/living/silicon/robot/sprites/engineering.dm
+++ b/modular_chomp/code/modules/mob/living/silicon/robot/sprites/engineering.dm
@@ -5,19 +5,21 @@
 	has_eye_light_sprites = TRUE
 	has_vore_belly_resting_sprites = TRUE
 
+/datum/robot_sprite/dogborg/tall/engineering
+	module_type = "Engineering"
 
-/datum/robot_sprite/dogborg/engineering/dullahan
+/datum/robot_sprite/dogborg/tall/engineering/dullahan
 	sprite_icon = 'modular_chomp/icons/mob/dullahanborg/dullahan_eng.dmi'
 	pixel_x = 0
 
-/datum/robot_sprite/dogborg/engineering/dullahan/engineer
+/datum/robot_sprite/dogborg/tall/engineering/dullahan/engineerv1
 	name = "Dullahan"
 	sprite_icon_state = "dullahaneng"
 	rest_sprite_options = list("Default", "Sit")
 	has_eye_light_sprites = TRUE
 	has_vore_belly_sprites = TRUE
 
-/datum/robot_sprite/dogborg/engineering/dullahan/engineeralt
+/datum/robot_sprite/dogborg/tall/engineering/dullahan/engineerv2
 	name = "Dullahan v2"
 	sprite_icon_state = "dullahaneng_alt"
 	rest_sprite_options = list("Default", "Sit")


### PR DESCRIPTION
https://github.com/CHOMPStation2/CHOMPStation2/issues/9630
issue reported

changed:  added tall/ to datum and pixel shift.

/datum/robot_sprite/dogborg/engineering/dullahan -> /datum/robot_sprite/dogborg/tall/engineering/dullahan

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fixed: Dullahan engineer chassis code and scaling issue. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
