### PR TITLE
fixes ladder

### DIFF
--- a/modular_chomp/maps/southern_cross/southern_cross-10.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-10.dmm
@@ -180,10 +180,6 @@
 "aW" = (
 /turf/simulated/floor/outdoors/dirt/sif/planetuse,
 /area/surface/outside/path/wilderness)
-"aX" = (
-/obj/structure/ladder/up,
-/turf/simulated/floor/outdoors/dirt/sif/planetuse,
-/area/surface/outpost/shelter/exterior)
 "aY" = (
 /obj/effect/map_effect/portal/master/side_b/wilderness_to_caves/river{
 	dir = 1
@@ -40275,7 +40271,7 @@ bz
 bz
 bz
 aT
-aX
+aT
 ac
 ab
 "}


### PR DESCRIPTION

## About The Pull Request
Oops, linter upset at ladder going up into **the void**
## Changelog
:cl:
maptweak: Removed pointless ladder in explo shelter.
/:cl:
