### PR TITLE
Equipment Vending Machines

### DIFF
--- a/modular_chomp/code/game/machinery/vending.dm
+++ b/modular_chomp/code/game/machinery/vending.dm
@@ -1,5 +1,6 @@
 /* CONTAINS:
 	Explo equipment vending machines
+	Sec equipment vending machines
 */
 
 /obj/machinery/vending/exploration_armor
@@ -43,13 +44,8 @@
 					/obj/item/gun/energy/locked/phasegun/pistol = 10,
 					/obj/item/gun/energy/locked/phasegun = 10,
 					/obj/item/gun/energy/locked/phasegun/rifle = 5,
-				// Laser
-					/obj/item/gun/energy/laser = 5,
-				// Ballistic
-					/obj/item/gun/projectile/colt = 5,
 				// Ammo
 					/obj/item/cell/device/weapon = 25,
-					/obj/item/ammo_magazine/m45 = 25,
 				// Melee
 					/obj/item/material/knife/tacknife/survival = 10,
 					/obj/item/material/knife/machete = 10,
@@ -125,6 +121,38 @@
 					/obj/item/fulton_core = 1
 				)
 
+/obj/machinery/vending/security_armor
+	name = "Security Plate Carrier Vendor"
+	desc = "A large vending machine stocked with a variety of plate carriers and accessories to accompany them."
+	vend_delay = 1
+	icon_state = "sec"
+	req_access = list(ACCESS_SECURITY)
+	products = list(
+				// The vests. No green, don't want to confuse exploration
+					/obj/item/clothing/suit/armor/pcarrier = 5,
+					/obj/item/clothing/suit/armor/pcarrier/blue = 5,
+					/obj/item/clothing/suit/armor/pcarrier/tan = 5,
+					/obj/item/clothing/suit/armor/pcarrier/navy = 5,
+				// Accessories
+					/obj/item/clothing/accessory/armor/tag/nt = 5,
+					/obj/item/clothing/accessory/armor/tag/sec = 5,
+					/obj/item/clothing/accessory/storage/pouches/large = 5,
+					/obj/item/clothing/accessory/storage/pouches/large/blue = 5,
+					/obj/item/clothing/accessory/storage/pouches/large/tan = 5,
+					/obj/item/clothing/accessory/storage/pouches/large/navy = 5,
+				// Armor fittings
+					/obj/item/clothing/accessory/armor/armguards = 5,
+					/obj/item/clothing/accessory/armor/armguards/blue = 5,
+					/obj/item/clothing/accessory/armor/armguards/tan = 5,
+					/obj/item/clothing/accessory/armor/armguards/navy = 5,
+					/obj/item/clothing/accessory/armor/armguards/merc = 5,
+					/obj/item/clothing/accessory/armor/legguards = 5,
+					/obj/item/clothing/accessory/armor/legguards/blue = 5,
+					/obj/item/clothing/accessory/armor/legguards/tan = 5,
+					/obj/item/clothing/accessory/armor/legguards/navy = 5,
+					/obj/item/clothing/accessory/armor/legguards/merc = 5,
+					/obj/item/clothing/accessory/armor/armorplate/tactical = 5
+				)
 
 
 //Temp Starhunter Fix

--- a/modular_chomp/maps/southern_cross/southern_cross-2.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-2.dmm
@@ -22687,11 +22687,12 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/machinery/vending/exploration_fieldmedic,
 /turf/simulated/floor/tiled/steel,
 /area/hangar/lockerroomthree)
 "nrb" = (
-/obj/structure/frame/computer,
 /obj/effect/floor_decal/steeldecal/steel_decals_central6,
+/obj/machinery/vending/exploration_pilot,
 /turf/simulated/floor/tiled/monotile,
 /area/hangar/lockerroomthree)
 "nrg" = (
@@ -24361,9 +24362,6 @@
 /turf/simulated/floor/tiled,
 /area/hangar/lockerroomthree)
 "pvA" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -25570,11 +25568,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/rust,
-/obj/structure/closet/secure_closet/guncabinet{
-	desc = "It's an immobile card-locked storage unit. For storing weapons and other items when station side.";
-	name = "Secure Locker";
-	req_one_access = list(67,43,3)
-	},
+/obj/machinery/vending/exploration_misc,
 /turf/simulated/floor/tiled,
 /area/hangar/lockerroomthree)
 "qGt" = (
@@ -25591,6 +25585,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/machinery/vending/exploration_weapons,
 /turf/simulated/floor/tiled,
 /area/hangar/lockerroomthree)
 "qGK" = (
@@ -25610,6 +25605,7 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6,
+/obj/machinery/vending/exploration_armor,
 /turf/simulated/floor/tiled,
 /area/hangar/lockerroomthree)
 "qGO" = (

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -16863,6 +16863,7 @@
 	},
 /obj/effect/floor_decal/borderfloor,
 /obj/effect/floor_decal/corner/red/border,
+/obj/machinery/vending/security_armor,
 /turf/simulated/floor/tiled,
 /area/security/main)
 "bbW" = (


### PR DESCRIPTION
:cl:
add: New vending machines with equipment for Exploration (weapons, armor, and miscellaneous gear) and Security (currently just plate carriers and accessories for them)
maptweak: Added Exploration vending machines to deck 1, in the room below the northern landing pad.
maptweak: Added a new Security vending machine to the Briefing Room.
/:cl: