### PR TITLE
replaces science protolathe with science variant

### DIFF
--- a/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus-2.dmm
@@ -23340,7 +23340,7 @@
 /turf/simulated/floor/tiled,
 /area/hallway/Port_2_Deck_Corridor_2)
 "bkB" = (
-/obj/machinery/r_n_d/protolathe,
+/obj/machinery/r_n_d/protolathe/science,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/firealarm{
 	dir = 8;

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -57017,9 +57017,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/research)
 "kQH" = (
-/obj/machinery/r_n_d/protolathe{
-	name = "Core R&D Protolathe"
-	},
+/obj/machinery/r_n_d/protolathe/science,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/reagent_dispensers/acid{
 	pixel_x = -30


### PR DESCRIPTION

## About The Pull Request
This broke a couple of science only RD recipes as the 'Normal protolathe' couldnt print 'science only' stuff. Both protolathes in SC and SN are replaced with this one. You should be able to print a couple of more implants.
## Changelog
:cl:
maptweak: Use the correct protolathes this time for science.
/:cl:
