### PR TITLE
Vacpack can clean under windows easier

### DIFF
--- a/modular_chomp/code/game/objects/items/devices/vacpack.dm
+++ b/modular_chomp/code/game/objects/items/devices/vacpack.dm
@@ -76,6 +76,8 @@
 		return
 	if(!output_dest)
 		return
+	if(istype(target,/obj/structure/window) || istype(target,/obj/structure/grille))
+		target = get_turf(target) // Windows can be clicked to clean their turf
 	if(istype(output_dest,/obj/item/storage/bag/trash))
 		if(get_turf(output_dest) != get_turf(user))
 			vac_power = 0


### PR DESCRIPTION
## About The Pull Request
Cleaning under windows currently requires you to altclick so that you can manually click the floor turf beneath it to vacuum the dirt up. This pr changes it so that you can just click the window.

## Changelog
Using vacpacks on windows will change the target to be cleaned to the turf. Allowing you to click windows and clean the plating under them.

:cl: Will
qol: clicking windows with a vacpack will clean the turfs under them
/:cl: