### PR TITLE
Obliterates all shards on Sif for real this time

### DIFF
--- a/modular_chomp/maps/submaps/surface_submaps/wilderness/deathden.dmm
+++ b/modular_chomp/maps/submaps/surface_submaps/wilderness/deathden.dmm
@@ -449,7 +449,7 @@
 /turf/simulated/floor/wood/sif/turfpack/sif,
 /area/submap/DeathDen)
 "vC" = (
-/obj/machinery/power/supermatter/shard,
+/obj/item/flame/lighter/supermatter,
 /turf/simulated/floor/wood/sif/turfpack/sif,
 /area/submap/DeathDen)
 "vD" = (


### PR DESCRIPTION
## About The Pull Request
Previously, I removed the exposed Supermatter Shard from the deathden POI as it was causing too many atmos issues. There are two versions of this POI, and we decided to keep the non-exposed version. However, this one also tends to get frequently exposed and agitated, thus causing severe atmos issues on Sif. This removes the shard fully, which only really existed as a setpiece anyway.

:cl:
maptweak: Removed the supermatter shard from the deathden POI.
/:cl: