### PR TITLE
Correct more alias usage for Simultaneous map definitions

### DIFF
--- a/modular_chomp/maps/common/common_defines.dm
+++ b/modular_chomp/maps/common/common_defines.dm
@@ -9,9 +9,9 @@
 #define Z_LEVEL_SC_STATION_TWO				3
 #define Z_LEVEL_SC_STATION_THREE			4
 
-#define Z_NAME_SC_SURFACE					"Southern Cross - Surface"
-#define Z_NAME_SC_SURFACE_MINE				"Southern Cross - Surface Mines"
-#define Z_NAME_SC_SURFACE_WILD				"Southern Cross - Surface Wild"
+#define Z_NAME_SC_SURFACE					"Southern Cross - Surface" // Aliased to Z_NAME_ALIAS_SURFACE
+#define Z_NAME_SC_SURFACE_MINE				"Southern Cross - Surface Mines" // Aliased to Z_NAME_ALIAS_SURFACE_MINES
+#define Z_NAME_SC_SURFACE_WILD				"Southern Cross - Surface Wild" // Aliased to Z_NAME_ALIAS_SURFACE_WILDS
 #define Z_NAME_SC_MISC						"Southern Cross - Misc" // Aliased to Z_NAME_ALIAS_MISC
 #define Z_NAME_SC_CENTCOM					"Southern Cross - Central Command" // Aliased to Z_NAME_ALIAS_CENTCOM
 #define Z_NAME_SC_TRANSIT					"Southern Cross - Transit"
@@ -33,10 +33,10 @@
 #define Z_LEVEL_RB_THE_SKY					5
 
 #define Z_NAME_RB_UNDERMINES				"Relic Base - Undermines"
-#define Z_NAME_RB_SURFACE_WILDS				"Relic Base - Surface Wilds"
+#define Z_NAME_RB_SURFACE_WILDS				"Relic Base - Surface Wilds" // Aliased to Z_NAME_ALIAS_SURFACE_WILDS
 #define Z_NAME_RB_WILDERNESS_SKY			"Relic Base - Wilderness Sky"
-#define Z_NAME_RB_SURFACE_OCEAN				"Relic Base - Surface Ocean"
-#define Z_NAME_RB_SURFACE_MINES				"Relic Base - Surface Mines"
+#define Z_NAME_RB_SURFACE_OCEAN				"Relic Base - Surface Ocean" // Aliased to Z_NAME_ALIAS_SURFACE
+#define Z_NAME_RB_SURFACE_MINES				"Relic Base - Surface Mines" // Aliased to Z_NAME_ALIAS_SURFACE_MINES
 #define Z_NAME_RB_CARRIER 					"Relic Base - Misc" // Aliased to Z_NAME_ALIAS_MISC
 #define Z_NAME_RB_CENTCOM					"Relic Base - Central Command" // Aliased to Z_NAME_ALIAS_CENTCOM
 #define Z_NAME_RB_TRANSIT					"Relic Base - Transit"
@@ -48,6 +48,11 @@
 #define Z_NAME_VR_WORLD_CH					"VR - VR World CH"
 #define Z_NAME_PLANET_THOR_CH				"Planet - Thor Surface CH"
 #define Z_NAME_PLANET_TYR_CH				"Planet - Desert Valley CH"
+
+// Common
+#define Z_NAME_ALIAS_SURFACE				"SURFACE"
+#define Z_NAME_ALIAS_SURFACE_MINES			"SURFACE MINES"
+#define Z_NAME_ALIAS_SURFACE_WILDS			"SURFACE WILDS"
 
 // Gateways (Aliased to Z_NAME_ALIAS_GATEWAY)
 #define Z_NAME_GATEWAY_SNOW_FIELD_CH		"Gateway - Snow Field CH"

--- a/modular_chomp/maps/common/common_shuttles_crew.dm
+++ b/modular_chomp/maps/common/common_shuttles_crew.dm
@@ -142,9 +142,9 @@ GLOBAL_LIST_EMPTY(shuttdisp_list)
 			last_z = Z_LEVEL_SC_STATION_ONE
 			location_desc = "docked on the station"
 
-		else if(my_shuttle.current_location.z == GLOB.map_templates_loaded[Z_NAME_SC_SURFACE])
+		else if(my_shuttle.current_location.z == GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE])
 			message2 = "Outp"
-			last_z = GLOB.map_templates_loaded[Z_NAME_SC_SURFACE]
+			last_z = GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE]
 			location_desc =	"docked on the outpost"
 
 		else
@@ -152,7 +152,7 @@ GLOBAL_LIST_EMPTY(shuttdisp_list)
 				message2 = "STS-O"
 				location_desc = "travelling to the outpost"
 
-			if(last_z == GLOB.map_templates_loaded[Z_NAME_SC_SURFACE])
+			if(last_z == GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE])
 				message2 = "STS-S"
 				location_desc = "travelling to the station"
 

--- a/modular_chomp/maps/common_submaps/sif/sif_defines.dm
+++ b/modular_chomp/maps/common_submaps/sif/sif_defines.dm
@@ -1,8 +1,8 @@
 /datum/planet/sif
 	expected_z_levels = list(
-		Z_NAME_SC_SURFACE,
-		Z_NAME_SC_SURFACE_MINE,
-		Z_NAME_SC_SURFACE_WILD,
+		Z_NAME_ALIAS_SURFACE,
+		Z_NAME_ALIAS_SURFACE_MINES,
+		Z_NAME_ALIAS_SURFACE_WILDS,
 		//Z_LEVEL_SURFACE_SKYLANDS, //Sky islands removal due to lack of use
 		//Z_LEVEL_SURFACE_VALLEY //Replaced with Tyr
 	)

--- a/modular_chomp/maps/overmap/sectors/common_overmap.dm
+++ b/modular_chomp/maps/overmap/sectors/common_overmap.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(station_waypoints) //Create global list for station waypoints,
 	start_y =  10
 	known = 1 // lets Sectors appear on shuttle navigation for easy finding.
 
-	extra_z_levels = list(Z_NAME_SN_TRANSIT, Z_NAME_SN_MISC, Z_NAME_SC_SURFACE, Z_NAME_SC_SURFACE_MINE, Z_NAME_SC_SURFACE_WILD) //This should allow for comms to reach people from the station. Basically this defines all the areas of Southern Cross and the Sif local system on the overmap.
+	extra_z_levels = list(Z_NAME_SN_TRANSIT, Z_NAME_ALIAS_MISC, Z_NAME_SC_SURFACE, Z_NAME_SC_SURFACE_MINE, Z_NAME_SC_SURFACE_WILD) //This should allow for comms to reach people from the station. Basically this defines all the areas of Southern Cross and the Sif local system on the overmap.
 	// "Z_LEVEL_SURFACE_SKYLANDS, " //removed due to lack of use
 	mob_announce_cooldown = 0
 
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(station_waypoints) //Create global list for station waypoints,
 	start_y =  10
 	known = 1 // lets Sectors appear on shuttle navigation for easy finding.
 
-	extra_z_levels = list(Z_NAME_SC_TRANSIT, Z_NAME_SC_MISC, Z_NAME_SC_SURFACE, Z_NAME_SC_SURFACE_MINE, Z_NAME_SC_SURFACE_WILD) //This should allow for comms to reach people from the station. Basically this defines all the areas of Southern Cross and the Sif local system on the overmap.
+	extra_z_levels = list(Z_NAME_SC_TRANSIT, Z_NAME_ALIAS_MISC, Z_NAME_SC_SURFACE, Z_NAME_SC_SURFACE_MINE, Z_NAME_SC_SURFACE_WILD) //This should allow for comms to reach people from the station. Basically this defines all the areas of Southern Cross and the Sif local system on the overmap.
 	// "Z_LEVEL_SURFACE_SKYLANDS, " //removed due to lack of use
 	mob_announce_cooldown = 0
 
@@ -209,7 +209,7 @@ GLOBAL_LIST_EMPTY(station_waypoints) //Create global list for station waypoints,
 [b]Notice[/b]: The Vir government welcomes you to this world."}
 
 	// Set map_z to your levels for a planetary base. If you're ever going to split this up/add more Z's to Thor, imitate SC. THESE MUST BE DEFINED FOR SENSORS + SUCH TO WORK.
-	map_z = list(Z_LEVEL_RB_CATACOMBS, Z_LEVEL_RB_UNDERGROUND, Z_LEVEL_RB_SURFACE, Z_LEVEL_RB_UPPER_FLOORS, Z_NAME_RB_SURFACE_WILDS, Z_NAME_RB_SURFACE_OCEAN, Z_NAME_RB_CARRIER)
+	map_z = list(Z_LEVEL_RB_CATACOMBS, Z_LEVEL_RB_UNDERGROUND, Z_LEVEL_RB_SURFACE, Z_LEVEL_RB_UPPER_FLOORS, Z_NAME_RB_SURFACE_WILDS, Z_NAME_RB_SURFACE_OCEAN, Z_NAME_ALIAS_MISC)
 
 	initial_generic_waypoints = list(
 		"baby_mammoth_dock",

--- a/modular_chomp/maps/overmap/sectors/common_overmap.dm
+++ b/modular_chomp/maps/overmap/sectors/common_overmap.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_EMPTY(station_waypoints) //Create global list for station waypoints,
 	start_y =  10
 	known = 1 // lets Sectors appear on shuttle navigation for easy finding.
 
-	extra_z_levels = list(Z_NAME_SN_TRANSIT, Z_NAME_ALIAS_MISC, Z_NAME_SC_SURFACE, Z_NAME_SC_SURFACE_MINE, Z_NAME_SC_SURFACE_WILD) //This should allow for comms to reach people from the station. Basically this defines all the areas of Southern Cross and the Sif local system on the overmap.
+	extra_z_levels = list(Z_NAME_SN_TRANSIT, Z_NAME_ALIAS_MISC, Z_NAME_ALIAS_SURFACE, Z_NAME_ALIAS_SURFACE_MINES, Z_NAME_ALIAS_SURFACE_WILDS) //This should allow for comms to reach people from the station. Basically this defines all the areas of Southern Cross and the Sif local system on the overmap.
 	// "Z_LEVEL_SURFACE_SKYLANDS, " //removed due to lack of use
 	mob_announce_cooldown = 0
 
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(station_waypoints) //Create global list for station waypoints,
 	start_y =  10
 	known = 1 // lets Sectors appear on shuttle navigation for easy finding.
 
-	extra_z_levels = list(Z_NAME_SC_TRANSIT, Z_NAME_ALIAS_MISC, Z_NAME_SC_SURFACE, Z_NAME_SC_SURFACE_MINE, Z_NAME_SC_SURFACE_WILD) //This should allow for comms to reach people from the station. Basically this defines all the areas of Southern Cross and the Sif local system on the overmap.
+	extra_z_levels = list(Z_NAME_SC_TRANSIT, Z_NAME_ALIAS_MISC, Z_NAME_ALIAS_SURFACE, Z_NAME_ALIAS_SURFACE_MINES, Z_NAME_ALIAS_SURFACE_WILDS) //This should allow for comms to reach people from the station. Basically this defines all the areas of Southern Cross and the Sif local system on the overmap.
 	// "Z_LEVEL_SURFACE_SKYLANDS, " //removed due to lack of use
 	mob_announce_cooldown = 0
 
@@ -209,7 +209,7 @@ GLOBAL_LIST_EMPTY(station_waypoints) //Create global list for station waypoints,
 [b]Notice[/b]: The Vir government welcomes you to this world."}
 
 	// Set map_z to your levels for a planetary base. If you're ever going to split this up/add more Z's to Thor, imitate SC. THESE MUST BE DEFINED FOR SENSORS + SUCH TO WORK.
-	map_z = list(Z_LEVEL_RB_CATACOMBS, Z_LEVEL_RB_UNDERGROUND, Z_LEVEL_RB_SURFACE, Z_LEVEL_RB_UPPER_FLOORS, Z_NAME_RB_SURFACE_WILDS, Z_NAME_RB_SURFACE_OCEAN, Z_NAME_ALIAS_MISC)
+	map_z = list(Z_LEVEL_RB_CATACOMBS, Z_LEVEL_RB_UNDERGROUND, Z_LEVEL_RB_SURFACE, Z_LEVEL_RB_UPPER_FLOORS, Z_NAME_ALIAS_SURFACE_WILDS, Z_NAME_ALIAS_SURFACE, Z_NAME_ALIAS_MISC)
 
 	initial_generic_waypoints = list(
 		"baby_mammoth_dock",
@@ -259,7 +259,7 @@ GLOBAL_LIST_EMPTY(station_waypoints) //Create global list for station waypoints,
 [i]Transponder[/i]: Transmitting (CIV), Vir IFF
 [b]Notice[/b]: The Vir government welcomes you to this world."}
 
-	map_z = list(Z_NAME_SC_SURFACE, Z_NAME_SC_SURFACE_MINE, Z_NAME_SC_SURFACE_WILD)
+	map_z = list(Z_NAME_ALIAS_SURFACE, Z_NAME_ALIAS_SURFACE_MINES, Z_NAME_ALIAS_SURFACE_WILDS)
 	//Z_LEVEL_SURFACE_SKYLANDS, //removed due to lack of use
 
 	initial_generic_waypoints = list(

--- a/modular_chomp/maps/relic_base/relicbase_defines.dm
+++ b/modular_chomp/maps/relic_base/relicbase_defines.dm
@@ -149,18 +149,18 @@
 
 	// Cave submaps are first.
 	var/undermines_z = GLOB.map_templates_loaded[Z_NAME_RB_UNDERMINES]
-	var/surface_mines_z = GLOB.map_templates_loaded[Z_NAME_RB_SURFACE_MINES]
+	var/surface_mines_z = GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE_MINES]
 	seed_submaps(list(undermines_z), 140, /area/surface/cave/unexplored/normal, /datum/map_template/surface/mountains/normal)
 	seed_submaps(list(undermines_z), 140, /area/surface/cave/unexplored/deep, /datum/map_template/surface/mountains/deep)
 	seed_submaps(list(surface_mines_z), 140, /area/surface/outside/wilderness/mountains, /datum/map_template/surface/mountains/normal)
 
 	// Plains to make them less plain.
-	var/surface_ocean_z = GLOB.map_templates_loaded[Z_NAME_RB_SURFACE_OCEAN]
+	var/surface_ocean_z = GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE]
 	seed_submaps(list(Z_LEVEL_RB_SURFACE), 220, /area/surface/outside/plains/normal, /datum/map_template/surface/plains) // Both of these will need a massive POI overhaul. The framework is in, and tiles will be mass-edited to match, but better POIs are wanted.
 	seed_submaps(list(surface_ocean_z), 220, /area/surface/outside/plains/normal, /datum/map_template/surface/plains) // Both of these will need a massive POI overhaul. The framework is in, and tiles will be mass-edited to match, but better POIs are wanted.
 
 	// Wilderness is next.
-	var/surface_wilds_z = GLOB.map_templates_loaded[Z_NAME_RB_SURFACE_WILDS]
+	var/surface_wilds_z = GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE_WILDS]
 	seed_submaps(list(surface_wilds_z), 240, /area/surface/outside/wilderness/normal, /datum/map_template/surface/wilderness/normal)
 	seed_submaps(list(surface_wilds_z), 240, /area/surface/outside/wilderness/deep, /datum/map_template/surface/wilderness/deep)
 	// If Space submaps are made, add a line to make them here as well.
@@ -284,6 +284,7 @@
 
 /datum/map_template/relicbase_lateload/surface_wild
 	name = Z_NAME_RB_SURFACE_WILDS
+	name_alias = Z_NAME_ALIAS_SURFACE_WILDS
 	mappath = "modular_chomp/maps/relic_base/relicbase-7.dmm"
 	associated_map_datum = /datum/map_z_level/relicbase_lateload/surface_wild
 
@@ -306,6 +307,7 @@
 
 /datum/map_template/relicbase_lateload/surface_ocean
 	name = Z_NAME_RB_SURFACE_OCEAN
+	name_alias = Z_NAME_ALIAS_SURFACE
 	mappath = "modular_chomp/maps/relic_base/relicbase-9.dmm"
 	associated_map_datum = /datum/map_z_level/relicbase_lateload/surface_ocean
 
@@ -317,6 +319,7 @@
 
 /datum/map_template/relicbase_lateload/surface_mine
 	name = Z_NAME_RB_SURFACE_MINES
+	name_alias = Z_NAME_ALIAS_SURFACE_MINES
 	mappath = "modular_chomp/maps/relic_base/relicbase-10.dmm"
 	associated_map_datum = /datum/map_z_level/relicbase_lateload/surface_mine
 
@@ -361,8 +364,8 @@
 		Z_LEVEL_RB_UPPER_FLOORS,
 		Z_LEVEL_RB_THE_SKY,
 		Z_NAME_RB_UNDERMINES,
-		Z_NAME_RB_SURFACE_WILDS,
+		Z_NAME_ALIAS_SURFACE_WILDS,
 		Z_NAME_RB_WILDERNESS_SKY,
-		Z_NAME_RB_SURFACE_OCEAN,
-		Z_NAME_RB_SURFACE_MINES,
+		Z_NAME_ALIAS_SURFACE,
+		Z_NAME_ALIAS_SURFACE_MINES,
 	)

--- a/modular_chomp/maps/soluna_nexus/soluna_nexus_defines.dm
+++ b/modular_chomp/maps/soluna_nexus/soluna_nexus_defines.dm
@@ -108,16 +108,16 @@
 	// First, place a bunch of submaps. This comes before tunnel/forest generation as to not interfere with the submap.(This controls POI limit generation, increase or lower its values to have more or less POI's)
 
 	// Cave submaps are first.
-	var/surface_mine_z = GLOB.map_templates_loaded[Z_NAME_SC_SURFACE_MINE]
+	var/surface_mine_z = GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE_MINES]
 	seed_submaps(list(surface_mine_z), 140, /area/surface/cave/unexplored/normal, /datum/map_template/surface/mountains/normal)
 	seed_submaps(list(surface_mine_z), 140, /area/surface/cave/unexplored/deep, /datum/map_template/surface/mountains/deep)
 
 	// Plains to make them less plain.
-	var/surface_z = GLOB.map_templates_loaded[Z_NAME_SC_SURFACE]
+	var/surface_z = GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE]
 	seed_submaps(list(surface_z), 220, /area/surface/outside/plains/normal, /datum/map_template/surface/plains) // Center area is WIP until map editing settles down.
 
 	// Wilderness is next.
-	var/surface_wild_z = GLOB.map_templates_loaded[Z_NAME_SC_SURFACE_WILD]
+	var/surface_wild_z = GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE_WILDS]
 	seed_submaps(list(surface_wild_z), 240, /area/surface/outside/wilderness/normal, /datum/map_template/surface/wilderness/normal)
 	seed_submaps(list(surface_wild_z), 240, /area/surface/outside/wilderness/deep, /datum/map_template/surface/wilderness/deep)
 	// If Space submaps are made, add a line to make them here as well.
@@ -201,7 +201,7 @@
 	transit_chance = 60
 */
 
-// Surface Z-Level
+// Surface Z-Level (overlaps with /datum/map_z_level/southern_cross_lateload/surface so could instead be a common map)
 /datum/map_z_level/soluna_nexus_lateload/surface
 	name = Z_NAME_SC_SURFACE
 	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONSOLES|MAP_LEVEL_VORESPAWN
@@ -209,10 +209,11 @@
 
 /datum/map_template/soluna_nexus_lateload/surface
 	name = Z_NAME_SC_SURFACE
+	name_alias = Z_NAME_ALIAS_SURFACE
 	mappath = "modular_chomp/maps/southern_cross/southern_cross-5.dmm"
 	associated_map_datum = /datum/map_z_level/soluna_nexus_lateload/surface
 
-// Surface Mine Z-Level
+// Surface Mine Z-Level (overlaps with /datum/map_z_level/southern_cross_lateload/surface_mine so could instead be a common map)
 /datum/map_z_level/soluna_nexus_lateload/surface_mine
 	name = Z_NAME_SC_SURFACE_MINE
 	flags = MAP_LEVEL_CONTACT|MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONSOLES
@@ -220,10 +221,11 @@
 
 /datum/map_template/soluna_nexus_lateload/surface_mine
 	name = Z_NAME_SC_SURFACE_MINE
+	name_alias = Z_NAME_ALIAS_SURFACE_MINES
 	mappath = "modular_chomp/maps/southern_cross/southern_cross-6.dmm"
 	associated_map_datum = /datum/map_z_level/soluna_nexus_lateload/surface_mine
 
-// Surface Wild Z-Level
+// Surface Wild Z-Level (overlaps with /datum/map_z_level/southern_cross_lateload/surface_wild so could instead be a common map)
 /datum/map_z_level/soluna_nexus_lateload/surface_wild
 	name = Z_NAME_SC_SURFACE_WILD
 	flags = MAP_LEVEL_PLAYER|MAP_LEVEL_SEALED|MAP_LEVEL_CONTACT|MAP_LEVEL_CONSOLES
@@ -231,6 +233,7 @@
 
 /datum/map_template/soluna_nexus_lateload/surface_wild
 	name = Z_NAME_SC_SURFACE_WILD
+	name_alias = Z_NAME_ALIAS_SURFACE_WILDS
 	mappath = "modular_chomp/maps/southern_cross/southern_cross-10.dmm"
 	associated_map_datum = /datum/map_z_level/soluna_nexus_lateload/surface_wild
 

--- a/modular_chomp/maps/southern_cross/southern_cross_defines.dm
+++ b/modular_chomp/maps/southern_cross/southern_cross_defines.dm
@@ -110,16 +110,16 @@
 	// First, place a bunch of submaps. This comes before tunnel/forest generation as to not interfere with the submap.(This controls POI limit generation, increase or lower its values to have more or less POI's)
 
 	// Cave submaps are first.
-	var/surface_mine_z = GLOB.map_templates_loaded[Z_NAME_SC_SURFACE_MINE]
+	var/surface_mine_z = GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE_MINES]
 	seed_submaps(list(surface_mine_z), 140, /area/surface/cave/unexplored/normal, /datum/map_template/surface/mountains/normal)  //CHOMPEdit bumped up from 60 to 80
 	seed_submaps(list(surface_mine_z), 140, /area/surface/cave/unexplored/deep, /datum/map_template/surface/mountains/deep)  //CHOMPEdit bumped up from 60 to 80
 
 	// Plains to make them less plain.
-	var/surface_z = GLOB.map_templates_loaded[Z_NAME_SC_SURFACE]
+	var/surface_z = GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE]
 	seed_submaps(list(surface_z), 220, /area/surface/outside/plains/normal, /datum/map_template/surface/plains) // Center area is WIP until map editing settles down.  //CHOMPEdit bumped up from 80 to 140
 
 	// Wilderness is next.
-	var/surface_wild_z = GLOB.map_templates_loaded[Z_NAME_SC_SURFACE_WILD]
+	var/surface_wild_z = GLOB.map_templates_loaded[Z_NAME_ALIAS_SURFACE_WILDS]
 	seed_submaps(list(surface_wild_z), 240, /area/surface/outside/wilderness/normal, /datum/map_template/surface/wilderness/normal)  //CHOMPEdit bumped up from 60 to 150
 	seed_submaps(list(surface_wild_z), 240, /area/surface/outside/wilderness/deep, /datum/map_template/surface/wilderness/deep)  //CHOMPEdit bumped up from 60 to 150
 	// If Space submaps are made, add a line to make them here as well.
@@ -210,6 +210,7 @@
 
 /datum/map_template/southern_cross_lateload/surface
 	name = Z_NAME_SC_SURFACE
+	name_alias = Z_NAME_ALIAS_SURFACE
 	mappath = "modular_chomp/maps/southern_cross/southern_cross-5.dmm"
 	associated_map_datum = /datum/map_z_level/southern_cross_lateload/surface
 
@@ -221,6 +222,7 @@
 
 /datum/map_template/southern_cross_lateload/surface_mine
 	name = Z_NAME_SC_SURFACE_MINE
+	name_alias = Z_NAME_ALIAS_SURFACE_MINES
 	mappath = "modular_chomp/maps/southern_cross/southern_cross-6.dmm"
 	associated_map_datum = /datum/map_z_level/southern_cross_lateload/surface_mine
 
@@ -232,6 +234,7 @@
 
 /datum/map_template/southern_cross_lateload/surface_wild
 	name = Z_NAME_SC_SURFACE_WILD
+	name_alias = Z_NAME_ALIAS_SURFACE_WILDS
 	mappath = "modular_chomp/maps/southern_cross/southern_cross-10.dmm"
 	associated_map_datum = /datum/map_z_level/southern_cross_lateload/surface_wild
 


### PR DESCRIPTION
Follow up PR to #11347 for #10295
- Corrects some usage of aliased Z_NAMEs
- Aliases surface, surface mine, and surface wild.

Very basic testing has been performed in game, but players more familiar with the codebase should be able to sus out any other issues. Relic base currently has a few runtimes when initializing however (no landmark for `hangar_2` (for Space bus shuttle) nor for `junkspawn` (for Junker shuttle); seemingly no controller for Cryostorage Shuttle, Large escape pod 1, and Large escape pod 2).