### PR TITLE
Ward-Takahashi Lies Fixed

### DIFF
--- a/code/modules/projectiles/guns/energy/protector_vr.dm
+++ b/code/modules/projectiles/guns/energy/protector_vr.dm
@@ -22,6 +22,7 @@
 
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 3, TECH_MAGNET = 2)
 
+	dna_lock = 1
 	charge_sections = 3 //For the icon
 	ammo_x_offset = 2
 	ammo_y_offset = 0


### PR DESCRIPTION
Actually made the DNA locked gun have a DNA lock.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
fix: Actually made the Ward-Takahashi WT-98a 'Protector' have a DNA lock. No more false advertising.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
