### PR TITLE
Soluna Nexus mapfix 2.2

### DIFF
--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-1.dmm
@@ -2785,16 +2785,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Central_1_Deck_Hall)
 "agy" = (
-/obj/machinery/turretid/lethal{
-	ailock = 1;
-	control_area = "\improper GravGen Room";
-	desc = "A firewall prevents AIs from interacting with this device.";
-	name = "GravityGen lethal turret control";
-	pixel_y = 29;
-	req_access = list(11, 19);
-	check_records = 0;
-	req_one_access = list(17,11,24)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2809,6 +2799,14 @@
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals4{
 	dir = 1
+	},
+/obj/machinery/turretid/stun{
+	check_records = 0;
+	control_area = "\improper GravGen Room";
+	name = "GravityGen lethal turret control";
+	req_access = list(11, 19);
+	req_one_access = list(17,11,24);
+	pixel_y = 29
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/GravGen_Room)
@@ -34343,6 +34341,7 @@
 	pixel_y = -14
 	},
 /obj/machinery/shield_diffuser,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock5)
 "jEl" = (
@@ -55669,12 +55668,12 @@
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 4
 	},
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
 /obj/machinery/light/floortube{
 	dir = 8;
 	pixel_x = -3
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_1Deck_Atrium)
@@ -59342,6 +59341,7 @@
 	pixel_y = -14
 	},
 /obj/machinery/shield_diffuser,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock5)
 "ssD" = (
@@ -72143,6 +72143,7 @@
 	},
 /obj/effect/map_helper/airlock/door/ext_door,
 /obj/machinery/shield_diffuser,
+/obj/structure/fans/tiny,
 /turf/simulated/floor/tiled/techmaint,
 /area/harbor/Dock5)
 "wXu" = (
@@ -101378,7 +101379,7 @@ pFU
 pFU
 pFU
 pFU
-vXj
+pFU
 pFU
 pFU
 pFU
@@ -103442,7 +103443,7 @@ pFU
 pFU
 pFU
 pFU
-pFU
+vXj
 pFU
 pFU
 pFU

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
@@ -199,6 +199,12 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/techmaint,
 /area/security/HoS_Office)
+"aan" = (
+/obj/machinery/computer/cryopod/robot{
+	pixel_x = 30
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/Drone_Fab)
 "aao" = (
 /obj/random/trash,
 /obj/structure/table/standard,
@@ -5856,8 +5862,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
 "ajz" = (
@@ -26395,8 +26399,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/lightgrey/bordercorner{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
 "bwK" = (
@@ -116967,8 +116975,8 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/borderfloor,
-/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/effect/floor_decal/borderfloor/corner,
+/obj/effect/floor_decal/corner/lightgrey/bordercorner,
 /turf/simulated/floor/tiled,
 /area/hallway/Star_2_Deck_Central_Corridor_1)
 "wZI" = (
@@ -140034,7 +140042,7 @@ aaa
 aaa
 uZK
 bNY
-mYL
+aan
 cge
 cgc
 tNw

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-6.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-6.dmm
@@ -23868,6 +23868,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Exp Carrier";
+	name_tag = "Exp Carrier Subgrid"
+	},
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
 "uJZ" = (
@@ -28120,7 +28124,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/obj/machinery/power/sensor,
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/engineering{
 	name = "R-UST Access"

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-7.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-7.dmm
@@ -35694,7 +35694,7 @@ boQ
 dmo
 azl
 gIQ
-deh
+uEv
 uEv
 lPM
 bSv
@@ -37758,7 +37758,7 @@ boQ
 dmo
 azl
 gIQ
-uEv
+deh
 uEv
 bGs
 uOU

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-8.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-8.dmm
@@ -35915,7 +35915,7 @@ aI
 aI
 aI
 aI
-fz
+aI
 aI
 aI
 aI
@@ -37979,7 +37979,7 @@ aI
 aI
 aI
 aI
-aI
+fz
 aI
 aI
 aI


### PR DESCRIPTION
-Exp Carrier, added name_tag to its powenet sensor. 
-Fixed the arrival shuttles not leaving at round end. 
-Fixed Dock Starboard and Star airlocks.
-Gravgen turrets now start on STUN mode, fixed access keys. 
-Fixed various missing decals.
-Added some missing lights.
-Added some missing security cameras.
-Added more random loot spawns in maints.

