### PR TITLE
blitz rod impact fix

### DIFF
--- a/code/modules/projectiles/projectile/magnetic_ch.dm
+++ b/code/modules/projectiles/projectile/magnetic_ch.dm
@@ -26,10 +26,15 @@
 	hud_state = "rocket_thermobaric"
 
 /obj/item/projectile/bullet/magnetic/fuelrod/blitz/on_impact(var/atom/A)
-	if(src.loc)
-		var/mob/living/M = A
-		if(istype(M) && M.maxHealth<=200)
-			M.dust()
-		visible_message(span_warning("\The [src] impacts energetically with its target and shatters in a violent explosion!"))
-		explosion(src.loc, 3, 4, 5, 10)
+	if(is_turf(loc))
+		explosion(loc, 3, 4, 5, 10)
 	..(A)
+
+/obj/item/projectile/bullet/magnetic/fuelrod/blitz/on_hit(atom/target, blocked = 0, def_zone)
+	var/mob/living/M = target
+	if(istype(M) && M.maxHealth<=200)
+		M.dust()
+	if(is_turf(loc))
+		explosion(loc, 3, 4, 5, 10)
+	visible_message(span_warning("\The [src] impacts energetically with its target and shatters in a violent explosion!"))
+	..(target, blocked, def_zone)


### PR DESCRIPTION
## About The Pull Request
Blitzrods used the wrong proc when impacting mobs, so their explosions never happen, despite clearly being intended by the wall impact proc checking for mobs that will never be passed to it.

## Changelog
Gives blitzrods on_hit so they properly impact mobs, and moves the mob code that will never run in on_impact into that proc.

:cl: Will
fix: Blitzrods use proper projectile code for mob hits
/:cl:
