### PR TITLE
Chomp edit notes and CI cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,6 @@ jobs:
       - name: Ensure +x on CI directory
         run: |
           chmod -R +x ./tools/ci
-      - name: Restore SpacemanDMM cache
-        uses: actions/cache@v4
-        with:
-          path: ~/SpacemanDMM
-          key: ${{ runner.os }}-spacemandmm-${{ hashFiles('dependencies.sh') }}
-          restore-keys: |
-            ${{ runner.os }}-spacemandmm-
       - name: Restore Yarn cache
         uses: actions/cache@v4
         with:
@@ -69,7 +62,6 @@ jobs:
           pip3 install setuptools
           bash tools/ci/install_build_deps.sh
           bash tools/ci/install_ripgrep.sh
-          bash tools/ci/install_spaceman_dmm.sh dreamchecker
           bash tools/ci/install_spaceman_dmm.sh dmm-tools
           tools/bootstrap/python -c ''
       - name: Run Validation Tests
@@ -88,6 +80,7 @@ jobs:
         run: tools/github-actions/nanomap-renderer-invoker.sh --testing
 
   dreamchecker:
+    if: ( !contains(github.event.head_commit.message, '[ci skip]') )
     name: DreamChecker
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/render_nanomaps.yml
+++ b/.github/workflows/render_nanomaps.yml
@@ -20,7 +20,7 @@ jobs:
       pull-requests: write # to create pull requests (repo-sync/pull-request)
 
     name: 'Generate NanoMaps'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Clone
       uses: actions/checkout@v4

--- a/tools/UpdatePaths/__main__.py
+++ b/tools/UpdatePaths/__main__.py
@@ -195,7 +195,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(prog=prog, description=desc, formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("update_source", help="update file path / line of update notation")
     parser.add_argument("--map", "-m", help="path to update, defaults to all maps in directory")
-    parser.add_argument("--directory", "-d", help="path to maps directory, defaults to modular_chomp/maps")
+    parser.add_argument("--directory", "-d", help="path to maps directory, defaults to modular_chomp/maps") # ChompEDIT
     parser.add_argument("--inline", "-i", help="treat update source as update string instead of path", action="store_true")
     parser.add_argument("--verbose", "-v", help="toggle detailed update information", action="store_true")
     main(parser.parse_args())

--- a/tools/ci/validate_files.sh
+++ b/tools/ci/validate_files.sh
@@ -23,7 +23,7 @@ if command -v rg >/dev/null 2>&1; then
 	fi
 	code_files="code/**/**.dm"
 	map_files="maps/**/**.dmm"
-	modular_map_files="modular_chomp/maps/**/**.dmm"
+	modular_map_files="modular_chomp/maps/**/**.dmm" # CHOMPEdit - Modular maps
 	# shuttle_map_files="_maps/shuttles/**.dmm"
 	# code_x_515="code/**/!(__byond_version_compat).dm"
 else
@@ -31,7 +31,7 @@ else
 	grep=grep
 	code_files="-r --include=code/**/**.dm"
 	map_files="-r --include=maps/**/**.dmm"
-	modular_map_files="-r --include=modular_chomp/maps/**/**.dmm"
+	modular_map_files="-r --include=modular_chomp/maps/**/**.dmm" # CHOMPEdit - Modular maps
 	# shuttle_map_files="-r --include=_maps/shuttles/**.dmm"
 	# code_x_515="-r --include=code/**/!(__byond_version_compat).dm"
 fi
@@ -61,12 +61,14 @@ if [ $retVal -ne 0 ]; then
   FAILED=1
 fi
 
+# ChompEDIT START
 (! $grep 'step_[xy]' $modular_map_files)
 retVal=$?
 if [ $retVal -ne 0 ]; then
   echo -e "${RED}The variables 'step_x' and 'step_y' are present on a map, and they 'break' movement ingame.${NC}"
   FAILED=1
 fi
+# ChompEDIT END
 
 part "test map included"
 #Checking for any 'checked' maps that include 'test'

--- a/tools/maplint/source/__main__.py
+++ b/tools/maplint/source/__main__.py
@@ -109,10 +109,12 @@ def main(args):
     for map_filename in (args.maps or glob.glob("**/*.dmm", recursive = True)):
         print(map_filename, end = " ")
 
+        # ChompEDIT START
         if not args.maps:
             if "modular_chomp/maps/" not in map_filename:
                 print(yellow("SKIPPED"))
                 continue
+        # ChompEDIT END
 
         success = True
         all_failures: list[MaplintError] = []

--- a/tools/mapmerge2/fixup.py
+++ b/tools/mapmerge2/fixup.py
@@ -60,7 +60,7 @@ def main(repo : pygit2.Repository):
 
     # Set up upstream remote if needed
     try:
-        repo.remotes.create("upstream", "https://github.com/CHOMPStation2/CHOMPStation2.git")
+        repo.remotes.create("upstream", "https://github.com/CHOMPStation2/CHOMPStation2.git") # ChompEDIT
     except ValueError:
         pass
     else:

--- a/tools/mapmerge2/frontend.py
+++ b/tools/mapmerge2/frontend.py
@@ -19,7 +19,7 @@ def read_settings():
     try:
         map_folder = os.environ['MAPROOT']
     except KeyError:
-        map_folder = 'modular_chomp/maps/'
+        map_folder = 'modular_chomp/maps/' # ChompEDIT
         for _ in range(8):
             if os.path.exists(map_folder):
                 break


### PR DESCRIPTION

## About The Pull Request

This PR is a follow up to #7620 and #9105 adding chomp edit comments where it differs from virgo, cleans up some of the CI redundant calls and missing CI skips, and updates the ubuntu version for nanomaps (virgo already has it on 24).

## Changelog
:cl: Drathek
code: Cleanup CI and add chomp edit comments to tooling edits
/:cl:
