### PR TITLE
Removing all hard access locks.

### DIFF
--- a/code/game/machinery/computer/supply.dm
+++ b/code/game/machinery/computer/supply.dm
@@ -23,7 +23,7 @@
 	icon_keyboard = "tech_key"
 	icon_screen = "supply"
 	light_color = "#b88b2e"
-	req_access = list(access_cargo)
+	//req_access = list(access_cargo) //CHOMPedit, removing hard access locks.
 	circuit = /obj/item/circuitboard/supplycomp/control
 	authorization = SUP_SEND_SHUTTLE | SUP_ACCEPT_ORDERS
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -8,7 +8,7 @@
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 20
 	active_power_usage = 5000
-	req_access = list(access_robotics)
+	//req_access = list(access_robotics) //CHOMPedit, removing hard access locks.
 	circuit = /obj/item/circuitboard/mechfab
 
 	/// Current items in the build queue.

--- a/code/game/mecha/mech_prosthetics.dm
+++ b/code/game/mecha/mech_prosthetics.dm
@@ -9,7 +9,7 @@
 	use_power = USE_POWER_IDLE
 	idle_power_usage = 20
 	active_power_usage = 5000
-	req_access = list(access_robotics)
+	//req_access = list(access_robotics) //CHOMPedit, removing hard access locks.
 	circuit = /obj/item/circuitboard/prosthetics
 
 	// Prosfab specific stuff

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST_EMPTY(all_waypoints)
 	var/dy		//coordinates
 	var/speedlimit = 1/(20 SECONDS) //top speed for autopilot, 5
 	var/accellimit = 0.001 //manual limiter for acceleration
-	req_one_access = list(access_pilot) //VOREStation Edit
+	//req_one_access = list(access_pilot) //VOREStation Edit //CHOMPstation edit, removed hard access locks.
 	ai_control = FALSE	//VOREStation Edit - AI/Borgs shouldn't really be flying off in ships without crew help // Chompstation Edit - Not an issue on this server, use of shuttles is extremely rare also . //Chompeditedit - No
 
 // fancy sprite

--- a/modular_chomp/maps/southern_cross/overmap/shuttles.dm
+++ b/modular_chomp/maps/southern_cross/overmap/shuttles.dm
@@ -20,7 +20,7 @@
 /obj/machinery/computer/shuttle_control/explore/stargazer
 	name = "short jump console"
 	shuttle_tag = "Stargazer"
-	req_one_access = list(access_pilot)
+	//req_one_access = list(access_pilot)
 
 //Baby_Mammoth
 /datum/shuttle/autodock/overmap/baby_mammoth
@@ -43,7 +43,7 @@
 /obj/machinery/computer/shuttle_control/explore/baby_mammoth
 	name = "short jump console"
 	shuttle_tag = "Baby_mammoth"
-	req_one_access = list(access_pilot)
+	//req_one_access = list(access_pilot)
 
 //Ursula
 /datum/shuttle/autodock/overmap/ursula
@@ -66,7 +66,7 @@
 /obj/machinery/computer/shuttle_control/explore/ursula
 	name = "short jump console"
 	shuttle_tag = "Ursula"
-	req_one_access = list(access_pilot)
+	//req_one_access = list(access_pilot)
 
 //Needle
 /datum/shuttle/autodock/overmap/needle
@@ -89,7 +89,7 @@
 /obj/machinery/computer/shuttle_control/explore/needle
 	name = "short jump console"
 	shuttle_tag = "Needle"
-	req_one_access = list(access_pilot)
+	//req_one_access = list(access_pilot)
 
 //Echidna
 /datum/shuttle/autodock/overmap/echidna
@@ -112,7 +112,7 @@
 /obj/machinery/computer/shuttle_control/explore/echidna
 	name = "short jump console"
 	shuttle_tag = "Echidna"
-	req_one_access = list(access_pilot)
+	//req_one_access = list(access_pilot)
 
 //Spacebus
 /datum/shuttle/autodock/overmap/spacebus
@@ -135,7 +135,7 @@
 /obj/machinery/computer/shuttle_control/explore/spacebus
 	name = "short jump console"
 	shuttle_tag = "Space Bus"
-	req_one_access = list(access_pilot)
+	//req_one_access = list(access_pilot)
 
 //POI Junker
 /datum/shuttle/autodock/overmap/junker

--- a/modular_chomp/maps/southern_cross/shuttles/crew_shuttles_ch.dm
+++ b/modular_chomp/maps/southern_cross/shuttles/crew_shuttles_ch.dm
@@ -7,7 +7,7 @@ GLOBAL_LIST_EMPTY(shuttdisp_list)
 /obj/machinery/computer/shuttle_control/web/shuttle3
 	name = "shuttle control console"
 	shuttle_tag = "Shuttle 3"
-	req_access = list(access_pilot)
+	//req_access = list(access_pilot)
 
 /datum/shuttle/autodock/web_shuttle/shuttle3
 	name = "Shuttle 3"


### PR DESCRIPTION
## About The Pull Request
Putting hard access locks that are unable to be bypassed except via access was a relic of a old past that 'babyproofed' a little bit too hard in case of job stealing, something that should be handled by moderation. And I feel like making the game 'anti player' for the sake of 'people following the rules' isn't good practice anymore. 

Plus, I think it would be great to have more conflict brewing if someone decides to step out of line.

Plus, if you managed to go as far as breaking into the department, hacking multiple doors after ordering things via cargo
Any computer console that had hard access (excluding the command console's login) had their hard access lock lifted.
closes #10728

## Changelog
:cl:
qol: Supply console, Robotics Fabs, and Pilot consoles no longer have hard access locks.
/:cl:
