### PR TITLE
Makes Sharp Melee a 0-point neutral trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/neutral_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/neutral_ch.dm
@@ -7,6 +7,14 @@
 	..()
 	add_verb(H,/mob/living/proc/mobegglaying) //CHOMPEdit TGPanel
 
+//CHOMPEdit - make sharp melee a free neutral trait
+/datum/trait/neutral/melee_attack
+	name = "Special Attack: Sharp Melee" // Trait Organization for easier browsing. TODO: Proper categorization of 'health/ability/resist/etc'
+	desc = "Provides sharp melee attacks that wound more easily." //CHOMPEdit - more accurate description
+	cost = 0
+	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp))
+//End CHOMPEdit
+
 /datum/trait/neutral/succubus_bite
 	name = "Succubus Bite"
 	desc = "Allows you to inject your prey with poison, much like a venemous snake."

--- a/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -92,16 +92,18 @@
 	banned_species = list(SPECIES_TAJARAN, SPECIES_SHADEKIN_CREW, SPECIES_SHADEKIN, SPECIES_XENOHYBRID, SPECIES_VULPKANIN, SPECIES_XENO, SPECIES_XENOCHIMERA, SPECIES_VASILISSAN, SPECIES_WEREBEAST) //These species already have strong darksight by default.
 */
 
+/* //CHOMPEdit - sharp melee moved to be a free neutral trait
 /datum/trait/positive/melee_attack
 	name = "Special Attack: Sharp Melee" // Trait Organization for easier browsing. TODO: Proper categorization of 'health/ability/resist/etc'
 	desc = "Provides sharp melee attacks that do slightly more damage."
 	cost = 1
 	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp))
+*/
 
 /datum/trait/positive/melee_attack_fangs
 	name = "Special Attack: Sharp Melee & Numbing Fangs" // Trait Organization for easier browsing. TODO: Proper categorization of 'health/ability/resist/etc'
-	desc = "Provides sharp melee attacks that do slightly more damage, along with fangs that makes the person bit unable to feel their body or pain."
-	cost = 2
+	desc = "Provides sharp melee attacks that wound more easily, along with fangs that makes the person bit unable to feel their body or pain." //CHOMPEdit - more accurate description
+	cost = 1 // CHOMPEdit - sharp melee is free now, so this should cost the same as fangs
 	var_changes = list("unarmed_types" = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp, /datum/unarmed_attack/bite/sharp/numbing))
 
 /datum/trait/positive/fangs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

This pull request changes Sharp Melee from a 1-point positive trait to a 0-point neutral trait. **Players who had the trait already will need to re-select it**, unless someone can tell me a way around this. Also reduces the cost of the sharp claws and numbing fangs trait accordingly and updates descriptions to be more accurate.

Most people who take this trait do so because they are simply playing a species with claws; not because they seek to gain any sort of significant mechanical advantage. It feels punishing to have it cost a point and take up a trait slot.

<!-- Describe The Pull Request. -->

**Balance Reasoning**
First, I want to clear up a misconception: Sharp Melee does not increase unarmed damage at all; the description is misleading.

Sharp Melee simply causes your unarmed attacks to do cutting damage rather than blunt damage. This gives a _minor_ advantage in _specifically_ unarmed fights against other players (simple mobs do not care what damage type you deal), since it causes significantly more bleeding and can more easily cause infections.

However, striking people for unarmed damage in PvP is not the most effective approach, nor is it even close. Punches cause an average of around 3 damage, and fighting with pretty much anything else is stronger. Further, bleeding and infection are slow enough threats in our codebase that an actual serious PvP fight where balance matters would long since be over before either became relevant. Bleeding and infections are mostly a PvE threat, where players may have limited supplies and not be able to readily treat wounds.

As the damage threshold for delimbing is 16 points (or 10 points for hands/feet, or 24 points to decapitate), even the newly-added +10 unarmed damage trait won't allow an unarmed attack to delimb by itself. Stacking other unarmed damage modifiers like knuckledusters, black fiber wire gloves, or rings would allow someone to cross that threshold, but at that point you're being very intentional about it.

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
balance: sharp melee is now a free neutral trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
