### PR TITLE
eary port for us

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   run_linters:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Run Linters
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: run_linters-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
@@ -82,7 +82,7 @@ jobs:
 
   dreamchecker:
     name: DreamChecker
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
@@ -117,7 +117,7 @@ jobs:
     # name: Integration Tests (${{ matrix.map }})
     name: Integration Tests
     # needs: ['run_linters', 'dreamchecker']
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Ensure +x on CI directory
@@ -159,7 +159,7 @@ jobs:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Integration Tests
     needs: ['run_linters', 'dreamchecker', 'unit_tests']
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Report Success
         run: |

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   compile:
     name: "Compile changelogs"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       #- name: "Check for ACTION_ENABLER secret and pass true to output if it exists to be checked by later steps"
       #  id: value_holder

--- a/.github/workflows/tgs_test.yml
+++ b/.github/workflows/tgs_test.yml
@@ -36,7 +36,7 @@ jobs:
   test_tgs_docker:
     if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: Test TGS Docker
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: test_tgs_docker-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true

--- a/.github/workflows/update_tgs_dmapi.yml
+++ b/.github/workflows/update_tgs_dmapi.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update-dmapi:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Updates the TGS DMAPI
     steps:
     - name: Clone

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 
 RUN dpkg --add-architecture i386 \
 	&& apt-get update \

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -22,7 +22,7 @@ export NODE_VERSION_COMPAT=20.2.0
 export SPACEMAN_DMM_VERSION=suite-1.8
 
 # Python version for mapmerge and other tools
-export PYTHON_VERSION=3.9.0
+export PYTHON_VERSION=3.11.9
 
 #dreamluau repo
 export DREAMLUAU_REPO="tgstation/dreamluau"

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,10 +1,10 @@
-pygit2==1.7.2
-bidict==0.22.0
+pygit2==1.16.0
+bidict==0.22.1
 Pillow==10.3.0
 
 # changelogs
 PyYaml==6.0.1
-beautifulsoup4==4.9.3
+beautifulsoup4==4.11.2
 
 # ezdb
 mysql-connector-python==9.1.0


### PR DESCRIPTION
Update dependencies, early port for us to test 

Updates dependencies

Python -> 3.11.9 (Needed for map linting in case virgo wants that too)
ubuntu -> 24.04

(Needed for python >=3.11)
pygit2 1.7.2 -> 1.16.0
bidict 0.22.0 -> 0.22.1
beautifulsoup4 4.9.3 -> 4.11.2

🆑 
code: just testing the changelog after the dependency update
/🆑 