### PR TITLE
Forbid Malignant Organ Basetypes From Xenoarch Spawn

### DIFF
--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -445,7 +445,13 @@
 			possible_object_paths += subtypesof(/obj/item/organ/internal)
 
 			//BLACKLIST BELOW
-			possible_object_paths -= list(/obj/item/organ/internal/mmi_holder, /obj/item/organ/internal/stack/vox)
+			possible_object_paths -= list(	/obj/item/organ/internal/mmi_holder,
+											/obj/item/organ/internal/stack/vox,
+											/obj/item/organ/internal/malignant,
+											/obj/item/organ/internal/malignant/tumor,
+											/obj/item/organ/internal/malignant/parasite,
+											/obj/item/organ/internal/malignant/engineered,
+											/obj/item/organ/internal/malignant/engineered/chemorgan) // //CHOMP Edit: Add malignant organ basetypes to exclusions.
 			//BLACKLIST ABOVE
 
 			var/obj/item/organ/internal/new_organ = pick(possible_object_paths)


### PR DESCRIPTION
## About The Pull Request
None of these should appear in normal gameplay. So forbidding them.

## Changelog
Blacklists malignant organ basetypes that do not have icons or functionality from being dropped by xenoarch.

:cl: Will
fix: Prevents nonfunctioning malignant organ types from spawning as xenoarch finds
/:cl: