### PR TITLE
Fixes fire extinguishers and splash

### DIFF
--- a/code/modules/reagents/holder/holder.dm
+++ b/code/modules/reagents/holder/holder.dm
@@ -285,10 +285,6 @@
 //If for some reason touch effects are bypassed (e.g. injecting stuff directly into a reagent container or person),
 //call the appropriate trans_to_*() proc.
 /datum/reagents/proc/trans_to(var/atom/target, var/amount = 1, var/multiplier = 1, var/copy = 0, var/force_open_container = FALSE)
-	//CHOMPEdit Start, do not splash brains!
-	if(ismob(target) && !isbrain(target))
-		return splash_mob(target, amount * multiplier, copy)
-	//CHOMPEdit End
 	touch(target, amount * multiplier) //First, handle mere touch effects
 
 	if(ismob(target))


### PR DESCRIPTION

## About The Pull Request
Makes splashing reagents on someone not turn them into a turf any longer.
Makes fire extinguishers work again
## Changelog
:cl:
fix: Splashing a player with select reagents will no longer turn them into a tile
fix: Fire extinguishers now put out players again
/:cl:
