### PR TITLE
Adds some more cosmetic turfs

### DIFF
--- a/code/game/turfs/flooring/flooring_ch.dm
+++ b/code/game/turfs/flooring/flooring_ch.dm
@@ -24,7 +24,7 @@
 	icon_state = "gym_mat"
 
 /turf/simulated/floor/grass2/sif
-	name = "light sif grass pass"
+	name = "light sif grass patch"
 	desc = "You can't tell if this is real grass or just cheap plastic imitation."
 	icon = 'icons/turf/outdoors.dmi'
 	icon_state = "grass_sif0"

--- a/code/game/turfs/flooring/flooring_ch.dm
+++ b/code/game/turfs/flooring/flooring_ch.dm
@@ -22,3 +22,15 @@
 /turf/simulated/floor/boxing/gym
 	name = "gym mat"
 	icon_state = "gym_mat"
+
+/turf/simulated/floor/grass2/sif
+	name = "light sif grass pass"
+	desc = "You can't tell if this is real grass or just cheap plastic imitation."
+	icon = 'icons/turf/outdoors.dmi'
+	icon_state = "grass_sif0"
+
+/turf/simulated/floor/grass2/sif/forest
+	name = "dark sif grass patch"
+	desc = "You can't tell if this is real grass or just cheap plastic imitation."
+	icon = 'icons/turf/outdoors.dmi'
+	icon_state = "grass_sif_dark0"

--- a/modular_chomp/maps/~turfpacks/packs_sim/turfpacks_sim_tiled.dm
+++ b/modular_chomp/maps/~turfpacks/packs_sim/turfpacks_sim_tiled.dm
@@ -216,6 +216,18 @@
 	nitrogen = TURFPACK_N2
 	phoron = TURFPACK_PHORON
 	carbon_dioxide = TURFPACK_CO2
+/turf/simulated/floor/grass2/sif/forest/turfpack/TURFPACK_PACKNAME
+	temperature = TURFPACK_TEMP
+	oxygen = TURFPACK_O2
+	nitrogen = TURFPACK_N2
+	phoron = TURFPACK_PHORON
+	carbon_dioxide = TURFPACK_CO2
+/turf/simulated/floor/grass2/sif/turfpack/TURFPACK_PACKNAME
+	temperature = TURFPACK_TEMP
+	oxygen = TURFPACK_O2
+	nitrogen = TURFPACK_N2
+	phoron = TURFPACK_PHORON
+	carbon_dioxide = TURFPACK_CO2
 /turf/simulated/floor/plating/turfpack/TURFPACK_PACKNAME
 	temperature = TURFPACK_TEMP
 	oxygen = TURFPACK_O2


### PR DESCRIPTION
Grass that look like sif turf
## About The Pull Request
Adds two grass flooring that looks like Sif turf. For use on stationside.

I haven't touched turfpacks before but I just followed what all the others were doing. 

Needed due to the fact that the /obj/machinery/shield_gen/external puts shields on tiles that are /turf/simulated/floor/outdoors even if it's a /turf/simulated/floor/outdoors/turfpack/station tile (as it's a /turf/simulated/floor/outdoors
## Changelog
Nothing player facing
