### PR TITLE
honkhounds no longer lose EAL on reset

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules/Widerobot_Command_ch.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules/Widerobot_Command_ch.dm
@@ -19,7 +19,7 @@
 					LANGUAGE_ROOTLOCAL	= 0,
 					LANGUAGE_GUTTER		= 0,
 					LANGUAGE_SCHECHI	= 1,
-					//LANGUAGE_EAL		= 1, //missed this in my other EAL removal. same reason as before, dont want borgs to lose eal
+					LANGUAGE_EAL		= 1,
 					LANGUAGE_SIGN		= 0,
 					LANGUAGE_BIRDSONG	= 1,
 					LANGUAGE_SAGARU		= 1,


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:
fix: honkhounds losing EAL on module selection after a reset
/:cl:
