### PR TITLE
Outdoor Turf Demote Needs To Be A Base Turf Proc

### DIFF
--- a/code/game/turfs/simulated/outdoors/outdoors_ch.dm
+++ b/code/game/turfs/simulated/outdoors/outdoors_ch.dm
@@ -11,7 +11,10 @@
 		T.demote_to = mytype
 
 // This proc removes the topmost layer.
-/turf/simulated/floor/outdoors/proc/demote()
+/turf/proc/demote()
+	return
+
+/turf/simulated/floor/outdoors/demote()
 	if(!demote_to)
 		return // Cannot demote further.
 


### PR DESCRIPTION
## About The Pull Request
This needs to be moved to base turf, or events that change turf after a delay, if something external causes the turf to change, will attempt to fire the proc without it existing. No player facing changes other than rare runtimes caused by alarms and explosions on ice/snow or such.

## Changelog
Moves turf/outdoors/demote() to /turf/demote()

:cl: Will
code: Ice and snow no longer runtime if demoted to baseturf during an explosion combined with a delayed action
/:cl:
