### PR TITLE
fixes a xenochimera brain runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_special_vr.dm
@@ -118,12 +118,12 @@
 			H.eye_blurry = max(5,H.eye_blurry)
 
 /obj/item/organ/internal/brain/xenochimera
-	var/laststress = 0
+	laststress = 0 //chompedit- move stress var to  basic brains to cure a runtime
 
 /datum/species/xenochimera/proc/handle_feralness(var/mob/living/carbon/human/H)
 	//first, calculate how stressed the chimera is
 	var/laststress = 0
-	var/obj/item/organ/internal/brain/xenochimera/B = H.internal_organs_by_name[O_BRAIN]
+	var/obj/item/organ/internal/brain/B = H.internal_organs_by_name[O_BRAIN]//chompedit- moves stress to basic brains to cure a runtime
 	if(B) //if you don't have a chimera brain in a chimera body somehow, you don't get the feraless protection
 		laststress = B.laststress
 

--- a/modular_chomp/code/modules/organs/internal/brain.dm
+++ b/modular_chomp/code/modules/organs/internal/brain.dm
@@ -1,0 +1,2 @@
+/obj/item/organ/internal/brain
+	var/laststress = 0

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -5058,6 +5058,7 @@
 #include "modular_chomp\code\modules\mob\new_player\sprite_accessories_tail.dm"
 #include "modular_chomp\code\modules\organs\organ_icon.dm"
 #include "modular_chomp\code\modules\organs\robolimbs.dm"
+#include "modular_chomp\code\modules\organs\internal\brain.dm"
 #include "modular_chomp\code\modules\organs\internal\malignant\malignant.dm"
 #include "modular_chomp\code\modules\overmap\dynamic_sector.dm"
 #include "modular_chomp\code\modules\paperwork\faxmachine.dm"


### PR DESCRIPTION

## About The Pull Request
Moves the "laststress" var to normal brains. This will do nothing normally, but will prevent runtimes if a normal brain finds its way into a xenochimera body, instead letting that brain go feral as normal. This could also be solved by making only xenochimera brains go feral, but that's less fun, and still just as difficult to modularize

## Changelog
:cl:
fix: fix a runtime related to xenochimera brains
/:cl:
