### PR TITLE
Removes water breathing var from Breathless

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/positive_ch.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/positive_ch.dm
@@ -381,7 +381,7 @@
 
 	can_take = ORGANICS
 
-	var_changes = list("breath_type" = "null", "poison_type" = "null", "exhale_type" = "null", "water_breather" = "TRUE")
+	var_changes = list("breath_type" = "null", "poison_type" = "null", "exhale_type" = "null")
 	excludes = list(/datum/trait/negative/breathes/phoron,
 					/datum/trait/negative/breathes/nitrogen,
 					/datum/trait/negative/breathes/carbon_dioxide,


### PR DESCRIPTION
## About The Pull Request

Breathless makes you take no oxyloss already so water breather is a bit redundant, plus  the var modifications make it clash with Aquatic.

## Changelog

:cl: Virgo113
del: Traits: removed redundant water breathing from Breathless so it doesn't clash with Aquatic
/:cl:
