### PR TITLE
Soluna Nexus map fixes 2.0

### DIFF
--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
@@ -629,6 +629,12 @@
 /obj/item/seeds/glowshroom,
 /turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Star_1Deck_Atrium)
+"abr" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
 "abs" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/GravGen_Room)
@@ -641,18 +647,10 @@
 	dir = 8
 	},
 /obj/structure/window/basic{
-	dir = 1
-	},
-/obj/structure/window/basic{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/Aft_1_Deck_Stairwell)
-"abu" = (
-/obj/random/maintenance/clean,
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck1_Star_Corridor)
 "abv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -732,13 +730,202 @@
 	},
 /turf/simulated/floor/carpet/purcarpet/turfpack/station,
 /area/hallway/Cryostorage_Lounge)
+"abE" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
 "abF" = (
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/Central_1_Deck_Hall)
+"abG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
+"abH" = (
+/obj/structure/sign/warning/evac,
+/turf/simulated/wall/r_wall,
+/area/harbor/Dock5)
+"abI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
+"abJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
+"abK" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
+"abL" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = -32;
+	layer = 4
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
+"abM" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = 32;
+	layer = 4
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
+"abN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 32;
+	layer = 4
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock1)
+"abO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -32;
+	layer = 4
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock4)
+"abP" = (
+/obj/structure/table/bench/sifwooden/padded,
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 32;
+	layer = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/harbor/Dock2)
+"abQ" = (
+/obj/structure/table/bench/sifwooden/padded,
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -32;
+	layer = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/harbor/Dock3)
+"abR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock1)
+"abS" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Fueling_Storage)
 "abT" = (
 /obj/structure/girder,
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/Telecomms_Control_Room)
+"abU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Fueling_Storage)
+"abV" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/arrows/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/arrows/blue{
+	dir = 8
+	},
+/obj/machinery/door/airlock/angled_bay/standard/color/engineering{
+	dir = 4;
+	name = "Pilotpot"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/harbor/Fueling_Storage)
+"abW" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/harbor/Dock5)
+"abX" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 1
+	},
+/obj/effect/landmark/start/pilot,
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Fueling_Storage)
 "abY" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -746,6 +933,64 @@
 /obj/machinery/door/airlock/angled_bay/elevator/glass,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/Deck1_Stairwell)
+"abZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 32;
+	layer = 4
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock1)
+"aca" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 8
+	},
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -32;
+	layer = 4
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock4)
+"acb" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Fueling_Storage)
+"acc" = (
+/obj/effect/floor_decal/corner/orange/border,
+/obj/effect/floor_decal/industrial/bot_outline/blue,
+/turf/simulated/floor/tiled/monotile{
+	color = "#989898"
+	},
+/area/harbor/Fueling_Storage)
 "acd" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -758,6 +1003,32 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/Mining_Ship_Bay)
+"ace" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/harbor/Dock5)
+"acf" = (
+/obj/structure/closet,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/melee/umbrella/random,
+/obj/item/melee/umbrella/random,
+/obj/item/melee/umbrella/random,
+/obj/random/maintenance/engineering,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Ship_Bay1)
 "acg" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -769,6 +1040,26 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/harbor/Dock3)
+"ach" = (
+/obj/structure/closet,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/melee/umbrella/random,
+/obj/item/melee/umbrella/random,
+/obj/item/melee/umbrella/random,
+/obj/random/maintenance/engineering,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Ship_Bay2)
 "aci" = (
 /obj/structure/janitorialcart{
 	dir = 4
@@ -807,6 +1098,66 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock2)
+"acl" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/backpack/parachute{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/storage/backpack/parachute{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/backpack/parachute{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/storage/backpack/parachute{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/backpack/parachute{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Ship_Bay1)
+"acm" = (
+/obj/structure/table/rack/shelf,
+/obj/item/storage/backpack/parachute{
+	pixel_x = 6;
+	pixel_y = -6
+	},
+/obj/item/storage/backpack/parachute{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/backpack/parachute{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/item/storage/backpack/parachute{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/storage/backpack/parachute{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Ship_Bay2)
 "acn" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
@@ -828,25 +1179,37 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobotany_Isolation_Chamber)
-"acs" = (
-/obj/effect/floor_decal/industrial/stand_clear/blue{
+"acq" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
 	dir = 1
 	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Star_Docking_Foyer)
+"acr" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Star_Docking_Foyer)
+"acs" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1;
-	color = "#989898"
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile{
-	color = "#989898"
-	},
+/turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "act" = (
 /obj/machinery/door/firedoor/border_only,
@@ -886,6 +1249,28 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/harbor/Ship_Bay4)
+"acw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
+/obj/machinery/door/airlock/angled_bay/external/glass{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
+/obj/machinery/access_button{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/map_helper/airlock/button/ext_button{
+	pixel_y = -14
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/harbor/Dock1)
 "acx" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -900,6 +1285,84 @@
 /obj/random/toolbox,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortChamber1)
+"acz" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/arrows{
+	dir = 4
+	},
+/obj/machinery/door/airlock/angled_bay/external/glass{
+	dir = 4
+	},
+/obj/effect/map_helper/airlock/door/ext_door,
+/obj/machinery/shield_diffuser,
+/obj/machinery/access_button{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/effect/map_helper/airlock/button/ext_button{
+	pixel_y = -14
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/harbor/Dock4)
+"acA" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay1)
+"acB" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay1)
+"acC" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Aft_1_Deck_Stairwell)
 "acD" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -953,6 +1416,64 @@
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock2)
+"acG" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay2)
+"acH" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay2)
+"acI" = (
+/obj/effect/catwalk_plated/white,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay1)
+"acJ" = (
+/obj/effect/catwalk_plated/white,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay1)
 "acK" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -966,8 +1487,11 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock3)
@@ -977,6 +1501,13 @@
 	},
 /turf/simulated/wall,
 /area/hallway/Port_1Deck_Central_Corridor_1)
+"acM" = (
+/obj/effect/catwalk_plated/white,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay2)
 "acN" = (
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
 /obj/effect/floor_decal/industrial/loading/blue,
@@ -989,6 +1520,13 @@
 	color = "#989898"
 	},
 /area/hallway/Central_1_Deck_Hall)
+"acO" = (
+/obj/effect/catwalk_plated/white,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay2)
 "acP" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -996,10 +1534,68 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor1)
+"acQ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Dock4)
 "acR" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Science_AftCorridor1)
+"acS" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Aft_1_Deck_Stairwell)
+"acT" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Aft_Transit_Lobby)
+"acU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/turf/simulated/floor/tiled,
+/area/hallway/Aft_Transit_Lobby)
+"acV" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Aft_Transit_Lobby)
 "acW" = (
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
@@ -1008,8 +1604,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Port_1Deck_Central_Corridor_1)
+"acX" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/turf/simulated/floor/tiled,
+/area/hallway/Aft_Transit_Lobby)
 "acY" = (
 /turf/simulated/floor/reinforced,
+/area/harbor/Ship_Bay3)
+"acZ" = (
+/obj/effect/catwalk_plated/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
 /area/harbor/Ship_Bay3)
 "ada" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
@@ -1023,6 +1636,26 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock2)
+"adb" = (
+/obj/effect/catwalk_plated/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay4)
+"adc" = (
+/obj/effect/catwalk_plated/white,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay3)
 "add" = (
 /obj/structure/table/rack/shelf,
 /obj/item/clothing/mask/gas{
@@ -1057,6 +1690,52 @@
 /obj/random/maintenance/research,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor3)
+"adf" = (
+/obj/effect/catwalk_plated/white,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/harbor/Ship_Bay4)
+"adg" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 6
+	},
+/obj/machinery/ai_status_display{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/AftPort_1_Deck_Observatory)
+"adh" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/green/border{
+	dir = 10
+	},
+/obj/machinery/ai_status_display{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/AftStar_1_Deck_Observatory)
+"adi" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"adj" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
 "adk" = (
 /obj/machinery/atmospheric_field_generator/perma/underdoors{
 	color = "Yellow"
@@ -1093,11 +1772,104 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobotany_Lab)
+"ado" = (
+/obj/random/humanoidremains,
+/turf/simulated/floor/plating,
+/area/maintenance/ab_StripBar)
+"adp" = (
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_AftPort_Corridor1)
+"adq" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Cargo_Corridor1)
+"adr" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Cargo_Corridor1)
+"ads" = (
+/obj/structure/table/standard,
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Cargo_Corridor1)
 "adt" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Corridor2)
+"adu" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Cargo_Corridor1)
+"adv" = (
+/obj/item/frame,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Science_AftCorridor1)
+"adw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Central_1_Deck_Hall)
+"adx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Central_1_Deck_Hall)
+"ady" = (
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Central_1_Deck_Hall)
+"adz" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/hallway/Star_1Deck_Central_Corridor_1)
+"adA" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/hallway/Star_1Deck_Central_Corridor_1)
 "adB" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1118,6 +1890,47 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/quartermaster/Mining_Ship_Bay)
+"adD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Port_1Deck_Atrium)
+"adE" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/hallway/Port_1Deck_Central_Corridor_1)
+"adF" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/hallway/Port_1Deck_Central_Corridor_1)
+"adG" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Central_1_Deck_Hall)
+"adH" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Central_1_Deck_Hall)
 "adI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -1131,6 +1944,39 @@
 /obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Chamber1)
+"adK" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Central_1_Deck_Hall)
+"adL" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Central_1_Deck_Hall)
+"adM" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/structure/sign/poster/nanotrasen{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Central_1_Deck_Hall)
 "adN" = (
 /obj/machinery/atmospheric_field_generator/perma/underdoors{
 	color = "Yellow"
@@ -1191,6 +2037,27 @@
 	},
 /turf/simulated/floor,
 /area/shuttle/echidna)
+"adT" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Central_1_Deck_Hall)
+"adU" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Central_1_Deck_Hall)
 "adV" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/door/airlock/angled_bay/elevator/glass,
@@ -1240,8 +2107,33 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	color = "#989898"
 	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock1)
+"aea" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/hallway/Star_1Deck_Central_Corridor_1)
+"aeb" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/hallway/Star_1Deck_Central_Corridor_1)
+"aec" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Star_1Deck_Atrium)
 "aed" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
@@ -1254,6 +2146,75 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock2)
+"aee" = (
+/turf/simulated/wall,
+/area/maintenance/Deck1_Star_Corridor)
+"aef" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Star_Corridor)
+"aeg" = (
+/obj/effect/floor_decal/industrial/arrows/blue,
+/obj/effect/floor_decal/industrial/arrows/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/maintenance/Deck1_Star_Corridor)
+"aeh" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows/yellow,
+/obj/effect/floor_decal/industrial/arrows/yellow{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance/int,
+/turf/simulated/floor/tiled/techmaint,
+/area/maintenance/Deck1_Star_Corridor)
+"aei" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Star_Corridor)
+"aej" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = 22
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/Deck1_Star_Corridor)
+"aek" = (
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/maintenance/Deck1_Star_Corridor)
 "ael" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/beakers,
@@ -1269,6 +2230,14 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Gateway)
+"aen" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/turf/simulated/floor/glass,
+/area/hallway/Port_1Deck_Atrium)
+"aeo" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/turf/simulated/floor/glass,
+/area/hallway/Star_1Deck_Atrium)
 "aep" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -1283,6 +2252,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Market_Stall_2)
+"aeq" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/glass,
+/area/hallway/Port_1Deck_Atrium)
 "aer" = (
 /obj/effect/floor_decal/road/center{
 	dir = 4
@@ -1294,6 +2269,12 @@
 /obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod1/station)
+"aet" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/rnd/Observation_Hall)
 "aeu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1301,6 +2282,10 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Port_Corridor)
+"aev" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForPort_Corridor3)
 "aew" = (
 /turf/simulated/wall,
 /area/security/Quantum_Pad_Checkpoint)
@@ -1308,6 +2293,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Harbor)
+"aey" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Cargo_Corridor2)
 "aez" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/effect/floor_decal/borderfloorblack{
@@ -1323,6 +2312,105 @@
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock4)
+"aeB" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_Cargo_Corridor2)
+"aeC" = (
+/obj/structure/loot_pile/maint/boxfort,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForStar_Chamber1)
+"aeD" = (
+/obj/effect/catwalk_plated/techmaint,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForPort_Corridor1)
+"aeE" = (
+/obj/structure/loot_pile/maint/boxfort,
+/obj/random/trash,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForPort_Corridor2)
+"aeF" = (
+/obj/effect/catwalk_plated/white,
+/obj/machinery/shield_diffuser,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"aeG" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/glass/reinforced,
+/area/security/Quantum_Pad_Checkpoint)
+"aeH" = (
+/obj/random/maintenance/security,
+/obj/structure/table/rack/shelf,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForPort_Corridor2)
+"aeI" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/security/Quantum_Pad_Checkpoint)
+"aeJ" = (
+/obj/random/maintenance/security,
+/obj/structure/table/rack/holorack,
+/obj/random/maintenance/security,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/misc,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck1_ForPort_Corridor2)
+"aeK" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/Quantum_Pad_Checkpoint)
+"aeL" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/glass,
+/area/hallway/Deck1_Transit_Hall)
+"aeM" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/security/Quantum_Pad_Storage)
 "aeN" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -1336,6 +2424,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobotany_Isolation_Chamber)
+"aeO" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/glass,
+/area/hallway/Deck1_Transit_Hall)
 "aeY" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -1402,7 +2496,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock2)
 "afw" = (
@@ -1537,11 +2636,6 @@
 "agl" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck1_ForStar_Chamber2)
-"agq" = (
-/obj/machinery/pipedispenser,
-/obj/effect/floor_decal/industrial/hatch/blue,
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Fueling_Storage)
 "agr" = (
 /obj/effect/floor_decal/industrial/stand_clear,
 /turf/simulated/floor/airless,
@@ -1559,12 +2653,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "agy" = (
@@ -1578,9 +2673,6 @@
 	check_records = 0;
 	req_one_access = list(17,11,24)
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -1589,6 +2681,12 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/GravGen_Room)
@@ -1756,14 +2854,14 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Deck1_Corridor)
@@ -2237,7 +3335,31 @@
 /turf/simulated/floor/tiled,
 /area/engineering/GravGen_Room)
 "aja" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/table/rack,
+/obj/item/clothing/shoes/magboots{
+	pixel_y = 7;
+	pixel_x = 4
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_y = -1;
+	pixel_x = 4
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_y = -8;
+	pixel_x = 4
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_y = -1;
+	pixel_x = -5
+	},
+/obj/item/clothing/shoes/magboots{
+	pixel_y = -8;
+	pixel_x = -5
+	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/camera/network/security{
 	dir = 5;
@@ -2353,7 +3475,12 @@
 /turf/simulated/wall/r_wall,
 /area/harbor/Dock4)
 "ajZ" = (
-/turf/simulated/floor/tiled,
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/shuttle/blue{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/hallway/AftStar_1_Deck_Observatory)
 "aka" = (
 /obj/structure/table/rack,
@@ -2882,6 +4009,7 @@
 /turf/simulated/wall/r_wall,
 /area/security/Quantum_Pad_Checkpoint)
 "anv" = (
+/obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
@@ -2889,7 +4017,10 @@
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/powered/pump/filled,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "anw" = (
@@ -2965,11 +4096,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Telecomms_Control_Room)
-"anL" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Fueling_Storage)
 "anM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3267,10 +4393,18 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Public_EVA)
 "apV" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	color = "#989898"
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/blast/shutters{
+	id = "sc-GCpilotpot";
+	layer = 3.1;
+	name = "PilotPot Shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
 /area/harbor/Fueling_Storage)
 "apY" = (
 /obj/machinery/light{
@@ -3314,16 +4448,13 @@
 /obj/structure/window/titanium{
 	dir = 4
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/machinery/door/firedoor/glass/hidden,
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/orange/bordercorner{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/glass/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "aqk" = (
@@ -3664,20 +4795,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Planetside_Equipment)
 "asG" = (
-/obj/machinery/suit_cycler/engineering{
-	req_one_access = list(11,24);
-	req_access = null
-	},
+/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
-	},
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 10
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 10
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
@@ -3973,10 +5100,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Telecomms_Control_Room)
 "auI" = (
@@ -4596,7 +5723,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "azZ" = (
@@ -4658,46 +5790,49 @@
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "aAQ" = (
-/obj/item/stack/material/phoron{
-	amount = 25;
-	pixel_x = 9;
-	pixel_y = -9
+/obj/structure/table/steel,
+/obj/item/clamp{
+	pixel_y = -3;
+	pixel_x = -7
 	},
-/obj/item/clothing/glasses/meson{
-	pixel_x = -6;
-	pixel_y = -13
+/obj/item/clamp{
+	pixel_x = -7
 	},
-/obj/item/clothing/glasses/welding{
-	pixel_x = -6;
-	pixel_y = -8
+/obj/item/clamp{
+	pixel_y = 3;
+	pixel_x = -7
 	},
-/obj/item/stack/material/plasteel{
-	amount = 30;
+/obj/item/clamp{
+	pixel_y = 6;
+	pixel_x = -7
+	},
+/obj/item/clamp{
+	pixel_y = 9;
+	pixel_x = -7
+	},
+/obj/item/clothing/mask/gas{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/item/clothing/mask/gas{
+	pixel_y = -2;
+	pixel_x = 7
+	},
+/obj/item/clothing/mask/gas{
 	pixel_y = 1;
-	pixel_x = -8
+	pixel_x = 8
 	},
-/obj/item/stack/material/steel{
-	amount = 50;
-	pixel_y = 4;
-	pixel_x = -8
+/obj/item/taperoll/atmos{
+	pixel_y = 12;
+	pixel_x = 8
 	},
-/obj/item/stack/material/glass{
-	amount = 50;
-	pixel_x = -8;
-	pixel_y = 7
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/item/taperoll/atmos{
+	pixel_y = 14;
+	pixel_x = 6
 	},
 /obj/item/t_scanner{
-	pixel_y = 3;
-	pixel_x = 11
-	},
-/obj/item/multitool{
-	pixel_x = 4
-	},
-/obj/structure/closet/crate/secure/large/nanotrasen{
-	req_access = list(10)
+	pixel_y = 5;
+	pixel_x = 2
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 6
@@ -5292,8 +6427,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock5)
@@ -5468,9 +6606,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Post)
@@ -5924,12 +7064,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Aft_1_Deck_Stairwell)
-"aKU" = (
-/obj/machinery/atmospherics/valve,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Fueling_Storage)
 "aLc" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/arrows/blue{
@@ -6254,9 +7388,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/engineering/GravGen_Room)
 "aMN" = (
@@ -7023,6 +8158,9 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/machinery/ai_status_display{
+	pixel_y = -32
+	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/ForPort_1_Deck_Observatory)
 "aSk" = (
@@ -7288,8 +8426,11 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock3)
@@ -7355,11 +8496,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Corridor1)
 "aUH" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_5)
 "aUI" = (
@@ -7383,6 +8527,7 @@
 /area/quartermaster/Mining_Ship_Bay)
 "aVf" = (
 /obj/machinery/light/small,
+/mob/living/simple_mob/metroid/juvenile/baby,
 /turf/simulated/floor/reinforced,
 /area/rnd/Xenobiology_Lab)
 "aVg" = (
@@ -7785,8 +8930,8 @@
 /obj/effect/floor_decal/shuttles{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -7854,9 +8999,6 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
@@ -8425,10 +9567,11 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Deck1_Transit_Hall)
 "bjg" = (
@@ -8792,8 +9935,9 @@
 "bqm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
@@ -9869,8 +11013,8 @@
 /turf/simulated/floor/plating,
 /area/rnd/Xenobotany_Isolation_Chamber)
 "bHe" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
@@ -9928,14 +11072,11 @@
 /turf/simulated/floor/tiled,
 /area/security/Exploration_Ship_Bay)
 "bJc" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/titanium{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/glass/hidden{
-	dir = 1
-	},
+/obj/machinery/suit_cycler/refit_only,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "bJd" = (
@@ -9991,8 +11132,11 @@
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Mining_Ship_Bay)
@@ -10191,8 +11335,11 @@
 	},
 /area/shuttle/escape_pod14/station)
 "bNS" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock2)
@@ -10322,8 +11469,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_1Deck_Atrium)
@@ -10459,9 +11607,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
 "bSj" = (
@@ -10695,6 +11841,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_Transit_Lobby)
@@ -11125,7 +12277,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "east bump";
@@ -11137,6 +12288,9 @@
 	dir = 8
 	},
 /obj/structure/cable/green,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Gateway)
 "ceA" = (
@@ -11356,17 +12510,9 @@
 	},
 /area/engineering/Telecomms_Network)
 "ckb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 1
-	},
-/obj/machinery/firealarm{
-	pixel_y = 25
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
@@ -11493,59 +12639,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor1)
 "clD" = (
-/obj/structure/table/steel,
-/obj/item/clamp{
-	pixel_y = -3;
-	pixel_x = -7
-	},
-/obj/item/clamp{
-	pixel_x = -7
-	},
-/obj/item/clamp{
-	pixel_y = 3;
-	pixel_x = -7
-	},
-/obj/item/clamp{
-	pixel_y = 6;
-	pixel_x = -7
-	},
-/obj/item/clamp{
-	pixel_y = 9;
-	pixel_x = -7
-	},
-/obj/item/clothing/mask/gas{
-	pixel_y = -5;
-	pixel_x = 6
-	},
-/obj/item/clothing/mask/gas{
-	pixel_y = -2;
-	pixel_x = 7
-	},
-/obj/item/clothing/mask/gas{
-	pixel_y = 1;
-	pixel_x = 8
-	},
-/obj/item/taperoll/atmos{
-	pixel_y = 12;
-	pixel_x = 8
-	},
-/obj/item/taperoll/atmos{
-	pixel_y = 14;
-	pixel_x = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/structure/closet/secure_closet/pilot,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 4
 	},
-/obj/item/t_scanner{
-	pixel_y = 5;
-	pixel_x = 2
-	},
+/obj/item/bluespaceradio/southerncross_prelinked,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "clF" = (
@@ -11554,6 +12656,9 @@
 "clT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -12157,7 +13262,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber2)
 "cxX" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_For)
 "cyc" = (
@@ -12195,8 +13302,9 @@
 /turf/simulated/wall/rshull,
 /area/shuttle/echidna)
 "cyN" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Deck1_Corridor)
@@ -12649,9 +13757,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Depot1)
 "cGe" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
@@ -12659,11 +13764,14 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Planetside_Equipment)
 "cGn" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Star_Docking_Foyer)
@@ -12732,9 +13840,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock4)
@@ -12773,7 +13881,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortChamber1)
 "cJk" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/security/Quantum_Pad_Checkpoint)
 "cJw" = (
@@ -12840,8 +13953,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Telecomms_Foyer)
@@ -13159,7 +14275,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock3)
 "cQS" = (
@@ -13227,6 +14348,10 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "cRm" = (
@@ -13247,7 +14372,7 @@
 /turf/simulated/floor/plating,
 /area/rnd/Observation_Hall)
 "cRo" = (
-/obj/structure/mob_spawner/mouse_nest,
+/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber1)
 "cRu" = (
@@ -13264,26 +14389,24 @@
 /turf/simulated/floor/plating,
 /area/engineering/GravGen_Room)
 "cRM" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/green/bordercorner2{
-	dir = 10
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack/station,
 /area/hallway/Cryostorage_Lounge)
 "cRQ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/security/Exploration_Sling_Shuttle)
@@ -13295,9 +14418,7 @@
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "cSh" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/security/Exploration_Ship_Bay)
 "cSw" = (
@@ -13968,10 +15089,10 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck1_ForStar_Chamber2)
 "ddP" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Star_1Deck_Atrium)
 "ddS" = (
@@ -14255,14 +15376,17 @@
 /turf/simulated/floor/plating/turfpack/airless,
 /area/space)
 "dis" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Star_1Deck_Central_Corridor_1)
@@ -14344,6 +15468,8 @@
 /obj/structure/table/rack,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Science_AftCorridor1)
 "djI" = (
@@ -14362,6 +15488,16 @@
 	layer = 3.3;
 	pixel_y = 26
 	},
+/obj/random/internal_organ,
+/obj/structure/closet/crate/freezer,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
 /turf/simulated/floor/tiled/white,
 /area/maintenance/ab_Medical)
 "djQ" = (
@@ -14526,8 +15662,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Chamber2)
 "dmD" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_EVA)
@@ -14613,15 +15752,13 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "doR" = (
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
+/obj/effect/floor_decal/industrial/bot_outline/blue,
 /turf/simulated/floor/tiled/monotile{
 	color = "#989898"
 	},
@@ -14733,6 +15870,7 @@
 /obj/random/junk,
 /obj/structure/table/standard,
 /obj/random/maintenance/clean,
+/obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Science_AftCorridor1)
 "drQ" = (
@@ -14761,8 +15899,8 @@
 "dsn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Transit_Foyer)
@@ -14894,7 +16032,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
 "duw" = (
@@ -15154,7 +16294,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
 "dxQ" = (
@@ -15378,11 +16520,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Ship_Bay4)
-"dBn" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Fueling_Storage)
 "dBE" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -15409,7 +16546,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "dBV" = (
@@ -15686,16 +16828,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock4)
 "dGL" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/titanium{
 	dir = 1
 	},
+/obj/machinery/suit_cycler/refit_only,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/cable/green{
 	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/glass/hidden{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
@@ -15890,8 +17029,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
@@ -15945,8 +17084,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/PA_Access)
@@ -16088,21 +17227,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/Port_1Deck_Atrium)
 "dNp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled,
 /area/maintenance/Deck1_Star_Corridor)
 "dNz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
@@ -16112,7 +17240,12 @@
 /turf/simulated/wall/rplastihull,
 /area/shuttle/needle)
 "dNN" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock5)
 "dNS" = (
@@ -16340,6 +17473,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/holoposter{
+	pixel_y = -32;
+	layer = 4;
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock3)
 "dSB" = (
@@ -16477,6 +17615,7 @@
 	dir = 1
 	},
 /obj/structure/table/standard,
+/obj/random/maintenance/cargo,
 /obj/random/maintenance/cargo,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor2)
@@ -16817,16 +17956,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Observation_Hall)
 "dWp" = (
-/obj/machinery/atmospherics/binary/passive_gate{
-	dir = 1;
-	regulate_mode = 0;
-	unlocked = 1
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 1
@@ -16834,7 +17968,10 @@
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/bot_outline/blue,
+/turf/simulated/floor/tiled/monotile{
+	color = "#989898"
+	},
 /area/harbor/Fueling_Storage)
 "dWy" = (
 /obj/structure/table/reinforced,
@@ -17918,6 +19055,7 @@
 /area/quartermaster/Depot2)
 "eal" = (
 /obj/structure/table/woodentable,
+/obj/item/toy/eight_ball/conch,
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/AftStar_1_Deck_Observatory)
 "eam" = (
@@ -18777,8 +19915,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
@@ -18798,8 +19936,11 @@
 /turf/simulated/floor/grass,
 /area/hallway/Port_1Deck_Atrium)
 "emE" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Locker_Room)
@@ -19004,12 +20145,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Chamber1)
 "erH" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -25
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock3)
@@ -19074,8 +20218,8 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/Aft_1_Deck_Stairwell)
 "esf" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Star_1Deck_Atrium)
@@ -19132,6 +20276,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock3)
 "ett" = (
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 32;
+	layer = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock2)
 "etu" = (
@@ -19142,15 +20291,19 @@
 /turf/simulated/wall/r_wall,
 /area/quartermaster/Mining_Ship_Bay)
 "etG" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/borderfloorblack/corner{
+/obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/orange/bordercorner{
-	dir = 1
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list(10);
+	name = "Pilotpot Reception"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/blast/shutters{
+	id = "sc-GCpilotpot";
+	layer = 3.1;
+	name = "PilotPot Shutters"
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/harbor/Fueling_Storage)
 "eue" = (
 /obj/effect/floor_decal/borderfloor/corner,
@@ -19405,14 +20558,16 @@
 /turf/simulated/floor/plating,
 /area/hallway/Aft_Transit_Lobby)
 "ezj" = (
-/obj/machinery/atmospherics/binary/pump,
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 9
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 9
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/bot_outline/blue,
+/turf/simulated/floor/tiled/monotile{
+	color = "#989898"
+	},
 /area/harbor/Fueling_Storage)
 "ezl" = (
 /obj/structure/sign/level/one/large,
@@ -19552,6 +20707,11 @@
 	c_tag = "D1-Har-4th Dock4";
 	network = list("Harbor")
 	},
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -32;
+	layer = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock4)
 "eCS" = (
@@ -19583,8 +20743,8 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
@@ -19731,8 +20891,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Depot1)
@@ -19743,20 +20903,12 @@
 /turf/simulated/wall,
 /area/security/Quantum_Pad_Checkpoint)
 "eGu" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "eGF" = (
@@ -19776,6 +20928,10 @@
 /area/security/Aft_Security_Post)
 "eGR" = (
 /obj/structure/table/woodentable,
+/obj/item/radio/intercom{
+	pixel_y = -22
+	},
+/obj/item/toy/eight_ball,
 /turf/simulated/floor/tiled,
 /area/hallway/ForPort_1_Deck_Observatory)
 "eGT" = (
@@ -19816,8 +20972,9 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/For_Restroom)
 "eHr" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/security/Quantum_Pad_Storage)
@@ -19895,6 +21052,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Aft_Security_Post)
 "eIg" = (
@@ -20463,17 +21626,18 @@
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "eTo" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
-	},
+/obj/structure/dispenser/oxygen,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 8;
+	name = "Station Intercom (General)";
+	pixel_x = -21
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
@@ -20980,18 +22144,23 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
 "eZQ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Port_1Deck_Central_Corridor_1)
@@ -21013,9 +22182,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Telecomms_Control_Room)
@@ -21060,7 +22231,7 @@
 	},
 /obj/machinery/button/remote/blast_door{
 	id = "SC-BDxenobiovent2";
-	name = "Containment Blast Doors";
+	name = "Containment Vent Doors";
 	req_access = list(55);
 	dir = 8;
 	pixel_x = 32;
@@ -21100,8 +22271,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/PA_Access)
@@ -21176,9 +22347,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Post)
 "fcV" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/glass/reinforced,
 /area/harbor/Dock5)
 "fdh" = (
@@ -21562,8 +22734,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/ab_Surgery)
 "flL" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Star_1Deck_Atrium)
@@ -21631,9 +22803,6 @@
 	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
@@ -21742,9 +22911,9 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/For_Restroom)
 "fpt" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay4)
@@ -21768,9 +22937,7 @@
 	},
 /area/maintenance/ab_Kitchen)
 "fpW" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "fqf" = (
@@ -22033,8 +23200,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Chamber1)
 "fwh" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock3)
@@ -22199,19 +23369,19 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/Stairwell_Star)
 "fzE" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/glass/hidden/steel{
+	dir = 1
+	},
+/obj/machinery/door/blast/shutters{
+	id = "sc-GCpilotpot";
+	layer = 3.1;
+	name = "PilotPot Shutters"
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	color = "#989898"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techmaint,
 /area/harbor/Fueling_Storage)
 "fzF" = (
 /obj/structure/girder,
@@ -22299,11 +23469,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/Aft_Security_Post)
 "fBC" = (
-/obj/effect/floor_decal/steeldecal/steel_decals5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Deck1_Corridor)
@@ -22525,9 +23695,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Research_Ship_Bay)
@@ -22606,8 +23775,11 @@
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod1/station)
 "fID" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Transit_Foyer)
@@ -22725,8 +23897,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -22747,9 +23920,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Corridor2)
 "fLM" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
@@ -22775,9 +23947,6 @@
 	req_access = list(10);
 	req_one_access = list(17,11,24)
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -22787,6 +23956,10 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/engineering/Telecomms_Control_Room)
 "fMw" = (
@@ -22823,8 +23996,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Chamber1)
 "fNc" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
@@ -22936,7 +24109,7 @@
 /turf/simulated/floor/tiled,
 /area/harbor/Dock5)
 "fPd" = (
-/obj/structure/mob_spawner/mouse_nest,
+/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor3)
 "fPg" = (
@@ -23431,8 +24604,8 @@
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
@@ -23464,22 +24637,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortChamber3)
 "fWW" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/small/warning/emerg_only{
-	desc = "Ladder for emergency use only";
-	pixel_y = -32
-	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Star_Corridor)
@@ -24030,6 +25187,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood/corner,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "gfC" = (
@@ -24097,8 +25255,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Star_Docking_Foyer)
@@ -24744,12 +25903,11 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
-	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/PA_Chamber)
@@ -26068,7 +27226,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock2)
 "gTv" = (
@@ -26266,8 +27429,9 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Deck1_Corridor)
@@ -26645,17 +27809,6 @@
 /obj/structure/sign/warning/vacuum,
 /turf/simulated/wall/r_wall,
 /area/harbor/Ship_Bay1)
-"hdB" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/empty,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Fueling_Storage)
 "hdP" = (
 /obj/structure/sign/warning/evac,
 /turf/simulated/shuttle/wall/no_join{
@@ -27338,8 +28491,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Deck1_Corridor)
@@ -27460,7 +28614,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor1)
 "huX" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_Gateway)
 "hvg" = (
@@ -28499,6 +29655,11 @@
 /turf/simulated/wall/r_wall,
 /area/harbor/Port_Docking_Foyer)
 "hPd" = (
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = -32;
+	layer = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock3)
 "hPg" = (
@@ -29109,8 +30270,8 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/quartermaster/Deck1_Stairwell)
 "icg" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Locker_Room)
@@ -29582,8 +30743,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Depot2)
@@ -30149,8 +31310,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Transit_Foyer)
 "isy" = (
@@ -30385,6 +31548,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -30940,8 +32106,8 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/Supply_Ship_Bay)
 "iKa" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_Transit_Lobby)
@@ -31095,6 +32261,10 @@
 	},
 /obj/effect/floor_decal/corner/green/border{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/AftPort_1_Deck_Observatory)
@@ -31496,8 +32666,9 @@
 /turf/simulated/wall/r_wall,
 /area/maintenance/ab_Surgery)
 "iYx" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Deck1_Transit_Hall)
@@ -31520,9 +32691,6 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31962,6 +33130,7 @@
 /area/quartermaster/Mining_Ship_Bay)
 "jhG" = (
 /obj/structure/table/woodentable,
+/obj/random/maintenance/foodstuff,
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/AftPort_1_Deck_Observatory)
 "jhM" = (
@@ -32274,27 +33443,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "jno" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/shuttle/blue{
+	pixel_x = -1;
+	pixel_y = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/orange/border,
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Fueling_Storage)
-"jnw" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/orange/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/techmaint,
 /area/harbor/Fueling_Storage)
 "job" = (
 /obj/structure/table/marble,
@@ -32427,8 +33585,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/AftStar_1_Deck_Observatory)
 "jpJ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Deck1_Transit_Hall)
@@ -32459,11 +33618,11 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
@@ -32597,10 +33756,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
-"jsW" = (
-/mob/living/simple_mob/animal/space/alien/drone,
-/turf/simulated/floor/reinforced,
-/area/rnd/Xenobiology_Lab)
 "jsZ" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/lightgrey/border,
@@ -32824,6 +33979,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/frame,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Science_AftCorridor1)
 "jzx" = (
@@ -33030,8 +34186,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Deck1_Corridor)
@@ -33452,9 +34609,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor1)
 "jJR" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /obj/effect/floor_decal/borderfloor/corner,
 /obj/effect/floor_decal/corner/lightgrey/bordercorner,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Port)
 "jJV" = (
@@ -33686,16 +34845,24 @@
 /obj/effect/floor_decal/corner/green/border{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = 22
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/AftStar_1_Deck_Observatory)
 "jOi" = (
-/obj/machinery/power/thermoregulator,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	layer = 3
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
@@ -33836,6 +35003,10 @@
 /area/maintenance/ab_Medical)
 "jSw" = (
 /obj/structure/table/woodentable,
+/obj/item/radio/intercom{
+	pixel_y = -22
+	},
+/obj/random/maintenance/foodstuff,
 /turf/simulated/floor/tiled,
 /area/hallway/ForStar_1_Deck_Observatory)
 "jSx" = (
@@ -34063,8 +35234,58 @@
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
 "jVV" = (
+/obj/structure/table/rack{
+	dir = 8;
+	layer = 2.6
+	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/empty,
+/obj/item/tank/emergency/oxygen{
+	pixel_y = 11;
+	pixel_x = 7
+	},
+/obj/item/tank/emergency/oxygen{
+	pixel_y = 7;
+	pixel_x = 6
+	},
+/obj/item/tank/emergency/oxygen{
+	pixel_y = 3;
+	pixel_x = 6
+	},
+/obj/item/tank/emergency/oxygen{
+	pixel_y = -2;
+	pixel_x = 6
+	},
+/obj/item/tank/emergency/nitrogen{
+	pixel_y = 12;
+	pixel_x = -3
+	},
+/obj/item/tank/emergency/oxygen{
+	pixel_y = -6;
+	pixel_x = 6
+	},
+/obj/item/tank/emergency/nitrogen{
+	pixel_y = 8;
+	pixel_x = -3
+	},
+/obj/item/tank/emergency/nitrogen{
+	pixel_y = 4;
+	pixel_x = -3
+	},
+/obj/item/tank/emergency/nitrogen{
+	pixel_y = -1;
+	pixel_x = -3
+	},
+/obj/item/tank/emergency/nitrogen{
+	pixel_y = -6;
+	pixel_x = -3
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 2;
+	id = "sc-GCpilotpot";
+	name = "Fueldepo Shutters Control";
+	req_access = list(10);
+	pixel_y = 24
+	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -34116,15 +35337,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock3)
-"jWw" = (
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/bot_outline/blue,
-/turf/simulated/floor/tiled/monotile{
-	color = "#989898"
-	},
-/area/harbor/Fueling_Storage)
 "jWx" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -34291,10 +35503,6 @@
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber3)
-"kaj" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck1_Star_Corridor)
 "kap" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -34364,8 +35572,8 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -34461,6 +35669,9 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/machinery/status_display{
+	pixel_x = -32
+	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/AftStar_1_Deck_Observatory)
 "kce" = (
@@ -34493,7 +35704,12 @@
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/ForStar_1_Deck_Observatory)
 "kdf" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_For)
 "kdk" = (
@@ -34682,7 +35898,6 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
 /obj/structure/grille,
-/obj/structure/window/titanium,
 /obj/structure/window/titanium{
 	dir = 4
 	},
@@ -34691,6 +35906,9 @@
 	},
 /obj/structure/window/titanium{
 	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Dock1)
@@ -34740,23 +35958,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Deck1_Stairwell)
-"kjz" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
-	},
-/obj/effect/floor_decal/corner/orange/bordercorner{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/glass/hidden,
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Fueling_Storage)
 "kjB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -34784,6 +35985,7 @@
 /obj/structure/table/standard,
 /obj/random/tool/powermaint,
 /obj/random/maintenance/clean,
+/obj/random/toolbox,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Star_Corridor)
 "kkp" = (
@@ -35022,9 +36224,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
 "kpM" = (
@@ -35244,8 +36444,8 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -35331,8 +36531,11 @@
 	},
 /area/maintenance/ab_Kitchen)
 "kxe" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Deck1_Transit_Hall)
@@ -35487,10 +36690,10 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/obj/effect/floor_decal/borderfloorblack/corner{
+/obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/orange/bordercorner{
+/obj/effect/floor_decal/corner/orange/border{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
@@ -35747,8 +36950,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/PA_Access)
@@ -35854,8 +37057,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Supply_Ship_Bay)
@@ -35965,7 +37171,7 @@
 	dir = 8;
 	id = "sc-GCminingbay";
 	name = "Shuttle Bay Entrance";
-	req_one_access = list(47);
+	req_one_access = list(48,10,67);
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/borderfloor{
@@ -36000,8 +37206,9 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobiology_Lab)
 "kKp" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
@@ -36231,11 +37438,14 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
 "kPv" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_2)
 "kPP" = (
@@ -36668,9 +37878,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor1)
 "kXn" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay2)
@@ -37122,8 +38331,8 @@
 /turf/simulated/floor/carpet/sblucarpet/turfpack/station,
 /area/hallway/Cryostorage_Lounge)
 "lgf" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/Port_1Deck_Central_Corridor_1)
@@ -37325,8 +38534,8 @@
 /obj/effect/floor_decal/shuttles/right{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -37421,6 +38630,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "llp" = (
@@ -37447,12 +38665,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/PA_Chamber)
@@ -37542,8 +38760,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber2)
 "lmU" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/PA_Access)
@@ -38086,8 +39304,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Telecomms_Foyer)
@@ -38136,9 +39357,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Research_Ship_Bay)
@@ -38596,8 +39816,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortChamber2)
 "lIv" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_1)
@@ -39171,8 +40392,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Deck1_Corridor)
@@ -39318,8 +40539,13 @@
 /turf/simulated/wall/rthull,
 /area/shuttle/spacebus)
 "lTL" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/shuttle/blue{
+	pixel_x = -1;
+	pixel_y = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/hallway/ForStar_1_Deck_Observatory)
 "lTM" = (
 /obj/random/trash_pile,
@@ -39455,6 +40681,10 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
+	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/ForStar_1_Deck_Observatory)
 "lWn" = (
@@ -39485,6 +40715,12 @@
 /area/engineering/GravGen_Room)
 "lWM" = (
 /obj/machinery/atmospherics/binary/pump,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Post)
 "lWV" = (
@@ -39636,6 +40872,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
+	},
+/obj/machinery/holoposter{
+	pixel_y = -32;
+	layer = 4;
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock2)
@@ -40189,8 +41430,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock2)
@@ -40243,8 +41485,8 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Depot2)
@@ -40355,9 +41597,7 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
 "mod" = (
@@ -40372,14 +41612,17 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/Star_1Deck_Atrium)
 "mow" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Port_1Deck_Central_Corridor_1)
@@ -40424,9 +41667,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay4)
@@ -40539,14 +41781,14 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -40692,10 +41934,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -40705,6 +41943,7 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "mtm" = (
@@ -40724,9 +41963,8 @@
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
 "mtP" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay1)
@@ -40871,12 +42109,14 @@
 /turf/simulated/floor,
 /area/shuttle/ursula)
 "mvL" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner{
 	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Star)
@@ -40950,13 +42190,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/Quantum_Pad_Checkpoint)
 "mwj" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/green/bordercorner2{
+/obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 5
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack/station,
@@ -41048,6 +42285,9 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/machinery/ai_status_display{
+	pixel_y = -32
+	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/ForStar_1_Deck_Observatory)
 "mxn" = (
@@ -41143,13 +42383,6 @@
 	},
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod2/station)
-"mzA" = (
-/obj/machinery/atmospherics/valve,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Fueling_Storage)
 "mzF" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/table/rack{
@@ -41271,7 +42504,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Aft_1_Deck_Stairwell)
 "mAy" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
 "mBf" = (
@@ -41655,8 +42890,11 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock2)
@@ -41698,7 +42936,7 @@
 /turf/space,
 /area/space)
 "mJa" = (
-/obj/structure/mob_spawner/mouse_nest,
+/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Corridor3)
 "mJG" = (
@@ -41768,6 +43006,11 @@
 	dir = 8;
 	c_tag = "D1-Har-1st Dock4";
 	network = list("Harbor")
+	},
+/obj/machinery/holoposter{
+	dir = 8;
+	pixel_x = 32;
+	layer = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/harbor/Dock1)
@@ -42038,20 +43281,8 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/Supply_Ship_Bay)
 "mOu" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/turf/simulated/floor/tiled,
 /area/maintenance/Deck1_Star_Corridor)
 "mOH" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -42139,8 +43370,8 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Deck1_Corridor)
@@ -42248,6 +43479,12 @@
 	},
 /obj/machinery/atmospherics/binary/pump,
 /obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/engineering/Telecomms_Control_Room)
 "mTi" = (
@@ -42410,7 +43647,13 @@
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
 "mWi" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -42687,18 +43930,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor2)
 "nbt" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows/yellow,
-/obj/effect/floor_decal/industrial/arrows/yellow{
+/obj/machinery/door/firedoor/multi_tile/glass,
+/obj/effect/floor_decal/industrial/arrows/blue,
+/obj/effect/floor_decal/industrial/arrows/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/angled_bay/double/glass/common{
+	name = "Stairwell"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance/int,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck1_Star_Corridor)
 "nbM" = (
@@ -42919,6 +44158,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "njR" = (
@@ -43020,8 +44262,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Corridor2)
 "nlq" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/shuttle/blue{
+	pixel_x = -1;
+	pixel_y = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/hallway/ForPort_1_Deck_Observatory)
 "nlw" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -43190,6 +44437,9 @@
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	color = "#989898"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock4)
@@ -43380,7 +44630,9 @@
 /turf/simulated/floor/plating,
 /area/harbor/Ship_Bay4)
 "ntB" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Port)
 "ntN" = (
@@ -43664,17 +44916,27 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/Aft_Transit_Lobby)
 "nyt" = (
+/obj/structure/closet,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/melee/umbrella/random,
+/obj/item/melee/umbrella/random,
+/obj/item/melee/umbrella/random,
+/obj/random/maintenance/engineering,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 4
+	},
 /obj/machinery/camera/network/security{
 	dir = 8;
 	c_tag = "D1-Har-3rd Ship Bay1";
 	network = list("Harbor")
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/structure/table/bench/steel,
-/obj/effect/floor_decal/corner/black/border{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay1)
@@ -43929,6 +45191,9 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/For_Transit_Foyer)
@@ -44528,7 +45793,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock4)
 "nML" = (
-/obj/structure/mob_spawner/mouse_nest,
+/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/ab_SportsField)
 "nMQ" = (
@@ -44554,8 +45819,8 @@
 /obj/effect/floor_decal/shuttles{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -44621,8 +45886,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Deck1_Corridor)
@@ -44967,9 +46235,9 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay2)
@@ -45017,8 +46285,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_1Deck_Atrium)
@@ -45280,8 +46548,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
@@ -45379,9 +46647,7 @@
 	dir = 8;
 	icon_state = "pipe-j2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "oaW" = (
@@ -45494,15 +46760,20 @@
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
 "ocA" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/light_switch{
+	pixel_x = 27;
+	pixel_y = -12;
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorblack/corner,
-/obj/effect/floor_decal/corner/orange/bordercorner,
+/obj/structure/cable/green,
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "ocC" = (
@@ -45531,16 +46802,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/green/bordercorner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/green/bordercorner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack/station,
@@ -45571,8 +46839,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Distro_Central)
 "ocR" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/security/Exploration_Sling_Shuttle)
@@ -46518,8 +47787,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Science_AftCorridor1)
 "ovZ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Port_Docking_Foyer)
@@ -46725,21 +47994,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/Mining_EVA)
-"oyt" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/orange/border,
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Fueling_Storage)
 "oyE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 9
 	},
@@ -46782,7 +48040,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Deck1_Corridor)
 "ozg" = (
@@ -46903,11 +48166,11 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/Xenobiology_Lab)
 "oBc" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	pixel_y = 25
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Star_1Deck_Atrium)
@@ -47575,7 +48838,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/Telecomms_Foyer)
 "oNd" = (
@@ -48166,7 +49434,12 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Mining_Ship_Bay)
 "oXE" = (
@@ -48485,8 +49758,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
@@ -49065,10 +50338,13 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
 /area/crew_quarters/Custodial_Office)
 "plp" = (
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
@@ -49106,8 +50382,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Deck1_Corridor)
@@ -49852,7 +51128,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_For)
 "pzO" = (
@@ -50089,7 +51367,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
 "pDP" = (
@@ -50163,15 +51443,18 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
 	},
-/obj/structure/sign/poster/nanotrasen{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "pFS" = (
@@ -50181,9 +51464,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Telecomms_Control_Room)
@@ -50368,9 +51653,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/quartermaster/Mining_EVA)
 "pJV" = (
@@ -50462,6 +51748,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/monotile{
 	color = "#989898"
 	},
@@ -50539,8 +51829,11 @@
 /turf/simulated/floor/grass2/turfpack/station,
 /area/maintenance/ab_SportsField)
 "pMx" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
@@ -50808,11 +52101,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Market_Stall_6)
 "pPx" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_3)
 "pPE" = (
@@ -50827,6 +52123,9 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/machinery/status_display{
+	pixel_x = 32
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/AftPort_1_Deck_Observatory)
@@ -50847,9 +52146,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay3)
@@ -50948,13 +52246,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/hallway/Deck1_Transit_Hall)
 "pSs" = (
@@ -50976,9 +52273,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor1)
 "pSB" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
 "pSW" = (
@@ -51046,17 +52341,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarChamber1)
 "pTK" = (
-/obj/effect/floor_decal/industrial/stand_clear/blue,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1;
-	color = "#989898"
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile{
-	color = "#989898"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "pUe" = (
 /obj/machinery/alarm{
@@ -51235,8 +52522,7 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/structure/table/standard,
-/obj/random/toolbox,
+/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Star_Corridor)
 "pWf" = (
@@ -51419,7 +52705,7 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/cryo/station)
 "pYp" = (
-/obj/random/maintenance/clean,
+/obj/structure/stairs/spawner/west,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Star_Corridor)
 "pYC" = (
@@ -51560,8 +52846,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/ab_SportsField)
 "qbv" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/Port_1Deck_Central_Corridor_1)
@@ -51574,14 +52860,17 @@
 /turf/simulated/wall/r_wall,
 /area/hallway/Aft_Transit_Lobby)
 "qcp" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Star_1Deck_Central_Corridor_1)
@@ -51759,10 +53048,6 @@
 /obj/structure/table/steel,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber2)
-"qgm" = (
-/obj/random/trash_pile,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck1_ForStar_Chamber1)
 "qgA" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows,
@@ -52159,8 +53444,9 @@
 /obj/effect/floor_decal/shuttles/right{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -52202,8 +53488,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_Transit_Lobby)
@@ -52600,13 +53886,18 @@
 /area/rnd/Xenobotany_Isolation_Chamber)
 "qxt" = (
 /obj/structure/cable/green{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "qyi" = (
@@ -52725,8 +54016,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Port_Docking_Foyer)
@@ -52739,7 +54030,9 @@
 /turf/simulated/shuttle/floor/voidcraft/dark,
 /area/security/Quantum_Pad_Checkpoint)
 "qBK" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
 "qCc" = (
@@ -52967,8 +54260,8 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
@@ -53417,8 +54710,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay2)
 "qOy" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/security/Exploration_Ship_Bay)
@@ -53505,18 +54801,6 @@
 /obj/machinery/door/airlock/angled_bay/double/glass/common{
 	dir = 8;
 	name = "Expedition Shuttle"
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/For_Locker_Room)
@@ -53646,6 +54930,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Chamber1)
 "qSb" = (
+/obj/machinery/pipedispenser,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
@@ -53653,7 +54938,6 @@
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 10
 	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "qSj" = (
@@ -54253,14 +55537,11 @@
 	},
 /area/maintenance/ab_Kitchen)
 "raY" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/green/bordercorner2{
-	dir = 6
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack/station,
 /area/hallway/Cryostorage_Lounge)
@@ -54518,8 +55799,8 @@
 /turf/simulated/floor/reinforced,
 /area/rnd/Xenobiology_Lab)
 "rdS" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Port_1Deck_Atrium)
@@ -54566,14 +55847,14 @@
 /turf/simulated/floor/plating,
 /area/rnd/Xenobiology_Lab)
 "reC" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Locker_Room)
@@ -55055,12 +56336,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor3)
 "rnD" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -25
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock2)
@@ -55241,8 +56523,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Supply_Ship_Bay)
@@ -55584,7 +56869,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "rxv" = (
-/turf/simulated/floor/tiled,
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/shuttle/blue{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/hallway/AftPort_1_Deck_Observatory)
 "rxz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -55595,7 +56885,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
 "rxK" = (
@@ -55767,13 +57059,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftStar1_Corridor2)
 "rBb" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Locker_Room)
 "rBj" = (
@@ -56117,8 +57414,8 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/security/Exploration_Ship_Bay)
@@ -56337,11 +57634,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
-"rNI" = (
-/obj/machinery/portable_atmospherics/powered/pump/filled,
-/obj/effect/floor_decal/industrial/hatch/blue,
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Fueling_Storage)
 "rOg" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 1
@@ -56770,9 +58062,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "rXw" = (
@@ -57068,7 +58361,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Xenobiology_Lab)
 "sbn" = (
-/obj/structure/mob_spawner/mouse_nest,
+/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber3)
 "sbu" = (
@@ -57453,11 +58746,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Deck1_Transit_Hall)
@@ -57604,13 +58897,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor1)
-"skc" = (
-/obj/effect/floor_decal/industrial/hatch/blue,
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/orange/border,
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Fueling_Storage)
 "ske" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable{
@@ -57677,9 +58963,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock1)
@@ -57782,7 +59070,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/rnd/Observation_Hall)
 "soy" = (
@@ -58401,8 +59691,8 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
@@ -58428,25 +59718,6 @@
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape_pod4/station)
-"sCH" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/hatch,
-/obj/structure/grille,
-/obj/structure/window/titanium,
-/obj/structure/window/titanium{
-	dir = 4
-	},
-/obj/structure/window/titanium{
-	dir = 1
-	},
-/obj/structure/window/titanium{
-	dir = 8
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/harbor/Dock1)
 "sCR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -58511,6 +59782,9 @@
 "sEk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock5)
@@ -58649,6 +59923,10 @@
 	},
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
@@ -58840,6 +60118,12 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/white/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Transit_Foyer)
 "sIR" = (
@@ -59139,6 +60423,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Corridor3)
 "sNT" = (
@@ -59378,8 +60663,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
@@ -59467,8 +60752,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_1Deck_Atrium)
@@ -59502,8 +60788,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Public_EVA)
@@ -59799,17 +61088,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarChamber1)
 "teK" = (
-/obj/machinery/atmospherics/unary/freezer{
-	icon_state = "freezer"
-	},
 /obj/structure/window/titanium{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor/glass/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "teW" = (
@@ -60099,6 +61384,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/security/Quantum_Pad_Checkpoint)
 "tkU" = (
@@ -60142,9 +61433,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_StarCorridor2)
 "tlw" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay3)
@@ -60518,10 +61808,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "tso" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Planetside_Equipment)
 "tss" = (
@@ -60714,9 +62004,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "sc-D1_L1A1_airlock";
@@ -60726,6 +62013,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 1;
 	color = "#989898"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock1)
@@ -61060,11 +62350,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck1_ForPort_Corridor3)
-"tBJ" = (
-/obj/structure/table/rack/steel,
-/obj/random/contraband,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck1_Star_Corridor)
 "tBL" = (
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
@@ -61119,10 +62404,17 @@
 /turf/simulated/floor/water/indoors,
 /area/hallway/Star_1Deck_Atrium)
 "tCJ" = (
-/obj/structure/sign/directions/janitor{
-	pixel_y = 9
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
 	},
-/turf/simulated/wall/r_wall,
+/obj/structure/window/basic{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
 /area/maintenance/Deck1_Star_Corridor)
 "tCK" = (
 /obj/machinery/power/apc{
@@ -61363,18 +62655,11 @@
 /area/maintenance/Deck1_AftPort_Chamber3)
 "tGz" = (
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Star_Corridor)
@@ -61427,8 +62712,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor1)
 "tHL" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/portable_atmospherics/canister/empty,
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "tHM" = (
@@ -61535,10 +62821,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock3)
-"tLp" = (
-/obj/random/crate,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck1_ForStar_Chamber1)
 "tLu" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	regulate_mode = 0;
@@ -61806,22 +63088,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Security_PortChamber2)
 "tRe" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
@@ -61904,6 +63172,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "tSu" = (
@@ -62115,7 +63384,9 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
 "tWH" = (
@@ -62370,6 +63641,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/rnd/Xenobiology_Lab)
@@ -62998,6 +64273,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "umz" = (
@@ -63297,11 +64575,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock1)
 "urY" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/maintenance/Market_Stall_4)
 "usa" = (
@@ -63327,13 +64608,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Deck1_Stairwell)
-"ust" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/mob/living/simple_mob/metroid/juvenile/baby,
-/turf/simulated/floor/reinforced,
-/area/rnd/Xenobiology_Lab)
 "usJ" = (
 /obj/structure/bed/chair/backed_red{
 	dir = 8
@@ -63488,7 +64762,9 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
 "uvZ" = (
@@ -63663,6 +64939,7 @@
 /area/maintenance/Deck1_Cargo_Corridor2)
 "uzI" = (
 /obj/structure/table/standard,
+/obj/random/maintenance/morestuff,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber1)
 "uzO" = (
@@ -64005,6 +65282,10 @@
 "uGv" = (
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/sign/small/warning/emerg_only{
+	desc = "Ladder for emergency use only";
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/Deck1_Star_Corridor)
 "uHz" = (
@@ -64054,16 +65335,6 @@
 	pixel_y = -4
 	},
 /obj/item/storage/briefcase/inflatable{
-	pixel_x = 8
-	},
-/obj/item/storage/briefcase/inflatable{
-	pixel_x = 8
-	},
-/obj/item/storage/briefcase/inflatable{
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/storage/briefcase/inflatable{
 	pixel_x = 8;
 	pixel_y = 8
 	},
@@ -64090,6 +65361,10 @@
 /obj/item/radio{
 	pixel_x = -2;
 	pixel_y = -1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	dir = 8
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -64293,12 +65568,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/crew_quarters/For_Restroom)
@@ -64687,24 +65961,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Corridor2)
 "uUc" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
-/obj/machinery/light_switch{
-	pixel_x = 27;
-	pixel_y = -12;
-	dir = 8
-	},
-/obj/structure/cable/green,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 4
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "uUf" = (
@@ -65471,8 +66731,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/rnd/Research_Ship_Bay)
 "vhh" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/PA_Access)
@@ -65618,6 +66879,11 @@
 	dir = 4;
 	light_color = "#DDFFD3"
 	},
+/obj/machinery/holoposter{
+	dir = 4;
+	pixel_x = 32;
+	layer = 4
+	},
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
 	},
@@ -65733,7 +66999,12 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Mining_Ship_Bay)
 "vkq" = (
@@ -65868,15 +67139,14 @@
 /turf/simulated/floor/plating,
 /area/hallway/Star_1Deck_Central_Corridor_1)
 "vna" = (
-/obj/machinery/door/firedoor/multi_tile/glass,
-/obj/effect/floor_decal/industrial/arrows/blue,
-/obj/effect/floor_decal/industrial/arrows/blue{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/orange/border,
+/obj/effect/floor_decal/industrial/outline/cut_corners/blue,
+/obj/effect/floor_decal/industrial/loading/blue,
+/turf/simulated/floor/tiled/monotile{
+	color = "#989898"
 	},
-/obj/machinery/door/airlock/angled_bay/double/glass/engineering{
-	name = "Fueldepo Storage"
-	},
-/turf/simulated/floor/tiled/techmaint,
 /area/harbor/Fueling_Storage)
 "vnl" = (
 /obj/effect/floor_decal/borderfloor,
@@ -66033,6 +67303,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/rnd/Xenobiology_Lab)
 "vpW" = (
@@ -66154,25 +67430,39 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Observation_Hall)
 "vry" = (
+/obj/structure/closet,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/shoes/boots/winter,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/clothing/suit/storage/hooded/wintercoat,
+/obj/item/melee/umbrella/random,
+/obj/item/melee/umbrella/random,
+/obj/item/melee/umbrella/random,
+/obj/random/maintenance/engineering,
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/black/border{
+	dir = 8
+	},
 /obj/machinery/camera/network/security{
 	dir = 4;
 	c_tag = "D1-Har-4th Ship Bay1";
 	network = list("Harbor")
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/structure/table/bench/steel,
-/obj/effect/floor_decal/corner/black/border{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay2)
 "vrz" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/holoposter{
 	dir = 8;
-	pixel_x = 6
+	pixel_x = -32;
+	layer = 4
 	},
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
@@ -66206,7 +67496,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/rnd/PA_Chamber)
 "vtC" = (
-/obj/structure/mob_spawner/mouse_nest,
+/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Chamber1)
 "vtD" = (
@@ -67015,7 +68305,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock3)
 "vDv" = (
@@ -67036,6 +68331,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/security/Quantum_Pad_Checkpoint)
@@ -67312,7 +68613,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Deck1_Corridor)
 "vKf" = (
@@ -67507,10 +68813,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/Aft_1_Deck_Stairwell)
-"vNe" = (
-/obj/random/maintenance/engineering,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck1_Star_Corridor)
 "vNk" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -67533,7 +68835,9 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/maintenance/Deck1_ForPort_Chamber1)
 "vNA" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Transit_Foyer)
 "vNE" = (
@@ -67633,17 +68937,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 8
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "vPS" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Deck1_Corridor)
@@ -67721,14 +69028,14 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
@@ -67946,6 +69253,10 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 9
 	},
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = 22
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "vVv" = (
@@ -68011,8 +69322,8 @@
 /turf/simulated/floor/tiled,
 /area/harbor/Dock3)
 "vWu" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_Transit_Lobby)
@@ -68295,9 +69606,8 @@
 /obj/structure/cable/green{
 	icon_state = "2-4"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Ship_Bay1)
@@ -68402,23 +69712,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Chamber1)
 "wdj" = (
-/obj/structure/closet/firecloset/full/double,
-/obj/item/suit_cooling_unit{
-	pixel_y = -4;
-	pixel_x = 8
-	},
-/obj/item/suit_cooling_unit{
-	pixel_x = 8
-	},
+/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/borderfloorblack{
-	dir = 9
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 9
+	dir = 8
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
@@ -68495,7 +69798,9 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
 "weW" = (
@@ -68634,8 +69939,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_Transit_Lobby)
@@ -68737,8 +70043,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/Depot1)
@@ -68818,16 +70124,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Corridor2)
 "wlp" = (
-/obj/effect/floor_decal/industrial/arrows/blue,
-/obj/effect/floor_decal/industrial/arrows/blue{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/corner/orange/border,
+/obj/effect/floor_decal/industrial/outline/cut_corners/blue,
+/obj/effect/floor_decal/industrial/loading/blue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile{
+	color = "#989898"
+	},
 /area/harbor/Fueling_Storage)
 "wlt" = (
 /obj/random/junk,
@@ -69194,6 +70501,7 @@
 /area/crew_quarters/Public_Gateway)
 "wtj" = (
 /obj/random/crate,
+/obj/random/contraband,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Chamber1)
 "wtx" = (
@@ -69522,7 +70830,9 @@
 	},
 /area/quartermaster/Mining_EVA)
 "wBh" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "wBk" = (
@@ -69603,6 +70913,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/engineering/GravGen_Room)
 "wCj" = (
@@ -69797,7 +71113,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "wFM" = (
@@ -69871,6 +71189,10 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
+	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
 	},
 /turf/simulated/floor/glass/reinforced,
 /area/hallway/ForPort_1_Deck_Observatory)
@@ -69969,7 +71291,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/AftPort_1_Deck_Observatory)
 "wKs" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Star)
 "wKM" = (
@@ -69979,6 +71303,7 @@
 "wKR" = (
 /obj/structure/table/rack,
 /obj/random/maintenance/research,
+/obj/random/maintenance/medical,
 /obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Science_AftCorridor1)
@@ -70256,9 +71581,6 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -70285,6 +71607,7 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "wQu" = (
@@ -70320,6 +71643,7 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "wRb" = (
@@ -70828,8 +72152,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_1Deck_Atrium)
@@ -70843,6 +72170,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile{
 	color = "#989898"
@@ -70884,8 +72217,8 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
@@ -71453,8 +72786,8 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Transit_Foyer)
@@ -71642,7 +72975,9 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
 "xmP" = (
@@ -71736,8 +73071,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Cargo_Corridor1)
 "xoB" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Port_1Deck_Atrium)
@@ -71889,27 +73224,24 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/random/maintenance/security,
+/obj/structure/table/rack/holorack,
+/obj/random/maintenance/security,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForPort_Corridor2)
 "xrC" = (
-/obj/structure/mob_spawner/mouse_nest,
+/obj/random/trash_pile,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_ForStar_Corridor2)
 "xrK" = (
+/obj/machinery/suit_cycler/pilot,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 4
-	},
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/orange/bordercorner,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "xrL" = (
@@ -72380,6 +73712,7 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "xEf" = (
@@ -72401,6 +73734,12 @@
 /obj/effect/floor_decal/industrial/danger,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/GravGen_Room)
 "xEz" = (
@@ -72737,14 +74076,8 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/bordercorner{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
@@ -73506,8 +74839,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
@@ -73607,18 +74941,12 @@
 /obj/structure/window/titanium{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/orange/bordercorner{
-	dir = 1
-	},
 /obj/machinery/door/firedoor/glass/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
 "yaq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
 	},
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
@@ -73629,6 +74957,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
 	dir = 1;
 	color = "#989898"
+	},
+/obj/structure/cable/white{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Dock4)
@@ -73669,7 +75000,9 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape_pod7/station)
 "ybD" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
 "ybV" = (
@@ -73817,8 +75150,11 @@
 /turf/simulated/floor/tiled/white,
 /area/maintenance/ab_Surgery)
 "yea" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Deck1_Transit_Hall)
@@ -73881,14 +75217,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/Telecomms_Foyer)
 "yfq" = (
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/steeldecal/steel_decals5{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/green/bordercorner2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/wood/alt/parquet/turfpack/station,
 /area/hallway/Cryostorage_Lounge)
@@ -73929,9 +75262,6 @@
 /turf/simulated/floor/tiled,
 /area/maintenance/Deck1_Cargo_Chamber1)
 "yfZ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
@@ -73944,6 +75274,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_Locker_Room)
@@ -74050,7 +75383,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_For)
 "yja" = (
@@ -82869,9 +84207,9 @@ ixO
 ixO
 ixO
 aaa
-aaa
-aaa
-aaa
+aaf
+iKg
+aaf
 aaa
 aaa
 aaa
@@ -83126,10 +84464,10 @@ aaa
 aaa
 aaa
 aaa
+svz
+adi
+cVn
 iFw
-iKg
-iKg
-aaa
 aaa
 aaa
 aaa
@@ -83384,10 +84722,10 @@ aaa
 aaa
 aaa
 aaa
-svz
-cVn
+adj
+aaf
 iFw
-aaa
+aaf
 aaa
 aaa
 aaa
@@ -83644,7 +84982,7 @@ aNX
 xvj
 gNJ
 myq
-iFw
+aaa
 aaa
 aaa
 aaa
@@ -83836,10 +85174,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+iKg
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -84094,10 +85432,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 iKg
-iKg
-iFw
+aCB
+aeF
+otU
 aaa
 aaa
 aaa
@@ -84352,10 +85690,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-iKg
-aCB
-otU
+aaf
+iFw
+aaf
+adj
 aaa
 aaa
 aaa
@@ -84611,7 +85949,7 @@ aaa
 aaa
 aaa
 aaa
-iFw
+aaa
 yhq
 tdK
 etu
@@ -86513,14 +87851,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+iFw
+iFw
+iFw
 szS
 bMe
-gwU
 tWM
 tWM
+acw
 bMe
 akd
 aaa
@@ -86553,9 +87891,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aaf
+iFw
+aaf
 aaa
 aaa
 aaa
@@ -86771,10 +88109,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
+iFw
+cmI
 aaf
-iFw
-iFw
+aaa
 aBe
 pSs
 tac
@@ -86811,9 +88149,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
 iFw
-aaf
+cmI
+iFw
 aaa
 aaa
 aaa
@@ -87029,10 +88367,10 @@ aaa
 aaa
 vuJ
 aaa
-aaa
 iFw
-cmI
+qIQ
 aaf
+aaa
 aBe
 aVI
 kgv
@@ -87069,9 +88407,9 @@ aaa
 aaa
 aaa
 aaa
-iFw
-cmI
-iFw
+aaf
+qIQ
+aaf
 aaa
 aaa
 aaa
@@ -87288,9 +88626,9 @@ aaa
 aaa
 aaa
 mIU
-iFw
 qIQ
-aaf
+aaa
+aaa
 aBe
 xMB
 pfw
@@ -87327,9 +88665,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aaa
 qIQ
-aaf
+aaa
 aaa
 aaa
 aaa
@@ -87477,7 +88815,7 @@ dSv
 dZb
 dZb
 aiB
-rdS
+aeq
 rdS
 aag
 fkD
@@ -87547,12 +88885,12 @@ aaa
 aaa
 cfp
 khE
-sCH
+gOu
 cfp
 xVx
-hTg
-eDP
 eZA
+eDP
+vgS
 xVx
 aaa
 aaa
@@ -87750,7 +89088,7 @@ iXF
 xop
 vYi
 vYi
-vYi
+adq
 iXF
 amX
 nuv
@@ -87816,7 +89154,7 @@ nCw
 rbq
 pMC
 fsK
-sll
+abR
 fsK
 wbE
 gOu
@@ -87826,7 +89164,7 @@ cfp
 rbq
 pMC
 fsK
-sll
+abR
 fsK
 wbE
 gOu
@@ -88252,7 +89590,7 @@ ylm
 vCX
 rxL
 xrX
-xoB
+aen
 hIf
 jJR
 oDp
@@ -88266,7 +89604,7 @@ iXF
 clC
 gMl
 vYi
-vYi
+adr
 iXF
 iuu
 lOo
@@ -88320,8 +89658,8 @@ aaa
 aaa
 aaa
 cfp
-khE
-khE
+rbq
+gOu
 cfp
 kwu
 aAX
@@ -88334,7 +89672,7 @@ lxS
 nis
 hpO
 uvb
-jAk
+abZ
 eXX
 rAi
 jAk
@@ -88351,7 +89689,7 @@ jAk
 rAi
 jAk
 juW
-meW
+abN
 bdR
 wRb
 rPV
@@ -90313,7 +91651,7 @@ rbf
 rbf
 ahV
 rbf
-rbf
+aey
 nFX
 rLt
 knD
@@ -90861,7 +92199,7 @@ vYi
 abz
 aVS
 uYn
-arR
+ado
 eYA
 stb
 xYR
@@ -91120,7 +92458,7 @@ kRo
 aVS
 dUf
 kqY
-arR
+ado
 ljT
 xYR
 aaf
@@ -91596,7 +92934,7 @@ ckt
 hzk
 dWO
 nnV
-rbf
+aeB
 xuI
 eae
 aFI
@@ -91620,7 +92958,7 @@ xrX
 cuT
 axL
 nFX
-vYi
+ads
 kZK
 ieT
 eGT
@@ -92136,7 +93474,7 @@ xrX
 oqF
 vaE
 nFX
-vYi
+adu
 dHs
 ieT
 qIe
@@ -93716,7 +95054,7 @@ mRk
 oZu
 jVB
 ffB
-kLw
+adg
 hak
 pPG
 gSQ
@@ -93900,10 +95238,10 @@ hvT
 lRU
 xwh
 qXZ
+lRr
 hOd
 hOd
-hOd
-hOd
+lRr
 hOd
 qHU
 hOd
@@ -93911,7 +95249,7 @@ peU
 mVK
 hOd
 hOd
-mVK
+aeD
 hOd
 hOd
 hOd
@@ -94450,7 +95788,7 @@ pdG
 fYR
 bta
 lNy
-sTq
+adD
 sTq
 toY
 pCS
@@ -94784,7 +96122,7 @@ lgu
 act
 aiO
 nwU
-nwU
+abP
 nwU
 aiO
 lUx
@@ -94800,7 +96138,7 @@ lgu
 act
 aiO
 nwU
-nwU
+abP
 nwU
 aiO
 lUx
@@ -94961,12 +96299,12 @@ frh
 ggs
 dpD
 aaU
-qbv
+adE
 qbv
 xAc
 ssD
 jjH
-qbv
+adE
 qbv
 glw
 kfd
@@ -97255,8 +98593,8 @@ wOS
 uwZ
 qYX
 rio
-tij
-tij
+aeE
+iBY
 ryB
 qPd
 eSM
@@ -97514,7 +98852,7 @@ uwZ
 rio
 rio
 tij
-tij
+qPd
 ryB
 iBY
 nbX
@@ -97766,9 +99104,9 @@ agv
 dTR
 agv
 agv
-tij
+aeJ
 xrz
-tij
+aeH
 tij
 tij
 ryB
@@ -98641,8 +99979,8 @@ ukU
 qCc
 qCc
 hOO
-hbs
-sHa
+acI
+acA
 aYK
 kkN
 arM
@@ -99086,7 +100424,7 @@ fDi
 mDc
 heY
 iEf
-eew
+aev
 kye
 gEu
 xAc
@@ -99094,7 +100432,7 @@ xAc
 wZZ
 ybw
 xAc
-lgf
+adF
 lgf
 acW
 aan
@@ -99591,7 +100929,7 @@ aaa
 aaa
 aaa
 aaa
-fzF
+abs
 fzF
 fzF
 fzF
@@ -99610,7 +100948,7 @@ tEX
 wrk
 aeu
 abm
-bHe
+adG
 bHe
 oXp
 cqF
@@ -101429,7 +102767,7 @@ hZj
 hZj
 xVa
 avE
-auk
+adp
 fiB
 auk
 lZZ
@@ -102004,8 +103342,8 @@ aMb
 aMb
 qoL
 nyt
-wIj
-wIj
+acl
+acf
 oyI
 asm
 wIj
@@ -102233,8 +103571,8 @@ gha
 uTo
 syg
 aiz
-fFD
-xjv
+adc
+acZ
 sRZ
 nui
 nui
@@ -102253,8 +103591,8 @@ pPW
 tlw
 glO
 sxW
-hbs
-dZJ
+acJ
+acB
 wZB
 aMb
 mtP
@@ -102522,9 +103860,9 @@ aKi
 aKi
 wdj
 asG
-jWw
+acb
+acb
 aKi
-hdB
 jVV
 aja
 eTo
@@ -102664,9 +104002,9 @@ jKH
 cVF
 kZC
 jsm
-jsm
+aeM
 hPg
-sfG
+aeK
 joI
 kWK
 tMx
@@ -102758,7 +104096,7 @@ gBT
 jOV
 jOV
 hBP
-oOP
+acT
 dbO
 njP
 nuc
@@ -102778,17 +104116,17 @@ fKQ
 ixE
 bJc
 ezj
-jnw
-oyt
 doR
-aKi
+doR
+doR
+acc
 etG
 tHL
-anL
-dBn
-agq
-rNI
-skc
+idD
+rff
+rff
+rff
+soy
 aKi
 ibt
 wgO
@@ -103016,7 +104354,7 @@ qGK
 jeX
 qIw
 mfA
-mfA
+acU
 qwt
 umx
 aaH
@@ -103036,16 +104374,16 @@ nPG
 nlS
 teK
 fLM
-aKU
+pTK
 jno
 pTK
 vna
 apV
-idD
-rff
-rff
+abX
+abU
 fpW
-rff
+fpW
+abS
 soy
 aKi
 aNG
@@ -103054,11 +104392,11 @@ mdY
 eKl
 rsR
 mdY
-mdY
+abL
 mdY
 bOS
 mdY
-mdY
+abL
 mdY
 bCp
 bap
@@ -103283,10 +104621,10 @@ bGL
 cIq
 cIq
 cIq
-abt
-abt
-abt
-abt
+acS
+acC
+acC
+acC
 abt
 lcw
 gEe
@@ -103294,7 +104632,7 @@ dHF
 vGp
 dGL
 dWp
-mzA
+acs
 eGu
 acs
 wlp
@@ -103323,11 +104661,11 @@ dVV
 xiM
 mkx
 buZ
-kSE
+abH
 jlA
 wEr
 dLR
-kSE
+abH
 bBM
 jwO
 xiM
@@ -103553,14 +104891,14 @@ agR
 nWG
 aqg
 wfe
-kjz
+wfe
 yae
 ouG
 aKi
 aKi
-aKi
-aKi
-aKi
+abV
+bLA
+ffT
 aKi
 aKi
 aKi
@@ -103688,7 +105026,7 @@ fpw
 fpw
 fpw
 fpw
-jpJ
+aeO
 jpJ
 oJL
 fpw
@@ -103697,13 +105035,13 @@ fpw
 kxe
 fpw
 fpw
-muZ
+aeL
 riw
 tkH
 xVH
 cJk
 atZ
-aLB
+aeG
 mEh
 aat
 gYy
@@ -103812,11 +105150,11 @@ eeZ
 bKR
 bKR
 bKR
-bKR
-bKR
+ace
 bKR
 pVq
 bKR
+abW
 bKR
 bKR
 bKR
@@ -103838,14 +105176,14 @@ pdf
 dNN
 bBx
 mWi
-sEk
+abI
 ebd
 mdY
 mdY
 mdY
 mlW
 sEk
-pdf
+abr
 pHp
 gxb
 aaa
@@ -104213,13 +105551,13 @@ iYx
 azk
 iYx
 fpw
-muZ
+aeL
 hpn
 vDC
 xVH
-cJk
+aeI
 atZ
-aLB
+aeG
 mEh
 iyo
 xCU
@@ -104353,15 +105691,15 @@ bKR
 kVb
 dNN
 bBx
-mWi
-sEk
+abK
+abJ
 gvO
 fHt
 fHt
 fHt
 aXg
-sEk
-pdf
+abG
+abE
 pHp
 bck
 aaa
@@ -104831,10 +106169,10 @@ uLm
 cIq
 cIq
 cIq
-abt
-abt
-abt
-abt
+acS
+acC
+acC
+acC
 abt
 lcw
 iij
@@ -105024,10 +106362,10 @@ kfX
 qVn
 aIN
 dTJ
+dTJ
 lfT
-dTJ
-tBJ
-dTJ
+lfT
+aee
 aga
 jnk
 mXL
@@ -105080,7 +106418,7 @@ bDS
 fOy
 dvt
 ycy
-ycy
+acV
 pUx
 iwf
 aaI
@@ -105118,11 +106456,11 @@ lbQ
 fnu
 acj
 fHt
-fHt
+abM
 fHt
 bDN
 fHt
-fHt
+abM
 fHt
 pCF
 lvp
@@ -105282,11 +106620,11 @@ mdg
 uad
 hUO
 dTJ
+dTJ
 lfT
-dTJ
-vNe
-dTJ
-tqY
+lfT
+aee
+adH
 abF
 abF
 abF
@@ -105338,7 +106676,7 @@ ykw
 aaT
 aaT
 wtU
-oOP
+acX
 sQj
 clT
 ngd
@@ -105540,11 +106878,11 @@ mdg
 uad
 gva
 dTJ
-lfT
 dTJ
-mbX
-dTJ
-xJm
+aee
+aee
+aee
+adK
 abF
 abF
 abF
@@ -105798,8 +107136,8 @@ vXu
 jYA
 jYA
 dTJ
-lfT
 dTJ
+pYp
 pYp
 tCJ
 tqY
@@ -105845,8 +107183,8 @@ sIG
 mng
 xsN
 eAA
-xGs
-tAT
+adf
+adb
 oGC
 amK
 amK
@@ -105865,8 +107203,8 @@ mpb
 fpt
 gfe
 nTw
-pTA
-iEc
+acM
+acG
 cda
 qOv
 kXn
@@ -106056,11 +107394,11 @@ beg
 abT
 lfT
 lfT
-lfT
 dTJ
+aei
 mbX
-dTJ
-xJm
+aef
+adL
 abF
 abF
 abF
@@ -106132,8 +107470,8 @@ qOv
 qOv
 qgY
 vry
-cWs
-cWs
+acm
+ach
 atM
 dzm
 cWs
@@ -106312,10 +107650,10 @@ dZO
 uqL
 beg
 abT
+lfT
+lfT
 dTJ
-dTJ
-dTJ
-dTJ
+aej
 dNp
 nbt
 tRe
@@ -106571,13 +107909,13 @@ avf
 ulX
 abT
 dTJ
-vzT
-mbX
-mbX
-mOu
 dTJ
+dTJ
+aek
+mOu
+aeg
 ckb
-ueQ
+adw
 bUY
 vWg
 pLO
@@ -106829,13 +108167,13 @@ gHQ
 aLZ
 abT
 dTJ
-kaj
-mbX
-mbX
-mOu
+dTJ
+dTJ
+dTJ
+dTJ
 dTJ
 jqw
-ueQ
+adx
 ykt
 nSG
 plm
@@ -107092,8 +108430,8 @@ mbX
 uGv
 fWW
 dTJ
-tqY
-ueQ
+adM
+adx
 oXp
 pXo
 xdS
@@ -107349,9 +108687,9 @@ pVV
 mbX
 vqa
 tGz
-dTJ
+aeh
 pFH
-ueQ
+ady
 nGX
 pXo
 bOw
@@ -107608,7 +108946,7 @@ mbX
 pVp
 gWH
 dTJ
-tqY
+adT
 ueQ
 oXp
 ekI
@@ -108119,7 +109457,7 @@ sRT
 hqp
 eap
 dTJ
-abu
+vzT
 mbX
 mbX
 bsH
@@ -108382,7 +109720,7 @@ kkY
 kkY
 bzT
 dTJ
-fNc
+adU
 fNc
 fDx
 cqF
@@ -108898,8 +110236,8 @@ adX
 hAP
 sOr
 adX
-adX
-adX
+aea
+adz
 rtQ
 vQi
 ygP
@@ -109393,7 +110731,7 @@ wHF
 wHF
 wHF
 rtZ
-eHV
+aeC
 iyx
 tpf
 iyx
@@ -109477,8 +110815,8 @@ dsz
 iam
 iam
 wNS
-pTA
-mUC
+acO
+acH
 tiK
 qow
 aCK
@@ -109909,7 +111247,7 @@ wHF
 wHF
 wHF
 rtZ
-qgm
+aeC
 iyx
 tpf
 iyx
@@ -111031,7 +112369,7 @@ aao
 pHO
 eBp
 tTw
-ptP
+acq
 aaa
 aaa
 aaa
@@ -111289,7 +112627,7 @@ slH
 hwK
 eBp
 fOm
-ptP
+acr
 aaa
 aaa
 aaa
@@ -112231,7 +113569,7 @@ ehx
 oMI
 pBm
 tpf
-tLp
+aeC
 iyx
 tpf
 oDE
@@ -113021,13 +114359,13 @@ dkj
 gCn
 dXp
 fjY
-adX
-adX
+aeb
+adA
 adX
 kEq
 bOT
-adX
-adX
+aeb
+adA
 ugh
 pQL
 vgc
@@ -113360,7 +114698,7 @@ aqv
 aLV
 pmj
 vpF
-vpF
+abQ
 vpF
 pmj
 bef
@@ -113376,7 +114714,7 @@ aqv
 aLV
 pmj
 vpF
-vpF
+abQ
 vpF
 pmj
 bef
@@ -113542,7 +114880,7 @@ bPy
 ahY
 nxr
 tXu
-sWL
+aec
 sWL
 lTc
 gDe
@@ -114356,7 +115694,7 @@ kZk
 ara
 tmJ
 xeZ
-hKn
+adh
 cUK
 kcc
 apD
@@ -118172,7 +119510,7 @@ fqf
 fqf
 aou
 dpG
-wBA
+btZ
 wVY
 rpo
 vuB
@@ -119321,7 +120659,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+mIU
 aaa
 aaa
 aaa
@@ -119741,7 +121079,7 @@ jev
 asp
 qTn
 hre
-xQV
+adv
 oVP
 asJ
 vBT
@@ -119810,7 +121148,7 @@ dbs
 mNM
 upe
 pie
-jtB
+aca
 gbv
 adQ
 jtB
@@ -119827,7 +121165,7 @@ jtB
 adQ
 jtB
 lGO
-vNF
+abO
 maT
 jFk
 kjB
@@ -119986,7 +121324,7 @@ lYy
 cxg
 ijM
 jww
-esf
+aeo
 eHM
 wKs
 ilK
@@ -120570,13 +121908,13 @@ aaa
 aaa
 aaa
 wOk
-oAw
+acQ
 gaP
 wOk
 xkT
-gzH
-tGZ
 cHa
+tGZ
+mcn
 xkT
 aaa
 aaa
@@ -120828,9 +122166,9 @@ aaa
 aaa
 aaa
 sLG
-iFw
 qIQ
-aaf
+aaa
+aaa
 viE
 dZR
 hIE
@@ -120867,9 +122205,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aaa
 qIQ
-aaf
+aaa
 aaa
 aaa
 aaa
@@ -121017,7 +122355,7 @@ eaE
 kXg
 eaE
 qoJ
-kKp
+aet
 kKp
 lhU
 fcN
@@ -121085,10 +122423,10 @@ aaa
 aaa
 vuJ
 aaa
-aaa
 iFw
-htS
+qIQ
 aaf
+aaa
 viE
 aFG
 cMm
@@ -121125,9 +122463,9 @@ aaa
 aaa
 aaa
 aaa
-iFw
-din
-iFw
+aaf
+qIQ
+aaf
 aaa
 aaa
 aaa
@@ -121343,10 +122681,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
+iFw
+htS
 aaf
-iFw
-iFw
+aaa
 viE
 nMG
 oAe
@@ -121383,9 +122721,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
 iFw
-aaf
+din
+iFw
 aaa
 aaa
 aaa
@@ -121601,14 +122939,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+iFw
+iFw
+iFw
 szS
 pMm
-vkS
 tdE
 tdE
+acz
 pMm
 akd
 aaa
@@ -121641,9 +122979,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aaf
+iFw
+aaf
 aaa
 aaa
 aaa
@@ -125673,7 +127011,7 @@ ubb
 eaY
 wTO
 yeh
-ust
+yeh
 wbn
 wry
 pcL
@@ -125922,7 +127260,7 @@ mYA
 mYA
 eaY
 fvd
-jsW
+mwp
 opH
 ecV
 rdP

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
@@ -9207,9 +9207,6 @@
 /obj/random/maintenance/clean,
 /obj/random/maintenance/clean,
 /obj/random/maintenance/security,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_AftCorridor1)
 "apD" = (

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
@@ -1070,9 +1070,6 @@
 	dir = 8
 	},
 /obj/structure/window/basic{
-	dir = 1
-	},
-/obj/structure/window/basic{
 	dir = 4
 	},
 /obj/structure/sign/directions/cargo{
@@ -2310,14 +2307,8 @@
 /area/hallway/Stairwell_Aft)
 "adS" = (
 /obj/structure/table/standard,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 3
-	},
 /obj/item/extinguisher,
 /obj/item/tool/crowbar,
-/obj/random/medical/lite,
 /turf/simulated/shuttle/floor/white,
 /area/shuttle/large_escape_pod3/station)
 "adT" = (
@@ -2451,6 +2442,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/harbor/Aft_2_Deck_Airlock_Access)
+"aee" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/medical,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftCorridor1)
 "aef" = (
 /obj/machinery/light{
 	dir = 1
@@ -4287,10 +4285,6 @@
 	pixel_x = -3
 	},
 /obj/item/gun/projectile/p92x/rubber{
-	pixel_y = 6;
-	pixel_x = 1
-	},
-/obj/item/gun/projectile/p92x/rubber{
 	pixel_y = 1;
 	pixel_x = 4
 	},
@@ -4878,6 +4872,10 @@
 	dir = 1;
 	c_tag = "D2-Com-Central Hall3";
 	network = list("Commons")
+	},
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
@@ -5990,6 +5988,9 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
+/obj/structure/sign/poster/nanotrasen{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Central_Corridor_1)
 "ajJ" = (
@@ -6109,36 +6110,26 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/Engineering_Substation)
-"ajU" = (
+"ajV" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/arrows/blue{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/arrows/blue,
+/obj/machinery/door/airlock/angled_bay/standard/glass/common{
+	dir = 4;
+	name = "Central Lobby";
+	tintable = 1;
+	id_tint = "sc-WTkitchen"
+	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/Central_2_Deck_Hall)
-"ajV" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/techmaint,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
 "ajW" = (
 /obj/machinery/firealarm{
@@ -6150,11 +6141,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
@@ -6259,6 +6250,9 @@
 /obj/effect/floor_decal/corner/lightgrey/border{
 	dir = 1
 	},
+/obj/structure/sign/poster/nanotrasen{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
 "akf" = (
@@ -6328,12 +6322,6 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
@@ -6490,12 +6478,6 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Port_Corridor)
-"akz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/Central_2_Deck_Hall)
 "akA" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -6510,13 +6492,6 @@
 /obj/machinery/vending/emergencyfood/filled,
 /turf/simulated/floor/tiled,
 /area/quartermaster/Breakroom)
-"akB" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck2_Star_Corridor)
 "akC" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
@@ -6558,9 +6533,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/steeldecal/steel_decals4{
@@ -6832,9 +6804,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_1)
 "alb" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -6847,6 +6816,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_1)
 "alc" = (
@@ -6856,6 +6828,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_1)
@@ -6894,6 +6869,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Chomp_Dinner_2)
@@ -7972,29 +7950,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Chomp_Kitchen)
-"ani" = (
-/obj/effect/catwalk_plated/techfloor,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 27;
-	pixel_y = -12
-	},
-/obj/machinery/button/windowtint{
-	id = "sc-WTdronefab";
-	name = "E-window tint control";
-	pixel_x = 27;
-	pixel_y = 12
-	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/plating,
-/area/engineering/Drone_Fab)
 "anj" = (
 /obj/effect/floor_decal/milspec/box,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -8425,12 +8380,11 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Chomp_Kitchen)
 "aoa" = (
-/obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Drone_Fab)
 "aob" = (
@@ -8579,21 +8533,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/Midnight_Kitchen)
-"aor" = (
-/obj/machinery/icecream_vat,
-/turf/simulated/floor/plating,
-/area/crew_quarters/Chomp_Kitchen)
 "aos" = (
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/Emergency_EVA)
-"aot" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/crew_quarters/Chomp_Kitchen)
 "aou" = (
 /obj/structure/reagent_dispensers/cookingoil,
 /obj/machinery/light/small{
@@ -8617,7 +8562,6 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/maintenance/int{
-	req_one_access = list(28);
 	name = "Kitchen Maintenance"
 	},
 /obj/structure/cable{
@@ -8683,8 +8627,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance/common{
-	name = "Kitchen Maintenance";
-	req_one_access = list(28)
+	name = "Kitchen Maintenance"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Chomp_Kitchen)
@@ -8746,6 +8692,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Corridor_2)
 "aoJ" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Engineering_ForStarCorridor1)
 "aoK" = (
@@ -8984,6 +8931,7 @@
 /area/harbor/Port_Shuttlebay)
 "ape" = (
 /obj/random/trash,
+/obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_ForStarCorridor1)
 "apf" = (
@@ -9211,7 +9159,7 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
-/obj/structure/sign/poster/nanotrasen,
+/obj/structure/sign/poster/custom,
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
 "apy" = (
@@ -9244,6 +9192,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
+"apB" = (
+/obj/structure/table/standard,
+/obj/random/tool/powermaint,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftCorridor1)
+"apC" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/rack,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/security,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftCorridor1)
 "apD" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/lino,
@@ -9254,6 +9222,27 @@
 	},
 /turf/simulated/wall,
 /area/security/Internal_Affairs_Office)
+"apF" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftCorridor1)
+"apG" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftCorridor1)
+"apH" = (
+/obj/random/unidentified_medicine,
+/obj/random/unidentified_medicine,
+/obj/structure/table/standard,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "apI" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -9273,8 +9262,22 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/structure/window/basic{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/hallway/Central_2_Deck_Hall)
+"apK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated/techmaint,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "apL" = (
 /turf/simulated/wall,
 /area/hallway/Port_2_Deck_Corridor_1)
@@ -9311,6 +9314,32 @@
 	},
 /turf/simulated/floor/tiled,
 /area/medical/Treatment_Hall)
+"apQ" = (
+/obj/random/multiple/corp_crate/no_weapons,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
+"apR" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
+"apS" = (
+/obj/random/tank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
+"apT" = (
+/obj/random/trash_pile,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
+"apU" = (
+/obj/structure/loot_pile/maint/technical,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
+"apV" = (
+/obj/structure/loot_pile/maint/boxfort,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "apW" = (
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/techfloor/corner{
@@ -9324,6 +9353,13 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/hallway/Port_Transit_Foyer)
+"apX" = (
+/obj/structure/loot_pile/maint/junk,
+/obj/random/trash,
+/obj/random/trash,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "apY" = (
 /turf/simulated/open,
 /area/maintenance/Deck2_Security_ForCorridor2)
@@ -9373,6 +9409,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Corridor_2)
+"aqc" = (
+/obj/random/trash_pile,
+/obj/random/trash,
+/obj/random/trash,
+/obj/random/junk,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "aqd" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/shieldwallgen,
@@ -9382,6 +9425,11 @@
 /obj/machinery/portable_atmospherics/hydroponics/soil,
 /turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/For_2_Deck_Central_Corridor_1)
+"aqf" = (
+/obj/structure/loot_pile/maint/boxfort,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "aqg" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/shuttle/blue{
@@ -9399,6 +9447,15 @@
 /obj/structure/sign/warning/caution,
 /turf/simulated/wall,
 /area/rnd/Toxins_Mixing_Room)
+"aqj" = (
+/obj/random/trash,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
+"aqk" = (
+/obj/structure/loot_pile/maint/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "aql" = (
 /turf/simulated/wall/r_wall,
 /area/medical/CMO_Office)
@@ -9411,6 +9468,52 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/Port_2_Deck_Stairwell)
+"aqn" = (
+/obj/random/trash_pile,
+/obj/random/trash,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
+"aqo" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
+"aqp" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/white,
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"aqq" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Stairwell_Aft)
+"aqr" = (
+/obj/structure/table/woodentable,
+/obj/random/mug,
+/turf/simulated/floor/carpet/green,
+/area/hallway/Aft_2_Deck_Lobby)
+"aqs" = (
+/obj/structure/girder,
+/obj/item/bodybag/large,
+/turf/simulated/floor/plating,
+/area/hallway/Aft_2_Deck_Lobby)
 "aqt" = (
 /obj/structure/cable/green{
 	icon_state = "1-4"
@@ -9430,12 +9533,117 @@
 	},
 /turf/simulated/floor/tiled/hydro,
 /area/crew_quarters/Public_Hydroponics)
+"aqu" = (
+/obj/machinery/ai_status_display{
+	name = "1N-AI display";
+	pixel_y = 32
+	},
+/turf/simulated/open,
+/area/hallway/AftPort_2_Deck_Observatory)
+"aqv" = (
+/obj/machinery/ai_status_display{
+	name = "1N-AI display";
+	pixel_y = 32
+	},
+/turf/simulated/open,
+/area/hallway/AftStar_2_Deck_Observatory)
+"aqw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows/yellow,
+/obj/effect/floor_decal/industrial/arrows/yellow{
+	dir = 1
+	},
+/obj/machinery/door/airlock/maintenance/int,
+/turf/simulated/floor/tiled/techmaint,
+/area/crew_quarters/Library)
 "aqx" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Mech_Bay)
+"aqy" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Medical_AftCorridor2)
+"aqz" = (
+/obj/item/frame,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Medical_AftStarChamber1)
+"aqA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/machinery/holoposter{
+	pixel_y = -32;
+	layer = 4;
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Port_2_Deck_Central_Corridor_1)
+"aqB" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Star_2_Deck_Central_Corridor_1)
+"aqC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/machinery/holoposter{
+	pixel_y = -32;
+	layer = 4;
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Star_2_Deck_Central_Corridor_1)
+"aqD" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/obj/structure/sign/directions/science{
+	dir = 4;
+	layer = 3.5;
+	pixel_y = 9
+	},
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	layer = 3.5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/hallway/Star_2_Deck_Central_Corridor_1)
+"aqE" = (
+/obj/item/frame,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Science_StarCorridor1)
 "aqF" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9458,6 +9666,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_ForPortChamber1)
+"aqH" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Port_Transit_Foyer)
+"aqI" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/paleblue/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Star_Transit_Foyer)
 "aqJ" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/tiled/dark,
@@ -9488,9 +9714,26 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/Reception)
+"aqM" = (
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/turf/simulated/floor/tiled,
+/area/hallway/Star_Transit_Foyer)
 "aqN" = (
 /turf/simulated/wall/r_wall,
 /area/engineering/CE_Office)
+"aqO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Central_2_Deck_Hall)
 "aqP" = (
 /obj/machinery/power/emitter{
 	dir = 4
@@ -9515,12 +9758,73 @@
 /obj/effect/decal/cleanable/spiderling_remains,
 /turf/simulated/floor/wood/alt/panel,
 /area/maintenance/ab_Theater)
+"aqS" = (
+/obj/item/frame,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Science_StarCorridor2)
+"aqT" = (
+/obj/structure/railing,
+/turf/simulated/open,
+/area/hallway/Central_2_Deck_Hall)
+"aqU" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Star_Corridor)
 "aqV" = (
 /obj/machinery/computer/secure_data/detective_computer{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/security/Forensics_Office)
+"aqW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/techmaint,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Star_Corridor)
+"aqX" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Port_Transit_Foyer)
+"aqY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/hallway/Central_2_Deck_Hall)
+"aqZ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/arrows/yellow,
+/obj/effect/floor_decal/industrial/arrows/yellow{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance/int,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/maintenance/Deck2_Star_Corridor)
+"ara" = (
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/purple/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Star_Transit_Foyer)
 "arb" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -9538,6 +9842,35 @@
 	color = "#8bbbd5"
 	},
 /area/medical/Port_Medical_Post)
+"arc" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/structure/loot_pile/surface/medicine_cabinet/fresh{
+	pixel_y = 25
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Science_StarCorridor1)
+"ard" = (
+/obj/structure/table/standard,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Science_StarChamber1)
+"are" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/holoposter{
+	pixel_y = 32;
+	layer = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Port_2_Deck_Central_Corridor_1)
 "arf" = (
 /obj/item/stool/padded{
 	dir = 8
@@ -9550,6 +9883,58 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Holodeck)
+"arg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/crew_quarters/Chomp_Dinner_2)
+"arh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/sif,
+/area/crew_quarters/Chomp_Dinner_2)
+"ari" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 1
+	},
+/obj/machinery/holoposter{
+	pixel_y = 32;
+	layer = 4
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Star_2_Deck_Central_Corridor_1)
 "arj" = (
 /obj/machinery/cell_charger{
 	pixel_y = 11
@@ -9570,9 +9955,28 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
+"ark" = (
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Engineering_PortChamber1)
 "arl" = (
 /turf/simulated/floor/carpet/brown/turfpack/station,
 /area/security/Prison_Wing)
+"arm" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/research,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_ForStar_Corridor)
+"arn" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/engineering,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_ForPort_Corridor)
 "aro" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -9590,6 +9994,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Library)
+"arp" = (
+/obj/structure/table/standard,
+/obj/random/toolbox,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_ForStar_Corridor)
+"arq" = (
+/obj/structure/table/rack/shelf,
+/obj/random/maintenance/research,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Science_StarCorridor1)
 "arr" = (
 /turf/simulated/wall/r_wall,
 /area/rnd/Testing_Chamber)
@@ -9599,6 +10015,22 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_2_Deck_Corridor_1)
+"art" = (
+/obj/structure/table/rack/shelf,
+/obj/random/maintenance/research,
+/obj/random/maintenance/research,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Science_StarCorridor1)
+"aru" = (
+/obj/structure/table/rack/steel,
+/obj/random/tech_supply/component,
+/obj/random/tech_supply,
+/obj/random/tech_supply,
+/obj/random/maintenance/engineering,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Engineering_PortCorridor2)
 "arv" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -9634,6 +10066,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Emergency_EVA)
+"arx" = (
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/medical,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_ForStar_Corridor)
+"ary" = (
+/obj/structure/frame,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Science_StarCorridor1)
 "arz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/tagger{
@@ -9642,6 +10085,36 @@
 	},
 /turf/simulated/floor/tiled/kafel_full/red,
 /area/security/Restroom)
+"arA" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Eng Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "sc-WTengireception"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engineering_EVA)
+"arB" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Eng Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!";
+	dir = 4
+	},
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "sc-WTengireception"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Reception)
 "arC" = (
 /obj/structure/table/rack,
 /obj/item/mecha_parts/mecha_equipment/tool/cable_layer{
@@ -9676,6 +10149,29 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Testing_Lab)
+"arE" = (
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_ForPort_Corridor)
+"arF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/border{
+	dir = 8
+	},
+/obj/structure/sign/poster/nanotrasen{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Star_2_Deck_Corridor_2)
+"arG" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/Chomp_Kitchen)
 "arH" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -9688,6 +10184,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck2_Engineering_ForStarCorridor1)
+"arI" = (
+/obj/structure/foodcart,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/Chomp_Kitchen)
+"arJ" = (
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
+/obj/machinery/icecream_vat,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/Chomp_Kitchen)
 "arK" = (
 /turf/simulated/wall,
 /area/crew_quarters/Chomp_Dinner_2)
@@ -9709,6 +10216,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/Evidence_Storage)
+"arM" = (
+/obj/structure/loot_pile/maint/boxfort,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Security_AftPortCorridor1)
 "arN" = (
 /obj/structure/ladder/updown{
 	pixel_y = 3
@@ -9783,6 +10295,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Internal_Affairs_Office)
+"arT" = (
+/obj/structure/loot_pile/maint/trash,
+/obj/random/junk,
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Security_AftPortCorridor1)
 "arU" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/status_display{
@@ -9796,6 +10314,30 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/HoS_Office)
+"arV" = (
+/obj/effect/catwalk_plated/techfloor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Drone_Fab)
+"arW" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "sc-WTdronefab"
+	},
+/obj/machinery/door/blast/regular/open{
+	layer = 3.5;
+	id = "Eng Lockdown";
+	name = "Lockdown Gate";
+	desc = "A heavily reinforced gate, sector lockdown!"
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Drone_Fab)
 "arX" = (
 /obj/effect/floor_decal/industrial/arrows/blue,
 /obj/effect/floor_decal/industrial/arrows/blue{
@@ -9809,12 +10351,98 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/For_2_Deck_Central_Corridor_1)
+"arY" = (
+/obj/random/junk,
+/obj/random/contraband/nofail,
+/obj/random/junk,
+/obj/random/junk,
+/obj/random/trash,
+/obj/random/obstruction,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Security_AftPortCorridor1)
+"arZ" = (
+/obj/random/obstruction,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Security_AftPortCorridor1)
 "asa" = (
 /obj/effect/floor_decal/spline/plain{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
+"asb" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/Drone_Fab)
+"asc" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	pixel_x = -26
+	},
+/obj/machinery/light_switch{
+	dir = 4;
+	pixel_x = -25;
+	pixel_y = 11
+	},
+/obj/machinery/button/windowtint{
+	id = "sc-WTdronefab";
+	name = "W-window tint control";
+	pixel_x = -27;
+	pixel_y = -11
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/Drone_Fab)
+"asd" = (
+/obj/effect/floor_decal/industrial/outline/cut_corners/blue,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/monotile{
+	color = "#989898"
+	},
+/area/crew_quarters/Emergency_EVA)
+"ase" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/Lobby)
+"asf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/Lobby)
+"asg" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Security_AftStarCorridor2)
 "ask" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9905,7 +10533,8 @@
 	},
 /obj/machinery/holoposter{
 	dir = 4;
-	pixel_x = -32
+	pixel_x = -32;
+	layer = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
@@ -12739,9 +13368,6 @@
 "aCM" = (
 /obj/structure/table/rack,
 /obj/item/gun/projectile/automatic/p90{
-	pixel_y = 12
-	},
-/obj/item/gun/projectile/automatic/p90{
 	pixel_y = 4;
 	pixel_x = 4
 	},
@@ -13152,6 +13778,15 @@
 /area/hallway/Aft_2_Deck_Stairwell)
 "aEo" = (
 /obj/structure/closet/walllocker/medical/south,
+/obj/random/medical/lite,
+/obj/item/storage/firstaid/fire{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/obj/item/storage/firstaid/toxin{
+	pixel_y = -2;
+	pixel_x = 2
+	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/large_escape_pod3/station)
 "aEr" = (
@@ -16615,6 +17250,10 @@
 /area/hallway/Aft_2_Deck_Lobby)
 "aQd" = (
 /obj/structure/table/steel,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/AftPort_2_Deck_Observatory)
 "aQg" = (
@@ -16834,19 +17473,11 @@
 	pixel_x = -7
 	},
 /obj/item/storage/firstaid/toxin{
-	pixel_y = 2;
-	pixel_x = -7
-	},
-/obj/item/storage/firstaid/toxin{
 	pixel_y = -3;
 	pixel_x = -7
 	},
 /obj/item/storage/firstaid/fire{
 	pixel_y = 7;
-	pixel_x = 7
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_y = 2;
 	pixel_x = 7
 	},
 /obj/item/storage/firstaid/fire{
@@ -16872,19 +17503,11 @@
 	},
 /obj/item/storage/firstaid/regular{
 	pixel_x = -7;
-	pixel_y = 2
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -7;
 	pixel_y = -3
 	},
 /obj/item/storage/firstaid/regular{
 	pixel_x = 7;
 	pixel_y = 7
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 7;
-	pixel_y = 2
 	},
 /obj/item/storage/firstaid/regular{
 	pixel_x = 7;
@@ -17064,9 +17687,7 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/brown/border,
-/obj/machinery/holoposter{
-	pixel_y = -32
-	},
+/obj/structure/sign/poster/custom,
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Central_Corridor_2)
 "aRN" = (
@@ -17729,6 +18350,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/security/Deck2_1_Corridor)
 "aTY" = (
+/obj/machinery/floodlight,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Port_Corridor)
 "aTZ" = (
@@ -17740,20 +18362,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Chapel_Morgue)
-"aUc" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/Central_2_Deck_Hall)
 "aUd" = (
 /obj/structure/table/woodentable,
 /obj/item/book/manual/standard_operating_procedure{
@@ -19366,11 +19974,11 @@
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape_pod12/station)
 "aZG" = (
-/obj/structure/table/standard,
 /obj/random/maintenance/security,
 /obj/random/maintenance/misc,
 /obj/random/maintenance/misc,
 /obj/random/maintenance/misc,
+/obj/random/maintenance/security,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftPortCorridor1)
 "aZI" = (
@@ -19610,9 +20218,6 @@
 /obj/item/gun/projectile/sec/flash{
 	pixel_y = 10;
 	pixel_x = -3
-	},
-/obj/item/gun/projectile/sec/flash{
-	pixel_y = 6
 	},
 /obj/item/gun/projectile/sec/flash{
 	pixel_y = 1;
@@ -19855,8 +20460,9 @@
 	dir = 4
 	},
 /obj/machinery/holoposter{
-	dir = 4;
-	pixel_x = 32
+	dir = 8;
+	pixel_x = 32;
+	layer = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
@@ -20052,15 +20658,6 @@
 	},
 /obj/fiftyspawner/steel,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	dir = 1;
 	pixel_y = 22
@@ -20242,6 +20839,9 @@
 	dir = 6;
 	pixel_x = -1
 	},
+/obj/machinery/ai_status_display{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/ForStar_2_Deck_Observatory)
 "bcN" = (
@@ -20322,6 +20922,9 @@
 	dir = 9;
 	layer = 3.5
 	},
+/obj/structure/sign/poster/custom{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/hallway/Star_2_Deck_Central_Corridor_2)
 "bcZ" = (
@@ -20333,33 +20936,14 @@
 /turf/simulated/floor/airless,
 /area/harbor/Star_Shuttlebay)
 "bdc" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 25
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/border{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
 "bdd" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows/yellow,
-/obj/effect/floor_decal/industrial/arrows/yellow{
-	dir = 1
-	},
-/obj/machinery/door/airlock/maintenance/int,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/maintenance/Deck2_Star_Corridor)
+/turf/simulated/open,
+/area/hallway/Central_2_Deck_Hall)
 "bdg" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
@@ -20388,15 +20972,6 @@
 "bdj" = (
 /obj/machinery/light/small{
 	dir = 8
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /obj/effect/floor_decal/shuttle/loading{
 	dir = 1;
@@ -20472,15 +21047,6 @@
 /area/hallway/Aft_2_Deck_Central_Corridor_1)
 "bdF" = (
 /obj/effect/floor_decal/industrial/stand_clear/blue{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/door/blast/regular/open{
@@ -22121,6 +22687,15 @@
 /obj/machinery/ai_status_display{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "biU" = (
@@ -22143,6 +22718,15 @@
 	desc = "A specialized crew transit system, a tight inflatable hole of soft fabric with a strong suction. A quick way to travel long distances!";
 	color = "#6b75ff"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/Lobby)
 "biW" = (
@@ -22159,6 +22743,15 @@
 /obj/structure/sign/department/eva{
 	name = "E.V.A. Section";
 	desc = "A sign indicating the location for Extra-Vehicular Activity. Use the nearby chute for quick access."
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile{
 	color = "#989898"
@@ -25200,20 +25793,12 @@
 	pixel_x = -7
 	},
 /obj/item/storage/firstaid/adv{
-	pixel_y = 2;
-	pixel_x = -7
-	},
-/obj/item/storage/firstaid/adv{
 	pixel_y = -3;
 	pixel_x = -7
 	},
 /obj/structure/table/rack,
 /obj/item/storage/firstaid/o2{
 	pixel_y = 7;
-	pixel_x = 7
-	},
-/obj/item/storage/firstaid/o2{
-	pixel_y = 2;
 	pixel_x = 7
 	},
 /obj/item/storage/firstaid/o2{
@@ -27521,6 +28106,7 @@
 /area/maintenance/Deck2_Medical_AftCorridor1)
 "bCU" = (
 /obj/structure/girder,
+/obj/structure/largecrate/animal/bugsect,
 /turf/simulated/floor/plating,
 /area/hallway/Port_2_Deck_Corridor_1)
 "bCV" = (
@@ -27989,6 +28575,7 @@
 /area/crew_quarters/Chomp_Kitchen)
 "bFh" = (
 /obj/structure/girder,
+/obj/structure/largecrate/donksoftvendor,
 /turf/simulated/floor/plating,
 /area/hallway/Star_2_Deck_Corridor_1)
 "bFi" = (
@@ -30242,8 +30829,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "bOt" = (
-/obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "bOx" = (
@@ -31383,6 +31970,9 @@
 "bTk" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 5
+	},
+/obj/machinery/ai_status_display{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/ForPort_2_Deck_Observatory)
@@ -32610,6 +33200,12 @@
 	desc = "A warning sign which reads 'RADIATION SHIELDING IN THIS AREA'.";
 	pixel_x = -32
 	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/purple/bordercorner{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_Transit_Foyer)
 "bXq" = (
@@ -33660,7 +34256,26 @@
 /area/crew_quarters/Chomp_Kitchen)
 "cbJ" = (
 /obj/structure/girder,
-/turf/simulated/floor/plating,
+/obj/random/organ,
+/obj/random/organ,
+/obj/random/organ,
+/obj/random/organ,
+/obj/random/organ,
+/obj/random/organ,
+/obj/random/organ,
+/obj/random/organ,
+/obj/random/organ,
+/obj/random/organ,
+/obj/item/organ/internal/malignant/tumor/cancer,
+/obj/item/organ/internal/malignant/tumor/cancer,
+/obj/item/organ/internal/malignant/tumor/cancer,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/turf/simulated/floor/flesh,
 /area/rnd/Toxins_Storage)
 "cbN" = (
 /obj/effect/floor_decal/spline/fancy{
@@ -34373,6 +34988,7 @@
 /area/quartermaster/For_Tool_Storage)
 "cec" = (
 /obj/structure/table/woodentable,
+/obj/random/mug,
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/Library)
 "cee" = (
@@ -35163,10 +35779,6 @@
 "cgC" = (
 /obj/structure/table/rack,
 /obj/structure/window/reinforced,
-/obj/item/gun/energy/pummeler{
-	pixel_y = 10;
-	pixel_x = -4
-	},
 /obj/item/gun/energy/pummeler{
 	pixel_y = 2;
 	pixel_x = -1
@@ -36265,6 +36877,8 @@
 /obj/structure/table/rack/shelf,
 /obj/random/medical/pillbottle,
 /obj/random/maintenance/clean,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Medical_AftPortChamber1)
 "cjI" = (
@@ -37524,6 +38138,10 @@
 	},
 /obj/structure/window/basic{
 	dir = 4
+	},
+/obj/structure/sign/department/drones{
+	layer = 3.5;
+	desc = "Sign of some important station compartment."
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Drone_Fab)
@@ -41075,9 +41693,6 @@
 /area/medical/Reception)
 "cBM" = (
 /obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/firealarm{
-	pixel_y = 25
-	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/Chomp_Kitchen)
 "cBN" = (
@@ -41289,6 +41904,10 @@
 /area/rnd/Robotics_Lab)
 "cCH" = (
 /obj/structure/table/steel,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/AftStar_2_Deck_Observatory)
 "cCI" = (
@@ -42200,15 +42819,6 @@
 /area/security/Firing_Range)
 "cEZ" = (
 /obj/effect/floor_decal/industrial/outline/cut_corners/blue,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/machinery/camera/network/security{
 	c_tag = "D2-Sec-EVA2"
 	},
@@ -42347,6 +42957,7 @@
 /area/crew_quarters/Library)
 "cFw" = (
 /obj/structure/loot_pile/maint/trash,
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftPortCorridor1)
 "cFC" = (
@@ -43150,6 +43761,7 @@
 /turf/simulated/floor/carpet/brown,
 /area/crew_quarters/Library)
 "cPl" = (
+/obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Cargo_AftStarCorridor1)
 "cPv" = (
@@ -45754,6 +46366,7 @@
 /obj/structure/table/rack/steel,
 /obj/random/tech_supply/component,
 /obj/random/tech_supply/component,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Engineering_PortCorridor2)
 "dCA" = (
@@ -46238,6 +46851,9 @@
 "dHX" = (
 /obj/random/trash,
 /obj/random/trash,
+/obj/structure/loot_pile/surface/medicine_cabinet/fresh{
+	pixel_y = 25
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Science_StarCorridor2)
 "dIf" = (
@@ -46795,6 +47411,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/Emergency_EVA)
@@ -48855,7 +49480,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance/int,
+/obj/machinery/door/airlock/maintenance/int{
+	name = "Kitchen Maintenance";
+	req_access = list(28)
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Chomp_Kitchen)
 "erH" = (
@@ -49609,10 +50237,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/ForStar_2_Deck_Observatory)
 "eEi" = (
-/obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /obj/effect/landmark{
 	name = "JoinLateCyborg"
 	},
@@ -53381,6 +54005,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Corridor_1)
 "fza" = (
@@ -53754,9 +54384,11 @@
 	pixel_y = -24
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Star_Corridor)
@@ -54863,6 +55495,12 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/lightorange/bordercorner{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_Transit_Foyer)
 "fRM" = (
@@ -55907,6 +56545,11 @@
 	pixel_y = 25
 	},
 /obj/random/crate,
+/obj/random/mainttoyloot,
+/obj/random/mainttoyloot,
+/obj/random/mainttoyloot,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_ForPortCorridor2)
 "gdr" = (
@@ -55961,36 +56604,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Medical_AftStarChamber1)
 "gdQ" = (
-/obj/structure/table/woodentable,
-/obj/item/stack/material/cardboard{
-	amount = 25
-	},
-/obj/item/tape_roll{
-	pixel_x = 3;
-	pixel_y = -5
-	},
-/obj/item/packageWrap{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/packageWrap{
-	pixel_x = -4;
-	pixel_y = 7
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -25
-	},
-/obj/machinery/power/apc{
 	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+	name = "E-fire alarm";
+	pixel_x = 25
 	},
-/obj/structure/cable/green,
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 27;
-	pixel_y = -12
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Chomp_Dinner_2)
@@ -57075,11 +57702,6 @@
 /obj/item/radio/intercom/department/security{
 	dir = 1;
 	pixel_y = 22
-	},
-/obj/item/gun/projectile/automatic/z8{
-	desc = "The Z9 Shepherd is the newer model of the old Z8 battle rifle, made by the now defunct Zendai Foundries. Makes you feel like an old-school badass when you hold it. This one fits AR-10 magazines. Chambered in 7.62x51mm, and has an under barrel grenade launcher.";
-	magazine_type = /obj/item/ammo_magazine/ar10;
-	pixel_y = 8
 	},
 /obj/item/gun/projectile/automatic/z8{
 	desc = "The Z9 Shepherd is the newer model of the old Z8 battle rifle, made by the now defunct Zendai Foundries. Makes you feel like an old-school badass when you hold it. This one fits AR-10 magazines. Chambered in 7.62x51mm, and has an under barrel grenade launcher.";
@@ -59294,6 +59916,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/window/basic{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/hallway/Central_2_Deck_Hall)
 "gVw" = (
@@ -59583,10 +60208,6 @@
 /area/hallway/Port_2_Deck_Corridor_1)
 "gZF" = (
 /obj/structure/table/rack,
-/obj/item/gun/energy/temperature{
-	pixel_y = 8;
-	pixel_x = -10
-	},
 /obj/item/gun/energy/temperature{
 	pixel_y = -2;
 	pixel_x = -4
@@ -60304,14 +60925,19 @@
 /turf/simulated/floor/airless,
 /area/quartermaster/Waste_Disposals)
 "hic" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/arrows/blue{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 6
+/obj/effect/floor_decal/industrial/arrows/blue,
+/obj/machinery/door/airlock/angled_bay/standard/glass/common{
+	dir = 4;
+	name = "Central Lobby";
+	tintable = 1;
+	id_tint = "sc-WTkitchen"
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/techmaint,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
 "hif" = (
 /obj/structure/sign/directions/science/toxins{
@@ -61080,6 +61706,10 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 22
 	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Library)
@@ -62633,6 +63263,12 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/random/internal_organ,
+/obj/structure/closet/crate/freezer/nanotrasen,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Medical_AftStarChamber1)
 "hSM" = (
@@ -62936,6 +63572,7 @@
 /obj/random/maintenance/clean,
 /obj/random/tech_supply/component,
 /obj/random/tech_supply/component,
+/obj/random/tool/power,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Engineering_PortCorridor2)
 "hWE" = (
@@ -66164,31 +66801,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Processing_Room)
-"iKN" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/industrial/hatch/blue,
-/obj/structure/grille,
-/obj/structure/window/basic,
-/obj/structure/window/basic{
-	dir = 8
-	},
-/obj/structure/window/basic{
-	dir = 1
-	},
-/obj/structure/window/basic{
-	dir = 4
-	},
-/obj/structure/sign/directions/science{
-	dir = 4;
-	layer = 3.5;
-	pixel_y = 9
-	},
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	layer = 3.5
-	},
-/turf/simulated/floor/plating,
-/area/hallway/Central_2_Deck_Hall)
 "iKY" = (
 /obj/machinery/light{
 	dir = 4
@@ -66479,11 +67091,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/medical/Patient_Ward)
-"iOZ" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
-/turf/simulated/floor/tiled,
-/area/hallway/Star_2_Deck_Central_Corridor_1)
 "iPq" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
@@ -68236,6 +68843,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Medical_AftStarChamber1)
 "joJ" = (
@@ -69723,6 +70331,7 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner{
 	dir = 8
 	},
+/obj/structure/sign/poster/custom,
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_2)
 "jMx" = (
@@ -69983,14 +70592,16 @@
 /turf/simulated/floor/tiled,
 /area/security/Visitation_Room)
 "jRQ" = (
-/obj/machinery/ai_status_display{
-	pixel_y = 32
-	},
 /obj/effect/floor_decal/borderfloor/corner{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner{
 	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
@@ -70643,18 +71254,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/AftStar_2_Deck_Observatory)
-"kbN" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/floor_decal/industrial/arrows/yellow,
-/obj/effect/floor_decal/industrial/arrows/yellow{
-	dir = 1
-	},
-/obj/machinery/door/airlock/maintenance/int,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/maintenance/Deck2_Star_Corridor)
 "kbR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -70789,10 +71388,6 @@
 /obj/structure/table/rack,
 /obj/machinery/alarm{
 	pixel_y = 25
-	},
-/obj/item/gun/projectile/automatic/serdy/keltec{
-	pixel_y = 8;
-	pixel_x = 12
 	},
 /obj/item/gun/projectile/automatic/serdy/keltec{
 	pixel_x = 16
@@ -71293,6 +71888,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_ForPortChamber1)
 "kjU" = (
@@ -71393,6 +71989,7 @@
 /obj/structure/table/rack/steel,
 /obj/random/tech_supply,
 /obj/random/tech_supply/component,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Engineering_PortCorridor2)
 "klO" = (
@@ -71483,7 +72080,7 @@
 	},
 /obj/machinery/door/airlock/maintenance/engi{
 	name = "Security Master Substation";
-	req_one_access = list(1,11,24)
+	req_one_access = list(1)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -72439,6 +73036,11 @@
 /area/maintenance/Cargo_Substation)
 "kCQ" = (
 /obj/machinery/light/small,
+/obj/structure/table/rack,
+/obj/random/tool/powermaint,
+/obj/random/tool/powermaint,
+/obj/random/tool,
+/obj/random/tool,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Engineering_ForStarChamber1)
 "kCW" = (
@@ -73355,10 +73957,6 @@
 "kPK" = (
 /obj/structure/table/rack,
 /obj/item/gun/energy/sniperrifle{
-	pixel_y = 8;
-	pixel_x = 1
-	},
-/obj/item/gun/energy/sniperrifle{
 	pixel_x = 5
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -73699,6 +74297,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/technology_scanner,
+/obj/item/disk/nifsoft/compliance,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck2_Civilian_StarChamber2)
 "kUC" = (
@@ -74807,6 +75406,8 @@
 	},
 /obj/structure/table/rack,
 /obj/random/maintenance/research,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/research,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Science_StarCorridor1)
 "llv" = (
@@ -75094,6 +75695,9 @@
 /obj/effect/catwalk_plated/techfloor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Drone_Fab)
 "lpj" = (
@@ -75133,6 +75737,7 @@
 	dir = 1
 	},
 /obj/structure/closet/emcloset,
+/obj/random/tool/powermaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Cargo_StarChamber1)
 "lqm" = (
@@ -76417,9 +77022,6 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/machinery/holoposter{
-	pixel_y = -32
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_2)
 "lKi" = (
@@ -76463,6 +77065,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Drone_Fab)
@@ -77276,13 +77881,6 @@
 	pixel_y = -4
 	},
 /obj/item/storage/briefcase/inflatable{
-	pixel_x = 8
-	},
-/obj/item/storage/briefcase/inflatable{
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/storage/briefcase/inflatable{
 	pixel_x = 8;
 	pixel_y = 8
 	},
@@ -77460,12 +78058,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals4,
-/obj/effect/floor_decal/steeldecal/steel_decals4{
-	dir = 10
-	},
-/obj/structure/sign/poster/custom{
+/obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
@@ -78379,9 +78981,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Aft_2_Deck_Lobby)
 "moy" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Wardens_Office)
@@ -80357,6 +80961,7 @@
 /area/hallway/Central_2_Deck_Hall)
 "mQi" = (
 /obj/structure/closet/emcloset,
+/obj/random/contraband,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_ForStar_Corridor)
 "mQx" = (
@@ -81036,12 +81641,8 @@
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/grille,
-/obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
-	},
-/obj/structure/window/basic{
-	dir = 1
 	},
 /obj/structure/window/basic{
 	dir = 4
@@ -81663,6 +82264,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Science_StarCorridor1)
 "nlp" = (
@@ -81891,6 +82493,10 @@
 /area/maintenance/Research_Substation)
 "nqk" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
 	},
@@ -82511,8 +83117,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Chomp_Dinner_2)
@@ -83163,10 +83769,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/medical/Chemistry)
-"nMv" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck2_Security_AftPortCorridor1)
 "nMJ" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -83693,9 +84295,10 @@
 /area/maintenance/ab_TeshDen)
 "nUR" = (
 /obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Central_2_Deck_Hall)
 "nUY" = (
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Science_ForPort_Corridor)
 "nVp" = (
@@ -85278,10 +85881,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/Deck2_Civilian_ForPortChamber1)
-"ops" = (
-/obj/structure/foodcart,
-/turf/simulated/floor/plating,
-/area/crew_quarters/Chomp_Kitchen)
 "opw" = (
 /obj/structure/lattice,
 /obj/effect/catwalk_plated/techmaint,
@@ -85630,6 +86229,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Drone_Fab)
 "owr" = (
@@ -85971,6 +86573,9 @@
 /obj/effect/floor_decal/corner/purple/bordercorner{
 	dir = 1
 	},
+/obj/random/tech_supply/nofail,
+/obj/random/tech_supply/component,
+/obj/random/tech_supply/component,
 /turf/simulated/floor/tiled/techfloor,
 /area/rnd/Research_Lab)
 "oBo" = (
@@ -87047,20 +87652,13 @@
 	color = "#ccc9ff";
 	desc = "An extra bright lighting fixture."
 	},
+/obj/effect/floor_decal/spline/fancy,
 /turf/simulated/floor/carpet/purcarpet,
 /area/hallway/Star_Transit_Foyer)
 "oSe" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_For)
-"oSr" = (
-/obj/structure/bed/chair/sofa/brown{
-	dir = 1;
-	pixel_y = 5
-	},
-/obj/structure/window/titanium,
-/turf/simulated/floor/carpet/purcarpet,
-/area/hallway/Star_Transit_Foyer)
 "oSs" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/grille,
@@ -87094,16 +87692,13 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/arrows/blue,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/angled_bay/standard/glass/common{
 	dir = 2;
 	name = "Chompers Dinner";
 	tintable = 1;
 	id_tint = "sc-WTkitchen"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/For_2_Deck_Central_Corridor_1)
 "oSA" = (
@@ -87116,12 +87711,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_Transit_Foyer)
-"oSF" = (
-/obj/machinery/holoposter{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/hallway/Star_2_Deck_Central_Corridor_2)
 "oSK" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/directions/evac,
@@ -87206,6 +87795,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/random/mug,
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Gallery)
 "oVj" = (
@@ -87266,7 +87856,7 @@
 /area/rnd/Mech_Bay)
 "oVV" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Central_2_Deck_Hall)
 "oVW" = (
 /obj/effect/floor_decal/industrial/arrows/red{
@@ -87840,12 +88430,30 @@
 /turf/simulated/floor/tiled,
 /area/hallway/AftPort_2_Deck_Observatory)
 "pdk" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 5
+/obj/structure/table/woodentable,
+/obj/item/stack/material/cardboard{
+	amount = 25
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 6
+/obj/item/tape_roll{
+	pixel_x = 3;
+	pixel_y = -5
+	},
+/obj/item/packageWrap{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/packageWrap{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/structure/cable/green,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 12;
+	pixel_y = -24
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Chomp_Dinner_2)
@@ -88120,6 +88728,10 @@
 /area/maintenance/Deck2_Science_StarChamber1)
 "php" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled/steel_ridged{
 	color = "#989898"
 	},
@@ -88338,24 +88950,20 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Midnight_Kitchen)
 "plL" = (
-/obj/machinery/door/firedoor/glass,
-/obj/effect/floor_decal/industrial/arrows/blue{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/arrows/blue,
-/obj/machinery/door/airlock/angled_bay/standard/glass/common{
-	dir = 4;
-	name = "Central Lobby";
-	tintable = 1;
-	id_tint = "sc-WTkitchen"
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/structure/sign/poster/nanotrasen{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
 "pmh" = (
 /obj/machinery/papershredder,
@@ -88520,18 +89128,6 @@
 /obj/effect/floor_decal/corner/paleblue/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Stairwell)
-"poR" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/Lobby)
 "poT" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -88722,12 +89318,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Corridor_2)
-"pre" = (
-/obj/machinery/holoposter{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/hallway/Port_2_Deck_Central_Corridor_2)
 "prq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89174,10 +89764,10 @@
 	dir = 5
 	},
 /obj/structure/cable/green{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
-	icon_state = "1-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/Chomp_Dinner_2)
@@ -89410,6 +90000,9 @@
 /obj/effect/catwalk_plated/techfloor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
 /area/engineering/Drone_Fab)
@@ -90831,6 +91424,9 @@
 	dir = 5;
 	layer = 3.5
 	},
+/obj/structure/sign/poster/custom{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/hallway/Port_2_Deck_Central_Corridor_2)
 "pTE" = (
@@ -91992,20 +92588,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Engineering_Substation)
-"qkK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/borderfloor/corner,
-/obj/effect/floor_decal/steeldecal/steel_decals10,
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/Central_2_Deck_Hall)
 "qkP" = (
 /obj/structure/table/woodentable,
 /obj/item/taperecorder,
@@ -92176,15 +92758,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Engineering_PortCorridor1)
 "qmc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
+/obj/machinery/holoposter{
+	pixel_y = 32;
 	dir = 1
 	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck2_Star_Corridor)
+/turf/simulated/open,
+/area/hallway/Central_2_Deck_Hall)
 "qme" = (
 /obj/random/trash,
 /obj/structure/closet/crate,
@@ -93603,6 +94182,7 @@
 /area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "qHk" = (
 /obj/random/maintenance/misc,
+/obj/structure/table/standard,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "qHU" = (
@@ -93968,18 +94548,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Locker_Room)
-"qMz" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/crew_quarters/Emergency_EVA)
 "qMD" = (
 /obj/effect/catwalk_plated/techmaint,
 /obj/structure/cable/green{
@@ -94523,6 +95091,9 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
+/obj/random/tool/powermaint,
+/obj/structure/table/standard,
+/obj/random/maintenance/engineering,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Cargo_AftStarCorridor1)
 "qUI" = (
@@ -95427,6 +95998,9 @@
 /area/crew_quarters/Gallery)
 "rgZ" = (
 /obj/random/crate,
+/obj/random/contraband/nofail,
+/obj/random/mainttoyloot,
+/obj/random/mainttoyloot,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_ForPortCorridor2)
 "rhe" = (
@@ -95968,6 +96542,9 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_2_Deck_Central_Corridor_1)
@@ -96969,6 +97546,8 @@
 /area/hallway/Star_Transit_Foyer)
 "rAP" = (
 /obj/structure/loot_pile/maint/boxfort,
+/obj/random/junk,
+/obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftPortCorridor1)
 "rBe" = (
@@ -99188,6 +99767,8 @@
 /obj/structure/table/rack/shelf,
 /obj/random/medical/pillbottle,
 /obj/random/maintenance/cargo,
+/obj/random/maintenance/medical,
+/obj/random/maintenance/medical,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Medical_AftPortChamber1)
 "seX" = (
@@ -100611,7 +101192,7 @@
 /area/quartermaster/Breakroom)
 "syY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Central_2_Deck_Hall)
 "syZ" = (
 /obj/machinery/alarm{
@@ -100959,6 +101540,8 @@
 /obj/machinery/newscaster{
 	pixel_x = 28
 	},
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/brown/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/Port_Transit_Foyer)
 "sCG" = (
@@ -101695,7 +102278,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/Deck2_1_Corridor)
 "sNt" = (
@@ -103594,10 +104182,6 @@
 /obj/structure/bed/chair/sofa/brown{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 22
-	},
 /turf/simulated/floor/carpet/oracarpet,
 /area/crew_quarters/Library)
 "tqI" = (
@@ -103923,12 +104507,6 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/lightgrey/bordercorner{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
@@ -104986,10 +105564,6 @@
 /turf/simulated/floor/plating,
 /area/rnd/Toxins_Storage)
 "tNw" = (
-/obj/effect/catwalk_plated/techfloor,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/Drone_Fab)
 "tNy" = (
@@ -107593,14 +108167,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 10
+/obj/effect/floor_decal/borderfloor{
+	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
@@ -108293,6 +108867,11 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/table/rack,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/cargo,
+/obj/random/maintenance/misc,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_AftPort_Corridor)
 "uMy" = (
@@ -108948,7 +109527,7 @@
 /area/rnd/Toxins_Storage)
 "uUH" = (
 /obj/machinery/portable_atmospherics/hydroponics/soil,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Central_2_Deck_Hall)
 "uUK" = (
 /obj/structure/cable/green{
@@ -110997,7 +111576,7 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Science_ForCorridor1)
 "vzc" = (
@@ -111085,10 +111664,6 @@
 /turf/simulated/floor/airless,
 /area/rnd/Testing_Chamber)
 "vAC" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
@@ -111096,10 +111671,10 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloor/corner{
-	dir = 1
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/lightgrey/bordercorner{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
@@ -111171,14 +111746,14 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 9
+	dir = 10
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10{
-	dir = 10
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Central_Corridor_1)
@@ -111784,6 +112359,9 @@
 "vOl" = (
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/lightgrey/border,
+/obj/machinery/ai_status_display{
+	pixel_y = -32
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_2_Deck_Hall)
 "vOB" = (
@@ -112739,11 +113317,6 @@
 	},
 /turf/space,
 /area/space)
-"wdD" = (
-/obj/random/trash_pile,
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck2_Star_Corridor)
 "wdI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white{
@@ -114320,9 +114893,6 @@
 "wvX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -116096,10 +116666,6 @@
 	},
 /obj/structure/window/reinforced,
 /obj/item/gun/energy/gun/burst{
-	pixel_y = 9;
-	pixel_x = 11
-	},
-/obj/item/gun/energy/gun/burst{
 	pixel_y = 3;
 	pixel_x = 15
 	},
@@ -117609,6 +118175,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Cargo_AftStarCorridor1)
 "xrV" = (
@@ -117981,15 +118548,6 @@
 "xyF" = (
 /turf/simulated/wall/r_wall,
 /area/maintenance/Deck2_Cargo_AftPortCorridor1)
-"xyP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/wood/sif,
-/area/crew_quarters/Chomp_Dinner_2)
 "xzg" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -119477,8 +120035,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Corridor_1)
@@ -119865,6 +120424,9 @@
 /area/maintenance/ab_Theater)
 "xZe" = (
 /obj/machinery/floodlight,
+/obj/structure/loot_pile/surface/medicine_cabinet{
+	pixel_y = 25
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Medical_AftPortCorridor1)
 "xZu" = (
@@ -120026,20 +120588,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_ForPortChamber1)
 "ybS" = (
-/obj/structure/cable/green{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/Lobby)
@@ -120304,6 +120862,9 @@
 "yfv" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/structure/loot_pile/surface/medicine_cabinet/fresh{
+	pixel_y = 25
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Medical_AftPortChamber1)
@@ -127795,7 +128356,7 @@ xiQ
 maU
 maU
 maU
-maU
+ark
 maU
 maU
 xka
@@ -128566,11 +129127,11 @@ feK
 qLy
 vSz
 xiQ
-maU
+ark
 maU
 wVW
 uCX
-maU
+ark
 maU
 xka
 fZD
@@ -129082,9 +129643,9 @@ aQE
 bKe
 aQE
 aQE
+aru
 wsZ
-wsZ
-wsZ
+aru
 cHe
 cAC
 jfz
@@ -133037,6 +133598,9 @@ aaa
 aaa
 aaa
 aaa
+aaf
+onO
+aaf
 aaa
 aaa
 aaa
@@ -133054,12 +133618,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+onO
+aaf
 aaa
 aaa
 aaa
@@ -133285,7 +133846,7 @@ aaa
 aaa
 aaf
 onO
-onO
+aaf
 aaa
 cCw
 mAT
@@ -133294,11 +133855,11 @@ lVS
 cCw
 aaa
 aaa
-onO
+aaa
 dqa
 bCe
 dqa
-onO
+aaa
 aaa
 aaa
 aaa
@@ -133314,11 +133875,11 @@ aaa
 aaa
 aaa
 aaa
-onO
+aaa
 dqa
 bCe
 dqa
-onO
+aaa
 aaa
 aaa
 aaa
@@ -133543,7 +134104,7 @@ aaa
 aaa
 gWp
 bCe
-aaf
+onO
 aaa
 cCw
 aYr
@@ -133715,7 +134276,7 @@ aim
 bSI
 rzV
 bJm
-aKT
+fCI
 aKT
 guC
 fCI
@@ -133799,8 +134360,8 @@ aaa
 aaa
 aaa
 aaa
-onO
-sOr
+aaf
+aqp
 aaf
 aaa
 cCw
@@ -133972,7 +134533,7 @@ aak
 aim
 hXE
 rzV
-bJm
+fCI
 aKT
 fCI
 guC
@@ -135263,7 +135824,7 @@ aJo
 amH
 bNU
 bGe
-bGe
+fCI
 vvp
 fCI
 vvp
@@ -135503,7 +136064,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaf
 onO
 aaf
 aaf
@@ -135761,7 +136322,7 @@ aaa
 aaa
 alW
 aaa
-aaa
+onO
 twU
 rzr
 mZp
@@ -136019,7 +136580,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaf
 onO
 aaf
 aaf
@@ -136038,7 +136599,7 @@ amH
 bNU
 kLg
 aBu
-aBu
+fCI
 fCI
 aqd
 bZF
@@ -136295,7 +136856,7 @@ aJo
 kog
 bNU
 kLg
-lCW
+fCI
 lCW
 bZF
 fCI
@@ -137346,11 +137907,11 @@ eRx
 urA
 vaX
 bhL
-aUV
+bXQ
 aUV
 flL
 aUV
-aUV
+bxR
 bhL
 teP
 nOA
@@ -137595,7 +138156,7 @@ hqD
 avx
 eWt
 fHh
-eYu
+arB
 eWt
 eWt
 sov
@@ -137834,8 +138395,8 @@ aaa
 aaa
 vpU
 caL
-mYL
-mYL
+asc
+asb
 pzJ
 vVV
 cpd
@@ -138094,7 +138655,7 @@ tGA
 dIm
 bZb
 mYL
-pzJ
+arV
 mYL
 mYL
 bVI
@@ -139165,7 +139726,7 @@ bei
 aEJ
 aSQ
 aIH
-bsd
+bmw
 vcR
 awj
 vcR
@@ -139386,7 +139947,7 @@ bNY
 mYL
 cge
 cgc
-ani
+tNw
 bDZ
 uZK
 xtI
@@ -139423,7 +139984,7 @@ bko
 tWG
 aSQ
 bkW
-bsd
+bmw
 atb
 vmk
 vcR
@@ -139452,7 +140013,7 @@ ajt
 aHO
 aHO
 bAi
-pFH
+aqu
 pFH
 tfo
 uPF
@@ -139642,9 +140203,9 @@ acU
 uZK
 uZK
 uZK
-aPr
+arW
 bRh
-uZK
+aPr
 uZK
 uZK
 kcF
@@ -139659,8 +140220,8 @@ xKl
 oYQ
 ahd
 dIq
-aau
-aau
+arA
+arA
 aTK
 wno
 qfZ
@@ -139668,11 +140229,11 @@ mCA
 iAT
 iAT
 bse
-aUV
+aqX
 aUV
 flL
 aUV
-aUV
+aqH
 bse
 oOS
 oOS
@@ -141017,9 +141578,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aaf
+onO
+aaf
 aaa
 aaa
 aaa
@@ -142573,9 +143134,9 @@ vre
 tpN
 cwI
 aKA
-sIx
-xDR
-xDR
+aqo
+kkc
+kkc
 bFD
 bFD
 bFD
@@ -142833,11 +143394,11 @@ bcs
 aKA
 sIx
 wRf
-xDR
-xDR
-xDR
-xDR
-xDR
+aqf
+aqc
+scW
+apX
+apT
 wZn
 oEW
 jnk
@@ -143090,15 +143651,15 @@ tpN
 aIj
 aKA
 sIx
+wRf
+aqj
 xDR
+wRf
+kkc
 kkc
 xDR
-xDR
-xDR
-xDR
-xDR
-xDR
-xDR
+wRf
+wRf
 wZn
 wZn
 wZn
@@ -143348,14 +143909,14 @@ tpN
 bjy
 aKA
 kFZ
-xDR
-xDR
-xDR
-xDR
+aqn
+aqk
+kWt
+aGf
 wRf
-xDR
-xDR
-xDR
+apU
+aGf
+kkc
 qHk
 tLw
 avh
@@ -143608,17 +144169,17 @@ bYF
 sIx
 xDR
 xDR
+aGf
+apU
 xDR
-xDR
-xDR
-xDR
-xDR
+apV
+wRf
 kkc
 xDR
 tLw
 xDR
 xDR
-xDR
+apR
 wZn
 wZn
 oEW
@@ -143871,12 +144432,12 @@ rSV
 rSV
 rSV
 rSV
-rSV
+vMx
 rSV
 bos
 rSV
 rSV
-rSV
+vMx
 rSV
 rSV
 rSV
@@ -144132,8 +144693,8 @@ qGX
 hJV
 lIl
 tLw
-xDR
-xDR
+hJV
+apS
 qQm
 tAg
 kkc
@@ -144314,7 +144875,7 @@ psv
 rek
 shL
 fNY
-pre
+vNh
 pTu
 rek
 jPs
@@ -144654,7 +145215,7 @@ fcX
 fcX
 fcX
 mga
-xDR
+uIz
 rSV
 wZn
 ctj
@@ -144826,7 +145387,7 @@ ctj
 ctj
 ctj
 cNF
-chy
+are
 aSh
 aSh
 suW
@@ -144834,7 +145395,7 @@ bsr
 tlY
 aSh
 aSh
-lGq
+aqA
 cNF
 ctj
 ctj
@@ -145172,7 +145733,7 @@ fcX
 mga
 gmo
 rSV
-xDR
+apH
 wZn
 ctj
 ctj
@@ -145428,7 +145989,7 @@ fcX
 fcX
 jRb
 mga
-xDR
+apQ
 rSV
 rSV
 wZn
@@ -146092,7 +146653,7 @@ fPi
 vLj
 csF
 ccD
-dDL
+arY
 aov
 ctj
 aaa
@@ -146107,13 +146668,13 @@ aFt
 awy
 axQ
 anb
-fMS
+arE
 iyB
 fMS
 fMS
 qot
 fMS
-fMS
+arn
 lzm
 aln
 vCo
@@ -146350,7 +146911,7 @@ kgh
 hjo
 uPu
 ccD
-chl
+arZ
 aov
 ctj
 aaa
@@ -147235,7 +147796,7 @@ fcX
 fcX
 ftC
 pPG
-kdH
+apK
 xDR
 xDR
 wXa
@@ -147383,7 +147944,7 @@ hbn
 csF
 ccD
 swc
-nMv
+rDT
 aov
 aaa
 aaa
@@ -147886,7 +148447,7 @@ bpc
 bVB
 biQ
 cEZ
-gZj
+asd
 gZj
 gZj
 jFF
@@ -148268,7 +148829,7 @@ xCr
 mga
 oGb
 biB
-tQg
+eae
 gDg
 gDg
 gDg
@@ -148401,7 +148962,7 @@ ykz
 pOp
 aTm
 biQ
-qMz
+biQ
 dOn
 qvt
 aai
@@ -148674,7 +149235,7 @@ caS
 akt
 qes
 cKO
-rDT
+arM
 aov
 aaa
 aaa
@@ -148932,7 +149493,7 @@ sDJ
 bUP
 qes
 dDL
-cFw
+arT
 aov
 aaa
 aaa
@@ -149175,8 +149736,8 @@ hNU
 aRo
 aTn
 aNP
-poR
 aNP
+ase
 boB
 bsZ
 bye
@@ -149434,7 +149995,7 @@ ssf
 mro
 mro
 ybS
-aNP
+asf
 boC
 bsZ
 xZy
@@ -149452,10 +150013,10 @@ uXf
 bAm
 mfA
 jAh
-ops
+aSq
 aou
-aor
 jAh
+arI
 rzc
 cDA
 bFb
@@ -149712,9 +150273,9 @@ kzJ
 aoD
 aoz
 oCX
-aot
 aue
 hZN
+arG
 pPi
 dXw
 dXw
@@ -149795,7 +150356,7 @@ qXc
 dSY
 qXc
 cmu
-mZV
+aqq
 mZV
 mZV
 mZV
@@ -149818,7 +150379,7 @@ svD
 aaS
 eae
 svD
-gDg
+aee
 sqb
 vGB
 ubp
@@ -149970,8 +150531,8 @@ aoA
 jAh
 emF
 bsn
-aSq
 jAh
+arJ
 cBM
 bpL
 afk
@@ -150039,7 +150600,7 @@ xAg
 hoK
 ckv
 ipd
-rDB
+aqr
 clJ
 dvr
 tkC
@@ -150076,7 +150637,7 @@ svD
 cXz
 tQg
 svD
-gDg
+apB
 gDg
 vGB
 sBD
@@ -150334,7 +150895,7 @@ svD
 aGz
 eae
 svD
-wMO
+apC
 gDg
 vGB
 mAn
@@ -150503,7 +151064,7 @@ vft
 vft
 alq
 ala
-gVv
+aqY
 aTa
 aTa
 aTa
@@ -151537,7 +152098,7 @@ qQc
 alb
 oSv
 akE
-aUc
+hru
 asR
 akj
 ajS
@@ -151795,7 +152356,7 @@ aQw
 alc
 aPc
 aiq
-akz
+aVG
 aVG
 aiq
 eWo
@@ -151882,7 +152443,7 @@ aao
 abn
 sua
 svD
-gDg
+apF
 aaN
 tQg
 bKO
@@ -152053,7 +152614,7 @@ alu
 roS
 akQ
 mdj
-qkK
+bdc
 bdc
 akk
 twz
@@ -152140,7 +152701,7 @@ svD
 svD
 svD
 svD
-gDg
+apG
 gDg
 tQg
 bKO
@@ -152272,7 +152833,7 @@ oXP
 aUu
 bfG
 gTh
-ijY
+asg
 xEp
 bqR
 msQ
@@ -152310,11 +152871,11 @@ alN
 sac
 ale
 czK
-eUr
+aqY
 bdd
-sOC
-sfv
-ajU
+aqT
+aqO
+eWo
 bIq
 ajx
 apO
@@ -152357,7 +152918,7 @@ kgw
 aMr
 cin
 ckg
-ckg
+aqs
 ckg
 vnH
 ckQ
@@ -152566,12 +153127,12 @@ cCK
 ikG
 ikG
 mDM
-fqL
+arg
 ots
-eUr
+aqY
 qmc
-sOC
-eUr
+aqT
+sfv
 vAC
 bIq
 bIq
@@ -152824,15 +153385,15 @@ dUk
 fgD
 fgD
 pww
-fqL
+arh
 pdk
-kbN
-mQf
-wdD
+eUr
+sOC
+sOC
 eUr
 lYe
 aVG
-qoA
+lSq
 yfQ
 fti
 aiw
@@ -153081,16 +153642,16 @@ tIv
 sAt
 xhd
 lAv
-xyP
+alA
 nAI
 gdQ
-eUr
-mQf
-tof
+aqZ
+aqW
+aqU
 eUr
 plL
-iKN
-ksl
+aVG
+qoA
 ipq
 psF
 afE
@@ -153343,11 +153904,11 @@ alA
 alf
 arK
 eUr
-akB
+tof
 fFj
 akm
 ajV
-eJq
+aqD
 hic
 afC
 bgF
@@ -153606,7 +154167,7 @@ mQf
 sOC
 ajW
 wCT
-cJG
+aqB
 bdg
 aiS
 jgH
@@ -153864,7 +154425,7 @@ jYg
 gMa
 ken
 wCT
-iOZ
+cJG
 bdg
 aCt
 bgI
@@ -154626,9 +155187,9 @@ amO
 amO
 sex
 ces
-iEX
-iEX
-iEX
+arx
+arp
+arm
 aSy
 rTE
 wCT
@@ -155956,7 +156517,7 @@ ctj
 bLI
 bWA
 bWA
-bWA
+aqw
 bWA
 bWA
 jfH
@@ -156178,7 +156739,7 @@ ctj
 ctj
 ctj
 mKm
-iQE
+ari
 aZE
 aZE
 lPb
@@ -156186,7 +156747,7 @@ aQW
 muk
 aZE
 aZE
-nID
+aqC
 mKm
 ctj
 ctj
@@ -156214,7 +156775,7 @@ ctj
 bQM
 bQM
 qgb
-qgb
+wDP
 oTp
 njG
 gCT
@@ -156472,7 +157033,7 @@ ctj
 ctj
 aph
 qgb
-qgb
+wDP
 maq
 njG
 gOI
@@ -156698,7 +157259,7 @@ gxC
 kPr
 gOr
 daU
-oSF
+bdn
 bcY
 kPr
 chW
@@ -156730,7 +157291,7 @@ ctj
 ctj
 bQM
 bQM
-qgb
+wDP
 aBl
 njG
 njG
@@ -156988,9 +157549,9 @@ ctj
 ctj
 ctj
 bQM
-qgb
-qgb
-qgb
+wDP
+wDP
+wDP
 ape
 uVE
 lyh
@@ -158490,7 +159051,7 @@ tgW
 bBB
 nsR
 xWb
-tgW
+arF
 iHh
 efB
 xWb
@@ -159994,9 +160555,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aaf
+gWp
+aaf
 aaa
 aaa
 aaa
@@ -161086,7 +161647,7 @@ bXk
 cTF
 cuE
 cTF
-mXo
+aqI
 oJo
 aWc
 aWc
@@ -161340,11 +161901,11 @@ kjc
 kTT
 kTT
 kTh
-mXo
+ara
 mXo
 rAK
 mXo
-mXo
+aqM
 kTh
 tUc
 tUc
@@ -161640,7 +162201,7 @@ aaa
 aaa
 aaa
 bXg
-cdr
+aqv
 cdr
 bma
 gUt
@@ -163145,7 +163706,7 @@ ipu
 mwR
 vwB
 nSe
-oSr
+cMC
 sXo
 sXo
 rzK
@@ -163662,11 +164223,11 @@ oeI
 hRL
 mlJ
 oJo
-mXo
+ydB
 mXo
 rAK
 mXo
-mXo
+aqI
 oJo
 uNQ
 aWc
@@ -164917,7 +165478,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaf
 onO
 aaf
 aaf
@@ -165175,7 +165736,7 @@ aaa
 aaa
 alW
 aaa
-aaa
+onO
 sWi
 kQT
 cKE
@@ -165433,7 +165994,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaf
 onO
 aaf
 aaf
@@ -166781,7 +167342,7 @@ xua
 ikJ
 mUY
 nXv
-xSE
+aqy
 dVm
 chL
 bVb
@@ -167339,8 +167900,8 @@ aaa
 aaa
 aaa
 aaa
-onO
-sOr
+aaf
+aqp
 aaf
 aaa
 qcZ
@@ -167599,7 +168160,7 @@ aaa
 aaa
 gWp
 xBF
-aaf
+onO
 aaa
 qcZ
 qJo
@@ -167857,7 +168418,7 @@ aaa
 aaa
 aaf
 onO
-onO
+aaf
 aaa
 qcZ
 sbk
@@ -167866,11 +168427,11 @@ gky
 qcZ
 aaa
 aaa
-onO
+aaa
 dqa
 oBS
 dqa
-onO
+aaa
 aaa
 aaa
 aaa
@@ -167886,11 +168447,11 @@ aaa
 aaa
 aaa
 aaa
-onO
+aaa
 dqa
 oBS
 dqa
-onO
+aaa
 aaa
 aaa
 aaa
@@ -168051,7 +168612,7 @@ uqR
 pBw
 rJB
 vge
-qMI
+aqS
 tBS
 uqR
 vAY
@@ -168125,6 +168686,9 @@ aaa
 aaa
 aaa
 aaa
+aaf
+gWp
+aaf
 aaa
 aaa
 aaa
@@ -168142,12 +168706,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+gWp
+aaf
 aaa
 aaa
 aaa
@@ -171137,9 +171698,9 @@ lrb
 nSZ
 nkY
 yiq
-yiq
+ary
 cGJ
-yiq
+arq
 cBg
 bft
 aUm
@@ -171395,9 +171956,9 @@ cDs
 cDs
 tyC
 yiq
-yiq
+aqE
 lWn
-yiq
+art
 cBg
 cBg
 cBg
@@ -171659,18 +172220,18 @@ yiq
 wLU
 gpk
 nSZ
-tyC
+arc
 lrb
 yiq
 lll
 akp
 uGP
-yiq
+aqE
 iBj
 vWb
 pjG
 pSZ
-jmU
+aqz
 gFK
 jmU
 jmU
@@ -172433,7 +172994,7 @@ gNu
 xYt
 xYt
 gNC
-xuB
+ard
 xuB
 bTV
 bTV

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
@@ -713,6 +713,7 @@
 /area/maintenance/Deck3_Dorms_ForCorridor1)
 "abC" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_ForCorridor1)
 "abD" = (
@@ -2104,6 +2105,171 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_2)
+"aeI" = (
+/obj/machinery/pointdefense{
+	id_tag = "PD Secondary"
+	},
+/obj/machinery/shield_diffuser,
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/white,
+/obj/structure/lattice,
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"aeJ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Aft_3_Deck_Stairwell)
+"aeK" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/Dorm_Corridor_3)
+"aeL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/crew_quarters/Dorm_Corridor_4)
+"aeM" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Stairwell_Aft)
+"aeN" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/structure/grille,
+/obj/structure/window/basic{
+	dir = 8
+	},
+/obj/structure/window/basic{
+	dir = 1
+	},
+/obj/structure/window/basic{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Stairwell_Aft)
+"aeO" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/machinery/shield_diffuser,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"aeP" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/glass,
+/area/medical/Stairwell)
+"aeQ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/glass,
+/area/medical/Lounge)
+"aeR" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_ForCorridor1)
+"aeS" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"aeT" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"aeU" = (
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Construction_Area)
+"aeV" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/turf/simulated/floor/glass,
+/area/hallway/Star_3_Deck_Stairwell)
+"aeW" = (
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Construction_Area)
+"aeX" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/engineering/Deck3_2_Corridor)
+"aeY" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Star_Breakroom)
+"aeZ" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/glass,
+/area/hallway/Star_3_Deck_Stairwell)
+"afa" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/turf/simulated/floor/glass,
+/area/hallway/Star_3_Deck_Stairwell)
+"afb" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/glass,
+/area/hallway/Star_3_Deck_Stairwell)
 "afc" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -2119,10 +2285,63 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Waste_Handling)
+"afe" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/Star_3_Deck_Stairwell)
 "aff" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"afg" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/turf/simulated/floor/tiled,
+/area/hallway/Stairwell_Star)
+"afh" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/floor_decal/industrial/hatch/blue,
+/obj/effect/wingrille_spawn/reinforced/polarized{
+	id = "sc-WTstage"
+	},
+/turf/simulated/floor/plating,
+/area/hallway/Central_3_Deck_Hall)
+"afi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	name = "Station Intercom (General)";
+	pixel_y = -21
+	},
+/turf/simulated/floor/wood/alt,
+/area/crew_quarters/Chomp_Stage)
+"afj" = (
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Construction_Area)
+"afk" = (
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Construction_Area)
+"afl" = (
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Airlock_Access)
 "afm" = (
 /obj/structure/transit_tube/station{
 	dir = 1
@@ -2132,12 +2351,86 @@
 /obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled,
 /area/bridge/Captain_Office)
+"afn" = (
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/turf/simulated/floor/plating,
+/area/engineering/Airlock_Access)
+"afo" = (
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Airlock_Access)
+"afp" = (
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Airlock_Access)
 "afq" = (
 /obj/structure/sign/securearea{
 	icon_state = "restroom"
 	},
 /turf/simulated/wall,
 /area/crew_quarters/Central_Restroom)
+"afr" = (
+/obj/structure/table/hardwoodtable,
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = 22
+	},
+/turf/simulated/floor/wood/alt,
+/area/crew_quarters/Chomp_Stage)
+"afs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine1_Chamber)
+"aft" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/engineering/Engine1_Chamber)
+"afu" = (
+/obj/structure/cable/cyan{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/cyan{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"afv" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"afw" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/structure/railing/grey,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
 "afx" = (
 /obj/effect/floor_decal/industrial/arrows/blue,
 /obj/effect/floor_decal/industrial/arrows/blue{
@@ -2154,12 +2447,165 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/hallway/Port_Breakroom)
+"afy" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/wood/alt,
+/area/bridge/Embassy)
 "afz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleep/Dormitory_04)
+"afA" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/wood/alt/parquet,
+/area/bridge/Captain_Office)
+"afB" = (
+/obj/structure/cable/cyan{
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"afC" = (
+/obj/machinery/pointdefense{
+	id_tag = "PD Secondary"
+	},
+/obj/machinery/shield_diffuser,
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/cyan{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"afD" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/bridge/Control_Atrium)
+"afE" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/kafel_full/white,
+/area/bridge/sleep/Captain_Quarters)
+"afF" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Bridge_AftStarCorridor1)
+"afG" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/bridge/AI_Core_Chamber)
+"afH" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/tiled/milspec/raised,
+/area/bridge/AI_Core_Chamber)
+"afI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/turf/simulated/floor/greengrid,
+/area/bridge/AI_Core_Chamber)
+"afJ" = (
+/obj/effect/catwalk_plated/techfloor,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/turf/simulated/floor/redgrid/animated,
+/area/bridge/AI_Core_Chamber)
+"afK" = (
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/airless,
+/area/space)
+"afL" = (
+/obj/effect/floor_decal/industrial/warning/color{
+	dir = 9
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"afM" = (
+/obj/effect/floor_decal/industrial/warning/color{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"afN" = (
+/obj/effect/floor_decal/industrial/warning/color{
+	dir = 5
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"afO" = (
+/obj/structure/railing/grey,
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/airless,
+/area/space)
+"afP" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/airless,
+/area/space)
+"afQ" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "agd" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/arrows/blue{
@@ -2302,6 +2748,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/medical/Deck3_Corridor)
@@ -3155,17 +3605,11 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Autoresleeving)
@@ -3534,14 +3978,12 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2,
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
 "aHx" = (
@@ -4037,13 +4479,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2,
-/obj/effect/floor_decal/corner/black/bordercorner2,
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Observation_Lounge)
@@ -4133,17 +4573,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 10
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Stairwell)
@@ -4995,7 +5429,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_AftCorridor1)
 "bks" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_1)
 "bkC" = (
@@ -5378,6 +5817,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Virology)
 "bsy" = (
@@ -5677,9 +6120,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /obj/structure/cable/green{
 	icon_state = "1-4"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Leisure_Room)
@@ -6043,18 +6488,6 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_ForStarChamber1)
-"bHh" = (
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/green/bordercorner2{
-	dir = 10
-	},
-/turf/simulated/floor/wood/alt/panel,
-/area/bridge/Leisure_Room)
 "bHv" = (
 /obj/structure/ladder{
 	pixel_y = 3
@@ -6164,8 +6597,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
@@ -6245,12 +6681,11 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleep/Dormitory_04)
@@ -6512,6 +6947,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/AI_Upload_Hall)
 "bPf" = (
@@ -6779,14 +7220,6 @@
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/crew_quarters/sleep/Dormitory_01)
-"bUf" = (
-/obj/effect/catwalk_plated/white,
-/obj/machinery/light_switch{
-	pixel_x = 12;
-	pixel_y = 27
-	},
-/turf/simulated/floor/glass/turfpack/airless,
-/area/space)
 "bUF" = (
 /obj/machinery/atmospherics/binary/pump{
 	name = "Air Mix to Connector"
@@ -6850,8 +7283,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_4)
@@ -6877,12 +7313,13 @@
 	name = "Atmospherics";
 	sortType = "Atmospherics"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/engineering/Atmospherics_Control_Room)
 "bWJ" = (
@@ -6953,6 +7390,10 @@
 /area/maintenance/Deck3_Medical_ForChamber3)
 "bYq" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/medical/Restrooms)
 "bYw" = (
@@ -6983,14 +7424,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2,
 /turf/simulated/floor/wood/alt,
 /area/medical/Patient_1)
 "bYS" = (
@@ -7050,7 +7490,9 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_3_Deck_Stairwell)
 "bZA" = (
@@ -7492,6 +7934,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "ciH" = (
@@ -7583,12 +8031,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_PortCorridor1)
 "cke" = (
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/sleep/Dormitory_08)
@@ -7852,8 +8299,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Atmospherics_Control_Room)
@@ -7955,13 +8405,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Control_Atrium)
 "cqa" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_Breakroom)
 "cqp" = (
@@ -8422,12 +8877,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/crew_quarters/sleep/Dormitory_02)
@@ -8648,6 +9102,12 @@
 	dir = 1
 	},
 /obj/machinery/ai_slipper,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/AI_Core_Chamber)
 "cDV" = (
@@ -9004,8 +9464,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
@@ -9016,13 +9477,12 @@
 /turf/simulated/floor/wood/alt,
 /area/bridge/Embassy)
 "cJZ" = (
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/sleep/Dormitory_03)
 "cKh" = (
@@ -9050,13 +9510,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_02)
 "cKI" = (
@@ -9412,6 +9871,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/Control_Atrium)
 "cRp" = (
@@ -9465,8 +9930,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/Control_Atrium)
 "cSp" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Deck3_Corridor)
@@ -9543,12 +10008,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/sleep/Dormitory_05)
@@ -9589,13 +10053,11 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2,
-/obj/effect/floor_decal/corner/black/bordercorner2,
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Public_Garden)
@@ -9633,23 +10095,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Center_Star)
 "cVP" = (
-/obj/effect/floor_decal/borderfloorwhite{
+/obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
-"cVS" = (
-/obj/structure/railing/grey,
-/obj/structure/lattice,
-/obj/machinery/shield_diffuser,
-/turf/space,
-/area/space)
 "cWO" = (
 /obj/structure/railing/grey{
 	dir = 8
@@ -9752,14 +10202,13 @@
 /obj/machinery/atmospherics/unary/freezer{
 	icon_state = "freezer"
 	},
-/obj/machinery/ai_status_display{
-	name = "1N-AI display";
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
+/obj/machinery/firealarm{
+	pixel_y = 25
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/medical/Aft_Medical_Post)
 "cYZ" = (
@@ -10083,6 +10532,12 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/wood/alt/tile,
 /area/medical/Autoresleeving)
 "dfh" = (
@@ -10101,6 +10556,12 @@
 	name = "1E-Bolt control";
 	id = "sc-DBCstall3";
 	specialfunctions = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/kafel_full,
 /area/crew_quarters/Central_Restroom)
@@ -10190,17 +10651,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_ForStarChamber1)
 "dhs" = (
-/obj/effect/floor_decal/borderfloorblack/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Observation_Lounge)
@@ -10413,6 +10868,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/Server_Room)
 "dlA" = (
@@ -10480,9 +10939,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine1_Substation)
@@ -10573,7 +11034,9 @@
 "doB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
 "doG" = (
@@ -10655,12 +11118,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_07)
@@ -10925,7 +11387,9 @@
 "dyf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_3_Deck_Stairwell)
 "dym" = (
@@ -11224,7 +11688,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_1)
 "dBF" = (
@@ -11294,8 +11763,9 @@
 /turf/simulated/open,
 /area/hallway/Port_Breakroom)
 "dDT" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/glass,
 /area/medical/Stairwell)
@@ -11700,17 +12170,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/medical/Patient_3)
@@ -12231,8 +12698,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
@@ -12533,6 +13001,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/old_cargo,
 /area/medical/Deck3_Corridor)
@@ -12905,6 +13379,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/bridge/Firstaid_Post)
 "ebr" = (
@@ -13040,9 +13520,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/bridge/Control_Atrium)
 "ecT" = (
@@ -13094,13 +13575,13 @@
 /area/engineering/Atmospherics_Chamber)
 "edG" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/medical/Restrooms)
 "edU" = (
@@ -13283,7 +13764,12 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
 "ehG" = (
@@ -13393,6 +13879,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/For_3_Deck_Stairwell)
 "ekr" = (
@@ -13843,8 +14335,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_ForStarChamber2)
 "etz" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
@@ -14131,18 +14623,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/Cyborg_Station)
 "eyL" = (
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 6
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/white,
 /area/medical/Aft_Medical_Post)
 "eyU" = (
@@ -14533,6 +15017,7 @@
 	color = "#ccc9ff";
 	desc = "An extra bright lighting fixture."
 	},
+/obj/structure/sign/poster/nanotrasen,
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Stage)
 "eFl" = (
@@ -14633,11 +15118,14 @@
 /area/crew_quarters/Chomp_Dinner_1)
 "eGG" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Deck3_Corridor)
@@ -14667,8 +15155,8 @@
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Waste_Handling)
 "eHp" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_3_Deck_Stairwell)
@@ -14718,7 +15206,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/Engine1_Control_Room)
 "eIx" = (
@@ -15186,13 +15679,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/borderfloor{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/carpet/turcarpet,
 /area/bridge/Captain_Office)
 "ePp" = (
@@ -15212,8 +15707,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_Breakroom)
@@ -15230,8 +15725,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_3)
@@ -16174,13 +16672,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_03)
 "fbp" = (
@@ -16465,6 +16962,9 @@
 /area/bridge/Control_Atrium)
 "feT" = (
 /obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine1_Chamber)
 "ffp" = (
@@ -16880,6 +17380,9 @@
 	icon_state = "1-4"
 	},
 /obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Airlock_Access)
 "flb" = (
@@ -17119,17 +17622,11 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 1
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Observation_Lounge)
@@ -17194,8 +17691,8 @@
 	name = "CE Quarters";
 	sortType = "CE Quarters"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Deck3_Corridor)
@@ -17837,9 +18334,7 @@
 	},
 /area/medical/Morgue)
 "fAa" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/glass,
 /area/hallway/Aft_3_Deck_Stairwell)
 "fAd" = (
@@ -17898,11 +18393,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/corner/white/bordercorner2,
 /obj/structure/cable/green{
 	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Autoresleeving)
@@ -18186,6 +18681,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Chamber)
 "fFq" = (
@@ -18491,8 +18992,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_2)
@@ -18685,8 +19187,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Foyer)
@@ -19437,6 +19939,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/Conference_Room)
 "gam" = (
@@ -19509,7 +20018,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals10,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/glass,
 /area/medical/Stairwell)
 "gbs" = (
@@ -19639,7 +20150,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
 "gcW" = (
@@ -20219,17 +20735,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 6
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Resleeving)
@@ -20290,12 +20798,11 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
 "gpq" = (
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/crew_quarters/sleep/Dormitory_06)
@@ -20487,6 +20994,9 @@
 	dir = 8
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Airlock_Access)
 "grh" = (
@@ -20647,17 +21157,11 @@
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_08)
 "guP" = (
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Autoresleeving)
@@ -20751,6 +21255,9 @@
 	dir = 4
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Airlock_Access)
 "gxC" = (
@@ -21094,8 +21601,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Engine1_Control_Room)
@@ -21173,18 +21683,12 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/paleblue/border,
-/obj/effect/floor_decal/corner/white/bordercorner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
@@ -21325,9 +21829,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/engineering/Engine3_Control_Room)
 "gIN" = (
@@ -21543,8 +22048,11 @@
 	name = "W-light switch";
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Engine2_Access_Hall)
@@ -22763,9 +23271,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine2_Substation)
@@ -23056,9 +23566,6 @@
 /area/maintenance/Deck3_Center_Star)
 "hqo" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/bridge/Leisure_Room)
 "hqp" = (
@@ -23200,8 +23707,8 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "huF" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Foyer)
@@ -23316,15 +23823,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 5
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 6
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/sleep/Captain_Quarters)
 "hwm" = (
@@ -23373,8 +23878,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
@@ -23768,6 +24273,7 @@
 	},
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/plating,
 /area/engineering/Airlock_Access)
 "hDT" = (
@@ -23813,12 +24319,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/sleep/Dormitory_01)
@@ -23903,6 +24408,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Virology)
@@ -24312,8 +24821,8 @@
 /turf/simulated/floor/glass,
 /area/hallway/Star_3_Deck_Stairwell)
 "hOx" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Aft_3_Deck_Stairwell)
@@ -24619,7 +25128,7 @@
 "hUW" = (
 /obj/structure/reagent_dispensers/foam,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForPort_Corridor1)
 "hVh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25043,8 +25552,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_For)
@@ -25176,8 +25685,9 @@
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
@@ -25285,6 +25795,12 @@
 /obj/effect/catwalk_plated/techfloor,
 /obj/item/toy/mistletoe{
 	pixel_y = 17
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/greengrid,
 /area/bridge/AI_Core_Chamber)
@@ -25410,7 +25926,7 @@
 	dir = 1
 	},
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForPort_Corridor1)
 "ihV" = (
 /obj/effect/catwalk_plated/techmaint,
@@ -25835,11 +26351,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/Construction_Area)
 "iqg" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
@@ -25982,17 +26501,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 6
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/medical/Virology)
@@ -26122,13 +26633,11 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2,
-/obj/effect/floor_decal/corner/black/bordercorner2,
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Public_Garden)
@@ -26433,14 +26942,11 @@
 	name = "Captain Office";
 	sortType = "Captain Office"
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/Captain_Office)
@@ -26699,12 +27205,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_06)
@@ -26744,15 +27249,6 @@
 	color = "#8bbbd5"
 	},
 /area/medical/Resleeving)
-"iGD" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/turfpack/airless,
-/area/space)
 "iGH" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor/plating,
@@ -27275,12 +27771,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/sleep/Dormitory_03)
@@ -27418,11 +27913,11 @@
 /obj/effect/floor_decal/industrial/stand_clear/red{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
-	},
 /obj/effect/floor_decal/industrial/outline/cut_corners/red,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/monotile{
 	color = "#989898"
 	},
@@ -27569,12 +28064,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/bridge/sleep/CE_Quarters)
@@ -27655,6 +28149,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/bridge/Cyborg_Station)
@@ -27777,8 +28277,8 @@
 /turf/simulated/floor/airless,
 /area/engineering/Solar_Control_ForStar)
 "iYR" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_3_Deck_Stairwell)
@@ -27844,6 +28344,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_ForStarChamber2)
 "jaC" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_4)
 "jaM" = (
@@ -27946,8 +28450,8 @@
 "jcN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Foyer)
@@ -28417,7 +28921,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_1)
 "jkH" = (
@@ -28437,6 +28946,12 @@
 /obj/machinery/light{
 	dir = 8;
 	layer = 3
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/Central_Restroom)
@@ -28548,9 +29063,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine1_Access_Hall)
@@ -28891,8 +29405,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
@@ -29084,7 +29601,9 @@
 "jwY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
 "jxD" = (
@@ -29100,8 +29619,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_4)
@@ -29275,8 +29797,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/Resleeving)
 "jBk" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
@@ -29303,13 +29825,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleep/Dormitory_07)
 "jCc" = (
@@ -29397,13 +29918,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_01)
 "jDJ" = (
@@ -29524,8 +30044,8 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Deck3_Corridor)
@@ -29804,8 +30324,8 @@
 "jIR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Port)
@@ -30297,8 +30817,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/bridge/Leisure_Room)
 "jUM" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_Breakroom)
@@ -30415,10 +30935,10 @@
 /obj/machinery/computer/guestpass{
 	pixel_y = 19
 	},
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/borderfloor/corner{
 	dir = 1
 	},
-/obj/effect/floor_decal/corner/blue/border{
+/obj/effect/floor_decal/corner/blue/bordercorner{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -30697,8 +31217,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Medical_ForPortChamber2)
 "kbw" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_3)
@@ -30921,8 +31441,9 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/Lounge)
 "kfZ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_3_Deck_Stairwell)
@@ -30945,8 +31466,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_3_Deck_Stairwell)
@@ -31151,6 +31673,9 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Construction_Area)
 "kjc" = (
@@ -31958,6 +32483,12 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/wood/alt,
 /area/medical/Autoresleeving)
 "kyx" = (
@@ -32184,9 +32715,8 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine1_Access_Hall)
@@ -32203,17 +32733,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 6
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/crew_quarters/Central_Restroom)
@@ -32375,7 +32897,9 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/bridge/Leisure_Room)
 "kFY" = (
@@ -32442,13 +32966,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor{
+/obj/effect/floor_decal/steeldecal/steel_decals6{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/medical/Restrooms)
 "kHP" = (
@@ -32549,8 +33069,8 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/bridge/Breakroom)
 "kJi" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_1)
@@ -32631,8 +33151,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_Breakroom)
@@ -33091,6 +33612,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/bridge/AI_Upload_Hall)
 "kTF" = (
@@ -33330,13 +33857,12 @@
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleep/Dormitory_07)
 "kXV" = (
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/sleep/Dormitory_01)
 "kXZ" = (
@@ -33364,6 +33890,13 @@
 	dir = 1;
 	name = "Conference";
 	sortType = "Conference"
+	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/Conference_Room)
@@ -33704,7 +34237,9 @@
 "lef" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_Breakroom)
 "lel" = (
@@ -33968,14 +34503,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/bridge/sleep/Captain_Quarters)
@@ -33992,18 +34524,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 6
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
 "ljD" = (
@@ -34092,7 +34616,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_2)
 "llg" = (
@@ -34173,8 +34702,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Engine2_Access_Hall)
@@ -34189,6 +34721,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
 /turf/simulated/floor/tiled,
 /area/medical/Deck3_Corridor)
 "lmX" = (
@@ -34248,13 +34784,11 @@
 	name = "Morgue";
 	sortType = "Morgue"
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2,
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Morgue)
@@ -34801,17 +35335,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 10
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/Psych_Room_2)
@@ -34900,9 +35431,6 @@
 /area/bridge/Leisure_Room)
 "lzD" = (
 /obj/effect/catwalk_plated/white,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/airless,
 /area/space)
 "lzJ" = (
@@ -35212,7 +35740,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_ForStarChamber2)
 "lEF" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
 "lEO" = (
@@ -35238,8 +35771,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Deck3_Corridor)
@@ -35395,8 +35928,11 @@
 /turf/simulated/floor/plating,
 /area/harbor/Aft_3_Deck_Airlock_Access)
 "lGP" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/glass,
 /area/medical/Stairwell)
@@ -35459,6 +35995,12 @@
 	dir = 4
 	},
 /obj/structure/cable/green,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/Central_Restroom)
 "lId" = (
@@ -36096,7 +36638,9 @@
 	pixel_y = -12;
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_3_Deck_Stairwell)
 "lQK" = (
@@ -36240,17 +36784,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 10
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
@@ -36378,12 +36916,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/bridge/sleep/CMO_Quarters)
@@ -36502,6 +37039,7 @@
 /area/bridge/sleep/CMO_Quarters)
 "lVI" = (
 /obj/machinery/light/small,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_AftPortCorridor1)
 "lVM" = (
@@ -36529,8 +37067,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Engine2_Access_Hall)
@@ -36938,7 +37477,9 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_3_Deck_Stairwell)
 "mbQ" = (
@@ -37381,6 +37922,12 @@
 	id = "sc-DBresleevingstall3";
 	specialfunctions = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/kafel_full,
 /area/medical/Restrooms)
 "miE" = (
@@ -37667,12 +38214,11 @@
 /area/space)
 "mlp" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/bridge/sleep/CE_Quarters)
@@ -37990,14 +38536,8 @@
 /turf/simulated/floor/wood/alt,
 /area/bridge/Embassy)
 "mpQ" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
@@ -38306,8 +38846,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Dorms_Substation)
 "muZ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_For)
@@ -38321,7 +38861,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Observation_Lounge)
 "mvw" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/glass,
 /area/medical/Stairwell)
 "mvK" = (
@@ -38405,13 +38947,12 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/wood/alt/panel,
 /area/crew_quarters/sleep/Dormitory_06)
 "mxJ" = (
@@ -38788,8 +39329,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_ForPort_Corridor1)
 "mFJ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Star_3_Deck_Stairwell)
@@ -38840,7 +39382,7 @@
 "mGn" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForPort_Corridor1)
 "mGv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -38920,23 +39462,15 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_Breakroom)
 "mIW" = (
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 5
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Morgue)
@@ -39075,10 +39609,8 @@
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_2)
 "mLq" = (
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/medical/Restrooms)
@@ -39251,6 +39783,12 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/bridge/AI_Upload_Hall)
 "mOv" = (
@@ -39460,7 +39998,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
 "mTT" = (
@@ -39472,12 +40012,11 @@
 /turf/simulated/floor/plating,
 /area/harbor/Port_3_Deck_Airlock_Access)
 "mUh" = (
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/sleep/Dormitory_09)
@@ -39544,8 +40083,8 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
@@ -39662,8 +40201,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Engine2_Canister_Storage)
@@ -39975,8 +40517,8 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/Psych_Room_1)
 "nbG" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/glass,
 /area/medical/Stairwell)
@@ -40197,17 +40739,11 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/medical/Patient_2)
 "ngJ" = (
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 1
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Observation_Atrium)
@@ -40217,6 +40753,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_3_Deck_Stairwell)
@@ -40491,8 +41036,8 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
@@ -40702,18 +41247,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 6
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/wood/alt/parquet,
 /area/medical/Patient_2)
 "npS" = (
@@ -40806,27 +41346,6 @@
 /obj/effect/floor_decal/corner/green/border,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Observation_Lounge)
-"nrB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/medical/Virology)
 "nrJ" = (
 /obj/structure/closet/emergsuit_wall{
 	dir = 1;
@@ -40967,12 +41486,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/medical/Aft_Medical_Post)
-"nuL" = (
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "nuN" = (
 /obj/machinery/power/apc{
 	name = "south bump";
@@ -41063,6 +41576,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/plating,
 /area/engineering/Engine1_Chamber)
 "nxf" = (
@@ -41518,7 +42032,8 @@
 	dir = 8
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/airless,
+/obj/structure/lattice,
+/turf/space,
 /area/space)
 "nDs" = (
 /obj/machinery/door/firedoor/border_only,
@@ -41631,10 +42146,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine2_Substation)
 "nGa" = (
@@ -41704,13 +42219,12 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/Genetics_Lab)
 "nGi" = (
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleep/Dormitory_04)
 "nGl" = (
@@ -41741,12 +42255,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Foyer)
@@ -42331,8 +42846,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
@@ -42490,11 +43006,15 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/greengrid,
 /area/bridge/AI_Core_Chamber)
 "nTu" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Star_3_Deck_Stairwell)
@@ -42880,6 +43400,12 @@
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "nZV" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/kafel_full,
 /area/crew_quarters/Central_Restroom)
 "oas" = (
@@ -43364,9 +43890,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine_Tech_Storage)
@@ -43915,12 +44440,6 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_ForCorridor1)
-"oqA" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/bridge/Control_Atrium)
 "oqC" = (
 /obj/machinery/suit_storage_unit/engineering,
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -44038,12 +44557,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/bridge/HoP_Office)
@@ -44302,17 +44820,11 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 1
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Observation_Lounge)
@@ -44335,9 +44847,6 @@
 /obj/structure/window/basic,
 /obj/structure/window/basic{
 	dir = 8
-	},
-/obj/structure/window/basic{
-	dir = 1
 	},
 /obj/structure/window/basic{
 	dir = 4
@@ -44407,13 +44916,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/crew_quarters/sleep/Dormitory_09)
 "oxN" = (
@@ -44434,8 +44942,8 @@
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/Captain_Office)
 "oyH" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Foyer)
@@ -44661,6 +45169,12 @@
 	id = "sc-DBresleevingstall2";
 	specialfunctions = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/kafel_full,
 /area/medical/Restrooms)
 "oDj" = (
@@ -44690,13 +45204,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/wood/alt/panel,
 /area/bridge/sleep/CE_Quarters)
 "oDC" = (
@@ -44781,12 +45294,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/bridge/sleep/RD_Quarters)
@@ -44819,12 +45331,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_09)
@@ -44900,7 +45411,9 @@
 "oIp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Foyer)
 "oIx" = (
@@ -44942,7 +45455,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_Breakroom)
 "oIU" = (
@@ -45271,13 +45786,11 @@
 /turf/simulated/open,
 /area/space)
 "oNf" = (
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2,
-/obj/effect/floor_decal/corner/black/bordercorner2,
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Observation_Lounge)
@@ -45684,7 +46197,7 @@
 "oVm" = (
 /obj/machinery/floodlight,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForPort_Corridor1)
 "oVr" = (
 /obj/structure/table/wooden_reinforced,
@@ -45718,6 +46231,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/plating,
 /area/bridge/AI_Upload_Hall)
 "oVS" = (
@@ -45792,9 +46309,7 @@
 "oWy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_3_Deck_Central_Corridor_1)
 "oWN" = (
@@ -46580,9 +47095,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
 "pmm" = (
@@ -47058,6 +47571,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/kafel_full,
 /area/medical/Restrooms)
 "pvp" = (
@@ -47308,8 +47827,8 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
@@ -47436,6 +47955,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "pAl" = (
@@ -47451,12 +47973,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_10)
@@ -47505,8 +48026,8 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_3_Deck_Stairwell)
@@ -48219,10 +48740,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/Embassy)
 "pNB" = (
@@ -48282,7 +48803,8 @@
 	pixel_y = 7
 	},
 /obj/machinery/status_display{
-	pixel_y = -32
+	pixel_y = -32;
+	layer = 4
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Stage)
@@ -48434,7 +48956,7 @@
 	},
 /obj/random/mainttoyloot,
 /obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/maintenance/Deck3_Bridge_ForPort_Corridor1)
 "pRI" = (
 /obj/structure/window/basic{
@@ -48445,13 +48967,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/wood/alt,
 /area/bridge/sleep/Secretary_Quarters)
 "pRL" = (
@@ -48599,9 +49120,9 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine_Tech_Storage)
@@ -48892,8 +49413,9 @@
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
 "pZl" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/glass,
 /area/medical/Lounge)
@@ -48997,11 +49519,12 @@
 /turf/simulated/floor/reinforced/nitrogen,
 /area/engineering/Atmospherics_Chamber)
 "qbw" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Aft_3_Deck_Stairwell)
@@ -49073,13 +49596,12 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/sleep/Dormitory_08)
 "qdr" = (
@@ -49430,9 +49952,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/bridge/Deck3_Corridor)
 "qiA" = (
@@ -49589,8 +50109,8 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_ForPort_Corridor1)
 "qkL" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
@@ -50402,8 +50922,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_3_Deck_Central_Corridor_1)
@@ -50464,8 +50984,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/bridge/Captain_Office)
 "qzK" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/glass,
 /area/bridge/Control_Atrium)
@@ -50605,6 +51128,10 @@
 /area/engineering/Solar_Control_AftPort)
 "qCl" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled/kafel_full/blue,
 /area/medical/Restrooms)
 "qCG" = (
@@ -50631,12 +51158,11 @@
 /area/space)
 "qCO" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/wood/alt,
 /area/bridge/sleep/Secretary_Quarters)
@@ -50721,8 +51247,11 @@
 /area/bridge/AI_Core_Chamber)
 "qEL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_3_Deck_Central_Corridor_1)
@@ -50781,6 +51310,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/greengrid,
 /area/bridge/AI_Core_Chamber)
 "qGB" = (
@@ -50795,9 +51328,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine1_Access_Hall)
@@ -51038,7 +51573,12 @@
 /turf/simulated/floor/tiled,
 /area/bridge/Leisure_Room)
 "qJy" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/glass,
 /area/bridge/Control_Atrium)
 "qJZ" = (
@@ -51064,12 +51604,11 @@
 /turf/simulated/floor/carpet/blucarpet,
 /area/medical/Autoresleeving)
 "qKB" = (
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleep/Dormitory_07)
@@ -51218,8 +51757,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/medical/Deck3_Corridor)
@@ -51550,7 +52090,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_3)
 "qTm" = (
@@ -51636,8 +52181,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
@@ -51655,11 +52200,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_1)
@@ -52215,18 +52760,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 5
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 6
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 5
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 6
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/Psych_Room_1)
 "reP" = (
@@ -52477,14 +53017,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
 /turf/simulated/floor/wood/sif,
 /area/bridge/Breakroom)
@@ -52545,8 +53082,11 @@
 	name = "HoS Quarters";
 	sortType = "HoS Quarters"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Deck3_Corridor)
@@ -52774,8 +53314,8 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/Genetics_Lab)
 "rod" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Star_3_Deck_Stairwell)
@@ -53089,7 +53629,6 @@
 /area/crew_quarters/Public_Garden)
 "rsu" = (
 /obj/machinery/vending/snack,
-/obj/structure/sign/poster/nanotrasen,
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Stage)
 "rsx" = (
@@ -53333,12 +53872,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_08)
@@ -53943,7 +54481,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_StarChamber1)
 "rJz" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/glass,
 /area/hallway/Star_3_Deck_Stairwell)
 "rJS" = (
@@ -54104,9 +54644,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Port)
 "rMA" = (
@@ -54153,6 +54691,7 @@
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "rNB" = (
@@ -54311,6 +54850,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Virology)
@@ -54638,9 +55183,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/tiled,
 /area/bridge/Deck3_Corridor)
 "rXX" = (
@@ -55068,17 +55614,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 1
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Observation_Atrium)
@@ -55191,9 +55731,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898";
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/medical/Surgery_Storage)
@@ -55613,8 +56155,11 @@
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_1)
 "son" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_3)
@@ -55865,9 +56410,7 @@
 "ssl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
 "ssq" = (
@@ -55943,12 +56486,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/borderfloor,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/sleep/Captain_Quarters)
@@ -56580,17 +57123,11 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 10
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Genetics_Lab)
@@ -56762,12 +57299,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/bridge/sleep/HoS_Quarters)
@@ -57354,6 +57890,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/old_cargo,
 /area/medical/Deck3_Corridor)
 "sSl" = (
@@ -57506,13 +58048,12 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/sleep/Dormitory_02)
 "sUF" = (
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/sleep/Dormitory_05)
 "sUG" = (
@@ -57737,18 +58278,16 @@
 "sZF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2,
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 9
-	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Aft_Medical_Post)
 "sZT" = (
@@ -57874,13 +58413,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/medical/Restrooms)
 "tbl" = (
@@ -58102,13 +58635,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_04)
 "tfe" = (
@@ -58456,14 +58988,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2,
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
 "tiw" = (
@@ -58567,12 +59097,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/bridge/sleep/Secretary_Quarters)
@@ -58635,12 +59164,11 @@
 /area/bridge/Captain_Office)
 "tll" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/wood/sif,
 /area/bridge/sleep/HoS_Quarters)
@@ -58726,8 +59254,8 @@
 /turf/simulated/floor/plating,
 /area/engineering/Engine3_Control_Room)
 "tmF" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Stairwell_Star)
@@ -58961,10 +59489,10 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Central_3_Deck_Hall)
 "trH" = (
-/obj/effect/catwalk_plated/white,
 /obj/structure/cable/white{
 	icon_state = "1-8"
 	},
+/obj/effect/catwalk_plated/white,
 /turf/simulated/floor/plating/turfpack/airless,
 /area/space)
 "trJ" = (
@@ -58990,8 +59518,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Engine2_Access_Hall)
@@ -59027,10 +59558,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_ForPort_Chamber1)
 "ttJ" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
 /obj/structure/noticeboard{
 	pixel_x = -27;
 	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/glass,
 /area/bridge/Control_Atrium)
@@ -59210,19 +59746,6 @@
 "tzt" = (
 /turf/simulated/floor/wood/sif,
 /area/bridge/Breakroom)
-"tzH" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/techmaint,
-/turf/simulated/open,
-/area/maintenance/Deck3_Bridge_ForPort_Corridor1)
 "tzJ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -59540,17 +60063,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/medical/Virology)
@@ -59930,7 +60447,8 @@
 	name = "N-window tint control";
 	pixel_x = -11;
 	pixel_y = 26;
-	id = "sc-WTcaptainbridge"
+	id = "sc-WTcaptainbridge";
+	range = 15
 	},
 /obj/structure/cable/white,
 /obj/structure/cable/green{
@@ -60632,6 +61150,9 @@
 /obj/effect/map_helper/airlock/atmos/chamber_pump,
 /obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Airlock_Access)
 "tYn" = (
@@ -60965,12 +61486,11 @@
 /area/engineering/Engine2_Chamber)
 "ueC" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/HoP_Office)
@@ -61277,9 +61797,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Foyer)
 "uju" = (
@@ -62261,13 +62779,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/wood/alt/tile,
 /area/bridge/sleep/CMO_Quarters)
 "uzx" = (
@@ -62597,8 +63114,8 @@
 /turf/simulated/open,
 /area/maintenance/Deck3_Dorms_StarChamber1)
 "uET" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_2)
@@ -63573,8 +64090,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
@@ -64047,7 +64564,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_2)
 "vck" = (
@@ -64129,8 +64651,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Port_3_Deck_Stairwell)
@@ -64320,7 +64842,9 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/For_3_Deck_Stairwell)
 "vgZ" = (
@@ -64375,11 +64899,12 @@
 /turf/simulated/floor/carpet/brown,
 /area/bridge/Deck3_Corridor)
 "vht" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	dir = 4;
+	name = "E-fire alarm";
+	pixel_x = 25
+	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/bridge/sleep/Captain_Quarters)
 "vhy" = (
@@ -65031,7 +65556,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Chamber)
 "vsE" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Foyer)
 "vsI" = (
@@ -65087,8 +65614,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
@@ -65229,7 +65759,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_4)
 "vxm" = (
@@ -65402,9 +65937,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
-	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled,
 /area/hallway/Star_Breakroom)
 "vAp" = (
@@ -65552,6 +66085,12 @@
 /turf/simulated/wall,
 /area/medical/Patient_3)
 "vBO" = (
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/Central_Restroom)
 "vBV" = (
@@ -65660,8 +66199,11 @@
 /area/engineering/Atmospherics_Chamber)
 "vDy" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/bridge/Deck3_Corridor)
@@ -65741,12 +66283,11 @@
 /area/hallway/Port_Breakroom)
 "vEE" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/wood/sif,
 /area/bridge/sleep/RD_Quarters)
@@ -66551,8 +67092,8 @@
 /turf/simulated/floor/plating,
 /area/engineering/Engine1_Chamber)
 "vQT" = (
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
@@ -67135,9 +67676,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 8;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine1_Access_Hall)
@@ -67448,8 +67988,9 @@
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/industrial/hatch/blue,
-/obj/machinery/firealarm{
-	pixel_y = 25
+/obj/machinery/ai_status_display{
+	name = "1N-AI display";
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/medical/Aft_Medical_Post)
@@ -67691,6 +68232,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "wjD" = (
@@ -67880,27 +68427,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/wood/alt/parquet,
 /area/bridge/HoP_Office)
 "wol" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloorwhite,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 9
-	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals6,
 /turf/simulated/floor/tiled/white,
 /area/medical/Autoresleeving)
 "woC" = (
@@ -68316,16 +68856,10 @@
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -68648,6 +69182,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 10
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4,
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Chamber)
 "wBR" = (
@@ -68816,7 +69354,12 @@
 "wFl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/Engine2_Access_Hall)
 "wFm" = (
@@ -68889,13 +69432,12 @@
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/sleep/Dormitory_08)
 "wGS" = (
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/wood/alt/panel,
 /area/crew_quarters/sleep/Dormitory_02)
 "wGW" = (
@@ -68915,12 +69457,11 @@
 /turf/simulated/open,
 /area/crew_quarters/Dorm_Foyer)
 "wHN" = (
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleep/Dormitory_10)
@@ -69004,17 +69545,14 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorwhite/corner2{
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
-/obj/effect/floor_decal/borderfloorwhite/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/white/bordercorner2{
-	dir = 4
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/wood/alt,
 /area/medical/Patient_4)
@@ -69695,7 +70233,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_Breakroom)
 "wSr" = (
@@ -69986,13 +70526,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/wood/sif,
 /area/crew_quarters/sleep/Dormitory_10)
 "wWb" = (
@@ -70513,13 +71052,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/tiled/kafel_full/white,
 /area/crew_quarters/sleep/Dormitory_05)
 "xes" = (
@@ -71104,6 +71642,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/Embassy)
 "xmR" = (
@@ -71132,9 +71676,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 4;
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine1_Access_Hall)
@@ -71173,11 +71717,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_4)
@@ -71280,17 +71827,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloorblack/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
-	},
-/obj/effect/floor_decal/borderfloorblack/corner2{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/black/bordercorner2{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Observation_Lounge)
@@ -71331,7 +71872,12 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_2_Corridor)
 "xpO" = (
@@ -71413,15 +71959,6 @@
 "xrr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 5
-	},
-/obj/effect/floor_decal/borderfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/green/bordercorner2{
-	dir = 8
 	},
 /turf/simulated/floor/wood/alt/panel,
 /area/bridge/Leisure_Room)
@@ -71690,13 +72227,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/wood/sif,
 /area/bridge/sleep/RD_Quarters)
 "xwQ" = (
@@ -71943,8 +72479,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	color = "#989898"
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine1_Substation)
@@ -72176,13 +72715,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
+/obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 4
 	},
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2,
 /turf/simulated/floor/wood/sif,
 /area/bridge/sleep/HoS_Quarters)
 "xFd" = (
@@ -73127,10 +73665,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/steeldecal/steel_decals_central5{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/Dorm_Corridor_1)
 "xSi" = (
@@ -73452,7 +73993,10 @@
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
 	},
-/obj/effect/floor_decal/corner/blue/border{
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
@@ -73504,12 +74048,11 @@
 /area/bridge/Firstaid_Post)
 "xXF" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/borderfloor/corner2,
-/obj/effect/floor_decal/borderfloor/corner2{
-	dir = 9
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
 	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
 	},
 /turf/simulated/floor/wood/alt/tile,
 /area/bridge/sleep/CMO_Quarters)
@@ -73813,6 +74356,12 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 5
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 8
+	},
 /turf/simulated/floor/wood/alt/parquet,
 /area/medical/Autoresleeving)
 "ydW" = (
@@ -74019,6 +74568,12 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 1
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 6
+	},
 /turf/simulated/floor/redgrid/animated,
 /area/bridge/AI_Core_Chamber)
 "yid" = (
@@ -74046,7 +74601,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/lightorange/border,
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 6
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals10{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Engine_Tech_Storage)
 "yiq" = (
@@ -77015,6 +77575,9 @@ apc
 apc
 apc
 apc
+aqj
+cDl
+aqj
 apc
 apc
 apc
@@ -77022,12 +77585,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
-apc
-apc
-apc
+aqj
+cDl
+aqj
 apc
 apc
 apc
@@ -77273,19 +77833,19 @@ apc
 apc
 apc
 apc
-aqj
 cDl
-aqj
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-aqj
+xFs
 cDl
-aqj
+apc
+apc
+apc
+apc
+apc
+apc
+apc
+cDl
+xFs
+cDl
 apc
 apc
 apc
@@ -77532,7 +78092,7 @@ phb
 phb
 phb
 phb
-xFs
+aeS
 phb
 phb
 phb
@@ -77542,7 +78102,7 @@ phb
 phb
 phb
 phb
-xFs
+aeS
 phb
 phb
 phb
@@ -77790,7 +78350,7 @@ jub
 jub
 jub
 jub
-iGD
+aeT
 jub
 jub
 jub
@@ -77800,7 +78360,7 @@ jub
 jub
 jub
 jub
-iGD
+aeT
 jub
 jub
 jub
@@ -79587,8 +80147,8 @@ apc
 apc
 apc
 apc
-apc
-apc
+aqj
+cDl
 phb
 qpl
 hjD
@@ -79845,13 +80405,13 @@ apc
 apc
 apc
 apc
-apc
-apc
-phb
-lwY
-hjD
-ava
-dXG
+cDl
+afC
+afB
+afw
+afv
+tYn
+afu
 ava
 ava
 ava
@@ -80103,8 +80663,8 @@ apc
 apc
 apc
 apc
-apc
-apc
+aqj
+cDl
 phb
 qpl
 hjD
@@ -80405,9 +80965,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+aqj
+cDl
+aqj
 apc
 apc
 apc
@@ -80663,9 +81223,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+cDl
+xFs
+cDl
 apc
 apc
 apc
@@ -80921,9 +81481,9 @@ jub
 jub
 jub
 jub
-apc
-apc
-apc
+aqj
+aeS
+aqj
 apc
 apc
 apc
@@ -81180,7 +81740,7 @@ kaL
 kaL
 prP
 qTC
-jub
+aeT
 jub
 jub
 apc
@@ -81438,7 +81998,7 @@ dHa
 dHa
 gXS
 kaL
-kaL
+sLi
 kaL
 prP
 bde
@@ -81696,7 +82256,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 gXS
 kaL
@@ -81710,9 +82270,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+aqj
+cDl
+aqj
 apc
 apc
 apc
@@ -81954,7 +82514,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -81968,9 +82528,9 @@ jub
 jub
 jub
 jub
-jub
-apc
-apc
+dZQ
+xFs
+cDl
 apc
 apc
 apc
@@ -82212,7 +82772,7 @@ dHa
 dHa
 dHa
 dHa
-xFs
+mJP
 dHa
 dHa
 dHa
@@ -82226,9 +82786,9 @@ aal
 aal
 aal
 aal
-xFs
-hXb
-apc
+agy
+aeO
+aqj
 apc
 apc
 apc
@@ -83479,11 +84039,11 @@ xgf
 rZF
 feT
 pmU
-liR
-liR
-liR
+afp
+afo
+afl
 hZZ
-aGi
+afj
 ubn
 pGG
 jcJ
@@ -83739,9 +84299,9 @@ nwU
 pLh
 fkV
 liR
-liR
+afn
 pQa
-aGi
+afk
 aGi
 pGG
 jcJ
@@ -83991,8 +84551,8 @@ jtr
 jtr
 hMz
 njv
-xgf
-rZF
+aft
+afs
 xJY
 mCr
 umx
@@ -85548,7 +86108,7 @@ sER
 pRZ
 mCr
 tfQ
-aGi
+aeW
 kjb
 vpF
 xDE
@@ -85557,8 +86117,8 @@ jcJ
 jcJ
 rhn
 yjL
-aGi
-aGi
+aeW
+aeU
 jcJ
 tXO
 jqU
@@ -86073,7 +86633,7 @@ gpF
 gpF
 sma
 msu
-ieb
+aeX
 ieb
 ehC
 iPV
@@ -100230,7 +100790,7 @@ qoi
 bgB
 htn
 rbp
-hcQ
+afy
 oVr
 abm
 dHa
@@ -100675,9 +101235,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+aqj
+cDl
+aqj
 phb
 apc
 apc
@@ -100933,18 +101493,18 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
-phb
-aqj
-aqj
-phb
-aqj
-aqj
-aqj
-aqj
-aRl
+cDl
+rTA
+afP
+afP
+afP
+afP
+afP
+afP
+afP
+afP
+afP
+afK
 oRH
 dHa
 dHa
@@ -101191,9 +101751,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+aqj
+cDl
+aqj
 phb
 apc
 phb
@@ -101202,7 +101762,7 @@ apc
 aqj
 apc
 qpl
-xes
+afL
 sLV
 dHa
 dHa
@@ -101226,7 +101786,7 @@ rbR
 bVh
 taO
 mGn
-tzH
+jbB
 aKm
 tWY
 xxJ
@@ -101243,7 +101803,7 @@ dPn
 wUP
 vkQ
 xrr
-bHh
+xqC
 lNB
 uxT
 xTY
@@ -101457,10 +102017,10 @@ apc
 phb
 apc
 apc
-dZQ
+saz
 jub
 poc
-oRH
+afM
 dHa
 dHa
 dHa
@@ -101714,11 +102274,11 @@ apc
 phb
 phb
 apc
-cVS
-rTA
+lwY
 lzD
 lzD
-nuL
+lzD
+mJP
 dHa
 dHa
 dHa
@@ -101742,7 +102302,7 @@ nlt
 pbN
 taO
 hUW
-tzH
+jbB
 aKm
 wSI
 xwX
@@ -101975,7 +102535,7 @@ aqj
 kqq
 hjD
 hjD
-bUf
+hjD
 mJP
 oaL
 hag
@@ -102000,7 +102560,7 @@ nlt
 fNI
 taO
 oVm
-tzH
+jbB
 aKm
 qHj
 mVT
@@ -102393,7 +102953,7 @@ xxk
 meA
 cEu
 fZG
-kbw
+aeK
 kbw
 uxE
 cmw
@@ -102758,7 +103318,7 @@ lBH
 lBH
 lBH
 fjH
-lBH
+afG
 gCJ
 pLe
 ggu
@@ -102802,7 +103362,7 @@ oSL
 iso
 fZY
 stg
-iSF
+afD
 eup
 eup
 iSF
@@ -103270,7 +103830,7 @@ bqN
 iUS
 xGf
 xGf
-euR
+afJ
 xGf
 xEA
 euR
@@ -103343,7 +103903,7 @@ aMh
 aMh
 vnT
 cEG
-ppD
+afr
 ppD
 ppD
 jVq
@@ -103418,10 +103978,10 @@ aaP
 muA
 bzQ
 bzQ
-owK
-owK
-owK
-owK
+aeN
+aeM
+aeM
+aeM
 owK
 mEG
 mEG
@@ -103610,7 +104170,7 @@ uDe
 fmC
 glv
 pOL
-fMV
+afh
 xPE
 xPE
 xPE
@@ -103834,7 +104394,7 @@ fLj
 fLj
 ttJ
 kMO
-oqA
+afD
 eup
 eup
 iSF
@@ -103868,7 +104428,7 @@ uDe
 bTy
 glv
 vUt
-fMV
+afh
 xPE
 xPE
 xPE
@@ -104350,7 +104910,7 @@ fLj
 fLj
 qJy
 kMO
-oqA
+afD
 eup
 eup
 iSF
@@ -104384,7 +104944,7 @@ uDe
 bTy
 glv
 bnp
-fMV
+afh
 xPE
 xPE
 xPE
@@ -104608,7 +105168,7 @@ tat
 tat
 qIj
 ofh
-cvU
+qsN
 eup
 eup
 iSF
@@ -104642,7 +105202,7 @@ uDe
 fmC
 glv
 fyW
-fMV
+afh
 xPE
 xPE
 xPE
@@ -104922,7 +105482,7 @@ fIA
 loO
 abY
 abb
-jHx
+aeR
 jHx
 jHx
 jHx
@@ -105157,7 +105717,7 @@ uOJ
 uDe
 bTy
 glv
-adJ
+afi
 hJj
 aeE
 aeB
@@ -105338,7 +105898,7 @@ rXN
 uLN
 pQl
 blt
-lBH
+afH
 kYN
 pLe
 vSs
@@ -105490,7 +106050,7 @@ fbg
 qCS
 xcG
 ngL
-iYR
+aeJ
 jHs
 aay
 smc
@@ -105673,7 +106233,7 @@ xiI
 wUV
 xAP
 iaG
-kpt
+adJ
 hJj
 aeF
 aeD
@@ -105854,7 +106414,7 @@ cNm
 cNm
 esF
 tTr
-qGo
+afI
 gGw
 tTr
 sAM
@@ -106005,7 +106565,7 @@ tKY
 nZp
 pVJ
 kAk
-kxy
+aeL
 jaC
 uxE
 uly
@@ -106358,11 +106918,11 @@ apc
 phb
 phb
 apc
-cVS
-rTA
+qpl
 lzD
 lzD
-jAg
+lzD
+mJP
 dHa
 dHa
 dHa
@@ -106617,10 +107177,10 @@ apc
 phb
 apc
 apc
-mMn
+afQ
 nhz
 oRO
-oRH
+afM
 dHa
 dHa
 dHa
@@ -106867,9 +107427,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+aqj
+cDl
+aqj
 phb
 apc
 phb
@@ -106878,7 +107438,7 @@ apc
 aqj
 apc
 qpl
-xGh
+afN
 vyl
 dHa
 dHa
@@ -107125,18 +107685,18 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
-phb
-aqj
-aqj
-phb
-aqj
-aqj
-aqj
-aqj
-rGJ
+cDl
+rTA
+afP
+afP
+afP
+afP
+afP
+afP
+afP
+afP
+afP
+afO
 oRH
 dHa
 dHa
@@ -107383,9 +107943,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+aqj
+cDl
+aqj
 phb
 apc
 apc
@@ -107955,7 +108515,7 @@ pQT
 eqE
 jdl
 xdc
-tWX
+afE
 vJd
 ljr
 thN
@@ -108486,7 +109046,7 @@ yfG
 lke
 xdo
 gMR
-pMP
+afA
 vDz
 ipv
 hjD
@@ -109759,7 +110319,7 @@ qMu
 dzj
 txw
 aXn
-cSS
+afF
 tfo
 bRu
 bRu
@@ -112199,7 +112759,7 @@ dXS
 lrU
 lrU
 lrU
-usd
+aeI
 cWO
 nhz
 nhz
@@ -112715,7 +113275,7 @@ ttG
 dHa
 dHa
 dHa
-dHa
+apc
 apc
 apc
 apc
@@ -112973,7 +113533,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+apc
 apc
 apc
 apc
@@ -113231,7 +113791,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+apc
 apc
 apc
 apc
@@ -117549,7 +118109,7 @@ iti
 wsw
 iti
 spN
-ePA
+aeY
 ePA
 wgt
 vAk
@@ -118065,7 +118625,7 @@ snz
 rVy
 gKO
 gKO
-mFJ
+aeZ
 mFJ
 pAE
 ghO
@@ -118344,7 +118904,7 @@ bTW
 hbE
 uMh
 nRE
-nbG
+aeP
 nbG
 jgF
 iDD
@@ -118860,7 +119420,7 @@ jge
 vJZ
 fls
 qxc
-pZl
+aeQ
 pZl
 qVo
 oBv
@@ -120127,9 +120687,9 @@ dXW
 dye
 ggZ
 wxt
-tmF
+afg
 bcg
-rJz
+afa
 fjQ
 pAE
 pAE
@@ -120646,7 +121206,7 @@ vhe
 vhe
 hJM
 sre
-nTu
+aeV
 uyA
 mpQ
 mBR
@@ -121677,7 +122237,7 @@ qko
 cwi
 oTJ
 cvI
-rod
+afb
 rod
 onu
 rfX
@@ -122193,7 +122753,7 @@ wfu
 ufc
 ery
 sIm
-kfZ
+afe
 kfZ
 onu
 oga
@@ -124253,7 +124813,7 @@ plL
 jXc
 uzM
 dBF
-nrB
+rRU
 wZL
 fSg
 jXc

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-7.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-7.dmm
@@ -76,6 +76,26 @@
 	icon_state = "steel"
 	},
 /area/centcom/terminal)
+"aan" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/external{
+	icon_state = "door_locked";
+	locked = 1;
+	name = "Shuttle Hatch";
+	req_access = list(13)
+	},
+/turf/simulated/shuttle/floor,
+/area/shuttle/escape/centcom)
+"aao" = (
+/obj/machinery/door/airlock/external{
+	icon_state = "door_locked";
+	locked = 1;
+	name = "Shuttle Hatch";
+	req_access = list(13)
+	},
+/obj/structure/fans/tiny,
+/turf/simulated/shuttle/floor,
+/area/shuttle/escape/centcom)
 "aar" = (
 /obj/effect/floor_decal/carpet,
 /turf/unsimulated/floor{
@@ -35416,15 +35436,15 @@ qNq
 vFi
 dmo
 uTl
-aFI
-aFI
+aao
+aan
 uTl
 boQ
 boQ
 boQ
 uTl
-aFI
-aFI
+aan
+aan
 uTl
 dmo
 dmo

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus_elevator.dm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus_elevator.dm
@@ -37,6 +37,7 @@
 
 /obj/turbolift_map_holder/soluna_nexus/center
 	name = "Southern Cross turbolift map placeholder - Center"
+	wall_type = null
 
 	areas_to_use = list(
 		/area/turbolift/center_deck_one,
@@ -47,6 +48,7 @@
 /obj/turbolift_map_holder/soluna_nexus/aft
 	name = "Southern Cross turbolift map placeholder - Aft"
 	dir = NORTH
+	wall_type = null
 
 	areas_to_use = list(
 		/area/turbolift/aft_deck_one,


### PR DESCRIPTION
-Fixed transfer shuttle not leaving at round end.
-Fixed missing chutes.
-Fixed missing wires.
-Overhauled all door decals on 1st & 3nd deck.
-Added a stairwell on the central deck. Access between 1st & 2nd deck. 
-Added missing wallcoms.
-Added missing lights.
-Added more security cameras.
-Cut resources in all departments.
-Fixed button names on Xenobiology
-Fixed various door access.
-Added more items/trashpiles/loot/secrets in maints. 
-Made central and southern/aft elevators larger and viewable past glass. 
-Fixed point defense turrets. Now in better and clear spots to shoot meteors down. 
-Dock 5, changed canister storage to a ``PilotPot`` civilian pilot room. (Engineering access, suggest we make pilot role a engineering role. Being able to maintain and fix the ships they run.)
