### PR TITLE
Balances teshari.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/teshari.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari.dm
@@ -53,9 +53,11 @@
 	slowdown = -1
 	snow_movement = -2	// Ignores light snow
 	item_slowdown_mod = 2	// Tiny birds don't like heavy things
-	total_health = 75 //Chompedit
-	brute_mod = 1 //Chompedit
-	burn_mod =  1 //Chompedit
+	//Chompedit begins
+	total_health = 75 
+	brute_mod = 1 
+	burn_mod =  1 
+	//Chompedit end
 	mob_size = MOB_SMALL
 	pass_flags = PASSTABLE
 	holder_type = /obj/item/holder/micro //CHOMPEdit from holder/human to holder/micro

--- a/code/modules/mob/living/carbon/human/species/station/teshari.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari.dm
@@ -53,11 +53,11 @@
 	slowdown = -1
 	snow_movement = -2	// Ignores light snow
 	item_slowdown_mod = 2	// Tiny birds don't like heavy things
-	//Chompedit begins
+	//CHOMPEdit Start
 	total_health = 75 
 	brute_mod = 1 
 	burn_mod =  1 
-	//Chompedit end
+	//CHOMPEdit End
 	mob_size = MOB_SMALL
 	pass_flags = PASSTABLE
 	holder_type = /obj/item/holder/micro //CHOMPEdit from holder/human to holder/micro

--- a/code/modules/mob/living/carbon/human/species/station/teshari.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari.dm
@@ -53,9 +53,9 @@
 	slowdown = -1
 	snow_movement = -2	// Ignores light snow
 	item_slowdown_mod = 2	// Tiny birds don't like heavy things
-	total_health = 50
-	brute_mod = 1.35
-	burn_mod =  1.35
+	total_health = 75
+	brute_mod = 1
+	burn_mod =  1
 	mob_size = MOB_SMALL
 	pass_flags = PASSTABLE
 	holder_type = /obj/item/holder/micro //CHOMPEdit from holder/human to holder/micro

--- a/code/modules/mob/living/carbon/human/species/station/teshari.dm
+++ b/code/modules/mob/living/carbon/human/species/station/teshari.dm
@@ -53,9 +53,9 @@
 	slowdown = -1
 	snow_movement = -2	// Ignores light snow
 	item_slowdown_mod = 2	// Tiny birds don't like heavy things
-	total_health = 75
-	brute_mod = 1
-	burn_mod =  1
+	total_health = 75 //Chompedit
+	brute_mod = 1 //Chompedit
+	burn_mod =  1 //Chompedit
 	mob_size = MOB_SMALL
 	pass_flags = PASSTABLE
 	holder_type = /obj/item/holder/micro //CHOMPEdit from holder/human to holder/micro


### PR DESCRIPTION
Teshari, as they stand, have 50hp and a 35% increase in damage. Totaling all their traits in a custom species gives you 11 points to spare. Their only boon is SLIGHTLY faster haste. Which is negated by a single hit from most mobs. 

Example being, the common brown spider. Upper limit of 30 damage, which is 40.5 on a teshari. of their 50 hp.

There is no reason whatsoever to play a base race teshari over a custom species which can have all the boons and more, with far far less to no downsides. 

We're a MRP server, true. But this is overtuned weakness that is beyond reasonable.

This change removes their weakness and sets their hp to 75. Setting their trait deficit to 2, rather than 11. They're still weak, have low blood, and DOUBLE slowdown. But now they're not as obscenely bad compared to anything else. 

There needs to be a single reason to pick a base race over a custom species, as it stands with teshari, this pr doesn't fix that, as I am not adding anything new to them you can't easily double with a custom species, but it at least makes them less of a crippling deficit to play.

There was a pretty long discussion about this in the development chat already, but feel free to discuss further.

A valid reason they should be as nerfed and tuned into dirt as they are beyond "Fast bird weak".
## About The Pull Request
## Changelog
:cl:
balance: tesh health and damage
/:cl:
