### PR TITLE
Fixes a runtime with acid pools and food items

### DIFF
--- a/code/modules/vore/eating/digest_act_vr.dm
+++ b/code/modules/vore/eating/digest_act_vr.dm
@@ -129,7 +129,7 @@
 				S.use(1)
 				digest_stage = w_class
 		else
-			if(istype(src, /obj/item/reagent_containers/food))
+			if(istype(B) && istype(src, /obj/item/reagent_containers/food)) //CHOMPEdit
 				if(ishuman(B.owner) && reagents)
 					var/mob/living/carbon/human/H = B.owner
 					reagents.trans_to_holder(H.ingested, (reagents.total_volume), B.nutrition_percent / 100, 0)


### PR DESCRIPTION

## About The Pull Request
Fixes missing belly check for acid pool food item digestion.
## Changelog
:cl:
fix: Fixed a runtime error with food items on acid turfs.
/:cl:
