### PR TITLE
Update pitcher.dm

### DIFF
--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/plants/pitcher.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/plants/pitcher.dm
@@ -23,11 +23,11 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 	icon_dead = "pitcher_plant_dead"
 	icon = 'modular_chomp/icons/mob/vore_ch.dmi'
 
-	anchored = 1 //Rooted plant. Only killing it will let you move it.
+	anchored = 1 // Rooted plant. Only killing it will let you move it.
 	maxHealth = 200
 	health = 200
-	a_intent = I_HELP //White this is help by default I'm leaving this here as a reminder thatdisarm will prevent playersfrom swapping places with the pitcher (but interfere with vore bump).
-	faction = "plants" //Makes plantbgone deadly.
+	a_intent = I_HELP // While this is already help by default, I'm leaving this variable here as a reminder that disarm will prevent players from swapping places with the pitcher, but interfere with vore bump.
+	faction = "plants" // Makes plant-b-gone deadly.
 	ai_holder_type = /datum/ai_holder/simple_mob/passive/pitcher //It's a passive carnivorous plant, it can't detect or interact with people.
 
 	min_oxy = 0 //Immune to atmos because so are space vines. This is arbitrary and can be tweaked if desired.
@@ -39,17 +39,19 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 	min_n2 = 0
 	max_n2 = 0
 	minbodytemp = 0
+	meat_type = /obj/item/reagent_containers/food/snacks/pitcher_fruit // Allows pitcher plants to be chopped up and replanted. Probably.
+	meat_amount = 1 // And allows you to replant them should you so please.
 
 	melee_damage_upper = 0 //This shouldn't attack people but if it does (admemes) no damage can be dealt.
 	melee_damage_lower = 0
 
 	armor = list(
-				"melee" = 0,
-				"bullet" = 0,
-				"laser" = -50,
+				"melee" = 95, // STOP TRYING TO HACK IT UP WITH AN AXE TO RESCUE A PERSON INSIDE LIKE OH MY GOD YOU ARE ONE UNLUCKY LAG SPIKE FROM CHOPPING THEIR FUCKING CHEST OPEN
+				"bullet" = 95, // NO DON'T SHOOT IT EITHER WHAT IS WRONG WITH YOU
+				"laser" = -50, // Okay fine fire type beats plant type
 				"energy" = 0,
 				"bomb" = 0,
-				"bio" = 0,
+				"bio" = -100, // Poison kills the plant good.
 				"rad" = 100)
 
 	var/fruit = FALSE //Has the pitcher produced a fruit?
@@ -59,11 +61,7 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 	var/scent_strength = 5 //How much can a hungry pitcher confuse nearby people?
 	var/last_lifechecks = 0 //Timing variable to limit vore/hungry proc calls
 	var/list/pitcher_plant_lure_messages = null
-
-	can_be_drop_prey = FALSE //CHOMP Add
-
-
-
+	can_be_drop_prey = FALSE
 
 /mob/living/simple_mob/vore/pitcher_plant //Putting vore variables separately because apparently that's tradition.
 	vore_bump_chance = 100
@@ -71,7 +69,7 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 	vore_active = 1
 	vore_icons = 1
 	vore_capacity = 1
-	vore_pounce_chance = 0 //Plants only eat people who stumble into them.
+	vore_pounce_chance = 100 // Either this makes mobs get eaten for attacking it or nothing happens and I don't know which.
 	swallowTime = 3 //3 deciseconds. This is intended to be nearly instant, e.g. victim trips and falls in.
 	vore_ignores_undigestable = 0
 	vore_default_mode = DM_DIGEST
@@ -79,17 +77,15 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 /mob/living/simple_mob/vore/pitcher_plant/init_vore()
 	if(!voremob_loaded)
 		return
-	if(LAZYLEN(vore_organs))
-		return
 	.=..()
 	var/obj/belly/B = vore_selected
-	B.desc	= "You leaned a little too close to the pitcher plant, stumbling over the lip and splashing into a puddle of liquid filling the bottom of the cramped pitcher. You squirm madly, righting yourself and scrabbling at the walls in vain as the slick surface offers no purchase. The dim light grows dark as the pitcher's cap lowers, silently sealing the exit. With a sinking feeling you realize you won't be able to push the exit open even if you could somehow climb that high, leaving you helplessly trapped in the slick, tingling fluid. ((You can't escape this mob without help but you may use OOC Escape if you wish.))"
-	B.digest_burn = 0.5
-	B.digest_brute = 0
+	B.desc	= "You leaned a little too close to the pitcher plant, stumbling over the lip and splashing into a puddle of liquid filling the bottom of the cramped pitcher. You squirm madly, righting yourself and scrabbling at the walls in vain as the slick surface offers no purchase. The dim light grows dark as the pitcher's cap lowers, silently sealing the exit. With a sinking feeling, you realize you won't be able to push the exit open even if you could somehow climb that high, leaving you helplessly trapped in the slick, tingling fluid. The ONLY POSSIBLE WAY OUT is if someone either kills this thing or lowers a lifeline down to help. Maybe some string, a wire, or a good rope would do the trick..."
+	B.digest_burn = 0.1 // Sloowwwwww churns
+	B.digest_brute = 0.1 // Okay so I know there's no physical churning because it's a plant just trust me on this you want both of these
 	B.vore_verb = "trip"
 	B.name = "pitcher"
 	B.mode_flags = DM_FLAG_THICKBELLY
-	B.wet_loop = 0 //As nice as the fancy internal sounds are this is a plant.
+	B.wet_loop = 0 // As nice as the fancy internal sounds are, this is a plant.
 	B.digestchance = 0
 	B.escapechance = 0
 	B.fancy_vore = 1
@@ -97,23 +93,38 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 	B.release_sound = "Pred Escape"
 	B.contamination_color = "purple"
 	B.contamination_flavor = "Wet"
-//Why is it we have all these customizeable belly options which nobody ever alters for mobs?
 
 	B.emote_lists[DM_HOLD] = list(
 		"Slick fluid trickles over you, carrying threads of sweetness.",
 		"Everything is still, dark, and quiet. Your breaths echo quietly.",
 		"The surrounding air feels thick and humid.")
-
 	B.emote_lists[DM_DIGEST] = list(
 		"The slimy puddle stings faintly. It seems the plant has no need to quickly break down victims.",
 		"The humid air settles in your lungs, keeping each breath more labored than the last.",
-		"Fluid drips onto you, burning faintly as your body heat warms it."
+		"Fluid drips onto you, burning faintly as your body heat warms it.",
+		"Digestive enzymes itch at your flesh as you are slowly dissolved into soupy nutrients."
 		)
-
 	B.emote_lists[DM_DRAIN] = list(
 		"Each bead of slick fluid running down your body leaves you feeling weaker.",
 		"It's cramped and dark, the air thick and heavy. Your limbs feel like lead.",
 		"Strength drains from your frame. The cramped chamber feels easier to settle into with each passing moment.")
+	B.struggle_messages_inside = list(
+		"The narrow shape of the pitcher plant's stomach make it impossible to get any leverage. You can't escape.",
+		"You struggle and push against the slick and slimy plant flesh surrounding you, but it's no use. There's no way out by yourself.",
+		"Other predators would probably be getting queasy by now with all that fussing. Unfortunately, this thing just doesn't care. You're plant food.",
+		"Squirm and struggle all you want, you're no closer to freedom. Nothing you're doing is working.",
+		"You're just exhausting yourself with all this resistance, and the fumes of the plant's stomach are making you lightheaded.",
+		"All that exertion is just making you exhausted. For something with no muscles, it seems perfectly built for keeping you in its gut.",
+		"You literally can't escape by yourself. All you can do is wait for rescue and hope this dreadfully slow digestion doesn't snuff you out first.",
+		"You can't reach the lid of the pitcher plant to pry yourself out. Even if you could, the walls are too slippery. If only someone could lower a string or a wire or a rope for you to grab on!",
+		"The waxy walls are far too slippery for you to climb your way out, and trying to do so only drenches you in even more stinging slime.",
+		"Although you try your best to claw your way to freedom, the pitcher's gut is too smooth and too tough for you to get any progress."
+	)
+	B.struggle_messages_outside = list(
+		"Struggles from inside %pred cause its bulbous form to slosh from side-to-side. They might need some help to escape.",
+		"You notice someone moving inside that pitcher plant! However, they clearly can't get out on their own.",
+		"%pred's stomach shifts and slushes as someone inside of it tries in vain to escape. It doesn't look like they can, though.",
+		"%pred seems unpertubed by the stubborn movement of its prey. They clearly aren't getting out on their own.")
 
 /mob/living/simple_mob/vore/pitcher_plant/Life()
 	. = ..()
@@ -136,11 +147,16 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 		last_lifechecks = world.time
 		vore_checks()
 		handle_hungry()
+	if (!anchored)
+		anchored = 1 // If it's alive, it should root itself back down and once again be impossible to move.
 
-/mob/living/simple_mob/vore/pitcher_plant/Initialize(mapload)
-	. = ..()
+/mob/living/simple_mob/vore/pitcher_plant/New()
+	..()
 	pitcher_plant_lure_messages = GLOB.pitcher_plant_lure_messages
 
+/mob/living/simple_mob/vore/pitcher_plant/Initialize()
+	..()
+	pitcher_plant_lure_messages = GLOB.pitcher_plant_lure_messages
 
 /mob/living/simple_mob/vore/pitcher_plant/death()
 	..()
@@ -148,8 +164,6 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 	if(fruit)
 		new /obj/item/reagent_containers/food/snacks/pitcher_fruit(get_turf(src))
 		fruit = FALSE
-
-
 
 /mob/living/simple_mob/vore/pitcher_plant/proc/grow_fruit() //This proc handles the pitcher turning nutrition into fruit (and new pitchers).
 	if(!fruit)
@@ -174,12 +188,12 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 /mob/living/simple_mob/vore/pitcher_plant/attack_hand(mob/living/user)
 	if(user.a_intent == I_HELP)
 		if(fruit)
-			to_chat(user, "You pick a fruit from \the [src].")
+			to_chat(user, span_infoplain("You pick a fruit from \the [src]."))
 			var/obj/F = new /obj/item/reagent_containers/food/snacks/pitcher_fruit(get_turf(user)) //Drops at the user's feet if put_in_hands fails
 			fruit = FALSE
 			user.put_in_hands(F)
 		else
-			to_chat(user, "The [src] hasn't grown any fruit yet!")
+			to_chat(user, span_infoplain("The [src] hasn't grown any fruit yet!"))
 	else
 		..()
 
@@ -191,33 +205,36 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 /mob/living/simple_mob/vore/pitcher_plant/attackby(obj/item/O, mob/user)
 	if(istype(O, /obj/item/reagent_containers/food/snacks/meat))
 		if(meat > NUTRITION_FRUIT - NUTRITION_MEAT) //Can't exceed 250
-			to_chat(user, "The [src] is full!")
+			to_chat(user, span_infoplain("The [src] is full!"))
 			return
 		else
 			meat += NUTRITION_MEAT
 			qdel(O)
 			return
-	if(istype(O, /obj/item/stack/cable_coil)) //How to free people without killing the pitcher. I guess cable is ss13 rope.
+	if(istype(O, /obj/item/stack/cable_coil)) //How to free people without killing the pitcher. I guess cable is SS13 rope.
 		var/mob/living/carbon/human/H
 		var/N = 0
 		for(H in vore_selected.contents) //Only works for carbons, RIP mice. Should pick the first human the code finds.
-			user.visible_message("[user] tries to fish somebody out of \the [src].", "You try to snag somebody trapped in \the [src]...")
+			user.visible_message(span_infoplain("[user] uses a loop of wire to try fishing someone out of \the [src]."), span_infoplain("You use a loop of wire to try snagging someone trapped in \the [src]..."))
 			if(do_after(user, rand(3 SECONDS, 7 SECONDS))) //You can just spam click to stack attempts if you feel like abusing it.
 				if(prob(15))
-					user.visible_message("[user] tugs a sticky [H] free from \the [src].", "You heft [H] free from \the [src].")
+					user.visible_message(span_notice("[user] pulls a sticky [H] free from \the [src]."), span_infoplain("You heft [H] free from \the [src]."))
 					LAZYSET(prey_excludes, H, world.time)
 					vore_selected.release_specific_contents(H)
 					N = 1
 					addtimer(CALLBACK(src, PROC_REF(removeMobFromPreyExcludes), WEAKREF(H)), 1 MINUTES)
 					break
 				else
-					to_chat(user, "The victim slips from your grasp!")
+					to_chat(user, span_notice("The victim slips from your grasp!"))
 					N = 1
-					break //We need to terminate the loop after each outcome or this could loop through multiple bellies. Of course, there should only be one belly.
+					break //We need to terminate the loop after each outcome or this could loop through multiple bellies. Of course, there should only be one belly, but leave this here anyway just in case.
 		if(!N)
-			to_chat(user, "The pitcher is empty.")
-	if(istype(O, /obj/item/newspaper))
-		return //Can't newspaper people to freedom.
+			to_chat(user, span_infoplain("The pitcher is empty."))
+		if(istype(O, /obj/item/newspaper))
+			user.visible_message(span_notice("[user] baps \the [src], but it doesn't seem to do anything."), span_notice("You whap \the [src] with a rolled up newspaper."))
+			if(N)
+				to_chat(user, span_notice("Weird. That usually works. Maybe you can fish out its victim with some string or wire or something? Or maybe kill the thing with some plant-b-gone. Both would probably be safer than hacking it up with a person still inside."))
+			return // You can't newspaper people to freedom like you do with other mobs, but since that doesn't work, fucking tell people.
 	..()
 
 /mob/living/simple_mob/vore/pitcher_plant/proc/vore_checks()
@@ -245,8 +262,6 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 			vore_selected.digest_mode = DM_DIGEST //Let's digest until we digest all the digestable prey, then move onto draining indigestable prey.
 		if(!N)
 			vore_selected.release_all_contents() //If there's no prey, spit out everything.
-
-
 
 /mob/living/simple_mob/vore/pitcher_plant/proc/handle_hungry() //Let's run this check every 30 seconds. This is how a hungry pitcher tries to lure prey.
 	if(nutrition <= PITCHER_HUNGRY) //Is sanity check another way to say redundancy?
@@ -281,7 +296,7 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 
 /obj/item/reagent_containers/food/snacks/pitcher_fruit //As much as I want to tie hydroponics harvest code to the mob, this is simpler (albeit kinda hacky).
 	name = "squishy fruit"
-	desc = "A tender, fleshy fruit with a thin skin."
+	desc = "A tender, fleshy fruit with a thin skin. Said to have an intensely sweet flavor, and also a narcotic paralyzing effect."
 	icon = 'icons/obj/hydroponics_products.dmi'
 	icon_state = "treefruit-product"
 	color = "#a839a2"
@@ -292,10 +307,11 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 	var/datum/seed/seed = null
 	var/obj/item/seeds/pit = null
 
-/obj/item/reagent_containers/food/snacks/pitcher_fruit/Initialize(mapload)
+/obj/item/reagent_containers/food/snacks/pitcher_fruit/Initialize()
 	. = ..()
 	reagents.add_reagent(REAGENT_ID_PITCHERNECTAR, 5)
-	bitesize = 4
+	reagents.add_reagent(REAGENT_ID_PARALYZE_FLUID, 5) // Something worth harvesting the fruits for.
+	bitesize = 1
 	pit = new /obj/item/seeds/pitcherseed(src.contents)
 	seed = pit.seed
 
@@ -307,14 +323,14 @@ GLOBAL_LIST_INIT(pitcher_plant_lure_messages, list(
 		qdel(src)
 	if(!(proximity && O.is_open_container()))
 		return
-	to_chat(user, span_notice("You squeeze \the [src], juicing it into \the [O]."))
+	to_chat(user, span_infoplain("You squeeze \the [src], juicing it into \the [O]."))
 	reagents.trans_to(O, reagents.total_volume)
 	user.drop_from_inventory(src)
 	pit.loc = user.loc
 	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/pitcher_fruit/attack_self(mob/user)
-	to_chat(user, span_notice("You plant the fruit."))
+	to_chat(user, span_infoplain("You plant the fruit."))
 	new /obj/machinery/portable_atmospherics/hydroponics/soil/invisible(get_turf(user),src.seed)
 	GLOB.seed_planted_shift_roundstat++
 	qdel(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

People don't realize that you can rescue players from pitcher plants by using wire because this is literally communicated nowhere in-game.

This PR fixes that, and also buffs the shit out of pitcher plant armor so people stop hacking them to pieces when they should be like, using plant-b-gone, or idk lasers I guess. Mostly this is to stop situations where a person gets eaten and some unlucky goober with a fire axe happens to get lagged the instant the plant spills its guts out and the lightly singed pitcher plant victim suddenly becomes medical gameplay.

Last of all I removed that unimmersive line about using OOC escape and instead communicated it in the clearest terms possible while staying in-character. There's no need to tell players they have to use OOC-escape when they are going to do that anyway if they want to. Don't ruin the immersion.

Oh yeah and I wanted to give pitcher fruit some kind of REASON to harvest them so I gave it a new reagent that briefly stuns you. Good for extracting and putting into needles to dart nerds and eat them or whatever.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl: Ace
add: Pitcher plants now have struggle emotes that TELL YOU that you need outside help to be rescued.
add: Pitcher plant fruits now have a new reagent.
fix: Pitcher plants would not be anchored after being killed and revived, or sometimes in other circumstances just wouldn't be anchored correctly.
fix: Pitcher plants did not effectively communicate that you can rescue players with wire and that a newspaper roll won't work.
code: Made pitchers more resistant to melee to deter players from hitting them with an axe and sometimes accidentally killing the person they were trying to rescue.
code: Removed OOC bracketed text about having to use OOC escape. Most players are smart enough to understand without bashing their heads with it.
code: Changed damage values of pitcher plant for a much slower digestion.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
