### PR TITLE
Adds Pilot access to Explorer

### DIFF
--- a/code/game/jobs/job/exploration.dm
+++ b/code/game/jobs/job/exploration.dm
@@ -103,8 +103,8 @@
 	selection_color = "#999440"
 	economic_modifier = 6
 	pto_type = PTO_EXPLORATION
-	access = list(access_explorer, access_external_airlocks, access_eva)
-	minimal_access = list(access_explorer, access_external_airlocks, access_eva)
+	access = list(access_explorer, access_external_airlocks, access_eva, access_pilot)
+	minimal_access = list(access_explorer, access_external_airlocks, access_eva, access_pilot)
 	outfit_type = /decl/hierarchy/outfit/job/explorer2
 	job_description = "An " + JOB_EXPLORER + " searches for interesting things, and returns them to the station."
 	alt_titles = list(JOB_ALT_SURVEYOR = /datum/alt_title/surveyor, JOB_ALT_OFFSITE_SCOUT = /datum/alt_title/offsite_scout)

--- a/code/game/jobs/job/exploration.dm
+++ b/code/game/jobs/job/exploration.dm
@@ -103,8 +103,8 @@
 	selection_color = "#999440"
 	economic_modifier = 6
 	pto_type = PTO_EXPLORATION
-	access = list(access_explorer, access_external_airlocks, access_eva, access_pilot)
-	minimal_access = list(access_explorer, access_external_airlocks, access_eva, access_pilot)
+	access = list(access_explorer, access_external_airlocks, access_eva, access_pilot) //CHOMPedit added pilot access
+	minimal_access = list(access_explorer, access_external_airlocks, access_eva, access_pilot) //CHOMPedit added pilot access
 	outfit_type = /decl/hierarchy/outfit/job/explorer2
 	job_description = "An " + JOB_EXPLORER + " searches for interesting things, and returns them to the station."
 	alt_titles = list(JOB_ALT_SURVEYOR = /datum/alt_title/surveyor, JOB_ALT_OFFSITE_SCOUT = /datum/alt_title/offsite_scout)

--- a/code/game/jobs/job/exploration.dm
+++ b/code/game/jobs/job/exploration.dm
@@ -103,8 +103,8 @@
 	selection_color = "#999440"
 	economic_modifier = 6
 	pto_type = PTO_EXPLORATION
-	access = list(access_explorer, access_external_airlocks, access_eva, access_pilot) //CHOMPedit added pilot access
-	minimal_access = list(access_explorer, access_external_airlocks, access_eva, access_pilot) //CHOMPedit added pilot access
+	access = list(access_explorer, access_external_airlocks, access_eva, access_pilot) //CHOMPedit added pilot access (67)
+	minimal_access = list(access_explorer, access_external_airlocks, access_eva, access_pilot) //CHOMPedit added pilot access (67)
 	outfit_type = /decl/hierarchy/outfit/job/explorer2
 	job_description = "An " + JOB_EXPLORER + " searches for interesting things, and returns them to the station."
 	alt_titles = list(JOB_ALT_SURVEYOR = /datum/alt_title/surveyor, JOB_ALT_OFFSITE_SCOUT = /datum/alt_title/offsite_scout)


### PR DESCRIPTION
## About The Pull Request
Adds Pilot access to the standard explorer role. This is by request of Asmuth per the #suggestions channel, though my own bias is obviously here being the one to add the access. (Medic has not been touched, but 'edit by maintainers' is on for such a reason, or just yap at me to edit it)

This appears to build fine, and private testing shows the access works, even if I do not actually know how to pilot all that well.
I am told 'internal reception' is well, but This is supposed to be for an already set or mostly received well idea per the staff topic (I would link if I could), and [this thread.](https://discord.com/channels/180538463655821312/1301373266384125963)
![image](https://github.com/user-attachments/assets/a25728b0-bbdf-47c3-bc0e-d304010897bb)
## Changelog
:cl:
add: Pilot access added the standard explorer role
/:cl:
