### PR TITLE
Patient Rooms now have Rad-Shielding

### DIFF
--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -7602,7 +7602,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "avJ" = (
 /obj/structure/closet,
 /obj/item/clothing/glasses/welding,
@@ -23069,7 +23069,7 @@
 	name = "Patient Room B"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "bsD" = (
 /obj/random/trash_pile,
 /turf/simulated/floor,
@@ -45173,7 +45173,7 @@
 	id = "pr1_window_tint"
 	},
 /turf/simulated/floor/plating,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "dsj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -47200,7 +47200,7 @@
 	name = "Patient Room A"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "evZ" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -49008,7 +49008,7 @@
 	},
 /obj/machinery/iv_drip,
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "fql" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -51572,7 +51572,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "gEM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
@@ -52245,7 +52245,7 @@
 /area/medical/patient_wing)
 "gVw" = (
 /turf/simulated/wall/r_wall,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "gWf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/chair{
@@ -54913,7 +54913,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "ini" = (
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/purple/bordercorner,
@@ -55247,7 +55247,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "izw" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -59157,7 +59157,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "kzz" = (
 /obj/machinery/pipedispenser,
 /turf/simulated/floor/tiled,
@@ -61651,7 +61651,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "lUC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -61667,7 +61667,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "lUX" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 5
@@ -62427,7 +62427,7 @@
 	},
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "mrF" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -64515,7 +64515,7 @@
 /area/teleporter)
 "nDN" = (
 /turf/simulated/wall,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "nDS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -64639,7 +64639,7 @@
 /area/maintenance/bar)
 "nGr" = (
 /turf/simulated/wall/r_wall,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "nGH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -65712,7 +65712,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "okh" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/industrial/outline/blue,
@@ -66695,7 +66695,7 @@
 	},
 /obj/machinery/iv_drip,
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "oRM" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -68639,7 +68639,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "pOW" = (
 /obj/structure/table/steel,
 /obj/fiftyspawner/steel,
@@ -68740,7 +68740,7 @@
 	},
 /obj/machinery/vitals_monitor,
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "pQK" = (
 /obj/machinery/light,
 /obj/structure/bookcase{
@@ -69735,7 +69735,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "qtD" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -70024,7 +70024,7 @@
 /obj/effect/floor_decal/corner/pink/border,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "qAW" = (
 /obj/machinery/door/blast/shutters{
 	dir = 2;
@@ -71560,7 +71560,7 @@
 	id = "pr2_window_tint"
 	},
 /turf/simulated/floor/plating,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "rEd" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/borderfloor{
@@ -71749,7 +71749,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "rIU" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -71793,7 +71793,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "rKQ" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -72693,7 +72693,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "siq" = (
 /obj/structure/sign/directions/engineering{
 	dir = 8;
@@ -72979,7 +72979,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "sup" = (
 /obj/machinery/papershredder,
 /obj/machinery/alarm{
@@ -73881,7 +73881,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "sVp" = (
 /obj/effect/shuttle_landmark{
 	base_area = /area/space;
@@ -75552,7 +75552,7 @@
 	},
 /obj/machinery/vitals_monitor,
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "ubP" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -77190,7 +77190,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "vdd" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled,
@@ -77766,7 +77766,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "vxG" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -78113,7 +78113,7 @@
 /obj/effect/floor_decal/corner/pink/border,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_b)
+/area/medical/sc_patient_b)
 "vHd" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -79056,7 +79056,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "wmj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -80063,7 +80063,7 @@
 	},
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
-/area/medical/patient_a)
+/area/medical/sc_patient_a)
 "wUN" = (
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/tiled/hydro,

--- a/modular_chomp/maps/southern_cross/southern_cross_areas.dm
+++ b/modular_chomp/maps/southern_cross/southern_cross_areas.dm
@@ -559,6 +559,16 @@
 	icon_state = "medbay_restroom"
 	sound_env = SMALL_ENCLOSED
 
+/area/medical/sc_patient_a
+	name ="\improper Patient A"
+	icon_state = "medbay_patient_room_a"
+	flags = RAD_SHIELDED
+
+/area/medical/sc_patient_b
+	name ="\improper Patient B"
+	icon_state = "medbay_patient_room_b"
+	flags = RAD_SHIELDED
+
 /area/security/aid_station
 	name = "\improper Security - Aid Station"
 	icon_state = "security_aid_station"


### PR DESCRIPTION
Adds rad-shielding flags to patient rooms in medbay. No longer do you need to worry about your recovering patients being cooked, or having to drag them into dirty maintenance halls.

:cl:
maptweak: Patient rooms in medbay now have rad-shielding.
/:cl: