### PR TITLE
Small fixes to southern cross

### DIFF
--- a/modular_chomp/maps/southern_cross/southern_cross-2.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-2.dmm
@@ -15898,6 +15898,7 @@
 	pixel_x = 11;
 	pixel_y = -24
 	},
+/obj/structure/closet/crate/hydroponics/prespawned,
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/xenoflora)
 "fFB" = (
@@ -15998,7 +15999,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "fKK" = (
-/obj/structure/closet/crate/hydroponics/prespawned,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
 	},

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -50203,6 +50203,10 @@
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 10
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/distillery)
 "hlX" = (
@@ -51427,6 +51431,9 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/wingrille_spawn/reinforced/polarized{
 	id = "hop_office"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/heads/sc/hop)
@@ -74128,9 +74135,6 @@
 	},
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay)
 "vyn" = (


### PR DESCRIPTION

## About The Pull Request

Fixes a few minor mapping errors

## Changelog
:cl:
maptweak: Moves the xenobotany hydroponics crate so it doesn't block the fridge at round start
maptweak: Adds an air alarm to the distillery room which was either missed or got lost again
maptweak: Deleted some redundant supply piping that had been accidentally placed in medical at some point
maptweak: Fixed the wires for the electrified grilles in the HoP's office
/:cl:
