### PR TITLE
Mob HP rebalance, the start

### DIFF
--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/animal/space/alien.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/animal/space/alien.dm
@@ -1,43 +1,4 @@
-//Combat refactor changes commented out
-/*
-/mob/living/simple_mob/animal/space/alien
-	maxHealth = 100
-	health = 100
-	harm_intent_damage = 5
-	melee_damage_lower = 25
-	melee_damage_upper = 25
-	attack_armor_pen = 15
 
-/mob/living/simple_mob/animal/space/alien/drone
-	health = 60
-	melee_damage_lower = 15
-	melee_damage_upper = 15
-
-/mob/living/simple_mob/animal/space/alien/sentinel
-	health = 120
-	melee_damage_lower = 15
-	melee_damage_upper = 15
-
-/mob/living/simple_mob/animal/space/alien/sentinel/praetorian
-	maxHealth = 200
-	health = 200
-
-/mob/living/simple_mob/animal/space/alien/queen
-	health = 125
-	maxHealth = 125
-	melee_damage_lower = 7
-	melee_damage_upper = 7
-
-/mob/living/simple_mob/animal/space/alien/queen/empress
-	maxHealth = 200
-	health = 200
-
-/mob/living/simple_mob/animal/space/alien/queen/empress/mother
-	maxHealth = 300
-	health = 300
-	melee_damage_lower = 7
-	melee_damage_upper = 12
-*/
 //what are this things?
 /mob/living/simple_mob/animal/space/alien/sentinel/praetorian/echo
 	name = "alien Echopraetorian"

--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/animal/spider.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/animal/spider.dm
@@ -1,71 +1,58 @@
-//Unfiying spider health, into two catagories. Disrupters and tanks.
-/mob/living/simple_mob/animal/giant_spider/carrier //Disrupter, old 100
+//Now that players will get less overpowered weapons, let mobs have lower HP to compensate. Assume a player has a 10 shot laser rifle doing 40 damage, or a 20 shot smg that does 20
+/mob/living/simple_mob/animal/giant_spider/carrier
 	maxHealth = 60
-	health = 60
-	//melee_damage_lower = 4
-	//melee_damage_upper = 12
 
-/mob/living/simple_mob/animal/giant_spider/electric //disrupter, old 210
+/mob/living/simple_mob/animal/giant_spider/electric
 	maxHealth = 60
 	health = 60
 	projectiletype = /obj/item/projectile/energy/mob/electric_spider
-	//melee_damage_lower = 5
-	//melee_damage_upper = 12
-/*
+
 /mob/living/simple_mob/animal/giant_spider/frost //tank, old 175
-	maxHealth = 60
-	health = 60
+	maxHealth = 75
+	health = 75
 
 /mob/living/simple_mob/animal/giant_spider //tank, old 200
-	maxHealth = 60
-	health = 60
-	melee_damage_lower = 9
-	melee_damage_upper = 15
+	maxHealth = 80
+	health = 80
 
 /mob/living/simple_mob/animal/giant_spider/ion //disrupter, old 90
-	maxHealth = 30
-	health = 30
+	maxHealth = 45
+	health = 45
 
 /mob/living/simple_mob/animal/giant_spider/hunter //disrupter, old 120
-	maxHealth = 30
-	health = 30
+	maxHealth = 40
+	health = 40
 
 /mob/living/simple_mob/animal/giant_spider/lurker //disrupter, old 100
-	maxHealth = 30
-	health = 30
+	maxHealth = 40
+	health = 40
 
 /mob/living/simple_mob/animal/giant_spider/pepper //tank, old 210
-	maxHealth = 60
-	health = 60
+	maxHealth = 80
+	health = 80
 
 /mob/living/simple_mob/animal/giant_spider/phorogenic //tank, old 225
-	maxHealth = 60
-	health = 60
-	melee_damage_lower = 12
-	melee_damage_upper = 20
+	maxHealth = 200 //Gives people a second to stand back
+	health = 200
 
 /mob/living/simple_mob/animal/giant_spider/thermic //tank, old 175
-	maxHealth = 60
-	health = 60
-	melee_damage_lower = 5
-	melee_damage_upper = 12
+	maxHealth = 75
+	health = 75
 
 /mob/living/simple_mob/animal/giant_spider/tunneler //disrupter, old 120
-	maxHealth = 30
-	health = 30
+	maxHealth = 65
+	health = 65
 
 /mob/living/simple_mob/animal/giant_spider/webslinger //disrupter, old 90
-	maxHealth = 30
-	health = 30
+	maxHealth = 40
+	health = 40
 
 /obj/effect/spider/eggcluster
 	spider_type = /obj/effect/spider/spiderling/varied
 
 /mob/living/simple_mob/animal/giant_spider/broodmother
-	maxHealth = 400
-	health = 400
-	melee_damage_lower = 12
-	melee_damage_upper = 20
+	maxHealth = 700
+	health = 700
 
 /mob/living/simple_mob/animal/giant_spider/frost/broodling
 	maxHealth = 20
@@ -115,7 +102,7 @@
 
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-*/
+
 
 //Hijacking this file to make new event spiders
 
@@ -154,8 +141,8 @@
 	*/
 
 /mob/living/simple_mob/animal/giant_spider/lurker/space
-	maxHealth = 20
-	health = 20
+	maxHealth = 40
+	health = 40
 
 /mob/living/simple_mob/animal/giant_spider/nurse/space
 	name = "giant space spider"
@@ -210,14 +197,6 @@
 	min_oxy = 0
 	max_tox = 0
 	max_co2 = 0
-
-	/* Use the parent
-	maxHealth = 30
-	health = 30
-
-	melee_damage_lower = 5
-	melee_damage_upper = 10
-	*/
 
 /mob/living/simple_mob/animal/giant_spider/tunneler/cave
 	name = "cave spider"

--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/humanoid/mercenary.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/humanoid/mercenary.dm
@@ -1,7 +1,27 @@
 /mob/living/simple_mob/humanoid/merc/ranged/laser
 	projectiletype = /obj/item/projectile/energy/mob/midlaser
-/* Combat refactor walkback, old 150
+
 /mob/living/simple_mob/humanoid/merc
-	health = 75			// improper cloning
-	maxHealth = 75
-*/
+	armor = list(melee = 20, bullet = 30, laser = 30, energy = 10, bomb = 10, bio = 100, rad = 100) //Leave the 150 health value to reflect carbon players, slightly reduced melee armor because fuck it.
+
+/mob/living/simple_mob/humanoid/merc/melee/sword
+	attack_sound = 'sound/weapons/blade1.ogg' //Use the proper sword noise
+
+//Keeping the bullet lethality without bullet hosing
+/mob/living/simple_mob/humanoid/merc/ranged/smg
+	base_attack_cooldown = 1.5 SECONDS
+
+/mob/living/simple_mob/humanoid/merc/ranged/rifle
+	base_attack_cooldown = 2 SECONDS
+	reload_max = 10
+
+/mob/living/simple_mob/humanoid/merc/ranged/laser
+	base_attack_cooldown = 2 SECONDS
+
+/mob/living/simple_mob/humanoid/merc/ranged/sniper
+	reload_time = 4 SECONDS
+	ranged_attack_delay = 1.5 SECONDS //They are a push over, a lil faster ;)
+
+/mob/living/simple_mob/humanoid/merc/voxpirate/ranged/suppressor
+	ranged_attack_delay = 1 SECONDS
+	reload_max = 20


### PR DESCRIPTION

## About The Pull Request
With the power level being reduced on exploration recently (A year ago), I finally got off my butt (and since I am stuck at an airport) to make the mob HP reflect the amount of firepower an average prepared player to have, with the general ball park of 2 laser shots or 3-4 bullets out of a gun, there is likely many many mobs I have missed but this is a start.

I want projectiles to keep their lethality, so I reduced the 'bullet hoseyness' of mercs and reduced spider HP

CHANGES
NERF: Spider HP reduced across the board
NERF: SMG merc firerate halved, with the bigger calibers quartered.
NERF: Halved melee armor on mercs
BUFF: Sniper merc shoots 1 second faster
poi changes in a future PR

Mercs: Slowed down fire
## Changelog
:cl:
balance: Mercenary firerate nerfed, some magazine sizes reduced on them,
balance: Sniper merc fires 1 second faster
balance: Spider HP massively nerfed.

/:cl:
