### PR TITLE
Brief map fix

### DIFF
--- a/modular_chomp/maps/southern_cross/southern_cross-4.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-4.dmm
@@ -4327,6 +4327,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/forestarboard)
 "dIz" = (


### PR DESCRIPTION
Fixes a missing power cable under the Third Deck Fore Starboard Maintenance APC.
## About The Pull Request
## Changelog
:cl:
fix: Fixes a missing power cable under the Third Deck Fore Starboard Maintenance APC.
/:cl:
