### PR TITLE
Enables self surgery as a proc

### DIFF
--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -23,7 +23,7 @@
 
 /mob/living/verb/toggle_selfsurgery() //CHOMPedit, make it a inherent verb instead of a proc
 	set name = "Allow Self Surgery"
-	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so. This does not work on if you are a full body prosthetic." //CHOMPedit description addition.
+	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so.
 	set category = "Object"
 
 	allow_self_surgery = !allow_self_surgery

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -21,9 +21,9 @@
 		plane = OBJ_PLANE
 		to_chat(src,span_notice("You are now hiding."))
 
-/mob/living/proc/toggle_selfsurgery()
+/mob/living/verb/toggle_selfsurgery() //CHOMPedit, make it a inherent verb instead of a proc
 	set name = "Allow Self Surgery"
-	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so."
+	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so. This does not work on if you are a full body prosthetic." //CHOMPedit description addition.
 	set category = "Object"
 
 	allow_self_surgery = !allow_self_surgery

--- a/code/modules/mob/living/living_powers.dm
+++ b/code/modules/mob/living/living_powers.dm
@@ -23,7 +23,7 @@
 
 /mob/living/verb/toggle_selfsurgery() //CHOMPedit, make it a inherent verb instead of a proc
 	set name = "Allow Self Surgery"
-	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so.
+	set desc = "Toggles the 'safeties' on self-surgery, allowing you to do so."
 	set category = "Object"
 
 	allow_self_surgery = !allow_self_surgery


### PR DESCRIPTION

## About The Pull Request
Things like risk vs reward probably will need to be refactored, but this will make self surgery an inherent proc on  all living things, you have the risk of passing out in pain or bloodloss when attempting this on yourself, making this risky. 

**This does not work if you're a full body prosthetic by design.**
## Changelog
:cl:
balance: Adds self surgery as a verb under the objects tab.
/:cl:
