### PR TITLE
Disables voidsuit breaching

### DIFF
--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -10,7 +10,7 @@
 
 /obj/item/clothing/suit/space
 
-	var/can_breach = 1                      // Set to 0 to disregard all breaching.
+	var/can_breach = 0                      // Set to 0 to disregard all breaching. //chompEDIT: Set this vaule to zero for removal of breaching.
 	var/list/breaches = list()              // Breach datum container.
 	var/resilience = 0.2                    // Multiplier that turns damage into breach class. 1 is 100% of damage to breach, 0.1 is 10%. 0.2 -> 50 brute/burn damage to cause 10 breach damage
 	var/breach_threshold = 3                // Min damage before a breach is possible. Damage is subtracted by this amount, it determines the "hardness" of the suit.

--- a/code/modules/mob/living/carbon/human/ai_controlled/ai_controlled.dm
+++ b/code/modules/mob/living/carbon/human/ai_controlled/ai_controlled.dm
@@ -33,7 +33,7 @@
 	var/to_wear_l_hand = null
 	var/to_wear_r_hand = /obj/item/melee/baton
 
-/mob/living/carbon/human/ai_controlled/Initialize(mapload)
+/mob/living/carbon/human/ai_controlled/Initialize(mapload, new_species)
 	if(generate_gender)
 		gender = pick(list(MALE, FEMALE, PLURAL, NEUTER))
 

--- a/modular_chomp/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/modular_chomp/code/modules/clothing/spacesuits/spacesuits.dm
@@ -2,5 +2,6 @@
 
 	can_breach = 0 //disabling breaching as a general mechanic
 
-
+/obj/item/clothing/suit/space/emergency
+	can_breach = 1
 

--- a/modular_chomp/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/modular_chomp/code/modules/clothing/spacesuits/spacesuits.dm
@@ -1,0 +1,6 @@
+/obj/item/clothing/suit/space
+
+	can_breach = 0 //disabling breaching as a general mechanic
+
+
+

--- a/modular_chomp/code/modules/living/carbon/human/ai_controlled/ai_controlled.dm
+++ b/modular_chomp/code/modules/living/carbon/human/ai_controlled/ai_controlled.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/ai_controlled/greytide/Initialize(mapload)
+/mob/living/carbon/human/ai_controlled/greytide/Initialize(mapload, new_species)
 	to_wear_r_hand = pick(
 		prob(20); /obj/item/storage/toolbox/electrical,
 		prob(20); /obj/item/storage/toolbox/mechanical,

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4955,6 +4955,7 @@
 #include "modular_chomp\code\modules\clothing\masks\hailer.dm"
 #include "modular_chomp\code\modules\clothing\masks\miscellaneous.dm"
 #include "modular_chomp\code\modules\clothing\shoes\miscellaneous.dm"
+#include "modular_chomp\code\modules\clothing\spacesuits\spacesuits.dm"
 #include "modular_chomp\code\modules\clothing\spacesuits\rig\.behemoth.dm"
 #include "modular_chomp\code\modules\clothing\spacesuits\rig\clockwork_ch.dm"
 #include "modular_chomp\code\modules\clothing\spacesuits\rig\other.dm"


### PR DESCRIPTION

## About The Pull Request
Breaching, a mostly disliked mechanic.
adds durability to some armor types.
Could this work...ehh, maybe, but the base values are so low for polaris damage values.
That and most armor lack durability issues.
So just disabling it for the general suit populous
Feature is still there, could 100% make a niche void/space suit that breaches by changing the value on that specific piece.

I also despise durability mechanics outside survival horror, yet to see it done well outside of that.

## Changelog
:cl:
balance: voidsuits should no longer breach
/:cl:
