### PR TITLE
Fixes firefighting foam hitting ghosts

### DIFF
--- a/code/modules/reagents/reagents/other_vr.dm
+++ b/code/modules/reagents/reagents/other_vr.dm
@@ -92,9 +92,9 @@
 		var/mob/living/simple_mob/slime/S = M
 		S.adjustToxLoss(15 * reac_volume)
 		S.visible_message(span_warning("[S]'s flesh sizzles where the foam touches it!"), span_danger("Your flesh burns in the foam!"))
-
-	M.adjust_fire_stacks(-reac_volume)
-	M.ExtinguishMob()
+	if(istype(M))
+		M.adjust_fire_stacks(-reac_volume)
+		M.ExtinguishMob()
 
 /datum/reagent/liquid_protean
 	name = REAGENT_LIQUIDPROTEAN


### PR DESCRIPTION

## About The Pull Request
This was already fixed upstream, no idea why it was excluded here.
## Changelog
:cl:
fix: Shooting a ghost with firefighting foam will no longer make the server explode
/:cl:
