### PR TITLE
Ventfix

### DIFF
--- a/code/ATMOSPHERICS/_atmos_setup.dm
+++ b/code/ATMOSPHERICS/_atmos_setup.dm
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(pipe_colors, list("grey" = PIPE_COLOR_GREY, "red" = PIPE_COLOR_
 	for(var/state in device.IconStates())
 		if(!state || findtext(state, "map"))
 			continue
-		device_icons["scrubber" + state] = image('icons/atmos/vent_scrubber.dmi', icon_state = state)
+		device_icons["scrubber" + state] = image('icons/atmos/vent_scrubber.dmi', icon_state = state + "_new") //CHOMPEdit - New Scrubbers
 
 /datum/pipe_icon_manager/proc/gen_omni_icons()
 	if(!omni_icons)


### PR DESCRIPTION

## About The Pull Request
Makes vents ands crubbers use the original sprites Chomp was using (square vents/scrubbers)
## Changelog
:cl: Diana 
image: Modified scrubbers to use the square sprites instead of the circular sprites
/:cl:
