### PR TITLE
Adds CO2 Breather Trait

### DIFF
--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -200,6 +200,39 @@
 	gauge_icon = "indicator_double"					// Ensuring unique sprite stuff ig.
 	volume = 10
 
+//CHOMPEdit Start - for CO2 breathers
+/obj/item/tank/carbon_dioxide
+	name = "carbon dioxide tank"
+	desc = "A tank of carbon dioxide"
+	icon_state = "emergency_double"
+	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+
+/obj/item/tank/carbon_dioxide/Initialize()
+	. = ..()
+	src.air_contents.adjust_gas(GAS_CO2, (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
+
+/obj/item/tank/emergency/carbon_dioxide
+	name = "emergency carbon dioxide tank"
+	desc = "An emergency tank of carbon dioxide"
+	icon_state = "emergency_tst"
+	slot_flags = SLOT_BELT
+	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+
+/obj/item/tank/emergency/carbon_dioxide/Initialize()
+	. = ..()
+	src.air_contents.adjust_gas(GAS_CO2, (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
+
+/obj/item/tank/emergency/carbon_dioxide/double
+	name = "double emergency carbon dioxide tank"
+	desc = "An double tank of carbon dioxide"
+	icon_state = "emergency_double"
+	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
+
+/obj/item/tank/emergency/carbon_dioxide/double/Initialize()
+	. = ..()
+	src.air_contents.adjust_gas(GAS_CO2, (10*ONE_ATMOSPHERE)*volume/(R_IDEAL_GAS_EQUATION*T20C))
+//CHOMPEdit End
+
 /*
  * Nitrogen
  */

--- a/code/game/objects/items/weapons/tanks/tank_types_vr.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types_vr.dm
@@ -95,3 +95,25 @@
 	icon_state = "oxygen_fr"
 	gauge_icon = "indicator_bigtank"
 	gauge_cap = 3
+
+//CHOMPEdit Start - for CO2 breathers
+/obj/item/tank/carbon_dioxide
+	icon = 'icons/obj/tank_vr.dmi'
+	icon_state = "oxygen_f"
+	gauge_icon = "indicator_bigtank"
+	gauge_cap = 3
+
+/obj/item/tank/emergency/carbon_dioxide
+	icon = 'icons/obj/tank_vr.dmi'
+	icon_state = "emergency_tst"
+	gauge_icon = "indicator_smalltank"
+	volume = 6
+	gauge_cap = 3
+
+/obj/item/tank/emergency/carbon_dioxide/double
+	icon = 'icons/obj/tank_vr.dmi'
+	icon_state = "emergency_double"
+	gauge_icon = "indicator_double"
+	volume = 12
+	gauge_cap = 3
+//CHOMPEdit End

--- a/code/modules/client/preference_setup/loadout/loadout_xeno_ch.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_xeno_ch.dm
@@ -29,3 +29,9 @@
 	path = /obj/item/tank/emergency/phoron/double
 	whitelisted = SPECIES_CUSTOM //CHOMPedit: voxes don't need phoron here, not full whitelist removal because I am unsure of what use non-customs get
 	sort_category = "Xenowear"
+
+/datum/gear/double_tank_carbon_dioxide
+	display_name = "Pocket sized double carbon dioxide tank (Customs)"
+	path = /obj/item/tank/emergency/carbon_dioxide/double
+	whitelisted = SPECIES_CUSTOM
+	sort_category = "Xenowear"

--- a/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits_vr/positive_ch.dm
@@ -421,6 +421,7 @@
 	var_changes = list("breath_type" = "null", "poison_type" = "null", "exhale_type" = "null", "water_breather" = "TRUE")
 	excludes = list(/datum/trait/negative/breathes/phoron,
 					/datum/trait/negative/breathes/nitrogen,
+					/datum/trait/negative/breathes/carbon_dioxide,
 					/datum/trait/positive/light_breather,
 					/datum/trait/negative/deep_breather
 )

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -929,6 +929,17 @@
     gas = list(
         GAS_N2 = 100)
 
+//CHOMPEdit Start - for CO2 breathers
+/datum/gas_mixture/belly_air/carbon_dioxide_breather
+    volume = 2500
+    temperature = 293.150
+    total_moles = 104
+
+/datum/gas_mixture/carbon_dioxide_breather/New()
+    . = ..()
+    gas = list(
+        GAS_CO2 = 100)
+//CHOMPEdit End
 
 /mob/living/proc/feed_grabbed_to_self_falling_nom(var/mob/living/user, var/mob/living/prey)
 	var/belly = user.vore_selected

--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/negative.dm
@@ -96,3 +96,8 @@
 	var_changes = list("lightweight_light" = 1)
 	excludes = list(/datum/trait/negative/lightweight)
 	custom_only = FALSE
+
+/datum/trait/negative/breathes/carbon_dioxide
+	name = "Carbon Dioxide Breather"
+	desc = "You breathe carbon dioxide instead of oxygen, much like a plant. Oxygen is not poisonous to you."
+	var_changes = list("breath_type" = GAS_CO2, "exhale_type" = GAS_O2, "ideal_air_type" = /datum/gas_mixture/belly_air/carbon_dioxide_breather)


### PR DESCRIPTION
Allows custom species the ability to breathe CO2, and exhale oxygen, much like plants!

Adds the trait, along with fitting tanks/loadout (that could use custom sprites in the future).

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: CO2 Breather trait, CO2 tanks, and loadout double-tanks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
