### PR TITLE
chomp clothing uses defines for pockets

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/alien.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/alien.dm
@@ -16,13 +16,7 @@
 	vision_restriction = 0  //This is dumb as hell and should be 0 if we want the suit to be even vaguely useful.
 	offline_vision_restriction = 2 //This actually serves as a good weakness for them, making them vulnerable to Ion weapons.
 	siemens_coefficient = 0.75
-	allowed = list(
-		/obj/item/gun,
-		/obj/item/flashlight,
-		/obj/item/tank,
-		/obj/item/suit_cooling_unit,
-		/obj/item/storage
-		)
+	allowed = list(POCKET_GENERIC, POCKET_EMERGENCY, POCKET_ALL_TANKS, POCKET_SUIT_REGULATORS, POCKET_STORAGE) //CHOMPedit end
 	chest_type = /obj/item/clothing/suit/space/rig/breacher
 	helm_type = /obj/item/clothing/head/helmet/space/rig/breacher
 	boot_type = /obj/item/clothing/shoes/magboots/rig/breacher

--- a/code/modules/clothing/spacesuits/rig/suits/station_ch.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station_ch.dm
@@ -42,15 +42,7 @@
 	offline_vision_restriction = 1
 	siemens_coefficient= 0.7
 	helm_type = /obj/item/clothing/head/helmet/space/rig/ch/pursuit
-
-	allowed = list(
-		/obj/item/gun,
-		/obj/item/flashlight,
-		/obj/item/tank,
-		/obj/item/suit_cooling_unit,
-		/obj/item/melee/baton,
-		/obj/item/storage/backpack,
-		)
+	allowed = list(POCKET_GENERIC, POCKET_EMERGENCY, POCKET_ALL_TANKS, POCKET_SUIT_REGULATORS, POCKET_STORAGE, POCKET_EXPLO)
 
 	req_access = list(ACCESS_HOS)
 	req_one_access = list()

--- a/code/modules/clothing/suits/aliens/teshari.dm
+++ b/code/modules/clothing/suits/aliens/teshari.dm
@@ -202,7 +202,7 @@
 	name = "head of security cloak"
 	desc = "A soft Teshari cloak made for the " + JOB_HEAD_OF_SECURITY + ". This one is made with stronger fibers." //CHOMPedot
 	icon_state = "tesh_cloak_hos"
-	allowed = list(/obj/item/gun/energy,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/flashlight/maglight,/obj/item/clothing/head/helmet) //CHOMPedit start
+	allowed = list(POCKET_GENERIC, POCKET_SECURITY) //CHOMPedit start
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	item_flags = THICKMATERIAL
 	siemens_coefficient = 0.6
@@ -212,7 +212,7 @@
 	name = "security cloak"
 	desc = "A soft Teshari cloak made for the Security department. This one is made with stronger fibers." //CHOMPedit
 	icon_state = "tesh_cloak_sec"
-	allowed = list(/obj/item/gun/energy,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/flashlight/maglight,/obj/item/clothing/head/helmet) //CHOMPedit start
+	allowed = list(POCKET_GENERIC, POCKET_SECURITY) //CHOMPedit start
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	item_flags = THICKMATERIAL
 	siemens_coefficient = 0.6
@@ -691,7 +691,7 @@
 	name = "security belted cloak"
 	desc = "A soft Teshari cloak made for the Security department. This one is made with stronger fibers." //CHOMPedit
 	icon_state = "tesh_beltcloak_sec"
-	allowed = list(/obj/item/gun/energy,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/flashlight/maglight,/obj/item/clothing/head/helmet) //CHOMPedit start
+	allowed = list(POCKET_GENERIC, POCKET_SECURITY) //CHOMPedit start
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	item_flags = THICKMATERIAL
 	siemens_coefficient = 0.6
@@ -721,7 +721,7 @@
 	name = "security chief belted cloak"
 	desc = "A soft Teshari cloak made for the " + JOB_HEAD_OF_SECURITY + ". This one is made with stronger fibers." //CHOMPedit
 	icon_state = "tesh_beltcloak_hos"
-	allowed = list(/obj/item/gun/energy,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/flashlight/maglight,/obj/item/clothing/head/helmet) //CHOMPedit start
+	allowed = list(POCKET_GENERIC, POCKET_SECURITY) //CHOMPedit start
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	item_flags = THICKMATERIAL
 	siemens_coefficient = 0.6

--- a/code/modules/clothing/suits/storage_yw.dm
+++ b/code/modules/clothing/suits/storage_yw.dm
@@ -7,7 +7,7 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 0, rad = 0)
 	siemens_coefficient = 0.9
 	flags_inv = HIDEHOLSTER //VOREStation Add - These obviously do.
-	allowed = list(/obj/item/tank/emergency/oxygen,/obj/item/flashlight,/obj/item/pen,/obj/item/clothing/head/soft,/obj/item/clothing/head/beret,/obj/item/storage/fancy/cigarettes,/obj/item/flame/lighter,/obj/item/taperecorder,/obj/item/analyzer,/obj/item/radio,/obj/item/taperoll)
+	allowed = list(POCKET_GENERIC, POCKET_EMERGENCY, POCKET_DETECTIVE, /obj/item/clothing/head/beret)
 
 /obj/item/clothing/suit/storage/explorer/crew
 	name = "\improper Explorer jacket"


### PR DESCRIPTION
## About The Pull Request
These pieces of clothing were missed when the define style pocket lists were merged. Also marks a previously unmarked chomp edit.

## Changelog
Makes yawn and chomp clothing use defined pockets

:cl: Will
code: Chomp clothing uses define based pockets
/:cl:

