### PR TITLE
Changelog Workflow Update Mirror

### DIFF
--- a/.github/workflows/autochangelog.yml
+++ b/.github/workflows/autochangelog.yml
@@ -15,10 +15,22 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+
+    - name: Generate App Token
+      id: app-token-generation
+      uses: actions/create-github-app-token@v1
+      if: env.APP_PRIVATE_KEY != '' && env.APP_ID != ''
+      with:
+        app-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      env:
+        APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        APP_ID: ${{ secrets.APP_ID }}
+
     - name: Run auto changelog
       uses: actions/github-script@v7
       with:
         script: |
           const { processAutoChangelog } = await import('${{ github.workspace }}/tools/pull_request_hooks/autoChangelog.js')
           await processAutoChangelog({ github, context })
-        github-token: ${{ secrets.COMFY_ORANGE_PAT || secrets.GITHUB_TOKEN }}
+        github-token: ${{ steps.app-token-generation.outputs.token || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -18,37 +18,54 @@ jobs:
       #    unset SECRET_EXISTS
       #    if [ -n "$ENABLER_SECRET" ]; then SECRET_EXISTS=true ; fi
       #    echo "ACTIONS_ENABLED=$SECRET_EXISTS" >> $GITHUB_OUTPUT
+
       - name: "Setup python"
         #if: steps.value_holder.outputs.ACTIONS_ENABLED
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+
       - name: "Install deps"
         #if: steps.value_holder.outputs.ACTIONS_ENABLED
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyyaml
           sudo apt-get install  dos2unix
+
       - name: "Checkout"
         #if: steps.value_holder.outputs.ACTIONS_ENABLED
         uses: actions/checkout@v4
         with:
           fetch-depth: 25
           persist-credentials: false
+
       - name: "Compile"
         #if: steps.value_holder.outputs.ACTIONS_ENABLED
         run: |
           python tools/ss13_genchangelog.py html/changelogs_ch
+
       - name: Commit
         #if: steps.value_holder.outputs.ACTIONS_ENABLED
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "Changelogs"
+          git config --local user.name "chompstation-ci[bot]"
+          git config --local user.email "12787406+chompstation-ci[bot]@users.noreply.github.com"
           git pull origin master
           git add html/changelogs_ch
           git commit -m "Automatic changelog compile [ci skip]" -a || true
+
+      - name: Generate App Token
+        id: app-token-generation
+        uses: actions/create-github-app-token@v1
+        if: env.APP_PRIVATE_KEY != '' && env.APP_ID != ''
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+        env:
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+          APP_ID: ${{ secrets.APP_ID }}
+
       - name: "Push"
         #if: steps.value_holder.outputs.ACTIONS_ENABLED
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.COMFY_ORANGE_PAT || secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token-generation.outputs.token || secrets.GITHUB_TOKEN }}

--- a/tools/pull_request_hooks/changelogParser.js
+++ b/tools/pull_request_hooks/changelogParser.js
@@ -42,7 +42,7 @@ function parseChangelogBody(lines, openTag) {
 
 			const entry = CHANGELOG_KEYS_TO_ENTRY[type] || CHANGELOG_KEYS_TO_ENTRY["rscadd"];
 
-			if (entry.placeholders.includes(description)) {
+			if (!entry || entry.placeholders.includes(description)) {
 				continue;
 			}
 
@@ -64,6 +64,9 @@ function parseChangelogBody(lines, openTag) {
 }
 
 export function parseChangelog(text) {
+	if(text == null) {
+		return undefined;
+	}
 	const lines = text.split("\n").map((line) => line.trim());
 
 	for (let index = 0; index < lines.length; index++) {


### PR DESCRIPTION
## About The Pull Request

> [!NOTE]
> You will be required to set up the repository secrets (see the workflow file), according to the values you get after creating a GitHub App. The compile_changelogs workflow also has to be changed to use the correct user.name and user.email. 
If it is not configured though, it will (or should) use the default github actions user (but this user cannot be added as an exception in rulesets). 

------

Mirror of https://github.com/VOREStation/VOREStation/pull/17173 because (once more) mirror bot did not want to mirror the PR.

This only updates the credentials of the workflow so it doesnt have anything happening on the server.
