### PR TITLE
Lets demuxers push data

### DIFF
--- a/code/modules/integrated_electronics/subtypes/data_transfer.dm
+++ b/code/modules/integrated_electronics/subtypes/data_transfer.dm
@@ -78,7 +78,7 @@
 	var/output_index = get_pin_data(IC_INPUT, 1)
 	for(var/i = 1 to outputs.len)
 		set_pin_data(IC_OUTPUT, i, i == output_index ? get_pin_data(IC_INPUT, 2) : null)
-
+	push_data() // CHOMPedit Data never got pushed before rendering demuxers useless.
 	activate_pin(2)
 
 /obj/item/integrated_circuit/transfer/demultiplexer/medium


### PR DESCRIPTION

## About The Pull Request
Fixes demuxers not pushing data.
## Changelog
Demuxers were missing `push_data()` so other circuits never picked up their output. Demuxers are now useful! 🎉
:cl:
fix: demuxer outputs
/:cl:
