### PR TITLE
Chem changes

### DIFF
--- a/modular_chomp/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/modular_chomp/code/game/objects/items/weapons/storage/firstaid.dm
@@ -15,43 +15,43 @@
 /obj/item/storage/pill_bottle/neotane
 	name = "pill bottle (" + REAGENT_NEOTANE + ")"
 	desc = "Contains experimental pills, good for soothing burns but tends to mangle the flesh."
-	starts_with = list(/obj/item/reagent_containers/pill/neotane = 7)
+	starts_with = list(/obj/item/reagent_containers/pill/neotane = 12)
 	wrapper_color = COLOR_ORANGE
 
 /obj/item/storage/pill_bottle/burncard
 	name = "pill bottle (" + REAGENT_BURNCARD + ")"
 	desc = "Contains experimental pills, good for sealing cuts and bruises but is quite searing."
-	starts_with = list(/obj/item/reagent_containers/pill/burncard = 7)
+	starts_with = list(/obj/item/reagent_containers/pill/burncard = 12)
 	wrapper_color = COLOR_RED
 
 /obj/item/storage/pill_bottle/flamecure
 	name = "pill bottle (" + REAGENT_FLAMECURE + ")"
 	desc = "Contains experimental pills, good for searing shut internal wounds."
-	starts_with = list(/obj/item/reagent_containers/pill/flamecure = 7)
+	starts_with = list(/obj/item/reagent_containers/pill/flamecure = 12)
 	wrapper_color = COLOR_ORANGE
 
 /obj/item/storage/pill_bottle/juggernog
 	name = "pill bottle (" + REAGENT_JUGGERNOG + ")"
 	desc = "Contains experimental pills good for letting folks keep standing underneath relentless pummeling."
-	starts_with = list(/obj/item/reagent_containers/pill/juggernog = 7)
+	starts_with = list(/obj/item/reagent_containers/pill/juggernog = 12)
 	wrapper_color = COLOR_RED
 
 /obj/item/storage/pill_bottle/curea
 	name = "pill bottle (" + REAGENT_CUREA + ")"
 	desc = "Contains experimental pills, very effective for frostfly and poisonfly hunting."
-	starts_with = list(/obj/item/reagent_containers/pill/curea = 7)
+	starts_with = list(/obj/item/reagent_containers/pill/curea = 12)
 	wrapper_color = COLOR_BLUE
 
 /obj/item/storage/pill_bottle/souldew
 	name = "pill bottle (" + REAGENT_SOULDEW + ")"
 	desc = "Contains experimental pills, for feeding the dead."
-	starts_with = list(/obj/item/reagent_containers/pill/souldew = 7)
+	starts_with = list(/obj/item/reagent_containers/pill/souldew = 12)
 	wrapper_color = COLOR_GREEN
 
 /obj/item/storage/pill_bottle/purifyingagent
 	name = "pill bottle (" + REAGENT_PURIFYINGAGENT + ")"
 	desc = "Contains experimental pills, having application as an anti-toxin."
-	starts_with = list(/obj/item/reagent_containers/pill/purifyingagent = 7)
+	starts_with = list(/obj/item/reagent_containers/pill/purifyingagent = 12)
 	wrapper_color = COLOR_GREEN
 
 /obj/item/storage/pill_bottle/methylphenidate
@@ -87,7 +87,7 @@
 
 /obj/item/reagent_containers/pill/neotane/Initialize(mapload)
 	. = ..()
-	reagents.add_reagent(REAGENT_ID_NEOTANE, 10)
+	reagents.add_reagent(REAGENT_ID_NEOTANE, 5)
 	color = reagents.get_color()
 
 /obj/item/reagent_containers/pill/burncard
@@ -97,7 +97,7 @@
 
 /obj/item/reagent_containers/pill/burncard/Initialize(mapload)
 	. = ..()
-	reagents.add_reagent(REAGENT_ID_BURNCARD, 10)
+	reagents.add_reagent(REAGENT_ID_BURNCARD, 5)
 	color = reagents.get_color()
 
 /obj/item/reagent_containers/pill/flamecure

--- a/modular_chomp/code/modules/reagents/reactions/distilling/distilling.dm
+++ b/modular_chomp/code/modules/reagents/reactions/distilling/distilling.dm
@@ -58,3 +58,14 @@
 	reaction_rate = HALF_LIFE(10)
 
 	temp_range = list(T0C + 230, T0C + 250)
+
+/decl/chemical_reaction/distilling/juggernog
+	name = "juggernog"
+	id = "distill_juggernog"
+	result = REAGENT_ID_JUGGERNOG
+	required_reagents = list(REAGENT_ID_CARBON = 1, REAGENT_ID_IRON = 1, REAGENT_ID_RADIUM = 1, REAGENT_ID_NEOLIQUIDFIRE = 1)
+	result_amount = 2
+
+	reaction_rate = HALF_LIFE(10)
+
+	temp_range = list(T0C + 180, T0C + 200)

--- a/modular_chomp/code/modules/reagents/reactions/distilling/distilling.dm
+++ b/modular_chomp/code/modules/reagents/reactions/distilling/distilling.dm
@@ -63,8 +63,8 @@
 	name = "juggernog"
 	id = "distill_juggernog"
 	result = REAGENT_ID_JUGGERNOG
-	required_reagents = list(REAGENT_ID_CARBON = 1, REAGENT_ID_IRON = 1, REAGENT_ID_RADIUM = 1, REAGENT_ID_NEOLIQUIDFIRE = 1)
-	result_amount = 2
+	required_reagents = list(REAGENT_ID_CARBON = 1, REAGENT_ID_IRON = 1, REAGENT_ID_QUADCORD = 1, REAGENT_ID_NEOLIQUIDFIRE = 1, REAGENT_ID_RADIUM = 1)
+	result_amount = 5
 
 	reaction_rate = HALF_LIFE(10)
 

--- a/modular_chomp/code/modules/reagents/reactions/instant/instant.dm
+++ b/modular_chomp/code/modules/reagents/reactions/instant/instant.dm
@@ -31,7 +31,7 @@
 	name = REAGENT_NEOTANE
 	id = REAGENT_ID_NEOTANE
 	result = REAGENT_ID_NEOTANE
-	required_reagents = list(REAGENT_ID_NEOLIQUIDFIRE = 1, REAGENT_ID_KELOTANE = 1, REAGENT_ID_IRON = 1)
+	required_reagents = list(REAGENT_ID_LIQUIDFIRE = 1, REAGENT_ID_KELOTANE = 1, REAGENT_ID_IRON = 1)
 	result_amount = 2
 
 /decl/chemical_reaction/instant/bloodsealer
@@ -71,12 +71,14 @@
 	result_amount = 3
 
 //tier 2
+/*
 /decl/chemical_reaction/instant/juggernog
 	name = REAGENT_JUGGERNOG
 	id = REAGENT_ID_JUGGERNOG
 	result = REAGENT_ID_JUGGERNOG
 	required_reagents = list(REAGENT_ID_PARACETAMOL = 1, REAGENT_ID_TRAMADOL = 1, REAGENT_ID_SYNAPTIZINE = 1, REAGENT_ID_MERCURY = 1)
 	result_amount = 4
+*/
 
 /decl/chemical_reaction/instant/curea
 	name = REAGENT_CUREA

--- a/modular_chomp/code/modules/reagents/reagents/medicalmods.dm
+++ b/modular_chomp/code/modules/reagents/reagents/medicalmods.dm
@@ -6,15 +6,14 @@
 	on_expired_text = span_notice("The surge subsides.")
 	stacks = MODIFIER_STACK_EXTEND
 	evasion = 20
-	accuracy = -30
 	attack_speed_percent = 0.75
 	siemens_coefficient = 3
 
 /datum/modifier/healingtide //carp
 	name = "Healing Tide"
-	desc = "You are filled with an overwhelming energy."
+	desc = "Your body is more receptive to chemicals."
 
-	on_created_text = span_critical("Your body begins to focus on recovering!")
+	on_created_text = span_critical("Your body is more receptive to chemicals!")
 	on_expired_text = span_notice("The healing subsides.")
 	stacks = MODIFIER_STACK_EXTEND
 
@@ -23,7 +22,7 @@
 
 /datum/modifier/radiationhide //deathclaw
 	name = "Radiation Hide"
-	desc = "Your body defensivly warps."
+	desc = "Your body is adorn with scales."
 
 	on_created_text = span_critical("Your body strangly mutates!")
 	on_expired_text = span_notice("Your body returns to normal.")
@@ -55,7 +54,7 @@
 
 /datum/modifier/protectivenumbing //spider
 	name = "Protective Numbing"
-	desc = "Your senses feel everything."
+	desc = "Your senses dull."
 
 	on_created_text = span_critical("Your body becomes numb!")
 	on_expired_text = span_notice("Sensation returns to your body.")
@@ -64,3 +63,15 @@
 	heat_protection = 1
 	cold_protection = 1
 	attack_speed_percent = 1.25
+
+/datum/modifier/juggernog
+	name = "Juggernog"
+	desc = "Your body is prepared for conflict."
+
+	on_created_text = span_critical("Your body becomes tougher!")
+	on_expired_text = span_notice("Your body returns to normal.")
+	stacks = MODIFIER_STACK_EXTEND
+
+	max_health_percent = 1.3
+	disable_duration_percent = 0.2
+

--- a/modular_chomp/code/modules/reagents/reagents/medicine.dm
+++ b/modular_chomp/code/modules/reagents/reagents/medicine.dm
@@ -113,7 +113,7 @@
 	taste_mult = 3
 	reagent_state = LIQUID
 	color = "#BF0000"
-	overdose = REAGENTS_OVERDOSE
+	overdose = REAGENTS_OVERDOSE * 0.2
 	overdose_mod = 1.25
 	scannable = 1
 
@@ -122,7 +122,8 @@
 	if(alien == IS_SLIME)
 		chem_effective = 0.75
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(6 * removed * chem_effective * chem_effective, -1 * removed)
+		M.heal_organ_damage(13 * removed * chem_effective, 0)
+		M.adjustFireLoss(1 * removed)
 
 /datum/reagent/burncard/overdose(var/mob/living/carbon/M, var/alien, var/removed)
 	..()
@@ -179,7 +180,7 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#FF6600"
-	overdose = REAGENTS_OVERDOSE
+	overdose = REAGENTS_OVERDOSE * 0.2
 	scannable = 1
 
 /datum/reagent/neotane/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
@@ -188,7 +189,8 @@
 		chem_effective = 0.5
 		M.adjustBruteLoss(3 * removed)
 	if(alien != IS_DIONA)
-		M.heal_organ_damage(-1 * removed, 6 * removed * chem_effective * chem_effective)
+		M.heal_organ_damage(0, 13 * removed * chem_effective)
+		M.adjustBruteLoss(1 * removed)
 
 /datum/reagent/bloodsealer
 	name = REAGENT_BLOODSEALER
@@ -292,20 +294,7 @@
 		M.adjustBrainLoss(-1 * removed * chem_effective)
 
 //tier 2
-/datum/reagent/juggernog
-	name = REAGENT_JUGGERNOG
-	id = REAGENT_ID_JUGGERNOG
-	description = "An experimental drug that toughens the body to blows and knockdown"
-	taste_description = "bitterness"
-	reagent_state = LIQUID
-	color = "#660066"
-	scannable = 1
-	overdose = REAGENTS_OVERDOSE * 0.25
 
-/datum/reagent/juggernog/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
-	M.AdjustParalysis(-1)
-	M.AdjustStunned(-1)
-	M.AdjustWeakened(-1)
 
 /datum/reagent/curea
 	name = REAGENT_CUREA
@@ -327,6 +316,10 @@
 	M.remove_a_modifier_of_type(/datum/modifier/deep_wounds)
 	M.remove_a_modifier_of_type(/datum/modifier/hivebot_weaken)
 	M.remove_a_modifier_of_type(/datum/modifier/fire)
+	M.remove_a_modifier_of_type(/datum/modifier/berserk_exhaustion)
+	M.remove_a_modifier_of_type(/datum/modifier/entangled)
+	M.remove_a_modifier_of_type(/datum/modifier/wizfire)
+	M.remove_a_modifier_of_type(/datum/modifier/wizpoison)
 
 //tier 3
 /datum/reagent/modapplying/liquidhealer

--- a/modular_chomp/code/modules/reagents/reagents/modapply.dm
+++ b/modular_chomp/code/modules/reagents/reagents/modapply.dm
@@ -1,7 +1,7 @@
 /datum/reagent/modapplying/energybooster
 	name = REAGENT_ENERGYBOOSTER
 	id = REAGENT_ID_ENERGYBOOSTER
-	description = "A strange forumla that increases the energy of a consumer."
+	description = "A strange formula that improves evasion and attack speed, but  makes one more conductive."
 	taste_description = "high voltage"
 	color = "#FFFF66"
 
@@ -11,7 +11,7 @@
 /datum/reagent/modapplying/oceaniccure
 	name = REAGENT_OCEANICCURE
 	id = REAGENT_ID_OCEANICCURE
-	description = "A strange liquid, altering the proprties of other chemicals."
+	description = "A strange formula that slows the body's rate of metabolism considerably, and improves the healing one's body receives"
 	taste_description = "sea breeze"
 	color = "#C8A5DC"
 
@@ -21,7 +21,7 @@
 /datum/reagent/modapplying/deathclawmutagen
 	name = REAGENT_DEATHCLAWMUTAGEN
 	id = REAGENT_ID_DEATHCLAWMUTAGEN
-	description = "An incredibly strange liquid that temporally changes a person's physical form."
+	description = "A strange formula known to increase the size of a person, increase their health, and reduce the damage they receive, at the cost of reduced healing."
 	taste_description = "buzzing radiation"
 	color = "#00A000"
 
@@ -31,7 +31,7 @@
 /datum/reagent/modapplying/senseenhancer
 	name = REAGENT_SENSEENHANCER
 	id = REAGENT_ID_SENSEENHANCER
-	description = "An incredibly strange liquid that allows consumers to see the world in a new light."
+	description = "A strange formula known to massively increase muscle performance, making one move faster, attack faster, and recover from stuns much more quickly. However, due to increased heart rate, bleeding is significantly worse, metabolism is accelerated three-fold, and death hovers not far behind. Caution advised."
 	taste_description = "blood"
 	color = "#808080"
 
@@ -41,9 +41,21 @@
 /datum/reagent/modapplying/heatnullifer
 	name = REAGENT_HEATNULLIFER
 	id = REAGENT_ID_HEATNULLIFER
-	description = "An incredibly strange liquid that let's consumer's body ignore the effects of tempature."
+	description = "An experimental drug that let's consumer's body ignore the effects of tempature, but slows down limb movements."
 	taste_description = "nothing"
 	color = "#561EC3"
 
 	modifier_to_add = /datum/modifier/protectivenumbing
+	modifier_duration = 3 SECONDS
+
+
+/datum/reagent/modapplying/juggernog
+	name = REAGENT_JUGGERNOG
+	id = REAGENT_ID_JUGGERNOG
+	description = "An experimental drug designed to increase the general amount of damage a person can take before reaching their limit. It also makes it easier to resist effects that disable the user."
+	taste_description = "bitterness"
+	reagent_state = LIQUID
+	color = "#660066"
+
+	modifier_to_add = /datum/modifier/juggernog
 	modifier_duration = 3 SECONDS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->
Neo Kelotane and Burning Bicard work differently now.
ODD of 6 (mostly because there isn't a clean way to make 30 * X = 5)
They heal 13 of their type, and deal 1 damage per.
Neo Kelo uses normal liquid fire now

The modifier chems have better descriptions, thanks Calza.

Juggernog has been altered completely.
It's now a modifier chem
+30% HP, 20% reduced knock down

Distiller (180 - 200 C): CARBON = 1, IRON = 1, QUADCORD = 1, NEOLIQUIDFIRE = 1, RADIUM = 1

Curea removes more mods.

Removed EB's random accuracy change

Orange medkit has more pills now. Pills are altered so the Neo Kelo and BB doesn't kill you.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: altered several experimental chems
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
