### PR TITLE
fixing empty hardsuit bug in cargo order.

### DIFF
--- a/code/datums/supplypacks/hardsuits.dm
+++ b/code/datums/supplypacks/hardsuits.dm
@@ -32,7 +32,7 @@
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "industrial hardsuit crate"
 	access = list(access_mining,
-				  access_eva)d
+				  access_eva)
 	one_access = TRUE
 
 /datum/supply_pack/hardsuits/medical_rig

--- a/code/datums/supplypacks/hardsuits.dm
+++ b/code/datums/supplypacks/hardsuits.dm
@@ -32,7 +32,7 @@
 	containertype = /obj/structure/closet/crate/secure/gear
 	containername = "industrial hardsuit crate"
 	access = list(access_mining,
-				  access_eva)
+				  access_eva)d
 	one_access = TRUE
 
 /datum/supply_pack/hardsuits/medical_rig
@@ -84,7 +84,7 @@
 	name = "solgov medical hardsuit (loaded)"
 	desc = "A fully-equipped Commonwealth of Sol-Procyon Medical hardsuit. Requires Medical access."
 	contains = list(
-			/obj/item/rig/baymed/equipped = 1
+			/obj/item/rig/baymed/equipped = 1 // CHOMPEdit
 			)
 	cost = 250
 	containertype = /obj/structure/closet/crate/secure/gear

--- a/code/datums/supplypacks/hardsuits.dm
+++ b/code/datums/supplypacks/hardsuits.dm
@@ -84,7 +84,7 @@
 	name = "solgov medical hardsuit (loaded)"
 	desc = "A fully-equipped Commonwealth of Sol-Procyon Medical hardsuit. Requires Medical access."
 	contains = list(
-			/obj/item/rig/baymed = 1
+			/obj/item/rig/baymed/equipped = 1
 			)
 	cost = 250
 	containertype = /obj/structure/closet/crate/secure/gear


### PR DESCRIPTION

## About The Pull Request
this was reported in suggestions as changing name to empty to reflect, but the code suggests its intended to have the modules, so i fixed it. it was using the wrong object.

## Changelog
:cl:
fix: adds modules to med solgov hardsuit, due to it using the wrong obj path. 
/:cl:
