### PR TITLE
Deconflicts Tea

### DIFF
--- a/modular_chomp/code/modules/reagents/reactions/distilling/hot_drinks.dm
+++ b/modular_chomp/code/modules/reagents/reactions/distilling/hot_drinks.dm
@@ -1,0 +1,32 @@
+/decl/chemical_reaction/distilling/drinks/cherrytea
+	name = REAGENT_CHERRYTEA
+	id = REAGENT_ID_CHERRYTEA
+	result = REAGENT_ID_CHERRYTEA
+	required_reagents = list(REAGENT_ID_TEA = 5, REAGENT_ID_CHERRYJELLY = 1)
+	result_amount = 6
+
+/decl/chemical_reaction/distilling/drinks/watermelontea
+	name = REAGENT_WATERMELONTEA
+	id = REAGENT_ID_WATERMELONTEA
+	result = REAGENT_ID_WATERMELONTEA
+	required_reagents = list(REAGENT_ID_TEA = 5, REAGENT_ID_WATERMELONJUICE = 1)
+	result_amount = 6
+
+/decl/chemical_reaction/distilling/drinks/matcha_latte
+	name = REAGENT_MATCHALATTE
+	id = REAGENT_ID_MATCHALATTE
+	result = REAGENT_ID_MATCHALATTE
+	required_reagents = list (REAGENT_ID_MATCHAPOWDER = 1, REAGENT_ID_MILK = 5)
+	result_amount = 5
+
+/decl/chemical_reaction/distilling/drinks/greenteafresh
+	id = REAGENT_ID_FRESHTEAGREEN
+	result = REAGENT_ID_FRESHTEAGREEN
+	required_reagents = list (REAGENT_ID_TEALEAVESGREEN = 1, REAGENT_ID_WATER = 9)
+	result_amount = 10
+
+/decl/chemical_reaction/distilling/drinks/matcha
+	id = REAGENT_ID_MATCHA
+	result = REAGENT_ID_MATCHA
+	required_reagents = list (REAGENT_ID_MATCHAPOWDER = 1, REAGENT_ID_WATER = 2)
+	result_amount = 2

--- a/modular_chomp/code/modules/reagents/reactions/instant/drinks.dm
+++ b/modular_chomp/code/modules/reagents/reactions/instant/drinks.dm
@@ -1,64 +1,3 @@
-/decl/chemical_reaction/instant/drinks/minttea
-	name = REAGENT_MINTTEA
-	id = REAGENT_ID_MINTTEA
-	result = REAGENT_ID_MINTTEA
-	required_reagents = list(REAGENT_ID_TEA = 5, REAGENT_ID_MINT = 1)
-	result_amount = 6
-
-/decl/chemical_reaction/instant/drinks/lemontea
-	name = REAGENT_LEMONTEA
-	id = REAGENT_ID_LEMONTEA
-	result = REAGENT_ID_LEMONTEA
-	required_reagents = list(REAGENT_ID_TEA = 5, REAGENT_ID_LEMONJUICE = 1)
-	result_amount = 6
-
-/decl/chemical_reaction/instant/drinks/limetea
-	name = REAGENT_LIMETEA
-	id = REAGENT_ID_LIMETEA
-	result = REAGENT_ID_LIMETEA
-	required_reagents = list(REAGENT_ID_TEA = 5, REAGENT_ID_LIMEJUICE = 1)
-	result_amount = 6
-
-/decl/chemical_reaction/instant/drinks/orangetea
-	name = REAGENT_ORANGETEA
-	id = REAGENT_ID_ORANGETEA
-	result = REAGENT_ID_ORANGETEA
-	required_reagents = list(REAGENT_ID_TEA = 5, REAGENT_ID_ORANGEJUICE = 1)
-	result_amount = 6
-
-/decl/chemical_reaction/instant/drinks/berrytea
-	name = REAGENT_BERRYTEA
-	id = REAGENT_ID_BERRYTEA
-	result = REAGENT_ID_BERRYTEA
-	required_reagents = list(REAGENT_ID_TEA = 5, REAGENT_ID_BERRYJUICE = 1)
-	result_amount = 6
-
-/decl/chemical_reaction/instant/drinks/cherrytea
-	name = REAGENT_CHERRYTEA
-	id = REAGENT_ID_CHERRYTEA
-	result = REAGENT_ID_CHERRYTEA
-	required_reagents = list(REAGENT_ID_TEA = 5, REAGENT_ID_CHERRYJELLY = 1)
-	result_amount = 6
-
-/decl/chemical_reaction/instant/drinks/watermelontea
-	name = REAGENT_WATERMELONTEA
-	id = REAGENT_ID_WATERMELONTEA
-	result = REAGENT_ID_WATERMELONTEA
-	required_reagents = list(REAGENT_ID_TEA = 5, REAGENT_ID_WATERMELONJUICE = 1)
-	result_amount = 6
-
-/decl/chemical_reaction/instant/tea/matcha_latte
-	id = REAGENT_ID_MATCHALATTE
-	result = REAGENT_ID_MATCHALATTE
-	required_reagents = list (REAGENT_ID_MATCHAPOWDER = 1, REAGENT_ID_MILK = 5)
-	result_amount = 5
-
-/decl/chemical_reaction/instant/freshtea/green
-	id = REAGENT_ID_FRESHTEAGREEN
-	result = REAGENT_ID_FRESHTEAGREEN
-	required_reagents = list (REAGENT_ID_TEALEAVESGREEN = 1, REAGENT_ID_WATER = 9)
-	result_amount = 10
-
 /decl/chemical_reaction/instant/instantteapowder/green
 	id = REAGENT_ID_INSTANTTEAPOWDERGREEN
 	result = REAGENT_ID_INSTANTTEAPOWDERGREEN
@@ -70,12 +9,6 @@
 	result = REAGENT_ID_INSTANTTEAGREEN
 	required_reagents = list (REAGENT_ID_INSTANTTEAPOWDERGREEN = 1, REAGENT_ID_WATER = 9)
 	result_amount = 10
-
-/decl/chemical_reaction/instant/matcha
-	id = REAGENT_ID_MATCHA
-	result = REAGENT_ID_MATCHA
-	required_reagents = list (REAGENT_ID_MATCHAPOWDER = 1, REAGENT_ID_WATER = 2)
-	result_amount = 2
 
 /decl/chemical_reaction/instant/drinks/spiderdrink
 	name = REAGENT_SPIDERDRINK

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -5335,6 +5335,7 @@
 #include "modular_chomp\code\modules\projectiles\precursor\tyr.dm"
 #include "modular_chomp\code\modules\reagents\machinery\dispenser\chem_synthesizer_ch.dm"
 #include "modular_chomp\code\modules\reagents\reactions\distilling\distilling.dm"
+#include "modular_chomp\code\modules\reagents\reactions\distilling\hot_drinks.dm"
 #include "modular_chomp\code\modules\reagents\reactions\instant\drinks.dm"
 #include "modular_chomp\code\modules\reagents\reactions\instant\instant.dm"
 #include "modular_chomp\code\modules\reagents\reagents\food_drinks.dm"


### PR DESCRIPTION
## About The Pull Request
Chomp's tea reagents were not updated to reflect changes in upstream tea making, also had duped recipes.

## Changelog
Moved cherry, watermelon, matcha latte, matcha, and fresh green tea to correct recipes
removed duplicate mint, lemon, lime, orange, and berry tea recipes 

:cl: Will
code: finished tea deconflict
/:cl:
