### PR TITLE
Revenge of Clong

### DIFF
--- a/code/modules/recycling/disposal_holder.dm
+++ b/code/modules/recycling/disposal_holder.dm
@@ -123,11 +123,10 @@
 	if(!isliving(user))
 		return
 
-	/* CHOMPEdit: Clong, clong baby.
+
 	if(user.stat || user.last_special <= world.time)
 		return
-	user.last_special = world.time+100
-	*/
+	user.last_special = world.time + (1 SECOND) // CHOMPEdit: Clong, clong baby.
 
 	if(QDELETED(src))
 		return

--- a/code/modules/recycling/disposal_holder.dm
+++ b/code/modules/recycling/disposal_holder.dm
@@ -123,9 +123,11 @@
 	if(!isliving(user))
 		return
 
+	/* CHOMPEdit: Clong, clong baby.
 	if(user.stat || user.last_special <= world.time)
 		return
 	user.last_special = world.time+100
+	*/
 
 	if(QDELETED(src))
 		return


### PR DESCRIPTION
## About The Pull Request
Chomp originally had an edit that makes disposal clonging instant and without any cooldown. This was missed on deconflict. Restores the edit. edit: I was requested to modify it to a 1 second cooldown instead of no cooldown

## Changelog
Clong

:cl:
fix: Chomp specific disposal clong cooldown restored 
/:cl: