### PR TITLE
deconflicts #10298 and adjusts the chomp addition

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_mask.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_mask.dm
@@ -58,16 +58,6 @@
 /datum/gear/mask/gaiter
 	display_name = "neck gaiter selection"
 	path = /obj/item/clothing/accessory/gaiter
-<<<<<<< HEAD
-	cost = 1
-	
-//CHOMPAdd - Put this mask in loadout
-/datum/gear/mask/death
-	display_name = "white mask"
-	path = /obj/item/clothing/mask/gas/cyborg
-	cost = 1
-=======
->>>>>>> edb68a5640 (Loadout Tweaks and Additions (#17203))
 
 /datum/gear/mask/gaiter/New()
 	..()
@@ -76,6 +66,11 @@
 		var/obj/item/clothing/accessory/gaiter_type = gaiter
 		gaiters[initial(gaiter_type.name)] = gaiter_type
 	gear_tweaks += new/datum/gear_tweak/path(sortTim(gaiters, GLOBAL_PROC_REF(cmp_text_asc)))
+
+//CHOMPAdd - Put this mask in loadout
+/datum/gear/mask/death
+	display_name = "white mask"
+	path = /obj/item/clothing/mask/gas/cyborg
 
 /datum/gear/mask/lace
 	display_name = "lace veil"

--- a/code/modules/client/preference_setup/loadout/loadout_mask.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_mask.dm
@@ -69,8 +69,9 @@
 
 //CHOMPAdd - Put this mask in loadout
 /datum/gear/mask/death
-	display_name = "white mask"
+	display_name = "cyborg visor" //This was named 'white mask' before when it's...Not. It's literally a cyborg visor gas mask.
 	path = /obj/item/clothing/mask/gas/cyborg
+	cost = 3 ///Because it functions as a gas mask, and therefore has a mechanical advantage.
 
 /datum/gear/mask/lace
 	display_name = "lace veil"


### PR DESCRIPTION
Deconflicts #10298

masks no longer have a cost = 1. It takes the parent cost now. (which is still = 1, so no reason to re-clarify it)

### Additionally, the 'death mask' seems to have had an improper display name and cost.
It's actually a gasmask with the name of 'cyborg visor'. Name updated to reflect this.
Additionally, gasmasks are 3 cost in the mask loadout. Every gasmask in the loadout has this, so I don't see why this one would be special. (If it's intended to be special, let me know and I can just axe the cost line and it'll go back to 1 cost.)

This should honestly be added upstream but whatever, that's for a later point in time. Chomp gets to keep it as a chomp edit for now until then.