### PR TITLE
Removes the taur clip mask from Big leggies

### DIFF
--- a/code/modules/mob/new_player/sprite_accessories_taur.dm
+++ b/code/modules/mob/new_player/sprite_accessories_taur.dm
@@ -1246,6 +1246,7 @@
 	fullness_icons = 3
 	ani_state = "bigleggy_stanced"
 	extra_overlay_w = "bigleggy_markings_stanced"
+	clip_mask_state = null
 
 /datum/sprite_accessory/tail/taur/bigleggy/canine
 	name = "Big Leggies (Canine Tail)"

--- a/code/modules/mob/new_player/sprite_accessories_taur.dm
+++ b/code/modules/mob/new_player/sprite_accessories_taur.dm
@@ -1246,7 +1246,7 @@
 	fullness_icons = 3
 	ani_state = "bigleggy_stanced"
 	extra_overlay_w = "bigleggy_markings_stanced"
-	clip_mask_state = null
+	clip_mask_state = null //ChompAdd - No clip mask for big legs
 
 /datum/sprite_accessory/tail/taur/bigleggy/canine
 	name = "Big Leggies (Canine Tail)"


### PR DESCRIPTION
## About The Pull Request
The big leggies sprites use the base path of "/datum/sprite_accessory/tail/taur", which carries with it the taur clip mask. This caused clothing to incorrectly render with the clip mask rather than how they do on bipedal characters. This PR adds an exemption to the big leggies parent type so that clothing renders over the boosted legs (See attachment). 

## Why it's good for the game
Fixes an error that was bugging me and I'm sure a lot of other people who play characters that utilize the big leggies tail type.

## Proof of testing
![Screenshot 2025-04-30 182903](https://github.com/user-attachments/assets/f9d800c3-7d3a-476d-a222-ccef6fabad03)

I tested this with all big leg styles. Clothing renders properly both in the character creator and in game.

## Changelog

:cl: Arrhythmia_V
fix: Clothing now correctly renders over big leggies 
/:cl:
