### PR TITLE
Bandaid check for chat_message.dm 185 error

### DIFF
--- a/code/datums/chat_message.dm
+++ b/code/datums/chat_message.dm
@@ -107,7 +107,7 @@ var/list/runechat_image_cache = list()
  */
 /datum/chatmessage/proc/generate_image(text, atom/target, mob/owner, list/extra_classes, lifespan)
 
-	if(!target || !owner)
+	if(!target || !owner || !owner.client) //CHOMPEdit
 		qdel(src)
 		return
 


### PR DESCRIPTION
No diddlin those nulls
## About The Pull Request
Fixing the null.measuretext runtime.
## Changelog
:cl:
fix: fixed one of the probably hundreds of those forgotten null sanity checks.
/:cl:
