### PR TITLE
Binder/Snatcher TF death fixes

### DIFF
--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -73,6 +73,12 @@
 		return 0
 	SEND_SIGNAL(src, COMSIG_MOB_DEATH, gibbed)
 	if(src.loc && istype(loc,/obj/belly) || istype(loc,/obj/item/dogborg/sleeper) || istype(loc, /obj/item/clothing/shoes)) deathmessage = "no message" //VOREStation Add - Prevents death messages from inside mobs - CHOMPEdit: Added in-shoe as well
+	//CHOMPAdd Start - Muffle original body death on Mob TF death
+	if(src.loc && isliving(loc))
+		var/mob/living/L = loc
+		if(L.tf_mob_holder == src)
+			deathmessage = "no message"
+	//CHOMPAdd End
 	facing_dir = null
 
 	if(!gibbed && deathmessage != DEATHGASP_NO_MESSAGE)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -20,7 +20,10 @@
 
 	if(isbelly(loc) && tf_mob_holder)
 		mind?.vore_death = TRUE
-		tf_mob_holder.mind?.vore_death = TRUE
+		//CHOMPEdit Start - Holder is used for OOC Escape now, make sure not to kill body swapped minds too
+		if(tf_mob_holder.loc == src)
+			tf_mob_holder.mind?.vore_death = TRUE
+		//CHOMPEdit End
 
 	for(var/datum/soul_link/S as anything in owned_soul_links)
 		S.owner_died(gibbed)

--- a/code/modules/vore/mouseray.dm
+++ b/code/modules/vore/mouseray.dm
@@ -279,6 +279,7 @@
 /mob/living/proc/handle_tf_holder()
 	if(!tf_mob_holder)
 		return
+	if(tf_mob_holder.loc != src) return //CHOMPAdd - Prevent bodyswapped creatures having their life linked
 	if(stat != tf_mob_holder.stat)
 		if(stat == DEAD)
 			tf_mob_holder.death(FALSE, null)


### PR DESCRIPTION

## About The Pull Request
A bug was introduced where after a body swap via either the snatcher or binder the death of one mob would result in the immediate death of the other linked mob. E.g. Body swapping and digesting your friend with their body made the pred digest themselves. This fixes that issue. Additionally, muffled the death message for actual Mob TF to hide the original body seizing up when the link does work as intended.
## Changelog
:cl:
qol: Death messages of the original body during Mob TF are now muffled
fix: Body swapping no longer links life state
/:cl:
