### PR TITLE
Soluna Nexus map fix 2.1

### DIFF
--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
@@ -651,6 +651,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/Aft_1_Deck_Stairwell)
+"abu" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 8
+	},
+/obj/effect/floor_decal/arrivals,
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
 "abv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -2091,26 +2098,23 @@
 /turf/simulated/floor/water/deep/indoors,
 /area/hallway/Star_1Deck_Atrium)
 "adZ" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/shuttle/blue{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8
 	},
-/obj/machinery/airlock_sensor{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "sc-D1_L1A1_airlock";
+	pixel_x = -24;
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 6
-	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1;
 	color = "#989898"
 	},
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/dark,
 /area/harbor/Dock1)
 "aea" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6{
@@ -2159,6 +2163,15 @@
 	},
 /obj/structure/window/basic{
 	dir = 4
+	},
+/obj/structure/sign/directions/bar{
+	pixel_y = 9;
+	layer = 3.5;
+	dir = 1
+	},
+/obj/structure/sign/directions/stairs_up{
+	dir = 1;
+	layer = 3.5
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_Star_Corridor)
@@ -2430,6 +2443,96 @@
 	},
 /turf/simulated/floor/glass,
 /area/hallway/Deck1_Transit_Hall)
+"aeP" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/floor_decal/shuttle/blue{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techmaint,
+/area/harbor/Dock5)
+"aeQ" = (
+/obj/effect/floor_decal/borderfloor{
+	dir = 4
+	},
+/obj/effect/floor_decal/arrivals/right,
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
+"aeR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/arrivals/right,
+/turf/simulated/floor/tiled,
+/area/harbor/Dock5)
+"aeS" = (
+/obj/effect/floor_decal/shuttle/blue{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techmaint,
+/area/hallway/Aft_1_Deck_Stairwell)
+"aeT" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock1)
+"aeU" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/harbor/Dock4)
+"aeV" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock1)
+"aeW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/harbor/Dock4)
+"aeX" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/shuttle/blue{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/machinery/airlock_sensor{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	color = "#989898"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/harbor/Dock1)
 "aeY" = (
 /obj/machinery/door/firedoor/glass/hidden/steel{
 	dir = 1
@@ -2467,6 +2570,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/Telecomms_Control_Room)
+"afb" = (
+/obj/machinery/hologram/holopad,
+/obj/effect/floor_decal/shuttle/blue{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/obj/machinery/airlock_sensor{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/map_helper/airlock/sensor/chamber_sensor,
+/obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	color = "#989898"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/harbor/Dock4)
 "afd" = (
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled,
@@ -2669,7 +2791,7 @@
 	desc = "A firewall prevents AIs from interacting with this device.";
 	name = "GravityGen lethal turret control";
 	pixel_y = 29;
-	req_access = list(10);
+	req_access = list(11, 19);
 	check_records = 0;
 	req_one_access = list(17,11,24)
 	},
@@ -6146,18 +6268,6 @@
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
-"aDh" = (
-/obj/effect/floor_decal/industrial/arrows/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/arrows/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/binary/pump{
-	name = "Waste to Scrubbers"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/hallway/Aft_1_Deck_Stairwell)
 "aDi" = (
 /turf/simulated/wall/r_wall,
 /area/harbor/Port_Docking_Foyer)
@@ -6433,6 +6543,7 @@
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 9
 	},
+/obj/effect/floor_decal/arrivals,
 /turf/simulated/floor/tiled,
 /area/harbor/Dock5)
 "aFj" = (
@@ -14633,6 +14744,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
+/obj/effect/floor_decal/arrivals/right,
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "cXm" = (
@@ -15737,6 +15849,7 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
+/obj/effect/floor_decal/arrivals,
 /turf/simulated/floor/tiled,
 /area/hallway/Aft_1_Deck_Stairwell)
 "doD" = (
@@ -17144,8 +17257,8 @@
 	},
 /obj/machinery/door/airlock/angled_bay/secure{
 	name = "Telecoms Control Room";
-	req_access = list(61);
-	req_one_access = list(61);
+	req_access = list(17);
+	req_one_access = list(17);
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -23944,7 +24057,7 @@
 	desc = "A firewall prevents AIs from interacting with this device.";
 	name = "Telecoms Control Room Turret Control";
 	pixel_y = 29;
-	req_access = list(10);
+	req_access = list(11, 19);
 	req_one_access = list(17,11,24)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -34991,6 +35104,10 @@
 "jSg" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = -4;
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Xenobiology_Lab)
 "jSv" = (
@@ -42199,7 +42316,6 @@
 /turf/simulated/floor/wood/alt/parquet/turfpack/station,
 /area/hallway/Cryostorage_Lounge)
 "mwm" = (
-/obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -42207,6 +42323,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Public_EVA)
 "mwp" = (
@@ -44422,26 +44539,23 @@
 /turf/simulated/floor/plating,
 /area/maintenance/ab_SportsField)
 "npa" = (
-/obj/machinery/hologram/holopad,
-/obj/effect/floor_decal/shuttle/blue{
-	pixel_x = -1;
-	pixel_y = 1
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
+	frequency = 1380;
+	id_tag = "sc-D1_L4A1_airlock";
+	pixel_x = 24;
+	dir = 8
 	},
-/obj/machinery/airlock_sensor{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/map_helper/airlock/sensor/chamber_sensor,
 /obj/effect/floor_decal/steeldecal/steel_decals_central2{
+	dir = 1;
 	color = "#989898"
 	},
 /obj/structure/cable/white{
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/dark,
 /area/harbor/Dock4)
 "npi" = (
 /obj/machinery/door/firedoor/multi_tile/glass{
@@ -48368,9 +48482,6 @@
 "oFa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock4)
@@ -56362,10 +56473,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/security/Exploration_Ship_Bay)
 "roQ" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	name = "Harbor automatic shutoff valve"
-	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/valve/open{
+	dir = 2
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Harbor)
 "rpf" = (
@@ -62000,25 +62111,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck1_AftPort_Chamber2)
-"twF" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 8
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
-	id_tag = "sc-D1_L1A1_airlock";
-	pixel_x = -24;
-	dir = 4
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1;
-	color = "#989898"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Dock1)
 "twM" = (
 /obj/structure/shuttle/engine/heater{
 	dir = 8
@@ -62827,6 +62919,7 @@
 	unlocked = 1;
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Central)
 "tLv" = (
@@ -63128,16 +63221,10 @@
 /obj/machinery/cell_charger{
 	pixel_y = 11
 	},
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/item/cell/device{
-	pixel_x = 8
-	},
+/obj/item/cell/device,
 /obj/item/cell/device{
 	pixel_y = -4;
-	pixel_x = 8
+	pixel_x = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Xenobiology_Lab)
@@ -65720,6 +65807,7 @@
 /obj/machinery/atmospherics/valve/digital/open{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Central)
 "uOA" = (
@@ -66778,6 +66866,10 @@
 "vic" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/reagent_dispensers/foam,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = -4;
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/rnd/Xenobiology_Lab)
 "vif" = (
@@ -69211,8 +69303,8 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Port_1Deck_Atrium)
 "vUD" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	name = "Central automatic shutoff valve";
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/valve/open{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -70496,6 +70588,9 @@
 /obj/structure/sign/directions/evac{
 	dir = 8;
 	pixel_y = -9
+	},
+/obj/structure/sign/directions/bar{
+	dir = 4
 	},
 /turf/simulated/wall,
 /area/crew_quarters/Public_Gateway)
@@ -74944,25 +75039,6 @@
 /obj/machinery/door/firedoor/glass/hidden,
 /turf/simulated/floor/tiled/dark,
 /area/harbor/Fueling_Storage)
-"yaq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden{
-	dir = 4
-	},
-/obj/machinery/embedded_controller/radio/airlock/docking_port{
-	frequency = 1380;
-	id_tag = "sc-D1_L4A1_airlock";
-	pixel_x = 24;
-	dir = 8
-	},
-/obj/effect/floor_decal/steeldecal/steel_decals_central2{
-	dir = 1;
-	color = "#989898"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/harbor/Dock4)
 "yaQ" = (
 /obj/structure/girder/reinforced,
 /obj/structure/cable/green{
@@ -75135,9 +75211,6 @@
 "ydF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/harbor/Dock1)
@@ -88372,9 +88445,9 @@ qIQ
 aaf
 aaa
 aBe
-aVI
-kgv
 cNg
+kgv
+aeT
 aBe
 aaa
 aaa
@@ -88882,10 +88955,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 cfp
 khE
 gOu
+cfp
 cfp
 xVx
 eZA
@@ -89138,14 +89211,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
 yek
 aaa
 com
+aeX
 adZ
-twF
 qOm
 weV
+aeV
 eDh
 aYG
 fWo
@@ -89398,12 +89471,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 nBE
 rkI
 hPL
 ezu
 ybD
+azD
 aAX
 aAX
 wZu
@@ -89656,12 +89729,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 cfp
 rbq
 gOu
 cfp
 kwu
+azD
 aAX
 aAX
 bRL
@@ -105179,7 +105252,7 @@ mWi
 abI
 ebd
 mdY
-mdY
+abu
 mdY
 mlW
 sEk
@@ -105403,7 +105476,7 @@ whv
 ese
 cnx
 sSr
-doz
+aeS
 bwK
 bKR
 bKR
@@ -105437,7 +105510,7 @@ sPh
 wpV
 pyv
 pyv
-pyv
+aeP
 pyv
 pyv
 kAW
@@ -105676,7 +105749,7 @@ bKR
 bKR
 pWo
 aJA
-aFh
+aeR
 aaY
 pkh
 aaY
@@ -105695,7 +105768,7 @@ abK
 abJ
 gvO
 fHt
-fHt
+aeQ
 fHt
 aXg
 abG
@@ -106949,7 +107022,7 @@ aeZ
 aKQ
 vNd
 uwl
-aDh
+aeZ
 mAs
 kAF
 aVW
@@ -121132,12 +121205,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 wOk
 oAw
 gaP
 wOk
 raD
+eKQ
 okm
 okm
 sCl
@@ -121388,7 +121461,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 lJp
 aaa
 hAm
@@ -121396,6 +121468,7 @@ vsv
 qwQ
 qGN
 qBK
+eKQ
 okm
 okm
 mnS
@@ -121648,12 +121721,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
 dZk
+afb
 npa
-yaq
 gOf
 tWs
+aeW
 qGW
 fmF
 kpI
@@ -121906,10 +121979,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 wOk
 acQ
 gaP
+wOk
 wOk
 xkT
 cHa
@@ -122428,9 +122501,9 @@ qIQ
 aaf
 aaa
 viE
-aFG
-cMm
 eVQ
+cMm
+aeU
 viE
 aaa
 aaa

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
@@ -199,9 +199,6 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/HoS_Office)
-"aan" = (
-/turf/simulated/wall/r_wall,
-/area/space)
 "aao" = (
 /obj/random/trash,
 /obj/structure/table/standard,
@@ -6085,6 +6082,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	layer = 3.5
+	},
+/obj/structure/sign/directions/science{
+	dir = 4;
+	layer = 3.5;
+	pixel_y = 9
+	},
+/obj/structure/sign/directions/security{
+	pixel_y = -9;
+	dir = 1;
+	layer = 3.5
+	},
 /turf/simulated/floor/plating,
 /area/hallway/Central_2_Deck_Hall)
 "ajS" = (
@@ -6110,6 +6121,18 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
 /area/maintenance/Engineering_Substation)
+"ajU" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "ajV" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/arrows/blue{
@@ -6478,6 +6501,13 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Port_Corridor)
+"akz" = (
+/obj/random/junk,
+/obj/random/trash,
+/obj/random/tech_supply,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/tiled/techmaint,
+/area/maintenance/Deck2_Civilian_StarChamber2)
 "akA" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -6492,6 +6522,11 @@
 /obj/machinery/vending/emergencyfood/filled,
 /turf/simulated/floor/tiled,
 /area/quartermaster/Breakroom)
+"akB" = (
+/obj/random/junk,
+/obj/random/maintenance/clean,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck2_Civilian_StarChamber2)
 "akC" = (
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 10
@@ -6513,11 +6548,6 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/directions/command{
-	pixel_y = -9;
-	dir = 1;
-	layer = 3.5
-	},
 /obj/structure/sign/directions/bar{
 	pixel_y = 9;
 	layer = 3.5;
@@ -7950,6 +7980,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/Chomp_Kitchen)
+"ani" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 9
+	},
+/obj/effect/floor_decal/steeldecal/steel_decals4{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/rnd/Toxins_Viewing_Port)
 "anj" = (
 /obj/effect/floor_decal/milspec/box,
 /turf/simulated/floor/tiled/steel_ridged,
@@ -8533,12 +8573,30 @@
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/Midnight_Kitchen)
+"aor" = (
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 6;
+	pixel_x = -1
+	},
+/turf/simulated/floor/plating/turfpack/airless,
+/area/harbor/Port_Shuttlebay)
 "aos" = (
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
 /turf/simulated/wall/r_wall,
 /area/crew_quarters/Emergency_EVA)
+"aot" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 5
+	},
+/turf/simulated/floor/plating/turfpack/airless,
+/area/harbor/Port_Shuttlebay)
 "aou" = (
 /obj/structure/reagent_dispensers/cookingoil,
 /obj/machinery/light/small{
@@ -9321,11 +9379,6 @@
 /area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "apS" = (
 /obj/random/tank,
-/turf/simulated/floor/plating,
-/area/maintenance/Deck2_Civilian_AftPortCorridor1)
-"apT" = (
-/obj/random/trash_pile,
-/obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Civilian_AftPortCorridor1)
 "apU" = (
@@ -10440,6 +10493,21 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftStarCorridor2)
+"ash" = (
+/obj/effect/catwalk_plated,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 9
+	},
+/turf/simulated/floor/plating/turfpack/airless,
+/area/harbor/Port_Shuttlebay)
+"asi" = (
+/obj/effect/catwalk_plated,
+/obj/machinery/shield_diffuser,
+/obj/effect/floor_decal/steeldecal/steel_decals6{
+	dir = 10
+	},
+/turf/simulated/floor/plating/turfpack/airless,
+/area/harbor/Port_Shuttlebay)
 "ask" = (
 /obj/machinery/door/firedoor/glass/hidden/steel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23669,11 +23737,11 @@
 /area/hallway/AftStar_2_Deck_Observatory)
 "bmb" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "bmd" = (
@@ -24694,7 +24762,7 @@
 "bqr" = (
 /obj/machinery/air_sensor{
 	frequency = 1430;
-	id_tag = "SC-toxins_mixing_exterior";
+	id_tag = "toxins_mixing_exterior";
 	output = 63
 	},
 /turf/simulated/floor/reinforced/airless,
@@ -24937,8 +25005,8 @@
 /area/crew_quarters/Emergency_EVA)
 "brG" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/light,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "brH" = (
@@ -27517,7 +27585,7 @@
 /area/hallway/AftPort_2_Deck_Observatory)
 "bAj" = (
 /obj/structure/dispenser/oxygen,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "bAk" = (
@@ -30822,12 +30890,12 @@
 /area/crew_quarters/Emergency_EVA)
 "bOr" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "bOt" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "bOx" = (
@@ -46973,6 +47041,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/maintenance/Medical_Substation)
 "dIY" = (
@@ -50985,7 +51054,6 @@
 	dir = 8;
 	layer = 2.6
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/item/tank/emergency/oxygen{
 	pixel_y = 11;
 	pixel_x = 7
@@ -51032,6 +51100,7 @@
 	name = "1S-requests console";
 	department = "EVA"
 	},
+/obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "eMA" = (
@@ -54508,6 +54577,9 @@
 "fGb" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/reagent_dispensers/acid{
+	pixel_y = 28
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Technical_Storage)
 "fGl" = (
@@ -54550,6 +54622,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
+	},
+/obj/effect/map_helper/airlock/button/int_button{
+	pixel_y = -14
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Toxins_Viewing_Port)
@@ -59790,11 +59865,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Security_AftStarCorridor2)
 "gTi" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	name = "Security automatic shutoff valve";
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/valve/open{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/maintenance/Security_Substation)
 "gTx" = (
@@ -61492,7 +61566,9 @@
 	autoclose = 0;
 	frequency = 1379;
 	id_tag = "SC-tox_airlock_exterior";
-	locked = 1
+	locked = 1;
+	req_access = list(7);
+	req_one_access = list(47)
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Toxins_Mixing_Room)
@@ -66454,9 +66530,7 @@
 /turf/simulated/open,
 /area/maintenance/Deck2_Civilian_PortChamber2)
 "iHv" = (
-/obj/random/junk,
-/obj/random/trash,
-/obj/random/tech_supply,
+/obj/random/maintenance/clean,
 /turf/simulated/floor/tiled/techmaint,
 /area/maintenance/Deck2_Civilian_StarChamber2)
 "iHz" = (
@@ -67180,10 +67254,10 @@
 /area/quartermaster/Recycling)
 "iQL" = (
 /obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
+/obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/Emergency_EVA)
 "iRm" = (
@@ -68367,6 +68441,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/valve/digital/open,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/maintenance/Research_Substation)
 "jiD" = (
@@ -79737,11 +79812,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
-	},
-/obj/structure/sign/directions/security{
-	pixel_y = -9;
-	dir = 1;
-	layer = 3.5
 	},
 /obj/structure/sign/directions/kitchen{
 	pixel_y = 9;
@@ -93853,6 +93923,7 @@
 	regulate_mode = 0;
 	unlocked = 1
 	},
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/maintenance/Research_Substation)
 "qBO" = (
@@ -94366,10 +94437,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/Deck2_Science_StarCorridor2)
 "qKI" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	name = "Domicile automatic shutoff valve"
-	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/valve/open{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/Distro_Civilian)
 "qKQ" = (
@@ -98126,7 +98197,7 @@
 "rHy" = (
 /obj/machinery/air_sensor{
 	frequency = 1430;
-	id_tag = "SC-toxins_mixing_interior";
+	id_tag = "toxins_mixing_interior";
 	output = 63
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -98326,6 +98397,9 @@
 	dir = 1
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
+/obj/effect/map_helper/airlock/button/ext_button{
+	pixel_y = -14
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Toxins_Viewing_Port)
 "rIN" = (
@@ -108659,10 +108733,10 @@
 /turf/simulated/floor/grass2/turfpack/station,
 /area/hallway/Aft_2_Deck_Central_Corridor_1)
 "uHv" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	name = "Cargo automatic shutoff valve"
-	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/valve/open{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/Cargo_Substation)
 "uHU" = (
@@ -110808,6 +110882,7 @@
 /area/crew_quarters/Library)
 "vpe" = (
 /obj/machinery/atmospherics/valve/digital/open,
+/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/maintenance/Medical_Substation)
 "vpj" = (
@@ -112571,6 +112646,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/sign/directions/cargo{
+	dir = 8;
+	layer = 3.5
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 8;
+	layer = 3.5;
+	pixel_y = 9
+	},
+/obj/structure/sign/directions/command{
+	pixel_y = -9;
+	dir = 1;
+	layer = 3.5
 	},
 /turf/simulated/floor/plating,
 /area/hallway/Central_2_Deck_Hall)
@@ -114376,8 +114465,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/Processing_Room)
 "woW" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	name = "Science automatic shutoff valve"
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/valve/open{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Research_Substation)
@@ -119036,7 +119126,9 @@
 	autoclose = 0;
 	frequency = 1379;
 	id_tag = "SC-tox_airlock_exterior";
-	locked = 1
+	locked = 1;
+	req_access = list(7);
+	req_one_access = list(47)
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/rnd/Toxins_Mixing_Room)
@@ -120532,8 +120624,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/valve/shutoff{
-	name = "Medical automatic shutoff valve"
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/valve/open{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Medical_Substation)
@@ -133337,6 +133430,9 @@ aaa
 aaa
 aaa
 aaa
+aaf
+onO
+aaf
 aaa
 aaa
 aaa
@@ -133354,12 +133450,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+onO
+aaf
 aaa
 aaa
 aaa
@@ -133587,6 +133680,17 @@ aaa
 aaa
 aaa
 aaa
+cCw
+mAT
+iiP
+lVS
+cCw
+aaa
+aaa
+aaa
+dqa
+bCe
+dqa
 aaa
 aaa
 aaa
@@ -133594,11 +133698,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaf
-onO
-aaf
-aaa
+ctj
+ctj
+ctj
 aaa
 aaa
 aaa
@@ -133606,18 +133708,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-onO
-aaf
+dqa
+bCe
+dqa
 aaa
 aaa
 aaa
@@ -133846,16 +133939,16 @@ onO
 aaf
 aaa
 cCw
-mAT
-iiP
-lVS
+aYr
+oht
+oht
 cCw
 aaa
 aaa
 aaa
-dqa
-bCe
-dqa
+ctj
+sOr
+ctj
 aaa
 aaa
 aaa
@@ -133873,9 +133966,9 @@ aaa
 aaa
 aaa
 aaa
-dqa
-bCe
-dqa
+ctj
+sOr
+ctj
 aaa
 aaa
 aaa
@@ -134104,7 +134197,7 @@ bCe
 onO
 aaa
 cCw
-aYr
+oht
 oht
 oht
 cCw
@@ -134112,7 +134205,7 @@ aaa
 aaa
 aaa
 ctj
-sOr
+key
 ctj
 aaa
 aaa
@@ -134132,7 +134225,7 @@ aaa
 aaa
 aaa
 ctj
-sOr
+key
 ctj
 aaa
 aaa
@@ -134614,7 +134707,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ctj
 cCw
 uKl
 cCw
@@ -134872,7 +134965,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ctj
 qmn
 vZd
 fsb
@@ -135040,8 +135133,8 @@ aop
 oGx
 uhW
 bNF
-klj
-klj
+ash
+aor
 klj
 paJ
 amH
@@ -135130,7 +135223,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ctj
 rCD
 ocV
 oht
@@ -135388,7 +135481,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ctj
 tAR
 jbZ
 wLS
@@ -136697,17 +136790,17 @@ aaa
 aaa
 aaa
 aaa
+ctj
+ctj
+ctj
+ctj
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ctj
+ctj
+ctj
+ctj
 aaa
 aaa
 aaa
@@ -137104,8 +137197,8 @@ foi
 foi
 foi
 foi
-foi
-wFO
+asi
+aot
 klj
 gKx
 lVo
@@ -139793,17 +139886,17 @@ aaa
 aaa
 aaa
 aaa
+ctj
+ctj
+ctj
+ctj
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ctj
+ctj
+ctj
+ctj
 aaa
 aaa
 aaa
@@ -143138,7 +143231,7 @@ bFD
 bFD
 bFD
 bFD
-aan
+aaa
 aaa
 aaa
 aaa
@@ -143395,9 +143488,9 @@ aqf
 aqc
 scW
 apX
-apT
 wZn
 oEW
+ajU
 jnk
 wZn
 aaa
@@ -166864,7 +166957,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ctj
 eBy
 pin
 pwn
@@ -167122,7 +167215,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ctj
 gFx
 kfm
 sQq
@@ -167380,7 +167473,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ctj
 qcZ
 fWy
 apw
@@ -167638,7 +167731,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+ctj
 qcZ
 pUY
 qcZ
@@ -167902,7 +167995,7 @@ aqp
 aaf
 aaa
 qcZ
-xss
+akB
 iHv
 sQq
 qcZ
@@ -168160,15 +168253,15 @@ xBF
 onO
 aaa
 qcZ
-qJo
-kUm
-wyG
+xss
+akz
+lGm
 qcZ
 aaa
 aaa
 aaa
 ctj
-sOr
+key
 ctj
 aaa
 aaa
@@ -168188,7 +168281,7 @@ aaa
 aaa
 aaa
 ctj
-sOr
+key
 ctj
 aaa
 aaa
@@ -168418,16 +168511,16 @@ onO
 aaf
 aaa
 qcZ
-sbk
-tKS
-gky
+qJo
+kUm
+wyG
 qcZ
 aaa
 aaa
 aaa
-dqa
-oBS
-dqa
+ctj
+sOr
+ctj
 aaa
 aaa
 aaa
@@ -168445,9 +168538,9 @@ aaa
 aaa
 aaa
 aaa
-dqa
-oBS
-dqa
+ctj
+sOr
+ctj
 aaa
 aaa
 aaa
@@ -168675,6 +168768,17 @@ aaa
 aaa
 aaa
 aaa
+qcZ
+sbk
+tKS
+gky
+qcZ
+aaa
+aaa
+aaa
+dqa
+oBS
+dqa
 aaa
 aaa
 aaa
@@ -168682,11 +168786,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaf
-gWp
-aaf
-aaa
+ctj
+ctj
+ctj
 aaa
 aaa
 aaa
@@ -168694,18 +168796,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-gWp
-aaf
+dqa
+oBS
+dqa
 aaa
 aaa
 aaa
@@ -168941,6 +169034,9 @@ aaa
 aaa
 aaa
 aaa
+aaf
+gWp
+aaf
 aaa
 aaa
 aaa
@@ -168958,12 +169054,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aaf
+gWp
+aaf
 aaa
 aaa
 aaa
@@ -172713,7 +172806,7 @@ wWX
 wWX
 cAy
 tZJ
-moa
+ani
 uRn
 moa
 hcl

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-3.dmm
@@ -109,10 +109,6 @@
 	},
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Lounge)
-"aal" = (
-/obj/effect/catwalk_plated/white,
-/turf/space,
-/area/space)
 "aam" = (
 /obj/effect/floor_decal/borderfloor{
 	dir = 8
@@ -2105,16 +2101,6 @@
 /obj/effect/floor_decal/spline/plain,
 /turf/simulated/floor/wood/alt,
 /area/crew_quarters/Chomp_Dinner_2)
-"aeI" = (
-/obj/machinery/pointdefense{
-	id_tag = "PD Secondary"
-	},
-/obj/machinery/shield_diffuser,
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/white,
-/obj/structure/lattice,
-/turf/simulated/floor/plating/turfpack/airless,
-/area/space)
 "aeJ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals6,
 /obj/effect/floor_decal/steeldecal/steel_decals6{
@@ -2606,6 +2592,120 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space)
+"afR" = (
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/white,
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/airless,
+/area/space)
+"afS" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/floor_decal/industrial/hatch,
+/obj/structure/grille,
+/obj/structure/window/titanium,
+/obj/structure/window/titanium{
+	dir = 4
+	},
+/obj/structure/window/titanium{
+	dir = 1
+	},
+/obj/structure/window/titanium{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/crew_quarters/Observation_Lounge)
+"afT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"afU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/r_wall,
+/area/crew_quarters/Observation_Lounge)
+"afV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/r_wall,
+/area/crew_quarters/Observation_Lounge)
+"afW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"afX" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8;
+	name = "Crew transit chute";
+	desc = "A specialized crew transit system, a tight inflatable hole of soft fabric with a strong suction. A quick way to travel long distances!";
+	color = "#9185ff"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"afY" = (
+/obj/structure/disposalpipe/sortjunction/wildcard{
+	dir = 4
+	},
+/turf/simulated/wall/r_wall,
+/area/crew_quarters/Observation_Lounge)
+"afZ" = (
+/obj/structure/disposalpipe/sortjunction/wildcard/flipped{
+	dir = 8
+	},
+/turf/simulated/wall/r_wall,
+/area/crew_quarters/Observation_Lounge)
+"aga" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 4;
+	name = "Crew transit pipes";
+	desc = "A specialized crew transit system, a tight inflatable hole of soft fabric with a strong suction. A quick way to travel long distances!";
+	color = "#6b75ff"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"agb" = (
+/obj/effect/floor_decal/industrial/warning/color{
+	dir = 6
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"agc" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
 "agd" = (
 /obj/machinery/door/firedoor/glass,
 /obj/effect/floor_decal/industrial/arrows/blue{
@@ -2623,6 +2723,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techmaint,
 /area/bridge/sleep/HoS_Quarters)
+"age" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"agf" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/shield_diffuser,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/airless,
+/area/space)
 "agg" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
@@ -2632,6 +2749,31 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor,
 /area/engineering/Engine2_Waste_Handling)
+"agh" = (
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"agi" = (
+/obj/effect/floor_decal/industrial/warning/color{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/reinforced/airless,
+/area/space)
+"agj" = (
+/obj/structure/lattice,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/turf/space,
+/area/space)
 "agk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -2643,6 +2785,64 @@
 /obj/effect/floor_decal/corner/brown/border,
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Port_Breakroom)
+"agl" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/machinery/shield_diffuser,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/airless,
+/area/space)
+"agm" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/machinery/shield_diffuser,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/airless,
+/area/space)
+"agn" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/machinery/camera/network/security{
+	c_tag = "D3-Eng-2nd cooling_pipes1";
+	network = list("engineering","Engine");
+	dir = 2
+	},
+/turf/space,
+/area/space)
+"ago" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/machinery/camera/network/security{
+	c_tag = "D3-Eng-2nd cooling_pipes2";
+	network = list("engineering","Engine");
+	dir = 2
+	},
+/turf/space,
+/area/space)
+"agp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 5
+	},
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_ForStarChamber1)
+"agq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+	dir = 10
+	},
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/maintenance/Deck3_Dorms_ForStarChamber1)
 "agr" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
@@ -2652,6 +2852,23 @@
 	},
 /turf/simulated/floor/water/deep/pool,
 /area/bridge/sleep/Captain_Quarters)
+"ags" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/white,
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/plating/turfpack/airless,
+/area/space)
+"agt" = (
+/obj/structure/table/steel,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/Stairwell_For)
 "agw" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/arrows/yellow,
@@ -4072,11 +4289,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/hallway/Star_Breakroom)
 "aJq" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	name = "Engineering automatic shutoff valve";
+/obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/valve/open{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Engineering_ForStarChamber1)
 "aJv" = (
@@ -8850,7 +9066,8 @@
 	charge = 2e+006;
 	input_attempt = 1;
 	input_level = 100000;
-	output_level = 200000
+	output_level = 200000;
+	cur_coils = 4
 	},
 /obj/effect/engine_setup/smes,
 /obj/structure/cable/cyan{
@@ -10100,17 +10317,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/Lounge)
-"cWO" = (
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/lattice,
-/obj/machinery/shield_diffuser,
-/turf/space,
-/area/space)
 "cXl" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
@@ -15238,6 +15444,9 @@
 "eIM" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/Observation_Lounge)
 "eIW" = (
@@ -23079,13 +23288,12 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/valve/shutoff{
-	name = "Bridge automatic shutoff valve";
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/valve/open{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/Bridge_Substation)
@@ -26841,9 +27049,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/medical/Morgue)
 "izE" = (
-/obj/random/trash,
-/obj/machinery/atmospherics/valve/shutoff{
-	name = "Dorms level automatic shutoff valve";
+/obj/machinery/atmospherics/valve/open{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -29157,7 +29363,6 @@
 /turf/simulated/floor/tiled/white,
 /area/bridge/Firstaid_Post)
 "jpB" = (
-/obj/random/trash,
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4;
 	unlocked = 1
@@ -29182,6 +29387,9 @@
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/Observation_Lounge)
 "jqe" = (
@@ -34910,6 +35118,9 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/Observation_Lounge)
 "lqG" = (
@@ -36817,17 +37028,6 @@
 /obj/effect/catwalk_plated/techmaint,
 /turf/simulated/open,
 /area/maintenance/Deck3_Bridge_ForStarCorridor1)
-"lTV" = (
-/obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/structure/railing/grey{
-	dir = 1
-	},
-/obj/structure/lattice,
-/obj/machinery/shield_diffuser,
-/turf/space,
-/area/space)
 "lTW" = (
 /obj/structure/bed/chair/sofa/corner/brown{
 	dir = 8
@@ -39668,11 +39868,10 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/medical/Psych_Room_2)
 "mMn" = (
+/obj/structure/lattice,
 /obj/structure/railing/grey{
 	dir = 8
 	},
-/obj/structure/lattice,
-/obj/machinery/shield_diffuser,
 /turf/space,
 /area/space)
 "mMo" = (
@@ -41378,6 +41577,9 @@
 /turf/simulated/floor/plating,
 /area/engineering/Engine2_Waste_Handling)
 "nso" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Observation_Lounge)
 "nst" = (
@@ -42027,14 +42229,6 @@
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/bridge/Embassy)
-"nDl" = (
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/machinery/shield_diffuser,
-/obj/structure/lattice,
-/turf/space,
-/area/space)
 "nDs" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/floor_decal/industrial/hatch,
@@ -43176,6 +43370,9 @@
 	pixel_x = -22
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/Observation_Lounge)
 "nWh" = (
@@ -43656,6 +43853,9 @@
 "oei" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/Observation_Lounge)
@@ -51870,6 +52070,9 @@
 /area/hallway/For_3_Deck_Stairwell)
 "qNj" = (
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/Observation_Lounge)
 "qNw" = (
@@ -52380,6 +52583,9 @@
 	pixel_x = 22
 	},
 /obj/effect/floor_decal/spline/fancy/wood,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/Observation_Lounge)
 "qZw" = (
@@ -58426,11 +58632,10 @@
 /turf/simulated/floor/tiled,
 /area/engineering/Deck3_1_Corridor)
 "tbt" = (
-/obj/machinery/atmospherics/valve/shutoff{
-	dir = 4;
-	name = "Atmospherics to Distro automatic shutoff valve"
-	},
 /obj/effect/floor_decal/industrial/outline/blue,
+/obj/machinery/atmospherics/valve/open{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/engineering/Atmospherics_Substation)
 "tbC" = (
@@ -60144,6 +60349,10 @@
 /obj/effect/floor_decal/shuttle/blue{
 	pixel_x = -1;
 	pixel_y = 1
+	},
+/obj/structure/disposalpipe/tagger{
+	dir = 4;
+	sort_tag = "transit_crew"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/crew_quarters/Observation_Lounge)
@@ -62303,15 +62512,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/sleep/Dormitory_06)
-"usd" = (
-/obj/machinery/pointdefense{
-	id_tag = "PD Secondary"
-	},
-/obj/machinery/shield_diffuser,
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/white,
-/turf/simulated/floor/plating/turfpack/airless,
-/area/space)
 "use" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -66700,7 +66900,8 @@
 	input_attempt = 1;
 	input_level = 100000;
 	output_level = 200000;
-	output_attempt = 0
+	output_attempt = 0;
+	cur_coils = 4
 	},
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
@@ -69084,6 +69285,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
 	},
+/obj/random/trash,
 /turf/simulated/floor/plating,
 /area/maintenance/Deck3_Dorms_ForStarChamber1)
 "wAG" = (
@@ -74838,6 +75040,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/wood/alt/tile,
 /area/crew_quarters/Observation_Lounge)
 "ykU" = (
@@ -81482,7 +81687,7 @@ jub
 jub
 jub
 aqj
-aeS
+ags
 aqj
 apc
 apc
@@ -82782,10 +82987,10 @@ oZB
 faI
 kaL
 kaL
-aal
-aal
-aal
-aal
+hjD
+hjD
+hjD
+hjD
 agy
 aeO
 aqj
@@ -83302,7 +83507,7 @@ nUr
 cko
 bYL
 dHa
-aal
+hjD
 hXb
 apc
 apc
@@ -83560,7 +83765,7 @@ nmO
 wFf
 ciH
 dHa
-aal
+hjD
 hXb
 apc
 apc
@@ -84336,31 +84541,31 @@ uBR
 dHa
 gXS
 prP
-hXb
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
-apc
+sgy
+aqj
+aqj
+aqj
+aqj
+phb
+phb
+phb
+phb
+phb
+phb
+phb
+phb
+phb
+phb
+phb
+phb
+phb
+phb
+aqj
+aqj
+aqj
+aqj
+aqj
+aqj
 aqj
 iIA
 aqj
@@ -86440,9 +86645,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+aqj
+cDl
+aqj
 apc
 apc
 apc
@@ -86663,7 +86868,7 @@ ciH
 jtv
 dHa
 nbo
-hXb
+agn
 fIy
 lMs
 lMs
@@ -86698,9 +86903,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+cDl
+xFs
+cDl
 apc
 apc
 apc
@@ -86956,9 +87161,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+aqj
+agf
+aqj
 apc
 apc
 apc
@@ -87212,11 +87417,11 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
-apc
-apc
+dHa
+dHa
+dHa
+mJP
+dHa
 apc
 apc
 apc
@@ -87473,7 +87678,7 @@ apc
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -87731,7 +87936,7 @@ apc
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -87989,7 +88194,7 @@ apc
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -88247,7 +88452,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -88505,7 +88710,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -88763,6 +88968,7 @@ dHa
 dHa
 dHa
 dHa
+mJP
 dHa
 dHa
 dHa
@@ -88798,10 +89004,9 @@ dHa
 dHa
 dHa
 dHa
-dHa
-apc
-apc
-apc
+aqj
+cDl
+aqj
 apc
 apc
 apc
@@ -88985,7 +89190,7 @@ ciH
 jtv
 dHa
 nbo
-hXb
+ago
 ykB
 lMs
 lMs
@@ -89021,45 +89226,45 @@ dHa
 dHa
 dHa
 dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-apc
-apc
-apc
+kBO
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+afR
+piu
+cDl
 apc
 apc
 apc
@@ -89279,6 +89484,7 @@ dHa
 dHa
 dHa
 dHa
+mJP
 dHa
 dHa
 dHa
@@ -89314,10 +89520,9 @@ dHa
 dHa
 dHa
 dHa
-dHa
-apc
-apc
-apc
+aqj
+cDl
+aqj
 apc
 apc
 apc
@@ -89537,7 +89742,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -89795,7 +90000,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -90053,7 +90258,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -90311,7 +90516,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -90569,7 +90774,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -90827,7 +91032,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -91085,7 +91290,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -91343,7 +91548,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -91601,7 +91806,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -91859,7 +92064,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -92117,7 +92322,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -92375,7 +92580,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 apc
 apc
 apc
@@ -92633,7 +92838,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 apc
 apc
 apc
@@ -92891,7 +93096,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 apc
 apc
 apc
@@ -93149,7 +93354,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -93407,7 +93612,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -93665,7 +93870,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -93923,7 +94128,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -94181,7 +94386,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -94439,7 +94644,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -94697,7 +94902,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -94955,7 +95160,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -95213,7 +95418,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -95458,12 +95663,12 @@ apc
 apc
 apc
 apc
+aqj
+cDl
+aqj
 apc
 apc
 apc
-apc
-apc
-apc
 dHa
 dHa
 dHa
@@ -95471,7 +95676,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -95716,9 +95921,9 @@ apc
 apc
 apc
 apc
-aqj
 cDl
-aqj
+xFs
+cDl
 apc
 apc
 apc
@@ -95729,7 +95934,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -95974,9 +96179,9 @@ apc
 jub
 jub
 jub
-dZQ
-xFs
-dZQ
+agj
+agl
+agj
 jub
 jub
 jub
@@ -95987,7 +96192,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -96245,7 +96450,7 @@ pmn
 pmn
 pmn
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -96503,10 +96708,10 @@ kaL
 kaL
 prP
 elz
+agh
 pmn
-pmn
-dZQ
-aqj
+apc
+apc
 apc
 apc
 apc
@@ -96761,10 +96966,10 @@ odW
 odW
 exE
 iZZ
-iZZ
-iZZ
-usd
-lTV
+agi
+prP
+apc
+apc
 jub
 jub
 apc
@@ -97020,8 +97225,8 @@ dHa
 dHa
 dHa
 dHa
-dHa
 gXS
+kaL
 kaL
 kaL
 prP
@@ -102710,8 +102915,8 @@ rpD
 avb
 uBy
 xWY
-dHa
-dHa
+afX
+afT
 dHa
 dHa
 nev
@@ -102968,9 +103173,9 @@ uxE
 uxE
 jhg
 ptq
-ptq
-fHI
-aVA
+afY
+afU
+afS
 ptq
 nev
 hXb
@@ -105134,7 +105339,7 @@ hcP
 tci
 mps
 oOz
-qpD
+agt
 qbY
 mrt
 jQL
@@ -106527,7 +106732,7 @@ dHa
 lmX
 lmX
 eIx
-gXM
+agp
 mpw
 dYI
 cLw
@@ -106580,9 +106785,9 @@ uxE
 uxE
 jhg
 ptq
-ptq
-fHI
-aVA
+afZ
+afV
+afS
 ptq
 nev
 hXb
@@ -106838,8 +107043,8 @@ gtn
 hZJ
 nTw
 hKY
-dHa
-dHa
+aga
+afW
 dHa
 dHa
 nev
@@ -107301,7 +107506,7 @@ dHa
 dHa
 lmX
 lmX
-eIx
+agq
 wAy
 sOH
 uPq
@@ -112500,8 +112705,8 @@ dHa
 dHa
 dHa
 dHa
-dHa
 rpR
+sra
 sra
 sra
 riY
@@ -112758,9 +112963,9 @@ odW
 dXS
 lrU
 lrU
-lrU
-aeI
-cWO
+agb
+uOo
+nhz
 nhz
 nhz
 apc
@@ -113016,9 +113221,9 @@ sra
 riY
 lhV
 ttG
-ttG
-nDl
-aqj
+agc
+apc
+apc
 apc
 apc
 apc
@@ -113274,7 +113479,7 @@ ttG
 ttG
 dHa
 dHa
-dHa
+mJP
 apc
 apc
 apc
@@ -113518,7 +113723,7 @@ nhz
 nhz
 nhz
 mMn
-grW
+agm
 mMn
 nhz
 nhz
@@ -113532,7 +113737,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 apc
 apc
 apc
@@ -113775,9 +113980,9 @@ apc
 apc
 apc
 apc
-aqj
 cDl
-aqj
+grW
+cDl
 apc
 apc
 apc
@@ -113790,7 +113995,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 apc
 apc
 apc
@@ -114033,13 +114238,13 @@ apc
 apc
 apc
 apc
+aqj
+cDl
+aqj
 apc
 apc
 apc
 apc
-apc
-apc
-apc
 dHa
 dHa
 dHa
@@ -114048,7 +114253,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -114306,7 +114511,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -114564,7 +114769,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -114822,7 +115027,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -115080,7 +115285,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -115338,7 +115543,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -115596,7 +115801,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -115854,7 +116059,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -116112,7 +116317,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -116370,7 +116575,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -116628,7 +116833,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 apc
 apc
 apc
@@ -116886,7 +117091,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 apc
 apc
 apc
@@ -117144,7 +117349,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 apc
 apc
 apc
@@ -117402,7 +117607,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -117660,7 +117865,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -117918,7 +118123,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -118176,7 +118381,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -118434,7 +118639,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -118692,7 +118897,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -118950,7 +119155,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -119208,7 +119413,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -119466,7 +119671,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -119724,7 +119929,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -119982,7 +120187,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -120240,6 +120445,7 @@ dHa
 dHa
 dHa
 dHa
+mJP
 dHa
 dHa
 dHa
@@ -120274,10 +120480,9 @@ dHa
 dHa
 dHa
 dHa
-dHa
-apc
-apc
-apc
+aqj
+cDl
+aqj
 apc
 apc
 apc
@@ -120498,44 +120703,44 @@ dHa
 dHa
 dHa
 dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-dHa
-apc
-apc
-apc
+age
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+odW
+afR
+piu
+cDl
 apc
 apc
 apc
@@ -120756,6 +120961,7 @@ dHa
 dHa
 dHa
 dHa
+mJP
 dHa
 dHa
 dHa
@@ -120790,10 +120996,9 @@ dHa
 dHa
 dHa
 dHa
-dHa
-apc
-apc
-apc
+aqj
+cDl
+aqj
 apc
 apc
 apc
@@ -121014,7 +121219,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 dHa
 dHa
@@ -121272,7 +121477,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -121530,7 +121735,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -121788,7 +121993,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -122046,7 +122251,7 @@ dHa
 dHa
 dHa
 dHa
-dHa
+mJP
 dHa
 apc
 apc
@@ -122303,9 +122508,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+aqj
+agf
+aqj
 apc
 apc
 apc
@@ -122561,9 +122766,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+cDl
+grW
+cDl
 apc
 apc
 apc
@@ -122819,9 +123024,9 @@ apc
 apc
 apc
 apc
-apc
-apc
-apc
+aqj
+cDl
+aqj
 apc
 apc
 apc


### PR DESCRIPTION
-Upgraded both engine SMES, hold a bit more power. 
-Replaced all ``automatic shutoff valves`` with ``manual valves`` 
-Moved and added more Point defense turrets, mostly to safeguard dorms from meteors. 
-Moved and added Point defense turrets for both engines. 
-Moved Point defense turrets for the AI room.
-Fixed some access doors and turret control in telecomms 
-Added various missing wall machines.
-Fixed various missing decals.
-Added a lot more loot in maints, loot relevant to departments can be found in maints. 
-Added cameras to the engine cool loop.
-Added some missing security cameras.
-Fixed dock airlocks sharing doors.
-A bunch of little fixes.

