### PR TITLE
Replaces Centcom doors in shuttles with normal doors

### DIFF
--- a/modular_chomp/maps/southern_cross/southern_cross-7.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-7.dmm
@@ -1077,9 +1077,7 @@
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
 "aEx" = (
-/obj/machinery/door/airlock/glass_centcom{
-	req_one_access = list(67)
-	},
+/obj/machinery/door/airlock/voidcraft,
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/shuttle3/start)
 "aEz" = (
@@ -2586,9 +2584,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
 "bTd" = (
-/obj/machinery/door/airlock/glass_centcom{
-	req_one_access = list(67)
-	},
+/obj/machinery/door/airlock/voidcraft,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "bTg" = (
@@ -13457,9 +13453,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
 "lis" = (
-/obj/machinery/door/airlock/centcom{
-	req_one_access = newlist()
-	},
+/obj/machinery/door/airlock/voidcraft,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/shuttle3/start)
 "liP" = (
@@ -14930,10 +14924,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
 "mkU" = (
-/obj/machinery/door/airlock/glass_centcom,
 /obj/structure/cable/blue{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/voidcraft,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "mld" = (
@@ -23350,15 +23344,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/expoutpost/portsternairlock)
-"sWF" = (
-/obj/machinery/door/airlock/glass_centcom{
-	req_one_access = list(67)
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/shuttle/baby_mammoth)
 "sXC" = (
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
@@ -28187,10 +28172,10 @@
 /turf/simulated/floor/carpet,
 /area/expoutpost/suite1)
 "wLJ" = (
-/obj/machinery/door/airlock/glass_centcom,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/voidcraft,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "wLS" = (
@@ -68212,7 +68197,7 @@ qoM
 qDn
 pmr
 dvl
-sWF
+wLJ
 qfx
 qfx
 qfx


### PR DESCRIPTION
:cl:
maptweak: Replaces Centcom Doors in the Carrier shuttles with regular voidcraft hatches. No more locked shuttles.
/:cl: