### PR TITLE
QoL change for fueldepot.dmm, air tanks now oxygen tanks

### DIFF
--- a/modular_chomp/maps/southern_cross/overmap/space/fueldepot.dmm
+++ b/modular_chomp/maps/southern_cross/overmap/space/fueldepot.dmm
@@ -215,6 +215,10 @@
 /obj/structure/railing,
 /turf/space,
 /area/space)
+"aA" = (
+/obj/machinery/portable_atmospherics/canister/empty,
+/turf/simulated/floor/tiled/techmaint/airless,
+/area/sc_away/fueldepot)
 "aC" = (
 /obj/structure/railing{
 	dir = 1
@@ -966,10 +970,10 @@
 /turf/simulated/shuttle/plating/airless,
 /area/sc_away/fueldepot)
 "cn" = (
-/obj/machinery/atmospherics/pipe/tank/air/full{
+/obj/machinery/atmospherics/pipe/tank/oxygen{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/techmaint/airless,
 /area/sc_away/fueldepot)
 "co" = (
@@ -1176,12 +1180,12 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	health = 1e+006;
+	health = 1e+06;
 	req_access = list(5)
 	},
 /obj/structure/window/reinforced{
 	dir = 4;
-	health = 1e+006
+	health = 1e+06
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/sc_away/fueldepotspawn)
@@ -1351,7 +1355,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/techmaint,
 /area/sc_away/fueldepotspawn)
 "rh" = (
@@ -1534,20 +1538,20 @@
 	pixel_x = -8
 	},
 /obj/item/spaceflare{
-	pixel_y = 12;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 12
 	},
 /obj/item/spaceflare{
-	pixel_y = 0;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 0
 	},
 /obj/item/spaceflare{
-	pixel_y = 4;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 4
 	},
 /obj/item/spaceflare{
-	pixel_y = 8;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/sc_away/fueldepotspawn)
@@ -1788,8 +1792,8 @@
 	name = "JoinLateFuelDepot"
 	},
 /obj/machinery/power/apc{
-	dir = 4;
 	name = "east bump";
+	dir = 4;
 	pixel_x = 24
 	},
 /obj/structure/cable/green{
@@ -11428,7 +11432,7 @@ bP
 be
 be
 co
-aG
+aA
 aG
 FK
 aF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

You use blue pipes for oxygen, yet you use mixed air tanks to supply them. This causes people to suffocate and not know why.

This PR that oversight. Also I tossed in an empty canister just for good measure, off to the side. First come first serve.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
maptweak: Changed fuel outpost air tanks to oxygen tanks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
