### PR TITLE
Cell-Loaded Revolver Update

### DIFF
--- a/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw.dm
+++ b/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw.dm
@@ -14,7 +14,7 @@
 	energy weapon that allows the user to mix and match their own fire modes. Up to two combinations of \
 	energy beams can be configured at once. Ammo not included."
 
-	description_info = "This gun is an energy weapon that uses interchangeable microbatteries in a magazine. Each battery is a different beam type, and up to three can be loaded in the magazine. Each battery usually provides four discharges of that beam type, and multiple from the same type may be loaded to increase the number of shots for that type."
+	description_info = "This gun is an energy weapon that uses interchangable microbatteries in a magazine. Each battery is a different beam type, and up to three can be loaded in the magazine. Each battery usually provides four discharges of that beam type, and multiple from the same type may be loaded to increase the number of shots for that type."
 	description_antag = ""
 	allowed_magazines = list(/obj/item/ammo_magazine/cell_mag/combat/prototype)
 
@@ -24,11 +24,11 @@
 // The Magazine //
 /obj/item/ammo_magazine/cell_mag/combat
 	name = "microbattery magazine"
-	desc = "A microbattery holder for the \'NSCW\'"
+	desc = "A microbattery holder for the \'NSFW\'."
 	icon_state = "nsfw_mag"
 	max_ammo = 4
 	x_offset = 4
-	description_info = "This magazine holds NSCW microbatteries to power the NSCW handgun. Up to three can be loaded at once, and each provides four shots of their respective energy type. Loading multiple of the same type will provide additional shots of that type. The batteries can be recharged in a normal recharger."
+	description_info = "This magazine holds NSFW microbatteries to power the NSFW handgun. Up to four can be loaded at once, and each provides four shots of their respective energy type. Loading multiple of the same type will provide additional shots of that type. The batteries can be recharged in a normal recharger."
 	ammo_type = /obj/item/ammo_casing/microbattery/combat
 
 /obj/item/ammo_magazine/cell_mag/combat/prototype
@@ -66,8 +66,6 @@
 	. = ..()
 	new /obj/item/gun/projectile/cell_loaded/combat(src)
 	new /obj/item/ammo_magazine/cell_mag/combat(src)
-	new /obj/item/ammo_magazine/cell_mag/combat(src)
-	new /obj/item/ammo_casing/microbattery/combat/lethal(src)
 	new /obj/item/ammo_casing/microbattery/combat/lethal(src)
 	new /obj/item/ammo_casing/microbattery/combat/lethal(src)
 	new /obj/item/ammo_casing/microbattery/combat/stun(src)

--- a/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw_cells.dm
+++ b/code/modules/projectiles/guns/energy/cell_loaded_vr/nsfw_cells.dm
@@ -1,41 +1,41 @@
 // The Casing //
 /obj/item/ammo_casing/microbattery/combat
-	name = "\'NSCW\' microbattery - UNKNOWN"
+	name = "\'NSFW\' microbattery - UNKNOWN"
 	desc = "A miniature battery for an energy weapon."
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 1, TECH_MAGNET = 2)
 
 /obj/item/ammo_casing/microbattery/combat/lethal
-	name = "\'NSCW\' microbattery - LETHAL"
+	name = "\'NSFW\' microbattery - LETHAL"
 	type_color = "#bf3d3d"
 	type_name = "<span style='color:#bf3d3d;font-weight:bold;'>LETHAL</span>"
 	projectile_type = /obj/item/projectile/beam
 
 /obj/item/ammo_casing/microbattery/combat/stun
-	name = "\'NSCW\' microbattery - STUN"
+	name = "\'NSFW\' microbattery - STUN"
 	type_color = "#0f81bc"
 	type_name = "<span style='color:#0f81bc;font-weight:bold;'>STUN</span>"
 	projectile_type = /obj/item/projectile/beam/stun/blue
 
 /obj/item/ammo_casing/microbattery/combat/net
-	name = "\'NSCW\' microbattery - NET"
+	name = "\'NSFW\' microbattery - NET"
 	type_color = "#43f136"
 	type_name = "<span style='color:#43d136;font-weight:bold;'>NET</span>"
 	projectile_type = /obj/item/projectile/beam/energy_net
 
 /obj/item/ammo_casing/microbattery/combat/xray
-	name = "\'NSCW\' microbattery - XRAY"
+	name = "\'NSFW\' microbattery - XRAY"
 	type_color = "#32c025"
 	type_name = "<span style='color:#32c025;font-weight:bold;'>XRAY</span>"
 	projectile_type = /obj/item/projectile/beam/xray
 
 /obj/item/ammo_casing/microbattery/combat/shotstun
-	name = "\'NSCW\' microbattery - SCATTERSTUN"
+	name = "\'NSFW\' microbattery - SCATTERSTUN"
 	type_color = "#88ffff"
 	type_name = "<span style='color:#88ffff;font-weight:bold;'>SCATTERSTUN</span>"
 	projectile_type = /obj/item/projectile/bullet/pellet/e_shot_stun
 
 /obj/item/projectile/bullet/pellet/e_shot_stun
-	icon_state = "spell"
+	icon_state = "spark"
 	damage = 2
 	agony = 20
 	pellets = 6			//number of pellets
@@ -47,13 +47,13 @@
 	check_armour = "melee"
 
 /obj/item/ammo_casing/microbattery/combat/ion
-	name = "\'NSCW\' microbattery - ION"
+	name = "\'NSFW\' microbattery - ION"
 	type_color = "#d084d6"
 	type_name = "<span style='color:#d084d6;font-weight:bold;'>ION</span>"
 	projectile_type = /obj/item/projectile/ion/small
 
 /obj/item/ammo_casing/microbattery/combat/stripper
-	name = "\'NSCW\' microbattery - STRIPPER"
+	name = "\'NSFW\' microbattery - STRIPPER"
 	type_color = "#fc8d0f"
 	type_name = "<span style='color:#fc8d0f;font-weight:bold;'>STRIPPER</span>"
 	projectile_type = /obj/item/projectile/bullet/stripper
@@ -83,7 +83,7 @@
 	..()
 
 /obj/item/ammo_casing/microbattery/combat/final
-	name = "\'NSCW\' microbattery - FINAL OPTION"
+	name = "\'NSFW\' microbattery - FINAL OPTION"
 	type_color = "#fcfc0f"
 	type_name = "<span style='color:#000000;font-weight:bold;'>FINAL OPTION</span>" //Doesn't look good in yellow in chat
 	projectile_type = /obj/item/projectile/beam/final_option


### PR DESCRIPTION
:cl:
fix: Cell-Loaded Revolver's 'Scatterstun' mode now has projectile icons.
spellcheck: Fixed some errors in the Revolver's description.
/:cl: