### PR TITLE
Use the roundstart landmarks for Dark Respite

### DIFF
--- a/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
+++ b/code/modules/mob/living/carbon/human/species/shadekin/shadekin.dm
@@ -141,10 +141,7 @@
 	var/area/current_area = get_area(H)
 	if((H.ability_flags & AB_DARK_RESPITE) || H.has_modifier_of_type(/datum/modifier/dark_respite) || current_area.flag_check(AREA_LIMIT_DARK_RESPITE))
 		return
-	var/list/floors = list()
-	for(var/turf/unsimulated/floor/dark/floor in get_area_turfs(/area/shadekin))
-		floors.Add(floor)
-	if(!LAZYLEN(floors))
+	if(!LAZYLEN(GLOB.latejoin_thedark))
 		log_and_message_admins("[H] died outside of the dark but there were no valid floors to warp to")
 		return
 
@@ -180,7 +177,7 @@
 		var/obj/belly/belly = H.loc
 		add_attack_logs(belly.owner, H, "Digested in [lowertext(belly.name)]")
 		to_chat(belly.owner, span_notice("\The [H.name] suddenly vanishes within your [belly.name]"))
-		H.forceMove(pick(floors))
+		H.forceMove(pick(GLOB.latejoin_thedark))
 		if(H.ability_flags & AB_PHASE_SHIFTED)
 			H.phase_shift()
 		else
@@ -206,7 +203,7 @@
 		H.add_modifier(/datum/modifier/dark_respite, 25 MINUTES)
 
 		spawn(1 SECOND)
-			H.forceMove(pick(floors))
+			H.forceMove(pick(GLOB.latejoin_thedark))
 			if(H.ability_flags & AB_PHASE_SHIFTED)
 				H.phase_shift()
 			else

--- a/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/shadekin/shadekin.dm
@@ -268,10 +268,7 @@
 		return ..(FALSE, deathmessage)
 
 
-	var/list/floors = list()
-	for(var/turf/unsimulated/floor/dark/floor in get_area_turfs(/area/shadekin))
-		floors.Add(floor)
-	if(!LAZYLEN(floors))
+	if(!LAZYLEN(GLOB.latejoin_thedark))
 		log_and_message_admins("[src] died outside of the dark but there were no valid floors to warp to")
 		icon_state = ""
 		spawn(1 SECOND)
@@ -301,7 +298,7 @@
 		var/obj/belly/belly = src.loc
 		add_attack_logs(belly.owner, src, "Digested in [lowertext(belly.name)]")
 		to_chat(belly.owner, span_notice("\The [src.name] suddenly vanishes within your [belly.name]"))
-		forceMove(pick(floors))
+		forceMove(pick(GLOB.latejoin_thedark))
 		flick("tp_in",src)
 		respite_activating = FALSE
 		belly.owner.handle_belly_update() // CHOMPEdit
@@ -319,7 +316,7 @@
 	else
 		spawn(1 SECOND)
 			respite_activating = FALSE
-			forceMove(pick(floors))
+			forceMove(pick(GLOB.latejoin_thedark))
 			update_icon()
 			flick("tp_in",src)
 			invisibility = initial(invisibility)


### PR DESCRIPTION

## About The Pull Request
Instead of compiling a list of valid turfs to send kin to every time one dies, now we just use the roundstart landmarks for where kin can spawn in instead.
## Changelog
:cl: Cerami
fix: Change how Dark Respite chooses locations to send kin.
/:cl:
