### PR TITLE
Improves Bluespace Lockers event

### DIFF
--- a/modular_chomp/code/modules/event/bluespacelocker.dm
+++ b/modular_chomp/code/modules/event/bluespacelocker.dm
@@ -9,7 +9,6 @@
 		/area/solar
 	)
 	var/list/area/pickable_areas
-	var/area/announce_area
 
 /datum/event/bluespace_locker/setup()
 	pickable_areas = get_station_areas(excluded)
@@ -42,7 +41,6 @@
 		if(!closet.can_open() && sealed)
 			continue
 		valid_lockers.Add(closet)
-		announce_area = picked_area
 		pickable_areas.Remove(picked_area)
 
 	if(!isemptylist(valid_lockers))
@@ -56,7 +54,7 @@
 	entry_point.AddComponent(/datum/component/bluespace_connection, list(exit_point))
 	exit_point.AddComponent(/datum/component/bluespace_connection, list(entry_point))
 
-	log_and_message_admins("Bluespace lockers linked. Entry: [get_area(exit_point)] Exit: [get_area(entry_point)]")
+	log_and_message_admins("Bluespace lockers linked. Entry: [get_area(entry_point)] Exit: [get_area(exit_point)]")
 
 /datum/event/bluespace_locker/announce()
-	command_announcement.Announce("Bluespace anomaly detected near [station_name()]. Possible location, [announce_area].", "Anomaly Alert")
+	command_announcement.Announce("Bluespace anomaly detected near [station_name()]. Possible location, [get_area(pick(entry_point, exit_point))].", "Anomaly Alert")


### PR DESCRIPTION

## About The Pull Request

Gives the bluespace locker event a few more tries before it gives up on finding a valid locker.
Entry/Exit picking have different attempts now, improving the chances of actually finding a locker.

## Changelog
:cl: Guti
refactor: Improved the bluespace lockers locker pick method
code: Bluespace Lockers event have a couple more attempts to pick a locker now
/:cl:
