### PR TITLE
Fix improper chomp edit and change it to cached icon states

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -31,9 +31,6 @@
 
 /obj/item/gun/energy/Initialize(mapload)
 	. = ..()
-	var/static/list/gun_icons = icon_states('icons/obj/gun_ch.dmi')
-	if (icon == 'icons/obj/gun_ch.dmi' && !(icon_state in gun_icons))
-		icon = 'icons/obj/gun.dmi'
 	if(self_recharge)
 		power_supply = new /obj/item/cell/device/weapon(src)
 		START_PROCESSING(SSobj, src)

--- a/modular_chomp/code/modules/projectiles/guns/energy.dm
+++ b/modular_chomp/code/modules/projectiles/guns/energy.dm
@@ -47,3 +47,8 @@
 	//damage = 5
 	mob_bonus_damage = 35
 	armor_penetration = 0
+
+/obj/item/gun/energy/Initialize(mapload)
+	if(icon == 'icons/obj/gun_ch.dmi' && !(icon_state in cached_icon_states('icons/obj/gun_ch.dmi')))
+		icon = 'icons/obj/gun.dmi'
+	return ..()


### PR DESCRIPTION

## About The Pull Request

This PR is a follow up to https://github.com/CHOMPStation2/CHOMPStation2/pull/11445 and does a couple things:
- Properly modularizes a chomp edit done in https://github.com/CHOMPStation2/CHOMPStation2/commit/246faa3c67ef68a59e748865b9f009b0c15dfaeb
- Fallback done in above for energy weapons now uses cached_icon_states instead of icon_states

## Changelog
:cl: Drathek
code: Energy weapons now use cached_icon_states for fallback icon behavior
/:cl:
