### PR TITLE
Back to old scrubbers

### DIFF
--- a/code/ATMOSPHERICS/_atmos_setup.dm
+++ b/code/ATMOSPHERICS/_atmos_setup.dm
@@ -151,7 +151,7 @@ GLOBAL_LIST_INIT(pipe_colors, list("grey" = PIPE_COLOR_GREY, "red" = PIPE_COLOR_
 	for(var/state in device.IconStates())
 		if(!state || findtext(state, "map"))
 			continue
-		device_icons["scrubber" + state] = image('icons/atmos/vent_scrubber.dmi', icon_state = state + "_new") //CHOMPEdit - New Scrubbers
+		device_icons["scrubber" + state] = image('icons/atmos/vent_scrubber.dmi', icon_state = state)
 
 /datum/pipe_icon_manager/proc/gen_omni_icons()
 	if(!omni_icons)


### PR DESCRIPTION

## About The Pull Request
Apparently they aren't supposed to be square... Reverts the scrubber portion in https://github.com/CHOMPStation2/CHOMPStation2/pull/11727, so that vents are square and scrubbers are circular.
## Changelog
:cl: Diana
image: Adjusts scrubbers to their circular state
/:cl:
