### PR TITLE
Adds more blacklisted designs per oversight

### DIFF
--- a/modular_chomp/code/modules/research/rdconsole.dm
+++ b/modular_chomp/code/modules/research/rdconsole.dm
@@ -5,4 +5,9 @@
 	is_public = TRUE
 	req_access = ""
 	circuit = /obj/item/circuitboard/rdconsole/public
-	LockedPrinterDesigns = list(/datum/design/circuit/protolathe,/datum/design/circuit/circuit_imprinter,/datum/design/circuit/destructive_analyzer)
+	LockedPrinterDesigns = list(/datum/design/circuit/protolathe,
+								/datum/design/circuit/circuit_imprinter,
+								/datum/design/circuit/destructive_analyzer,
+								/datum/design/circuit/rdconsole,
+								/datum/design/circuit/rdservercontrol
+								)


### PR DESCRIPTION

## About The Pull Request
Outsider console didnt restrict the normal RND console either, this fixes it.
## Changelog
:cl:
fix: Oversight research datum added to outsider console to prevent core RND being printed from it.
/:cl:
