### PR TITLE
Fixes simplemob kin being able to dark tunnel

### DIFF
--- a/modular_chomp/maps/southern_cross/southern_cross_overrides.dm
+++ b/modular_chomp/maps/southern_cross/southern_cross_overrides.dm
@@ -23,6 +23,13 @@
 		to_chat(src, span_danger("The VR systems cannot comprehend this power! This is useless to you!"))
 		. = FALSE
 
+/obj/effect/shadekin_ability/dark_tunneling/do_ability()
+	if(istype(get_area(my_kin), /area/vr))
+		to_chat(my_kin, span_danger("The VR systems cannot comprehend this power! This is useless to you!"))
+		return FALSE
+	else
+		..()
+
 
 /obj/item/disposable_teleporter/attack_self(mob/user as mob)//Prevents people from using technomancer gear to escape to station from the VR pods.
 	if(istype(get_area(user), /area/vr))


### PR DESCRIPTION

## About The Pull Request
Fixes simplemob kin in VR being able to dark tunnel.
## Changelog
:cl:
fix: removes an unintended way to break into/out of VR
/:cl:
