### PR TITLE
Makes the dialog/attacklog tables clear again after each round

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -641,6 +641,24 @@ var/failed_old_db_connections = 0
 		to_world_log("Your server failed to establish a connection with the feedback database.")
 	else
 		to_world_log("Feedback database connection established.")
+		// CHOMPEdit Begin - Truncating the temporary dialog/attacklog tables
+		var/datum/db_query/query_truncate = SSdbcore.NewQuery("TRUNCATE erro_dialog")
+		var/num_tries = 0
+		while(!query_truncate.Execute() && num_tries<5)
+			num_tries++
+
+		if(num_tries==5)
+			log_admin("ERROR TRYING TO CLEAR erro_dialog")
+		qdel(query_truncate)
+		var/datum/db_query/query_truncate2 = SSdbcore.NewQuery("TRUNCATE erro_attacklog")
+		num_tries = 0
+		while(!query_truncate2.Execute() && num_tries<5)
+			num_tries++
+
+		if(num_tries==5)
+			log_admin("ERROR TRYING TO CLEAR erro_attacklog")
+		qdel(query_truncate2)
+		// CHOMPEdit End
 	return 1
 
 /proc/setup_database_connection()


### PR DESCRIPTION

## About The Pull Request

The tables fill up but do not get cleared, which will cause lag in the log windows as the logs are basically getting infinitely big.

This PR reintroduces the lines removed from the https://github.com/CHOMPStation2/CHOMPStation2/pull/9963 mirror so that the tables get cleared again each round.

## Changelog
:cl:
fix: makes the dialog/attacklog tables clear again after each round
/:cl:
