### PR TITLE
Removes spatial_anomaly.dmm from POI rotation

### DIFF
--- a/modular_chomp/maps/submaps/surface_submaps/mountains/mountains.dm
+++ b/modular_chomp/maps/submaps/surface_submaps/mountains/mountains.dm
@@ -34,7 +34,7 @@
 #include "ritual.dmm"
 #include "Rockb1.dmm"
 #include "Scave1.dmm"
-#include "spatial_anomaly.dmm"
+// #include "spatial_anomaly.dmm" //Incredibly bugged.
 #include "speakeasy_vr.dmm"
 #include "SupplyDrop1.dmm"
 #include "SwordCave.dmm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

The spatial_anomaly.dmm map is supposed to be this weird looping non-euclidean space sort of POI. You walk in and find out that the simple looking entrance unwitting leads to a small labyrinth of repeating rooms and passages.

What actually happens is it's a visually glitchy mess and players generally don't interact with it because it's frustrating walking into what looks like an empty path or solid wall and finding out it's the opposite.

Removing this from rotation until somebody fixes it.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
del: Disabled spatial_anomaly.dmm POI.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
