### PR TITLE
paralysis toxin prevents movement

### DIFF
--- a/code/modules/reagents/reagents/vore_vr.dm
+++ b/code/modules/reagents/reagents/vore_vr.dm
@@ -223,8 +223,9 @@
 	scannable = 0 //YOU ARE NOT SCANNING THE FUNNY PARALYSIS TOXIN. NO. BAD. STAY AWAY.
 
 /datum/reagent/paralysis_toxin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	if(M.weakened < 50) //Let's not leave them PERMA stuck, after all.
+	if(M.weakened < 50 || M.stunned <50 ) //Let's not leave them PERMA stuck, after all. //CHOMPedit, stun accounting for crawl
 		M.AdjustWeakened(5) //Stand in for paralyze so you can still talk/emote/see
+		M.AdjustStunned(5) //CHOMPadd, stun accounting for crawl
 
 /datum/reagent/pain_enzyme
 	name = REAGENT_PAINENZYME


### PR DESCRIPTION

## About The Pull Request
Crawling broke this chem, might add more chems later that were unintentionally nerfed due to crawling.
## Changelog
:cl:
fix: paralysis toxin now commits paralysis.
/:cl:
