### PR TITLE
Map Fixes and Access list update

### DIFF
--- a/config/example/access levels.txt
+++ b/config/example/access levels.txt
@@ -16,64 +16,104 @@ For example, a brig door would have it be "2" while a door that requires you hav
 
 Here is a list of the permissions and their numbers (this may be out of date, see code/game/access.dm for an updated version):
 
-access_security = 1
-access_brig = 2
-access_armory = 3
-access_forensics_lockers= 4
-access_medical = 5
-access_morgue = 6
-access_tox = 7
-access_tox_storage = 8
-access_genetics = 9
-access_engine = 10
-access_engine_equip= 11
-access_maint_tunnels = 12
-access_external_airlocks = 13
-access_emergency_storage = 14
-access_change_ids = 15
-access_ai_upload = 16
-access_teleporter = 17
-access_eva = 18
-access_heads = 19
-access_captain = 20
-access_all_personal_lockers = 21
-access_chapel_office = 22
-access_tech_storage = 23
-access_atmospherics = 24
-access_bar = 25
-access_janitor = 26
-access_crematorium = 27
-access_kitchen = 28
-access_robotics = 29
-access_rd = 30
-access_cargo = 31
-access_construction = 32
-access_chemistry = 33
-access_cargo_bot = 34
-access_hydroponics = 35
-access_manufacturing = 36
-access_library = 37
-access_lawyer = 38
-access_virology = 39
-access_cmo = 40
-access_qm = 41
-access_court = 42
-access_clown = 43
-access_mime = 44
-access_surgery = 45
-access_theatre = 46
-access_research = 47
-access_mining = 48
-access_mining_office = 49 //not in use
-access_mailsorting = 50
-access_mint = 51
-access_mint_vault = 52
-access_heads_vault = 53
-access_mining_station = 54
-access_xenobiology = 55
-access_ce = 56
-access_hop = 57
-access_hos = 58
-access_RC_announce = 59 //Request console announcements
-access_keycard_auth = 60 //Used for events which require at least two people to confirm them
-access_tcomsat = 61 // has access to the entire telecomms satellite / machinery
+Access
+Here are the various door access.
+
+access_security = 1 //Security Equipment
+access_brig = 2 //Holding Cells
+access_armory = 3 //Armory
+access_forensics_lockers= 4 //Forensics
+access_medical = 5 //Medical
+access_morgue = 6 //Morgue
+access_tox = 7 //R&D Lab
+access_tox_storage = 8 //Toxins Lab
+access_genetics = 9 //Genetics Lab
+access_engine = 10 //Engineering
+access_engine_equip= 11 //Engine Room
+access_maint_tunnels = 12 //Maintenance
+access_external_airlocks = 13 //External Airlocks
+access_emergency_storage = 14 //Emergency Storage
+access_change_ids = 15 //ID Computer
+access_ai_upload = 16 //AI Upload
+access_teleporter = 17 //Teleporter
+access_eva = 18 //EVA
+access_heads = 19 //Bridge
+access_captain = 20 //Captain (JOB_SITE_MANAGER)
+access_all_personal_lockers = 21 //Personal Lockers
+access_chapel_office = 22 //Chapel Office
+access_tech_storage = 23 //Technical Storage
+access_atmospherics = 24 //Atmospherics
+access_bar = 25 //Bar
+access_janitor = 26 //Custodial Closet
+access_crematorium = 27 //Crematorium
+access_kitchen = 28 //Kitchen
+access_robotics = 29 //Robotics
+access_rd = 30 //Research Director (JOB_RESEARCH_DIRECTOR)
+access_cargo = 31 //Cargo Bay
+access_construction = 32 //Contruction Areas
+access_chemistry = 33 //Chemistry Lab
+access_cargo_bot = 34 //Cargo Bot Delivery
+access_hydroponics = 35 //Hydroponics
+access_manufacturing = 36 //Manufacturing (not used)
+access_library = 37 //Library
+access_lawyer = 38 //Internal Affairs
+access_virology = 39 //Virology
+access_cmo = 40 //CMO (JOB_CHIEF_MEDICAL_OFFICER)
+access_qm = 41 //Quartermaster (JOB_QUARTERMASTER)
+access_network = 42 //Station Network
+access_explorer = 43 //Explorer (JOB_EXPLORER)
+access_pathfinder = 44 //Pathfinder (JOB_PATHFINDER)
+access_surgery = 45 //Surgery
+free_access_id = 46 //(Not used / commented out)
+access_research = 47 //Science
+access_mining = 48 //Mining
+access_mining_office = 49 //Mining office (not used)
+access_mailsorting = 50 //Cargo Office
+free_access_id = 51 //(Not used / commented out)
+free_access_id = 52 //(Not used / commented out)
+access_heads_vault = 53 //Main Vault
+access_mining_station = 54 //Mining EVA
+access_xenobiology = 55 //Xenobiology Lab
+access_ce = 56 //Cheif Engineer (JOB_CHIEF_ENGINEER)
+access_hop = 57 //Head of Personnel (JOB_HEAD_OF_PERSONNEL)
+access_hos = 58 //Head of Security (JOB_HEAD_OF_SECURITY)
+access_RC_announce = 59 //RC Announcements (Request console announcements)
+access_keycard_auth = 60 //Keycode Auth. Device (Used for events which require at least two people to confirm them such as the red alert panel in the bridge)
+access_tcomsat = 61 //Telecommunications (Has access to the entire telecomms satellite / machinery)
+access_gateway = 62 //Gateway
+access_sec_doors = 63 //Security
+access_psychiatrist = 64 //Psychiatrist's Office (JOB_PSYCHIATRIST + "'s Office")
+access_xenoarch = 65 //Xenoarchaeology
+access_medical_equip = 66 //Medical Equipment
+access_pilot = 67 //Pilot
+access_entertainment = 72 //Entertainment Backstage
+access_xenobotany = 77 //Xenobotany Garden
+
+CentCom Access
+Mostly for admin use.
+
+access_cent_general = 101 //General Facilities
+access_cent_thunder = 102 //Entertainment Facilities (Thunderdome)
+access_cent_specops = 103 //ERT Prep / Special Ops (JOB_EMERGENCY_RESPONSE_TEAM + "Prep")
+access_cent_medical = 104 //Medical Facilities
+access_cent_living = 105 //Dormitories
+access_cent_storage = 106 //Storage
+access_cent_teleporter = 107 //Central Command Teleporter
+access_cent_creed = 108 //ERT Administration / ERT Leader Office (JOB_EMERGENCY_RESPONSE_TEAM + "Administration")
+access_cent_captain = 109 //Central Command Administration (Captain's office/ID comp/AI)
+access_clown = 136 //Clown Office (JOB_CLOWN + "Office")
+access_tomfoolery = 137 //Tomfoolery Closet
+access_mime = 138 //Mime Office (JOB_MIME + "Office")
+
+Antag Access
+
+access_syndicate = 150 //Syndicate (General Syndicate Access)
+
+Misc Access
+
+access_synth = 199 //Synthetic
+access_crate_cash = 200 //Crate cash (Money Crates?)
+access_trader = 160 //Trader (General Beruang Trader Access?)
+access_alien = 300 //#%_^&*@! (For things like crashed ships)
+access_talon = 301 //Talon
+access_lost = 511 //Lost (For outsider borgs)

--- a/config/example/access levels.txt
+++ b/config/example/access levels.txt
@@ -16,104 +16,64 @@ For example, a brig door would have it be "2" while a door that requires you hav
 
 Here is a list of the permissions and their numbers (this may be out of date, see code/game/access.dm for an updated version):
 
-Access
-Here are the various door access.
-
-access_security = 1 //Security Equipment
-access_brig = 2 //Holding Cells
-access_armory = 3 //Armory
-access_forensics_lockers= 4 //Forensics
-access_medical = 5 //Medical
-access_morgue = 6 //Morgue
-access_tox = 7 //R&D Lab
-access_tox_storage = 8 //Toxins Lab
-access_genetics = 9 //Genetics Lab
-access_engine = 10 //Engineering
-access_engine_equip= 11 //Engine Room
-access_maint_tunnels = 12 //Maintenance
-access_external_airlocks = 13 //External Airlocks
-access_emergency_storage = 14 //Emergency Storage
-access_change_ids = 15 //ID Computer
-access_ai_upload = 16 //AI Upload
-access_teleporter = 17 //Teleporter
-access_eva = 18 //EVA
-access_heads = 19 //Bridge
-access_captain = 20 //Captain (JOB_SITE_MANAGER)
-access_all_personal_lockers = 21 //Personal Lockers
-access_chapel_office = 22 //Chapel Office
-access_tech_storage = 23 //Technical Storage
-access_atmospherics = 24 //Atmospherics
-access_bar = 25 //Bar
-access_janitor = 26 //Custodial Closet
-access_crematorium = 27 //Crematorium
-access_kitchen = 28 //Kitchen
-access_robotics = 29 //Robotics
-access_rd = 30 //Research Director (JOB_RESEARCH_DIRECTOR)
-access_cargo = 31 //Cargo Bay
-access_construction = 32 //Contruction Areas
-access_chemistry = 33 //Chemistry Lab
-access_cargo_bot = 34 //Cargo Bot Delivery
-access_hydroponics = 35 //Hydroponics
-access_manufacturing = 36 //Manufacturing (not used)
-access_library = 37 //Library
-access_lawyer = 38 //Internal Affairs
-access_virology = 39 //Virology
-access_cmo = 40 //CMO (JOB_CHIEF_MEDICAL_OFFICER)
-access_qm = 41 //Quartermaster (JOB_QUARTERMASTER)
-access_network = 42 //Station Network
-access_explorer = 43 //Explorer (JOB_EXPLORER)
-access_pathfinder = 44 //Pathfinder (JOB_PATHFINDER)
-access_surgery = 45 //Surgery
-free_access_id = 46 //(Not used / commented out)
-access_research = 47 //Science
-access_mining = 48 //Mining
-access_mining_office = 49 //Mining office (not used)
-access_mailsorting = 50 //Cargo Office
-free_access_id = 51 //(Not used / commented out)
-free_access_id = 52 //(Not used / commented out)
-access_heads_vault = 53 //Main Vault
-access_mining_station = 54 //Mining EVA
-access_xenobiology = 55 //Xenobiology Lab
-access_ce = 56 //Cheif Engineer (JOB_CHIEF_ENGINEER)
-access_hop = 57 //Head of Personnel (JOB_HEAD_OF_PERSONNEL)
-access_hos = 58 //Head of Security (JOB_HEAD_OF_SECURITY)
-access_RC_announce = 59 //RC Announcements (Request console announcements)
-access_keycard_auth = 60 //Keycode Auth. Device (Used for events which require at least two people to confirm them such as the red alert panel in the bridge)
-access_tcomsat = 61 //Telecommunications (Has access to the entire telecomms satellite / machinery)
-access_gateway = 62 //Gateway
-access_sec_doors = 63 //Security
-access_psychiatrist = 64 //Psychiatrist's Office (JOB_PSYCHIATRIST + "'s Office")
-access_xenoarch = 65 //Xenoarchaeology
-access_medical_equip = 66 //Medical Equipment
-access_pilot = 67 //Pilot
-access_entertainment = 72 //Entertainment Backstage
-access_xenobotany = 77 //Xenobotany Garden
-
-CentCom Access
-Mostly for admin use.
-
-access_cent_general = 101 //General Facilities
-access_cent_thunder = 102 //Entertainment Facilities (Thunderdome)
-access_cent_specops = 103 //ERT Prep / Special Ops (JOB_EMERGENCY_RESPONSE_TEAM + "Prep")
-access_cent_medical = 104 //Medical Facilities
-access_cent_living = 105 //Dormitories
-access_cent_storage = 106 //Storage
-access_cent_teleporter = 107 //Central Command Teleporter
-access_cent_creed = 108 //ERT Administration / ERT Leader Office (JOB_EMERGENCY_RESPONSE_TEAM + "Administration")
-access_cent_captain = 109 //Central Command Administration (Captain's office/ID comp/AI)
-access_clown = 136 //Clown Office (JOB_CLOWN + "Office")
-access_tomfoolery = 137 //Tomfoolery Closet
-access_mime = 138 //Mime Office (JOB_MIME + "Office")
-
-Antag Access
-
-access_syndicate = 150 //Syndicate (General Syndicate Access)
-
-Misc Access
-
-access_synth = 199 //Synthetic
-access_crate_cash = 200 //Crate cash (Money Crates?)
-access_trader = 160 //Trader (General Beruang Trader Access?)
-access_alien = 300 //#%_^&*@! (For things like crashed ships)
-access_talon = 301 //Talon
-access_lost = 511 //Lost (For outsider borgs)
+access_security = 1
+access_brig = 2
+access_armory = 3
+access_forensics_lockers= 4
+access_medical = 5
+access_morgue = 6
+access_tox = 7
+access_tox_storage = 8
+access_genetics = 9
+access_engine = 10
+access_engine_equip= 11
+access_maint_tunnels = 12
+access_external_airlocks = 13
+access_emergency_storage = 14
+access_change_ids = 15
+access_ai_upload = 16
+access_teleporter = 17
+access_eva = 18
+access_heads = 19
+access_captain = 20
+access_all_personal_lockers = 21
+access_chapel_office = 22
+access_tech_storage = 23
+access_atmospherics = 24
+access_bar = 25
+access_janitor = 26
+access_crematorium = 27
+access_kitchen = 28
+access_robotics = 29
+access_rd = 30
+access_cargo = 31
+access_construction = 32
+access_chemistry = 33
+access_cargo_bot = 34
+access_hydroponics = 35
+access_manufacturing = 36
+access_library = 37
+access_lawyer = 38
+access_virology = 39
+access_cmo = 40
+access_qm = 41
+access_court = 42
+access_clown = 43
+access_mime = 44
+access_surgery = 45
+access_theatre = 46
+access_research = 47
+access_mining = 48
+access_mining_office = 49 //not in use
+access_mailsorting = 50
+access_mint = 51
+access_mint_vault = 52
+access_heads_vault = 53
+access_mining_station = 54
+access_xenobiology = 55
+access_ce = 56
+access_hop = 57
+access_hos = 58
+access_RC_announce = 59 //Request console announcements
+access_keycard_auth = 60 //Used for events which require at least two people to confirm them
+access_tcomsat = 61 // has access to the entire telecomms satellite / machinery

--- a/modular_chomp/maps/southern_cross/southern_cross-2.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-2.dmm
@@ -13660,21 +13660,8 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/item/reagent_containers/glass/bottle/diethylamine{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/glass/bottle/diethylamine{
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/glass/bottle/mutagen{
-	pixel_y = 10;
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/glass/bottle/mutagen{
-	pixel_x = 5;
-	pixel_y = 10
-	},
 /obj/structure/table/standard,
+/obj/machinery/chemical_dispenser/full,
 /turf/simulated/floor/tiled/hydro,
 /area/rnd/xenobiology/xenoflora)
 "dZe" = (

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -3311,7 +3311,7 @@
 /obj/machinery/door/airlock/highsecurity{
 	name = "Armoury Tactical Equipment";
 	req_access = list(3);
-	req_one_access = list(3)
+	req_one_access = null
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -7930,7 +7930,7 @@
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Armoury Section";
 	req_access = list(3);
-	req_one_access = list(3)
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/armoury)
@@ -9773,8 +9773,7 @@
 "aET" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	name = "Central Maintenance Access";
-	req_one_access = list(12,19)
+	name = "Central Maintenance Access"
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -10505,7 +10504,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/security{
 	name = "Security Locker Room";
-	req_access = list(1)
+	req_access = list(1);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/security_lockerroom)
@@ -11534,7 +11534,8 @@
 	},
 /obj/machinery/door/airlock/security{
 	name = "Equipment Storage";
-	req_access = list(2)
+	req_access = list(1);
+	req_one_access = null
 	},
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -11593,7 +11594,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11876,8 +11878,7 @@
 "aMc" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	name = "Central Maintenance Access";
-	req_one_access = list(12,19)
+	name = "Central Maintenance Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -13496,7 +13497,8 @@
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "prisonentry";
 	name = "Brig Entry";
-	req_access = list(2)
+	req_access = list(2);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/prison)
@@ -13505,7 +13507,8 @@
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "prisonentry";
 	name = "Brig Entry";
-	req_access = list(2)
+	req_access = list(2);
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel_grid,
@@ -13754,7 +13757,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/security{
 	name = "Warden's Office";
-	req_access = list(3)
+	req_access = list(3);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/warden)
@@ -13839,7 +13843,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence_storage)
@@ -15033,7 +15038,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
 	name = "Firing Range";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/range)
@@ -15969,8 +15975,7 @@
 "aZF" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	name = "Central Maintenance Access";
-	req_one_access = list(12,19)
+	name = "Central Maintenance Access"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -16496,6 +16501,12 @@
 "baN" = (
 /obj/structure/cable/green{
 	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/medical_restroom)
@@ -17222,8 +17233,7 @@
 /obj/machinery/door/window/brigdoor/northright{
 	id = "Cell 2";
 	name = "Cell 2";
-	req_access = null;
-	req_one_access = list(2,4)
+	req_access = list(2)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/brig)
@@ -17306,8 +17316,7 @@
 /obj/machinery/door/window/brigdoor/northright{
 	id = "Cell 1";
 	name = "Cell 1";
-	req_access = null;
-	req_one_access = list(2,4)
+	req_access = list(2)
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/brig)
@@ -17319,7 +17328,8 @@
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "prisonexit";
 	name = "Brig Exit";
-	req_access = list(2)
+	req_access = list(2);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/prison)
@@ -17335,7 +17345,8 @@
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "prisonexit";
 	name = "Brig Exit";
-	req_access = list(2)
+	req_access = list(2);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/prison)
@@ -17867,7 +17878,8 @@
 	},
 /obj/machinery/door/airlock/security{
 	name = "Security Processing";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/security_processing)
@@ -21599,7 +21611,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass_security{
 	name = "Briefing Room";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/main)
@@ -21747,7 +21760,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/security{
 	name = "Riot Control";
-	req_access = list(2)
+	req_access = list(2);
+	req_one_access = null
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -21782,7 +21796,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass_security{
 	name = "Solitary Confinement 1";
-	req_access = list(2)
+	req_access = list(2);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/brig)
@@ -21792,7 +21807,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass_security{
 	name = "Solitary Confinement 2";
-	req_access = list(2)
+	req_access = list(2);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/brig)
@@ -22084,7 +22100,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Cells";
-	req_access = list(1)
+	req_access = list(2);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/brig)
@@ -22433,7 +22450,8 @@
 	},
 /obj/machinery/door/airlock/security{
 	name = "Warden's Office";
-	req_access = list(3)
+	req_access = list(3);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/security/warden)
@@ -22624,7 +22642,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/security{
 	name = "Security Processing";
-	req_access = list(1)
+	req_access = list(63);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/security_processing)
@@ -23446,8 +23465,7 @@
 "bxg" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/maintenance{
-	name = "Disposal Access";
-	req_access = list(12)
+	name = "Disposal Access"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23988,7 +24006,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Cells";
-	req_access = list(1)
+	req_access = list(2);
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24707,7 +24726,8 @@
 	},
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Medical";
-	req_access = newlist()
+	req_access = list(1);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/white,
 /area/security/aid_station)
@@ -24728,7 +24748,8 @@
 	},
 /obj/machinery/door/airlock/security{
 	name = "Secondary Equipment Storage";
-	req_access = list(2)
+	req_access = list(1);
+	req_one_access = null
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -26298,7 +26319,9 @@
 /obj/machinery/door/airlock/glass_security{
 	id_tag = "BrigFoyer";
 	layer = 2.8;
-	name = "Security Wing"
+	name = "Security Wing";
+	req_access = list(63);
+	req_one_access = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27384,7 +27407,8 @@
 /obj/machinery/door/airlock/security{
 	id_tag = "detdoor";
 	name = "Detective";
-	req_access = list(4)
+	req_access = list(4);
+	req_one_access = null
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable/green{
@@ -27418,7 +27442,8 @@
 	id_tag = "BrigFoyer";
 	layer = 2.8;
 	name = "Security Wing";
-	req_access = list(63)
+	req_access = list(63);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/security_hallway)
@@ -27637,7 +27662,8 @@
 	id_tag = "BrigFoyer";
 	layer = 2.8;
 	name = "Security Wing";
-	req_access = list(63)
+	req_access = list(63);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/security_hallway)
@@ -27718,7 +27744,8 @@
 	id_tag = "BrigFoyer";
 	layer = 2.8;
 	name = "Security Wing";
-	req_access = list(63)
+	req_access = list(63);
+	req_one_access = null
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/security/security_hallway)
@@ -29044,7 +29071,8 @@
 /obj/machinery/door/airlock/command{
 	id_tag = "HoSdoor";
 	name = "Head of Security Quarters";
-	req_access = list(58)
+	req_access = list(58);
+	req_one_access = null
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -29373,8 +29401,8 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/atmos{
 	name = "Riot Control Maintenance";
-	req_access = newlist();
-	req_one_access = list(2)
+	req_access = list(2);
+	req_one_access = null
 	},
 /turf/simulated/floor/plating,
 /area/security/riot_control)
@@ -29635,7 +29663,8 @@
 "bSD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/southleft{
-	name = "Secure Door"
+	name = "Secure Door";
+	req_access = list(63)
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -29666,7 +29695,8 @@
 "bSH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/southright{
-	name = "Secure Door"
+	name = "Secure Door";
+	req_access = list(63)
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -30574,7 +30604,8 @@
 /obj/machinery/door/airlock/security{
 	id_tag = "detdoor";
 	name = "Detective";
-	req_access = list(4)
+	req_access = list(4);
+	req_one_access = null
 	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
@@ -51732,12 +51763,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "hYU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
@@ -55534,9 +55560,6 @@
 	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -60344,9 +60367,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/borderfloorwhite/corner,
@@ -63995,9 +64015,6 @@
 	pixel_x = -21
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
@@ -70829,9 +70846,12 @@
 /turf/simulated/floor,
 /area/engineering/engine_room)
 "thh" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Maintenance Access"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/research_medical)
+/area/maintenance/central)
 "thu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72630,15 +72650,6 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/tiled,
 /area/maintenance/research_medical)
 "uvq" = (
@@ -72682,21 +72693,9 @@
 /area/chapel/office)
 "uwj" = (
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/maintenance{
 	req_access = null;
 	req_one_access = null
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/maintenance/research_medical)
@@ -72713,18 +72712,6 @@
 /obj/effect/floor_decal/corner/white/border,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"uxi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/research_medical)
 "uxj" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -72735,13 +72722,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/entry/D2)
-"uxr" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/research_medical)
 "uxW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/steeldecal/steel_decals6{
@@ -74340,15 +74320,6 @@
 	opacity = 0
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/research_medical)
 "vEe" = (
@@ -74386,15 +74357,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/maintenance/research_medical)
@@ -74456,7 +74418,12 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/medical/cryo)
 "vIb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/medical/medical_restroom)
 "vIn" = (
@@ -75584,11 +75551,6 @@
 	name = "Medical Access";
 	req_access = list(5)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/medical/medbay2)
@@ -76240,10 +76202,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/aft)
 "wTK" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	icon_state = "2-4"
@@ -76958,13 +76922,6 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
@@ -77030,9 +76987,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/window/reinforced{
@@ -78374,9 +78328,8 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
@@ -78416,7 +78369,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/ai_monitored/storage/emergency/eva)
 "yiw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
@@ -78428,6 +78380,9 @@
 	},
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medbay2)
@@ -111836,7 +111791,7 @@ dsj
 jEn
 kLo
 lJs
-mEJ
+thh
 aZC
 owO
 pmd
@@ -127581,8 +127536,8 @@ pGB
 qSA
 oiA
 oiA
-thh
-uxi
+rJB
+rJB
 jjH
 aAu
 veJ
@@ -127840,7 +127795,7 @@ qSS
 rQu
 oiA
 tiT
-uxr
+hxN
 jjH
 qoZ
 pVZ

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -892,6 +892,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/security_port)
+"abB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Maintenance Access"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/central)
 "abC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72705,13 +72712,6 @@
 /obj/effect/floor_decal/corner/white/border,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
-"uxi" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Maintenance Access"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/central)
 "uxj" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -111791,7 +111791,7 @@ dsj
 jEn
 kLo
 lJs
-uxi
+abB
 aZC
 owO
 pmd

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -70845,13 +70845,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor,
 /area/engineering/engine_room)
-"thh" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance{
-	name = "Central Maintenance Access"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/central)
 "thu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72712,6 +72705,13 @@
 /obj/effect/floor_decal/corner/white/border,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/dockhallway)
+"uxi" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance{
+	name = "Central Maintenance Access"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/central)
 "uxj" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -111791,7 +111791,7 @@ dsj
 jEn
 kLo
 lJs
-thh
+uxi
 aZC
 owO
 pmd

--- a/modular_chomp/maps/southern_cross/southern_cross-5.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-5.dmm
@@ -10896,6 +10896,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/atmos_room)
 "uQ" = (
@@ -26280,6 +26281,7 @@
 "Zi" = (
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/atmos_room)
 "Zj" = (

--- a/modular_chomp/maps/southern_cross/southern_cross-5.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-5.dmm
@@ -76,6 +76,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/outpost/main/corridor/left_lower)
+"ak" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
+"al" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
 "am" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -189,7 +199,12 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/mining_main/emergencystorage)
 "av" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/atmos_room)
 "aw" = (
@@ -271,6 +286,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/outpost/main/corridor/dorms)
+"aC" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
 "aD" = (
 /obj/effect/mist,
 /turf/simulated/floor/water/pool,
@@ -308,6 +329,13 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled,
 /area/surface/outpost/mining_main/tools)
+"aH" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
 "aI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -428,6 +456,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/security)
+"aU" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
 "aV" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister,
@@ -514,6 +549,23 @@
 /obj/effect/zone_divider,
 /turf/simulated/floor/tiled/steel/sif/planetuse,
 /area/surface/outside/plains/outpost)
+"bd" = (
+/obj/machinery/atmospherics/omni/mixer{
+	active_power_usage = 7500;
+	tag_east = 2;
+	tag_south_con = 0.79;
+	tag_west = 1;
+	tag_west_con = 0.21;
+	tag_south = 1
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
+"be" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
 "bf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
@@ -2699,17 +2751,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/engineering/monitoring)
-"fv" = (
-/obj/machinery/atmospherics/omni/mixer{
-	active_power_usage = 7500;
-	tag_east = 2;
-	tag_south_con = 0.79;
-	tag_west = 1;
-	tag_west_con = 0.21;
-	tag_south = 1
-	},
-/turf/simulated/floor/plating,
-/area/surface/outpost/engineering/atmos_room)
 "fw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -4205,13 +4246,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/outpost/civilian/sauna)
-"iv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/surface/outpost/engineering/atmos_room)
 "iw" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/white/border,
@@ -7526,14 +7560,6 @@
 /obj/machinery/computer/timeclock/premade/north,
 /turf/simulated/floor/tiled,
 /area/surface/outpost/main/corridor/left_lower)
-"oG" = (
-/obj/machinery/atmospherics/omni/atmos_filter{
-	tag_north = 4;
-	tag_south = 1;
-	tag_west = 2
-	},
-/turf/simulated/floor/plating,
-/area/surface/outpost/engineering/atmos_room)
 "oH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -10890,15 +10916,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/reactor_smes)
-"uP" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/plating,
-/area/surface/outpost/engineering/atmos_room)
 "uQ" = (
 /obj/structure/cable/blue{
 	icon_state = "0-2"
@@ -12115,8 +12132,10 @@
 	},
 /area/surface/outside/path/plains)
 "xr" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 8
+/obj/machinery/atmospherics/omni/atmos_filter{
+	tag_north = 4;
+	tag_south = 1;
+	tag_west = 2
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/atmos_room)
@@ -18758,12 +18777,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/outpost/main/exploration)
-"Kq" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/surface/outpost/engineering/atmos_room)
 "Kr" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Reactor Room External Access";
@@ -25625,13 +25638,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/outpost/main/janitor)
-"XT" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor/plating,
-/area/surface/outpost/engineering/atmos_room)
 "XU" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/white/bordercorner,
@@ -26278,12 +26284,6 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled,
 /area/surface/outpost/main/corridor/right_upper)
-"Zi" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/plating,
-/area/surface/outpost/engineering/atmos_room)
 "Zj" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/monotile,
@@ -50768,11 +50768,11 @@ nH
 ha
 ha
 KP
-Zi
-xr
+be
+aC
+al
 av
-uP
-Kq
+ak
 yI
 KP
 Ih
@@ -51027,9 +51027,9 @@ ha
 ha
 KP
 ZA
-fv
+bd
+aC
 xr
-oG
 qd
 CB
 dT
@@ -51286,7 +51286,7 @@ ha
 KP
 qy
 mE
-iv
+aH
 hZ
 jY
 jY
@@ -51544,7 +51544,7 @@ ha
 KP
 dU
 yB
-XT
+aU
 yB
 as
 Kk

--- a/modular_chomp/maps/southern_cross/southern_cross-5.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-5.dmm
@@ -189,9 +189,7 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/mining_main/emergencystorage)
 "av" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/atmos_room)
 "aw" = (
@@ -2702,7 +2700,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/surface/outpost/engineering/monitoring)
 "fv" = (
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/omni/mixer{
+	active_power_usage = 7500;
+	tag_east = 2;
+	tag_south_con = 0.79;
+	tag_west = 1;
+	tag_west_con = 0.21;
+	tag_south = 1
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/atmos_room)
 "fw" = (
@@ -4000,6 +4005,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/atmos_room)
 "ib" = (
@@ -4199,6 +4205,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/outpost/civilian/sauna)
+"iv" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
 "iw" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/white/border,
@@ -7513,6 +7526,14 @@
 /obj/machinery/computer/timeclock/premade/north,
 /turf/simulated/floor/tiled,
 /area/surface/outpost/main/corridor/left_lower)
+"oG" = (
+/obj/machinery/atmospherics/omni/atmos_filter{
+	tag_north = 4;
+	tag_south = 1;
+	tag_west = 2
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
 "oH" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -8283,7 +8304,7 @@
 	tag_east = 5;
 	tag_north = 2;
 	tag_south = 1;
-	tag_west = 6
+	tag_west = 3
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/atmos_room)
@@ -10870,10 +10891,11 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/reactor_smes)
 "uP" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
-/obj/machinery/meter,
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/atmos_room)
 "uQ" = (
@@ -12092,8 +12114,8 @@
 	},
 /area/surface/outside/path/plains)
 "xr" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/atmos_room)
@@ -14867,7 +14889,8 @@
 /obj/machinery/atmospherics/omni/atmos_filter{
 	tag_east = 7;
 	tag_north = 2;
-	tag_south = 1
+	tag_south = 1;
+	tag_west = 6
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/engineering/atmos_room)
@@ -15602,6 +15625,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/surface/outpost/mining_main/uxstorage)
 "Em" = (
@@ -18733,6 +18757,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/surface/outpost/main/exploration)
+"Kq" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
 "Kr" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Reactor Room External Access";
@@ -25594,6 +25624,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel_grid,
 /area/surface/outpost/main/janitor)
+"XT" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
 "XU" = (
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/white/bordercorner,
@@ -26240,6 +26277,11 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled,
 /area/surface/outpost/main/corridor/right_upper)
+"Zi" = (
+/obj/machinery/atmospherics/portables_connector,
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/plating,
+/area/surface/outpost/engineering/atmos_room)
 "Zj" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/monotile,
@@ -50465,7 +50507,7 @@ ha
 nH
 ha
 ha
-ha
+KP
 KP
 KP
 KP
@@ -50724,12 +50766,12 @@ nH
 ha
 ha
 KP
-KP
+Zi
+xr
 av
-av
-av
+uP
+Kq
 yI
-fv
 KP
 Ih
 pg
@@ -50983,9 +51025,9 @@ ha
 ha
 KP
 ZA
-mE
+fv
 xr
-xr
+oG
 qd
 CB
 dT
@@ -51241,8 +51283,8 @@ ha
 ha
 KP
 qy
-uP
-hZ
+mE
+iv
 hZ
 jY
 jY
@@ -51500,7 +51542,7 @@ ha
 KP
 dU
 yB
-yB
+XT
 yB
 as
 Kk

--- a/modular_chomp/maps/southern_cross/southern_cross-5.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-5.dmm
@@ -22044,7 +22044,7 @@
 	icon_state = "0-8"
 	},
 /obj/structure/cable/heavyduty{
-	icon_state = "0-1"
+	icon_state = "0-4"
 	},
 /obj/effect/wingrille_spawn/reinforced_phoron,
 /obj/machinery/door/firedoor/border_only,

--- a/modular_chomp/maps/southern_cross/southern_cross-6.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-6.dmm
@@ -3408,6 +3408,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hh" = (
@@ -3736,6 +3737,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hT" = (
@@ -4328,6 +4330,7 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "KX" = (

--- a/modular_chomp/maps/southern_cross/southern_cross-6.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-6.dmm
@@ -3121,14 +3121,15 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "gy" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
-	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "gz" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "gA" = (
@@ -3236,22 +3237,30 @@
 /area/surface/outpost/research/xenoarcheology/smes)
 "gO" = (
 /obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "gP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
+	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "gQ" = (
-/obj/machinery/atmospherics/binary/pump,
+/obj/machinery/atmospherics/pipe/tank/phoron{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "gR" = (
 /obj/machinery/atmospherics/omni/atmos_filter{
 	tag_east = 7;
 	tag_north = 1;
-	tag_south = 2
+	tag_south = 2;
+	tag_west = 6
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
@@ -3302,10 +3311,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/surface/outpost/research/xenoarcheology/restroom)
 "gW" = (
-/obj/item/reagent_containers/glass/bottle/toxin,
-/obj/item/reagent_containers/glass/beaker/sulphuric{
-	name = "beaker 'sulphuric acid'"
-	},
+/obj/machinery/chemical_dispenser/full,
 /obj/structure/table/glass,
 /obj/effect/floor_decal/corner/beige{
 	dir = 9
@@ -3398,28 +3404,30 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/emergencystorage)
 "hg" = (
-/obj/structure/closet/crate,
-/obj/item/stack/material/phoron{
-	amount = 25
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1
+	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hi" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hj" = (
 /obj/machinery/atmospherics/omni/atmos_filter{
-	tag_east = 5;
 	tag_north = 1;
-	tag_south = 2
+	tag_south = 2;
+	tag_west = 3
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
@@ -3548,12 +3556,13 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/emergencystorage)
 "hy" = (
-/obj/structure/closet/toolcloset,
-/obj/random/maintenance/clean,
-/obj/random/maintenance/clean,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -21
+	},
+/obj/structure/closet/crate,
+/obj/item/stack/material/phoron{
+	amount = 25
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
@@ -3573,28 +3582,37 @@
 /turf/simulated/floor/tiled,
 /area/surface/outpost/research/xenoarcheology/anomaly)
 "hA" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/omni/mixer{
+	active_power_usage = 7500;
+	tag_east = 1;
+	tag_east_con = 0.79;
+	tag_north = 1;
+	tag_north_con = 0.21;
+	tag_south_con = null;
+	tag_west = 2
+	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hB" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hC" = (
 /obj/machinery/atmospherics/omni/atmos_filter{
-	tag_east = 6;
 	tag_north = 1;
-	tag_west = 2
+	tag_south = 2;
+	tag_west = 4
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hD" = (
-/obj/machinery/atmospherics/pipe/tank/phoron{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hE" = (
@@ -3686,10 +3704,13 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/emergencystorage)
 "hP" = (
-/obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/tank/air{
+	dir = 1;
+	start_pressure = 740
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
@@ -3704,23 +3725,25 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hR" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 1;
-	start_pressure = 740
-	},
 /obj/machinery/light/small,
+/obj/structure/closet/toolcloset,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hS" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 1;
-	start_pressure = 740
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/empty,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hT" = (
 /obj/machinery/status_display{
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
@@ -3768,6 +3791,7 @@
 /obj/effect/floor_decal/corner/beige/full{
 	dir = 4
 	},
+/obj/item/reagent_containers/glass/bottle/toxin,
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology/analysis)
 "hY" = (
@@ -4143,6 +4167,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/cave/explored/trader)
+"vj" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/concrete,
+/area/surface/cave/explored/trader)
+"vA" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/concrete,
+/area/surface/cave/explored/trader)
 "xh" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating{
@@ -4189,6 +4223,13 @@
 /obj/item/bedsheet/cosmos,
 /mob/living/simple_mob/humanoid/starhunter/trader/farmer,
 /turf/simulated/floor/concrete,
+/area/surface/cave/explored/trader)
+"Ce" = (
+/obj/structure/cable/blue{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/rtg/advanced,
+/turf/simulated/floor/plating,
 /area/surface/cave/explored/trader)
 "Co" = (
 /obj/machinery/light{
@@ -4252,6 +4293,12 @@
 	},
 /turf/simulated/mineral/floor/ignore_mapgen/sif,
 /area/surface/outpost/research/xenoarcheology/exterior)
+"Gr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/concrete,
+/area/surface/cave/explored/trader)
 "Hs" = (
 /obj/effect/map_effect/portal/master/side_b/caves_to_plains{
 	dir = 1
@@ -4266,10 +4313,29 @@
 "In" = (
 /turf/simulated/floor/plating,
 /area/surface/cave/explored/trader)
+"Jh" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/surface/cave/explored/trader)
 "Jk" = (
 /obj/effect/map_effect/portal/line/side_a,
 /turf/simulated/wall/solidrock,
 /area/surface/outpost/wall/checkpoint)
+"Kt" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/plating,
+/area/surface/outpost/research/xenoarcheology/smes)
+"KX" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/concrete,
+/area/surface/cave/explored/trader)
 "LO" = (
 /turf/simulated/wall/solidrock,
 /area/surface/cave/explored/trader)
@@ -4410,6 +4476,9 @@
 "Xk" = (
 /obj/structure/cable/blue{
 	icon_state = "1-2"
+	},
+/obj/structure/cable/blue{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
 /area/surface/cave/explored/trader)
@@ -38222,8 +38291,8 @@ fD
 fW
 gw
 gw
-gw
-gw
+hi
+io
 hP
 fD
 il
@@ -38480,8 +38549,8 @@ fD
 fX
 gw
 gO
-gO
-io
+hD
+gy
 hQ
 fD
 il
@@ -38994,7 +39063,7 @@ eV
 fn
 fF
 fZ
-gy
+gw
 gQ
 hi
 hB
@@ -39513,8 +39582,8 @@ gb
 gA
 gS
 hk
-hD
 hU
+Kt
 fD
 eh
 eh
@@ -68408,7 +68477,7 @@ kx
 RM
 YU
 YU
-YU
+Gr
 YU
 YU
 YU
@@ -68660,7 +68729,7 @@ ae
 ae
 ae
 RM
-YU
+vA
 YU
 YU
 sH
@@ -69180,12 +69249,12 @@ RM
 RM
 RM
 RM
-YU
+vA
 YU
 kx
 kx
 YU
-YU
+vj
 RM
 nr
 nr
@@ -69435,7 +69504,7 @@ ae
 ae
 RM
 In
-In
+Ce
 UB
 RM
 St
@@ -69951,12 +70020,12 @@ ae
 ae
 RM
 In
-In
+Jh
 In
 sH
 YU
 YU
-YU
+KX
 YU
 YU
 YU

--- a/modular_chomp/maps/southern_cross/southern_cross-6.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-6.dmm
@@ -1761,6 +1761,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/anomaly)
+"dI" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/concrete,
+/area/surface/cave/explored/trader)
 "dJ" = (
 /obj/structure/table/steel,
 /obj/effect/floor_decal/industrial/warning/dust{
@@ -2437,6 +2441,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/surface/outpost/research/xenoarcheology)
+"fc" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/industrial/outline,
+/turf/simulated/floor/plating,
+/area/surface/outpost/research/xenoarcheology/smes)
+"fd" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
+/turf/simulated/floor/plating,
+/area/surface/outpost/research/xenoarcheology/smes)
 "fe" = (
 /obj/item/anobattery{
 	pixel_x = -6;
@@ -3120,11 +3137,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
-"gy" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
-/turf/simulated/floor/plating,
-/area/surface/outpost/research/xenoarcheology/smes)
 "gz" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
@@ -3236,10 +3248,11 @@
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "gO" = (
-/obj/machinery/space_heater,
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "gP" = (
@@ -3416,12 +3429,6 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/plating,
-/area/surface/outpost/research/xenoarcheology/smes)
-"hi" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hj" = (
@@ -3606,14 +3613,6 @@
 	tag_south = 2;
 	tag_west = 4
 	},
-/turf/simulated/floor/plating,
-/area/surface/outpost/research/xenoarcheology/smes)
-"hD" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/surface/outpost/research/xenoarcheology/smes)
 "hE" = (
@@ -3965,6 +3964,18 @@
 	temperature = 243.15
 	},
 /area/surface/outpost/mining_main/cave)
+"iu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/research/xenoarcheology/smes)
+"iv" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/concrete,
+/area/surface/cave/explored/trader)
 "iw" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -3985,6 +3996,12 @@
 	temperature = 243.15
 	},
 /area/surface/outpost/mining_main/cave)
+"iy" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/concrete,
+/area/surface/cave/explored/trader)
 "iz" = (
 /obj/effect/floor_decal/industrial/warning/dust,
 /obj/structure/ore_box,
@@ -4005,6 +4022,32 @@
 	outdoors = 0
 	},
 /area/surface/outpost/wall)
+"iC" = (
+/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/surface/outpost/research/xenoarcheology/smes)
+"iD" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/concrete,
+/area/surface/cave/explored/trader)
+"iE" = (
+/obj/structure/cable/blue{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/rtg/advanced,
+/turf/simulated/floor/plating,
+/area/surface/cave/explored/trader)
+"iF" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/surface/cave/explored/trader)
 "iH" = (
 /obj/effect/map_effect/portal/master/side_b/caves_to_plains/river{
 	dir = 1
@@ -4169,16 +4212,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/surface/cave/explored/trader)
-"vj" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/concrete,
-/area/surface/cave/explored/trader)
-"vA" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/concrete,
-/area/surface/cave/explored/trader)
 "xh" = (
 /obj/effect/zone_divider,
 /turf/simulated/floor/plating{
@@ -4225,13 +4258,6 @@
 /obj/item/bedsheet/cosmos,
 /mob/living/simple_mob/humanoid/starhunter/trader/farmer,
 /turf/simulated/floor/concrete,
-/area/surface/cave/explored/trader)
-"Ce" = (
-/obj/structure/cable/blue{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/rtg/advanced,
-/turf/simulated/floor/plating,
 /area/surface/cave/explored/trader)
 "Co" = (
 /obj/machinery/light{
@@ -4295,12 +4321,6 @@
 	},
 /turf/simulated/mineral/floor/ignore_mapgen/sif,
 /area/surface/outpost/research/xenoarcheology/exterior)
-"Gr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/concrete,
-/area/surface/cave/explored/trader)
 "Hs" = (
 /obj/effect/map_effect/portal/master/side_b/caves_to_plains{
 	dir = 1
@@ -4315,30 +4335,10 @@
 "In" = (
 /turf/simulated/floor/plating,
 /area/surface/cave/explored/trader)
-"Jh" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/surface/cave/explored/trader)
 "Jk" = (
 /obj/effect/map_effect/portal/line/side_a,
 /turf/simulated/wall/solidrock,
 /area/surface/outpost/wall/checkpoint)
-"Kt" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/industrial/outline,
-/turf/simulated/floor/plating,
-/area/surface/outpost/research/xenoarcheology/smes)
-"KX" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/concrete,
-/area/surface/cave/explored/trader)
 "LO" = (
 /turf/simulated/wall/solidrock,
 /area/surface/cave/explored/trader)
@@ -38294,7 +38294,7 @@ fD
 fW
 gw
 gw
-hi
+iu
 io
 hP
 fD
@@ -38551,9 +38551,9 @@ am
 fD
 fX
 gw
+iC
 gO
-hD
-gy
+fd
 hQ
 fD
 il
@@ -39068,7 +39068,7 @@ fF
 fZ
 gw
 gQ
-hi
+iu
 hB
 hS
 fD
@@ -39586,7 +39586,7 @@ gA
 gS
 hk
 hU
-Kt
+fc
 fD
 eh
 eh
@@ -68480,7 +68480,7 @@ kx
 RM
 YU
 YU
-Gr
+iv
 YU
 YU
 YU
@@ -68732,7 +68732,7 @@ ae
 ae
 ae
 RM
-vA
+iD
 YU
 YU
 sH
@@ -69252,12 +69252,12 @@ RM
 RM
 RM
 RM
-vA
+iD
 YU
 kx
 kx
 YU
-vj
+dI
 RM
 nr
 nr
@@ -69507,7 +69507,7 @@ ae
 ae
 RM
 In
-Ce
+iE
 UB
 RM
 St
@@ -70023,12 +70023,12 @@ ae
 ae
 RM
 In
-Jh
+iF
 In
 sH
 YU
 YU
-KX
+iy
 YU
 YU
 YU


### PR DESCRIPTION
## About The Pull Request

Fixes some minor map issues and updates the config file with an up to date list of the access level numbers to help with proper future mapping. Also had an OCD sergal update the scrubber loops on Sif to help the xenoarch nerds.

## Changelog
:cl:
maptweak: Removed access requirement to main part of space disposals to muffin monster can be accessed without ID to enable retrieval of flushed items
maptweak: Chemical dispensers returned to xenobotany and to xenoarchaeology
maptweak: Sif outpost and xenoarchaology outpost scrubber loops updated to filter properly and also filter volatile fuel
maptweak: Removed access requirement to the central maints tunnel. Any secure exits to this tunnel are still access protected
maptweak: Fixed medical bathrooms not being attached to station atmos. Removed some excess piping and wiring going to no destination in maints
maptweak: Added a bit more power and some lights to the starhunter base. The vending machines should hopefully have enough power now
maptweak: Fixes the heavy duty wire by the outpost R-UST that wasn't properly oriented. Power should flow now
maptweak: Tweaked security doors to have correct access levels. Main areas will now be Security instead of Security equipment.
/:cl:
