### PR TITLE
Removes duplicate RPD science research design

### DIFF
--- a/code/modules/research/designs/engineering.dm
+++ b/code/modules/research/designs/engineering.dm
@@ -34,16 +34,6 @@
 	sort_string = "NAAAC"
 	department = LATHE_ALL | LATHE_ENGINEERING // CHOMPAdd
 // YW addition begins
-/datum/design/item/tool/rpd
-	name = "Rapid Piping Device (RPD)"
-	desc = "A device used to rapidly pipe things."
-	id = "RPD"
-	req_tech = list(TECH_ENGINEERING = 3, TECH_MATERIAL = 2, TECH_BLUESPACE = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 300, MAT_SILVER = 100, MAT_DIAMOND = 500)
-	build_path = /obj/item/pipe_dispenser
-	sort_string = "NAAAB"
-	department = LATHE_ALL | LATHE_ENGINEERING // CHOMPAdd
-
 /datum/design/item/tool/rms
 	name = "Rapid Material Synthesizer (RMS)"
 	desc = "A tool that converts battery charge to materials."


### PR DESCRIPTION
## About The Pull Request

- Removes a copy-paste error. The actual RPD path (which overwrote this anyways) is below it and untouched.

Upstream doesn't have this RPD copy paste error either, as I was going to fix it there first and realized it didn't exist there.

This changes nothing in game as it was already overwritten underneath it.
