### PR TITLE
Tiny typo fix for OOC-escape

### DIFF
--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -616,7 +616,7 @@
 			s.undo_prey_takeover(TRUE)
 			return
 		var/obj/belly/B = loc
-		var/confirm = tgui_alert(src, "Please feel free to press use this button at any time you are uncomfortable and in a belly. Consent is important.", "Confirmation", list("Okay", "Cancel")) //CHOMPedit
+		var/confirm = tgui_alert(src, "Please feel free to use this button at any time you are uncomfortable and in a belly. Consent is important.", "Confirmation", list("Okay", "Cancel")) //CHOMPedit
 		if(confirm != "Okay" || loc != B)
 			return
 		//Actual escaping


### PR DESCRIPTION
Apparently someone already beat me to chomp editing this.
## About The Pull Request
## Changelog
:cl:
fix: OOC-Escape typo
/:cl:
