### PR TITLE
Enables spontaneous prey on xenobio slimes

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio_vr.dm
@@ -2,6 +2,7 @@
 	temperature_range = 5
 	mob_bump_flag = SLIME
 	vore_attack_override = TRUE
+	can_be_drop_prey = TRUE
 
 /mob/living/simple_mob/slime/xenobio/Initialize(mapload, var/mob/living/simple_mob/slime/xenobio/my_predecessor)
 	. = ..()

--- a/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio_vr.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/slime/xenobio/xenobio_vr.dm
@@ -2,7 +2,7 @@
 	temperature_range = 5
 	mob_bump_flag = SLIME
 	vore_attack_override = TRUE
-	can_be_drop_prey = TRUE
+	can_be_drop_prey = TRUE //CHOMP Edit
 
 /mob/living/simple_mob/slime/xenobio/Initialize(mapload, var/mob/living/simple_mob/slime/xenobio/my_predecessor)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
A lot of people (myself included) have been wanting this. It turns out many people want to eat slimes! But currently the only way of doing so is manually grabbing them one by one, which takes forever. This would help speed up the process greatly. I don't believe this would be much of a balance issue, as the most this would do is allow you to move slimes around faster, which isn't necessary for seasoned xenobio players who can already grow any color they'd like on demand.

It would also make cleaning up slime outbreaks a lot more fun if you could grab a vacuum and go full Slime Rancher.

## Changelog
:cl:
add: Xenobio slimes now have spontaneous prey enabled.
/:cl:
