### PR TITLE
Fixes food replicator math error (and buffs it a little bit)

### DIFF
--- a/modular_chomp/code/game/machinery/food_replicator.dm
+++ b/modular_chomp/code/game/machinery/food_replicator.dm
@@ -71,7 +71,7 @@
 		var/product_path = products[choice]
 		var/obj/item/reagent_containers/foodItem = new product_path
 
-		var/total = abs(foodItem.reagents.total_volume-foodItem.reagents.get_free_space())
+		var/total = foodItem.reagents.total_volume
 
 		if(!container)
 			to_chat(user, span_warning("There is no container!"))
@@ -196,7 +196,7 @@
     for(var/obj/item/stock_parts/manipulator/M in component_parts)
         man_rating += M.rating
 
-    efficiency = (man_rating > 0) ? 6 / man_rating : 3
+    efficiency = 3 / man_rating
     speed = cap_rating / 2
 
 


### PR DESCRIPTION

## About The Pull Request
The food replicator had an issue where the amount of nutriment needed to print an item depended on how far it was from half of its maximum volume. I figured that was way too overcomplicated and simply made the cost be based on the total volume of reagents in the dish.
I also made the efficiency, which is a multiplier to the amount of nutriment used, be equal to 3 divided by the manipulator's tier. This way, at any level below 3, it will cost more nutriment to make the food than the food has. At 3 it will be equal, and above 3, it will be even cheaper. The reasoning behind this is that nutriment is incredibly easy to get. The largest limiting factor is that you have to grind up whatever has nutriment in order to use it in the first place. Letting the nutriment cost get this low helps the food replicator actually serve as a scene tool.
## Changelog
:cl:
fix: The food replicator now costs nutriment based on how many units of reagents are in the replicated dish.
/:cl:
