### PR TITLE
Fixed missing vaules

### DIFF
--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/mechanical/hivebot/orginalAlts.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/mechanical/hivebot/orginalAlts.dm
@@ -58,7 +58,7 @@
 		attackcycle = 0
 	else if(attackcycle == 3)
 		specialattackprojectile = /obj/item/projectile/energy/spikeenergy_ball/boss
-		addtimer(CALLBACK(src, PROC_REF(dual_spin), A, 4), 1 SECOND, TIMER_DELETE_ME)
+		addtimer(CALLBACK(src, PROC_REF(dual_spin), A, 4, 25), 1 SECOND, TIMER_DELETE_ME)
 		attackcycle = 0
 	else if(attackcycle == 4)
 		specialattackprojectile = /obj/item/projectile/energy/spikeenergy_ball/boss
@@ -124,7 +124,7 @@
 		specialattackprojectile = /obj/item/projectile/energy/wallbreaker/boss
 		rng_cycle = rand(1,4)
 		say("PROTOCOL: PRECISION. SWEEP.")
-		addtimer(CALLBACK(src, PROC_REF(dual_spin), A, rng_cycle), 2 SECONDS, TIMER_DELETE_ME)
+		addtimer(CALLBACK(src, PROC_REF(dual_spin), A, rng_cycle, 25), 2 SECONDS, TIMER_DELETE_ME)
 		attackcycle = 0
 	else if(attackcycle == 3)
 		specialattackprojectile = /obj/item/projectile/energy/lightingspark/nanoweave


### PR DESCRIPTION

## About The Pull Request
Seems during the code refactoring, I forgot to include two vaules for two of the attacked, causing the entire attack to occur in a millisecond.
Fixed that.

## Changelog
:cl:
fix: sif hivebot bosses regained delay for their spinny attack
/:cl:
