### PR TITLE
sloog head icon multiply fix

### DIFF
--- a/modular_chomp/code/modules/mob/new_player/sprite_accessories_extra.dm
+++ b/modular_chomp/code/modules/mob/new_player/sprite_accessories_extra.dm
@@ -267,6 +267,7 @@
 	icon = 'modular_chomp/icons/mob/human_races/sprite_accessories/sloog.dmi'
 	icon_state = "slooghead"
 	body_parts = list(BP_HEAD)
+	color_blend_mode = ICON_MULTIPLY
 	// placed in seperate dmi till normal one is functional.
 
 


### PR DESCRIPTION

## About The Pull Request
color_blend_mode = ICON_MULTIPLY added to sloog head

## Changelog
:cl:
fix: fixed sloog head not coloring right.
/:cl:
