### PR TITLE
Absorbed Prey Names

### DIFF
--- a/code/modules/emotes/custom_emote.dm
+++ b/code/modules/emotes/custom_emote.dm
@@ -64,7 +64,17 @@
 
 /mob/proc/build_the_emote(m_type, message, input, range, runemessage)
 	if(client)
-		message = span_emote(span_bold("[src]") + " [input]")
+		// CHOMPEdit - Start
+		if(src.absorbed && isbelly(src.loc))
+			var/obj/belly/B = src.loc
+			var/formatted_name = B.absorbedrename_name
+			formatted_name = replacetext(formatted_name,"%pred",B.owner)
+			formatted_name = replacetext(formatted_name,"%belly",B.name)
+			formatted_name = replacetext(formatted_name,"%prey",name)
+			message = span_emote(span_bold("[formatted_name]") + " [input]")
+		else
+			message = span_emote(span_bold("[src]") + " [input]")
+		// CHOMPEdit - End
 	else
 		message = span_npc_emote(span_bold("[src]") + " [input]")
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -2,6 +2,12 @@
 	var/datum/component/shadekin/SK = get_shadekin_component()
 	if(SK && SK.in_phase)
 		return ""
+	// CHOMPAdd - Start
+	if(absorbed && isbelly(loc))
+		var/obj/belly/B = loc
+		if(B.absorbedrename_enabled)
+			return "" // Don't use alt name if under absorbed rename.
+	// CHOMPAdd - End
 	if(name != GetVoice())
 		return " (as [get_id_name("Unknown")])"
 
@@ -107,6 +113,16 @@
 		return comp.mimicing
 	if(GetSpecialVoice())
 		return GetSpecialVoice()
+	// CHOMPAdd - Start
+	if(absorbed && isbelly(loc)) // If absorbed in a belly, check and apply absorbed rename if applicable.
+		var/obj/belly/B = loc
+		if(B.absorbedrename_enabled)
+			var/formatted_name = B.absorbedrename_name
+			formatted_name = replacetext(formatted_name,"%pred",B.owner)
+			formatted_name = replacetext(formatted_name,"%belly",B.name)
+			formatted_name = replacetext(formatted_name,"%prey",name)
+			return formatted_name
+	// CHOMPAdd - End
 	return real_name
 
 /mob/living/carbon/human/proc/SetSpecialVoice(var/new_voice)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -75,7 +75,17 @@
 
 	if(input)
 		log_subtle(message,src)
-		message = span_emote_subtle(span_bold("[src]") + " " + span_italics("[input]"))
+		// CHOMPEdit - Start
+		if(src.absorbed && isbelly(src.loc))
+			var/obj/belly/B = src.loc
+			var/formatted_name = B.absorbedrename_name
+			formatted_name = replacetext(formatted_name,"%pred",B.owner)
+			formatted_name = replacetext(formatted_name,"%belly",B.name)
+			formatted_name = replacetext(formatted_name,"%prey",name)
+			message = span_emote_subtle(span_bold("[formatted_name]") + " " + span_italics("[input]"))
+		else
+			message = span_emote_subtle(span_bold("[src]") + " " + span_italics("[input]"))
+		// CHOMPEdit - End
 		if(!(subtle_mode == "Adjacent Turfs (Default)"))
 			message = span_bold("(T) ") + message
 	else
@@ -273,6 +283,7 @@
 	var/f = FALSE		//did we find someone to send the message to other than ourself?
 	var/mob/living/pb	//predator body
 	var/mob/living/M = src
+	var/formatted_name = "\The [M]" // CHOMPAdd
 	if(istype(M, /mob/living/dominated_brain))
 		var/mob/living/dominated_brain/db = M
 		if(db.loc != db.pred_body)
@@ -288,7 +299,17 @@
 			f = TRUE
 	else if(M.absorbed && isbelly(M.loc))
 		pb = M.loc.loc
-		to_chat(pb, span_psay("\The [M] thinks, \"[message]\""))	//To our pred if absorbed
+		// CHOMPEdit - Start
+		var/obj/belly/B = M.loc
+		if(B.absorbedrename_enabled)
+			formatted_name = B.absorbedrename_name
+			formatted_name = replacetext(formatted_name,"%pred",B.owner)
+			formatted_name = replacetext(formatted_name,"%belly",B.name)
+			formatted_name = replacetext(formatted_name,"%prey","\The [M]")
+			to_chat(pb, span_psay("[formatted_name] thinks, \"[message]\""))
+		else
+			to_chat(pb, span_psay("\The [M] thinks, \"[message]\""))	//To our pred if absorbed
+		// CHOMPEdit - End
 		if(pb.read_preference(/datum/preference/toggle/subtle_sounds))
 			if(voice_sounds_list)	//CHOMPEdit, changes subtle emote sound to use mob voice instead
 				pb << sound(pick(voice_sounds_list), volume = 25)
@@ -307,7 +328,7 @@
 		for(var/B in pb.vore_organs)
 			for(var/mob/living/L in B)
 				if(L.absorbed && L != M && L.ckey)
-					to_chat(L, span_psay("\The [M] thinks, \"[message]\""))	//To any absorbed people in the pred
+					to_chat(L, span_psay("[formatted_name] thinks, \"[message]\""))	//To any absorbed people in the pred - CHOMPEdit
 					if(L.read_preference(/datum/preference/toggle/subtle_sounds))
 						if(voice_sounds_list)	//CHOMPEdit, changes subtle emote sound to use mob voice instead
 							L << sound(pick(voice_sounds_list), volume = 25)
@@ -317,7 +338,7 @@
 	for(var/I in M.contents)
 		if(istype(I, /mob/living/dominated_brain))
 			var/mob/living/dominated_brain/db = I
-			to_chat(db, span_psay(span_bold("\The [M] thinks, \"[message]\"")))	//To any dominated brains inside us
+			to_chat(db, span_psay(span_bold("[formatted_name] thinks, \"[message]\"")))	//To any dominated brains inside us - CHOMPEdit
 			if(db.read_preference(/datum/preference/toggle/subtle_sounds))
 				if(voice_sounds_list)	//CHOMPEdit, changes subtle emote sound to use mob voice instead
 					db << sound(pick(voice_sounds_list), volume = 25)
@@ -325,7 +346,7 @@
 	for(var/B in M.vore_organs)
 		for(var/mob/living/L in B)
 			if(L.absorbed)
-				to_chat(L, span_psay(span_bold("\The [M] thinks, \"[message]\"")))	//To any absorbed people inside us
+				to_chat(L, span_psay(span_bold("[formatted_name] thinks, \"[message]\"")))	//To any absorbed people inside us - CHOMPEdit
 				if(L.read_preference(/datum/preference/toggle/subtle_sounds))
 					if(voice_sounds_list)	//CHOMPEdit, changes subtle emote sound to use mob voice instead
 						L << sound(pick(voice_sounds_list), volume = 25)
@@ -348,7 +369,7 @@
 			else if(isobserver(G) &&  G.client?.prefs?.read_preference(/datum/preference/toggle/ghost_ears) && \
 			G.client?.prefs?.read_preference(/datum/preference/toggle/ghost_see_whisubtle))
 				if(client?.prefs?.read_preference(/datum/preference/toggle/whisubtle_vis) || check_rights_for(G.client, R_HOLDER))
-					to_chat(G, span_psay("\The [M] thinks, \"[message]\""))
+					to_chat(G, span_psay("[formatted_name] thinks, \"[message]\"")) //CHOMPEdit
 		log_say(message,M)
 	else		//There wasn't anyone to send the message to, pred or prey, so let's just say it instead and correct our psay just in case.
 		M.forced_psay = FALSE
@@ -377,6 +398,7 @@
 	var/f = FALSE		//did we find someone to send the message to other than ourself?
 	var/mob/living/pb	//predator body
 	var/mob/living/M = src
+	var/formatted_name = "\The [M]" // CHOMPAdd
 	if(istype(M, /mob/living/dominated_brain))
 		var/mob/living/dominated_brain/db = M
 		if(db.loc != db.pred_body)
@@ -393,7 +415,17 @@
 
 	else if(M.absorbed && isbelly(M.loc))
 		pb = M.loc.loc
-		to_chat(pb, span_pemote("\The [M] [message]"))	//To our pred if absorbed
+		// CHOMPEdit - Start
+		var/obj/belly/B = M.loc
+		if(B.absorbedrename_enabled)
+			formatted_name = B.absorbedrename_name
+			formatted_name = replacetext(formatted_name,"%pred",B.owner)
+			formatted_name = replacetext(formatted_name,"%belly",B.name)
+			formatted_name = replacetext(formatted_name,"%prey","\The [M]")
+			to_chat(pb, span_pemote("[formatted_name] [message]"))
+		else
+			to_chat(pb, span_pemote("\The [M] [message]"))	//To our pred if absorbed
+		// CHOMPEdit - End
 		if(pb.read_preference(/datum/preference/toggle/subtle_sounds))
 			if(voice_sounds_list)	//CHOMPEdit, changes subtle emote sound to use mob voice instead
 				pb << sound(pick(voice_sounds_list), volume = 25)
@@ -404,7 +436,7 @@
 		for(var/I in pb.contents)
 			if(istype(I, /mob/living/dominated_brain) && I != M)
 				var/mob/living/dominated_brain/db = I
-				to_chat(db, span_pemote("\The [M] [message]"))	//To any dominated brains in the pred
+				to_chat(db, span_pemote("[formatted_name] [message]"))	//To any dominated brains in the pred - CHOMPEdit
 				if(db.read_preference(/datum/preference/toggle/subtle_sounds))
 					if(voice_sounds_list)	//CHOMPEdit, changes subtle emote sound to use mob voice instead
 						pb << sound(pick(voice_sounds_list), volume = 25)
@@ -412,7 +444,7 @@
 		for(var/B in pb.vore_organs)
 			for(var/mob/living/L in B)
 				if(L.absorbed && L != M && L.ckey)
-					to_chat(L, span_pemote("\The [M] [message]"))	//To any absorbed people in the pred
+					to_chat(L, span_pemote("[formatted_name] [message]"))	//To any absorbed people in the pred - CHOMPEdit
 					if(L.read_preference(/datum/preference/toggle/subtle_sounds))
 						if(voice_sounds_list)	//CHOMPEdit, changes subtle emote sound to use mob voice instead
 							L << sound(pick(voice_sounds_list), volume = 25)
@@ -422,7 +454,7 @@
 	for(var/I in M.contents)
 		if(istype(I, /mob/living/dominated_brain))
 			var/mob/living/dominated_brain/db = I
-			to_chat(db, span_pemote(span_bold("\The [M] [message]")))	//To any dominated brains inside us
+			to_chat(db, span_pemote(span_bold("[formatted_name] [message]")))	//To any dominated brains inside us - CHOMPEdit
 			if(db.read_preference(/datum/preference/toggle/subtle_sounds))
 				if(voice_sounds_list)	//CHOMPEdit, changes subtle emote sound to use mob voice instead
 					db << sound(pick(voice_sounds_list), volume = 25)
@@ -430,7 +462,7 @@
 	for(var/B in M.vore_organs)
 		for(var/mob/living/L in B)
 			if(L.absorbed)
-				to_chat(L, span_pemote(span_bold("\The [M] [message]")))	//To any absorbed people inside us
+				to_chat(L, span_pemote(span_bold("[formatted_name] [message]")))	//To any absorbed people inside us - CHOMPEdit
 				if(L.read_preference(/datum/preference/toggle/subtle_sounds))
 					if(voice_sounds_list)	//CHOMPEdit, changes subtle emote sound to use mob voice instead
 						L << sound(pick(voice_sounds_list), volume = 25)
@@ -438,7 +470,7 @@
 
 	if(f)	//We found someone to send the message to
 		if(pb)
-			to_chat(M, span_pemote("\The [M] [message]"))	//To us if we are the prey
+			to_chat(M, span_pemote("[formatted_name] [message]"))	//To us if we are the prey - CHOMPEdit
 			if(M.read_preference(/datum/preference/toggle/subtle_sounds))
 				if(voice_sounds_list)	//CHOMPEdit, changes subtle emote sound to use mob voice instead
 					M << sound(pick(voice_sounds_list), volume = 25)
@@ -453,7 +485,7 @@
 			else if(isobserver(G) && G.client?.prefs?.read_preference(/datum/preference/toggle/ghost_ears) && \
 			G.client?.prefs?.read_preference(/datum/preference/toggle/ghost_see_whisubtle))
 				if(client?.prefs?.read_preference(/datum/preference/toggle/whisubtle_vis) || check_rights_for(G.client, R_HOLDER))
-					to_chat(G, span_pemote("\The [M] [message]"))
+					to_chat(G, span_pemote("[formatted_name] [message]")) // CHOMPEdit
 		log_say(message,M)
 	else	//There wasn't anyone to send the message to, pred or prey, so let's just emote it instead and correct our psay just in case.
 		M.forced_psay = FALSE

--- a/code/modules/vore/eating/belly_import.dm
+++ b/code/modules/vore/eating/belly_import.dm
@@ -604,6 +604,18 @@
 			if(new_private_struggle == 1)
 				new_belly.private_struggle = TRUE
 
+		if(isnum(belly_data["absorbedrename_enabled"]))
+			var/new_absorbedrename_enabled = belly_data["absorbedrename_enabled"]
+			if(new_absorbedrename_enabled == 0)
+				new_belly.absorbedrename_enabled = FALSE
+			if(new_absorbedrename_enabled == 1)
+				new_belly.absorbedrename_enabled = TRUE
+
+		if(istext(belly_data["absorbedrename_name"]))
+			var/new_absorbedrename_name = sanitize(belly_data["absorbedrename_name"],MAX_MESSAGE_LEN,0,0,0)
+			if(new_absorbedrename_name)
+				new_belly.absorbedrename_name = new_absorbedrename_name
+
 		if(istext(belly_data["eating_privacy_local"]))
 			var/new_eating_privacy_local = html_encode(belly_data["eating_privacy_local"])
 			if(new_eating_privacy_local && (new_eating_privacy_local in list("default","subtle","loud")))

--- a/code/modules/vore/eating/belly_obj_vr.dm
+++ b/code/modules/vore/eating/belly_obj_vr.dm
@@ -68,7 +68,8 @@
 	var/belly_overall_mult = 1	//Multiplier applied ontop of any other specific multipliers
 	var/private_struggle = FALSE			// If struggles are made public or not
 	var/prevent_saving = FALSE				// Can this belly be saved? For special bellies that mobs and adminbus might have.
-
+	var/absorbedrename_enabled = FALSE		// If absorbed prey are renamed.
+	var/absorbedrename_name = "%pred's %belly"	// What absorbed prey are renamed to.
 
 	var/vore_sprite_flags = DM_FLAG_VORESPRITE_BELLY
 	var/tmp/static/list/vore_sprite_flag_list= list(
@@ -439,6 +440,8 @@
 	"entrance_logs",
 	"noise_freq",
 	"private_struggle",
+	"absorbedrename_enabled",
+	"absorbedrename_name",
 	"item_digest_logs",
 	"show_fullness_messages",
 	"digest_max",

--- a/code/modules/vore/eating/exportpanel_vr.dm
+++ b/code/modules/vore/eating/exportpanel_vr.dm
@@ -311,6 +311,8 @@
 			belly_data["item_digest_logs"] = B.item_digest_logs
 			belly_data["eating_privacy_local"] = B.eating_privacy_local
 			belly_data["private_struggle"] = B.private_struggle
+			belly_data["absorbedrename_enabled"] = B.absorbedrename_enabled
+			belly_data["absorbedrename_name"] = B.absorbedrename_name
 
 			// Sounds
 			belly_data["is_wet"] = B.is_wet

--- a/code/modules/vore/eating/panel_databackend/vorepanel_set_attribute.dm
+++ b/code/modules/vore/eating/panel_databackend/vorepanel_set_attribute.dm
@@ -877,6 +877,14 @@
 		if("b_private_struggle")
 			host.vore_selected.private_struggle = !host.vore_selected.private_struggle
 			. = TRUE
+		if("b_absorbedrename_enabled")
+			host.vore_selected.absorbedrename_enabled = !host.vore_selected.absorbedrename_enabled
+			. = TRUE
+		if("b_absorbedrename_name")
+			var/new_absorbedrename_name = sanitize(params["val"], MAX_MESSAGE_LEN, FALSE, TRUE, FALSE)
+			if(new_absorbedrename_name)
+				host.vore_selected.absorbedrename_name = new_absorbedrename_name
+			. = TRUE
 		if("b_vorespawn_blacklist")
 			host.vore_selected.vorespawn_blacklist = !host.vore_selected.vorespawn_blacklist
 			. = TRUE

--- a/code/modules/vore/eating/panel_databackend/vorepanel_vore_data.dm
+++ b/code/modules/vore/eating/panel_databackend/vorepanel_vore_data.dm
@@ -184,6 +184,10 @@
 				"vorespawn_whitelist" = selected.vorespawn_whitelist,
 				"vorespawn_absorbed" = (global_flag_check(selected.vorespawn_absorbed, VS_FLAG_ABSORB_YES) + global_flag_check(selected.vorespawn_absorbed, VS_FLAG_ABSORB_PREY)),
 				"private_struggle" = selected.private_struggle,
+				"absorbedrename_enabled" = selected.absorbedrename_enabled,
+				"absorbedrename_name" = selected.absorbedrename_name,
+				"absorbedrename_name_max" = BELLIES_NAME_MAX,
+				"absorbedrename_name_min" = BELLIES_NAME_MIN,
 				"drainmode" = selected.drainmode,
 				"drainmode_options" = selected.drainmodes,
 			)

--- a/tgui/packages/tgui/interfaces/VorePanel/VoreSelectedBellyTabs/OptionTab/BellyOptionsLeft.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/VoreSelectedBellyTabs/OptionTab/BellyOptionsLeft.tsx
@@ -7,6 +7,7 @@ import { VorePanelColorBox } from '../../VorePanelElements/VorePanelCommonElemen
 import { VorePanelEditDropdown } from '../../VorePanelElements/VorePanelEditDropdown';
 import { VorePanelEditNumber } from '../../VorePanelElements/VorePanelEditNumber';
 import { VorePanelEditSwitch } from '../../VorePanelElements/VorePanelEditSwitch';
+import { VorePanelEditText } from '../../VorePanelElements/VorePanelEditText';
 import { VoreSelectedWhitelist } from '../VisualTab/VoreSelecetedWhitelist';
 
 export const BellyOptionsLeft = (props: {
@@ -27,6 +28,10 @@ export const BellyOptionsLeft = (props: {
     save_digest_mode,
     eating_privacy_local,
     private_struggle,
+    absorbedrename_enabled,
+    absorbedrename_name,
+    absorbedrename_name_max,
+    absorbedrename_name_min,
     vorespawn_blacklist,
     vorespawn_whitelist,
     vorespawn_absorbed,
@@ -163,6 +168,31 @@ export const BellyOptionsLeft = (props: {
             }
           />
         </LabeledList.Item>
+        <LabeledList.Item label="Toggle Absorbed Rename">
+          <VorePanelEditSwitch
+            action="set_attribute"
+            subAction="b_absorbedrename_enabled"
+            editMode={editMode}
+            active={!!absorbedrename_enabled}
+            tooltip={
+              (absorbedrename_enabled ? 'Dis' : 'En') +
+              'ables renaming absorbed prey.'
+            }
+          />
+        </LabeledList.Item>
+        {!!absorbedrename_enabled && (
+          <LabeledList.Item label="Absorbed Prey Name">
+            <VorePanelEditText
+              action="set_attribute"
+              subAction="b_absorbedrename_name"
+              editMode={editMode}
+              limit={absorbedrename_name_max}
+              min={absorbedrename_name_min}
+              entry={absorbedrename_name}
+              tooltip="Name your absorbed prey, works with %pred, %prey and %belly."
+            />
+          </LabeledList.Item>
+        )}
         <LabeledList.Item label="Save Digest Mode">
           <VorePanelEditSwitch
             action="set_attribute"

--- a/tgui/packages/tgui/interfaces/VorePanel/types.ts
+++ b/tgui/packages/tgui/interfaces/VorePanel/types.ts
@@ -131,6 +131,10 @@ export type bellyOptionData = {
   vorespawn_whitelist: string[];
   vorespawn_absorbed: number;
   private_struggle: BooleanLike;
+  absorbedrename_enabled: BooleanLike;
+  absorbedrename_name: string;
+  absorbedrename_name_max: number;
+  absorbedrename_name_min: number;
   drainmode_options: string[];
   drainmode: string;
 };


### PR DESCRIPTION

## About The Pull Request
Adds a belly-specific toggle and text field for pred's to modify absorbed prey's visible name in Me, Subtle, Say, Whisper, Pme and Psay commands. This toggle is disabled by default, and the default name for absorbed prey is "%pred's %belly". Once enabled, it will show this name in place of the absorbed prey's name when they send messages. It does not rename their character. This means it will not update for the manifest, transcore messages, admin logs, or things like LOOC. This should enable those who enjoy name changes to experience it without needing to rename their whole slot.
## Changelog
:cl:
add: Added belly option to change the visual name on absorbed prey's messages.
/:cl:
