### PR TITLE
physically impossible cigar case

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy_ch.dm
+++ b/code/game/objects/items/weapons/storage/fancy_ch.dm
@@ -1,7 +1,7 @@
 /obj/item/storage/fancy/cigar/cohiba
 	name = "cohiban cigar case"
-	starts_with = list(/obj/item/clothing/mask/smokable/cigarette/cigar/cohiba = 7)
+	starts_with = list(/obj/item/clothing/mask/smokable/cigarette/cigar/cohiba = 5)
 
 /obj/item/storage/fancy/cigar/havana
 	name = "havanian cigar case"
-	starts_with = list(/obj/item/clothing/mask/smokable/cigarette/cigar/havana = 7)
+	starts_with = list(/obj/item/clothing/mask/smokable/cigarette/cigar/havana = 5)


### PR DESCRIPTION
## About The Pull Request
Chomp edit for the cigar cases gave them 7, the case holds a maximum of 5.

## Changelog
Chomp edit cigar case now starts with 5 instead of 7 cigars

:cl: Will
fix: Cigar cases no longer violate spatial limitations by starting with 5 cigars instead of 7 in a case that only holds 5
/:cl:
