### PR TITLE
Adds a Non-Persistant sheet storage to Cargo's front

### DIFF
--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -1001,6 +1001,13 @@
 	desc = "An industrial sized storage unit for materials. B-Shift's agreement to retain materials doesn't extend to this storage device, so you should probably only stock this with sheets you need.";
 	name = "\improper Non-Persistent Industrial Sheet Storage"
 	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	health = 1e+006
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/office)
 "abJ" = (

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -63206,6 +63206,14 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
+"oAA" = (
+/obj/structure/fans/tiny,
+/obj/machinery/smartfridge/sheets{
+	desc = "An industrial sized storage unit for materials. B-Shift's agreement to retain materials doesn't extend to this storage device, so you should probably only stock this with sheets you need.";
+	name = "\improper Non-Persistent Industrial Sheet Storage"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "oAV" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -101748,7 +101756,7 @@ bYD
 bRG
 bqo
 bqn
-bsn
+oAA
 bug
 bCU
 bEJ

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -995,6 +995,14 @@
 /obj/random/trash,
 /turf/simulated/floor,
 /area/maintenance/engineering)
+"abI" = (
+/obj/structure/fans/tiny,
+/obj/machinery/smartfridge/sheets{
+	desc = "An industrial sized storage unit for materials. B-Shift's agreement to retain materials doesn't extend to this storage device, so you should probably only stock this with sheets you need.";
+	name = "\improper Non-Persistent Industrial Sheet Storage"
+	},
+/turf/simulated/floor/plating,
+/area/quartermaster/office)
 "abJ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/wingrille_spawn/reinforced,
@@ -63206,14 +63214,6 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/maintenance/cargo)
-"oAA" = (
-/obj/structure/fans/tiny,
-/obj/machinery/smartfridge/sheets{
-	desc = "An industrial sized storage unit for materials. B-Shift's agreement to retain materials doesn't extend to this storage device, so you should probably only stock this with sheets you need.";
-	name = "\improper Non-Persistent Industrial Sheet Storage"
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/office)
 "oAV" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -101756,7 +101756,7 @@ bYD
 bRG
 bqo
 bqn
-oAA
+abI
 bug
 bCU
 bEJ


### PR DESCRIPTION

## About The Pull Request

As requested. This sounds like a good option; Allows Cargo technicians to place storage sheets at the start of the shift or when asked for, instead of Miners having to stop their mining operations and sending materials to Science. And reduced crimes.

## Changelog
:cl:
maptweak: Added a Non-Persistant storage sheet to Southern Cross' Cargo
/:cl:
