### PR TITLE
fix a light issue

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -182,7 +182,7 @@
 
 	propogate_sunlight_changes(oldtype, old_density, new_turf)
 	var/turf/simulated/cur_turf = src
-	if(is_open != was_open)
+	if(istype(cur_turf) && is_open != was_open)
 		do
 			cur_turf = GetBelow(cur_turf)
 			if(is_open)

--- a/code/modules/lighting/sunlight_handler_ch.dm
+++ b/code/modules/lighting/sunlight_handler_ch.dm
@@ -25,6 +25,11 @@
 			shandler = new(src)
 			shandler.manualInit()
 
+/turf/simulated/lighting_build_overlay()
+	..()
+	if(shandler)
+		shandler.only_sun_object = lighting_object
+
 /datum/sunlight_handler
 	var/datum/simple_sun/sun
 	var/turf/simulated/holder


### PR DESCRIPTION
This might negatively effect performance, so going to test merge it first. But when we call changeArea, we delete light objects and never reattach them to their handlers. This can lead to turfs with light objects that are no longer assigned to their handlers.
## About The Pull Request
## Changelog
:cl:
fix: light handling going missing after area changes
/:cl:
