### PR TITLE
Fix teshari rad hood sprite, and map in tesh rad suits

### DIFF
--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -114,7 +114,7 @@
 /obj/item/clothing/head/radiation/teshari
 	name = "Small radiation hood"
 	desc = "A specialist hood with radiation protective properties, designed specifically for use by Teshari. Made to order by Aether."
-	icon = 'icons/inventory/head/item_teshari.dmi' //CHOMPEdit - Actually use the proper icon path... (I'll up-port it in a bit)
+	icon = 'icons/inventory/head/item_teshari.dmi'
 	icon_override = 'icons/inventory/head/mob_teshari.dmi'
 	icon_state = "rad_fitted"
 	species_restricted = list(SPECIES_TESHARI)

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -114,7 +114,7 @@
 /obj/item/clothing/head/radiation/teshari
 	name = "Small radiation hood"
 	desc = "A specialist hood with radiation protective properties, designed specifically for use by Teshari. Made to order by Aether."
-	icon = 'icons/inventory/suit/item_teshari.dmi'
+	icon = 'icons/inventory/head/item_teshari.dmi' //CHOMPEdit - Actually use the proper icon path... (I'll up-port it in a bit)
 	icon_override = 'icons/inventory/head/mob_teshari.dmi'
 	icon_state = "rad_fitted"
 	species_restricted = list(SPECIES_TESHARI)

--- a/modular_chomp/maps/southern_cross/southern_cross-1.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-1.dmm
@@ -10704,6 +10704,8 @@
 /obj/structure/sign/warning/radioactive{
 	pixel_y = 32
 	},
+/obj/item/clothing/head/radiation/teshari,
+/obj/item/clothing/suit/radiation/teshari,
 /turf/simulated/floor/tiled,
 /area/maintenance/substation/gravgen)
 "US" = (

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -14800,6 +14800,8 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/item/clothing/head/radiation/teshari,
+/obj/item/clothing/suit/radiation/teshari,
 /turf/simulated/floor/tiled,
 /area/engineering/engine_monitoring)
 "aVb" = (
@@ -52248,6 +52250,8 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
+/obj/item/clothing/suit/radiation/teshari,
+/obj/item/clothing/head/radiation/teshari,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "ilQ" = (


### PR DESCRIPTION

## About The Pull Request
Two things!
First, changes the icon path for teshari radiation hoods to use the correct path.
Second, adds one full teshari radiation suit+hood to each of Southern Cross's engine room, gravity generator room, and science research lab.
## Changelog
:cl:
add: Adds radiation suits for teshari to some lockers in Southern Cross
fix: Fixes sprite used for teshari radiation hood
/:cl:
