### PR TITLE
Prepares pda_timeclock for migration to tgui-core

### DIFF
--- a/tgui/packages/tgui/interfaces/chompstation/Pda/pda_screens/pda_timeclock.tsx
+++ b/tgui/packages/tgui/interfaces/chompstation/Pda/pda_screens/pda_timeclock.tsx
@@ -4,12 +4,12 @@ import { useBackend } from 'tgui/backend';
 import {
   Box,
   Button,
-  Flex,
   LabeledList,
   NoticeBox,
   Section,
-} from 'tgui/components';
-import { formatTime } from 'tgui/format';
+  Stack,
+} from 'tgui-core/components';
+import { formatTime } from 'tgui-core/format';
 
 import { RankIcon } from '../../../common/RankIcon';
 
@@ -86,20 +86,14 @@ export const pda_timeclock = (props) => {
           {!!job_datum && (
             <>
               <LabeledList.Item label="Rank">
-                <Box backgroundColor={job_datum.selection_color} p={0.8}>
-                  <Flex justify="space-between" align="center">
-                    <Flex.Item>
-                      <Box ml={1}>
-                        <RankIcon color="white" rank={job_datum.title} />
-                      </Box>
-                    </Flex.Item>
-                    <Flex.Item>
-                      <Box fontSize={1.5} inline mr={1}>
-                        {job_datum.title}
-                      </Box>
-                    </Flex.Item>
-                  </Flex>
-                </Box>
+                <Stack backgroundColor={job_datum.selection_color} p={0.8}>
+                  <Stack.Item ml={1}>
+                    <RankIcon color="white" rank={job_datum.title} />
+                  </Stack.Item>
+                  <Stack.Item fontSize={1.5} grow textAlign="right" mr={1}>
+                    {job_datum.title}
+                  </Stack.Item>
+                </Stack>
               </LabeledList.Item>
               <LabeledList.Item label="Departments">
                 {job_datum.departments}


### PR DESCRIPTION

## About The Pull Request
Prepares the PDA Timeclock interface for migration to tgui-core
## Changelog
:cl:
code: Changes tgui/components and tgui/format to their tgui-core equivalents, and replaces a Flex element with Stack
/:cl:
