### PR TITLE
De-crumbs a table name query and a couple other things for a test

### DIFF
--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -358,7 +358,7 @@ GLOBAL_PROTECT(protected_ranks)
 		var/datum/admins/holder = GLOB.protected_admins[holder_ckey]
 		sql_admins += list(list("ckey" = holder.target, "rank" = holder.rank_names()))
 	SSdbcore.MassInsert(format_table_name("admin"), sql_admins, duplicate_key = TRUE)
-	var/datum/db_query/query_admin_rank_update = SSdbcore.NewQuery("UPDATE [format_table_name("player")] AS p INNER JOIN [format_table_name("admin")] AS a ON p.ckey = a.ckey SET p.lastadminrank = a.rank")
+	var/datum/db_query/query_admin_rank_update = SSdbcore.NewQuery("UPDATE [format_table_name("erro_player")] AS p INNER JOIN [format_table_name("admin")] AS a ON p.ckey = a.ckey SET p.lastadminrank = a.rank")
 	query_admin_rank_update.Execute()
 	qdel(query_admin_rank_update)
 

--- a/code/modules/asset_cache/validate_assets.html
+++ b/code/modules/asset_cache/validate_assets.html
@@ -23,7 +23,6 @@
 				}
 			};
 			xhr.send(null);
-			</script>
-
-</body>
+		</script>
+	</body>
 </html>

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -325,11 +325,12 @@
 
 	// Forcibly enable hardware-accelerated graphics, as we need them for the lighting overlays.
 	// (but turn them off first, since sometimes BYOND doesn't turn them on properly otherwise)
-	spawn(5) // And wait a half-second, since it sounds like you can do this too fast.
-		if(src)
-			winset(src, null, "command=\".configure graphics-hwmode off\"")
-			sleep(2) // wait a bit more, possibly fixes hardware mode not re-activating right
-			winset(src, null, "command=\".configure graphics-hwmode on\"")
+	// CHOMPEdit Start
+	// spawn(5) // And wait a half-second, since it sounds like you can do this too fast.
+	//	if(src)
+	//		winset(src, null, "command=\".configure graphics-hwmode off\"")
+	//		sleep(2) // wait a bit more, possibly fixes hardware mode not re-activating right
+	winset(src, null, "command=\".configure graphics-hwmode on\"") // CHOMPEdit End
 
 	log_client_to_db()
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -532,7 +532,7 @@
 
 	//Logging player access
 	var/serverip = "[world.internet_address]:[world.port]"
-	var/datum/db_query/query_accesslog = SSdbcore.NewQuery("INSERT INTO `erro_connection_log`(`id`,`datetime`,`serverip`,`ckey`,`ip`,`computerid`) VALUES(null,Now(),'[serverip]','[sql_ckey]','[sql_ip]','[sql_computerid]');")
+	var/datum/db_query/query_accesslog = SSdbcore.NewQuery("INSERT INTO erro_connection_log (`id`,`datetime`,`serverip`,`ckey`,`ip`,`computerid`) VALUES(null,Now(),'[serverip]','[sql_ckey]','[sql_ip]','[sql_computerid]');") //CHOMPEdit
 	query_accesslog.Execute()
 	qdel(query_accesslog)
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -532,7 +532,7 @@
 
 	//Logging player access
 	var/serverip = "[world.internet_address]:[world.port]"
-	var/datum/db_query/query_accesslog = SSdbcore.NewQuery("INSERT INTO erro_connection_log (`id`,`datetime`,`serverip`,`ckey`,`ip`,`computerid`) VALUES(null,Now(),'[serverip]','[sql_ckey]','[sql_ip]','[sql_computerid]');") //CHOMPEdit
+	var/datum/db_query/query_accesslog = SSdbcore.NewQuery("INSERT INTO erro_connection_log (id, datetime, serverip, ckey, ip, computerid) VALUES (null, Now(), '[serverip]', '[sql_ckey]', '[sql_ip]', '[sql_computerid]')") //CHOMPEdit
 	query_accesslog.Execute()
 	qdel(query_accesslog)
 


### PR DESCRIPTION
## About The Pull Request
Trims off backticks from a connection log query in client joins to match the rest of the code. It's the only INSERT INTO query that has backticks in its name call and I suspect it to be the potential culprit behind the 10 second timeout delay on lobby logins. Could merge for a test and see what happens. Also trimmed out some ancient naptimes. Also corrected a faulty table name query.
## Changelog
Fixed an inconsistency in a db query in client/new.
Snipped ancient redundant delays in client/new.
Fixed a wonky html file in asset validation.
Fixed a db query looking for nonexisting table.
:cl:
fix: Fixed a few old inconsistencies in new client logins.
/:cl:
