### PR TITLE
fix bad loyalty implant calls

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -357,7 +357,7 @@
 				log_admin("[key_name_admin(usr)] has de-loyalty implanted [current].")
 			if("add")
 				to_chat(H, span_danger(span_large("You somehow have become the recepient of a loyalty transplant, and it just activated!")))
-				H.implant_loyalty(override = TRUE)
+				H.implant_loyalty(TRUE)
 				log_admin("[key_name_admin(usr)] has loyalty implanted [current].")
 
 	else if (href_list["silicon"])

--- a/code/game/jobs/job/blueshield.dm
+++ b/code/game/jobs/job/blueshield.dm
@@ -25,4 +25,4 @@
 /datum/job/blueshield/equip(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
-		H.implant_loyalty(src)
+		H.implant_loyalty()

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -44,7 +44,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 /datum/job/captain/equip(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
-		H.implant_loyalty(src)
+		H.implant_loyalty()
 */
 
 /datum/job/captain/get_access()

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -251,7 +251,7 @@
 /datum/job/lawyer/equip(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
-		H.implant_loyalty(H)
+		H.implant_loyalty()
 //YW UNCOMMENTING END
 
 /datum/alt_title/ia_liaison

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -56,7 +56,7 @@
 /datum/job/hos/equip(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
-		H.implant_loyalty(src)
+		H.implant_loyalty()
 //YW ADDITION END
 
 //////////////////////////////////

--- a/code/game/jobs/job/special.dm
+++ b/code/game/jobs/job/special.dm
@@ -28,7 +28,7 @@
 /datum/job/centcom_officer/equip(var/mob/living/carbon/human/H)
 	. = ..()
 	if(.)
-		H.implant_loyalty(src)
+		H.implant_loyalty()
 //YW UNCOMMENTING END
 
 /*/datum/job/centcom_visitor //For Pleasure // You mean for admin abuse... -Ace


### PR DESCRIPTION
## About The Pull Request
Loyalty implant procs on equip were coded wrong, and always overriding the config file.

## Changelog
Loyalty implants on spawn are meant to be controlled by a config file entry. However all the YW edits for them pass the src of the object as the first argument. This is incorrect, as the first argument was at some point changed to if it should ignore the config or not, resulting in the proc always being forced true regardless of config. The only valid call where override was needed is retained.

:cl:
fix: roundstart loyalty implant code will no longer ignore the config file
/:cl: