### PR TITLE
fixes halo_alt

### DIFF
--- a/code/modules/clothing/head/misc_vr.dm
+++ b/code/modules/clothing/head/misc_vr.dm
@@ -153,6 +153,10 @@
 	icon = 'modular_chomp/icons/inventory/head/item.dmi'
 	default_worn_icon = 'modular_chomp/icons/inventory/head/mob_halo.dmi'
 	icon_state = "halo"
+
+/obj/item/clothing/head/halo/alt
+	icon = 'icons/inventory/head/item.dmi'
+	default_worn_icon = 'icons/inventory/head/mob.dmi'
 // CHOMPEdit End
 
 //Replikant Hat


### PR DESCRIPTION
## About The Pull Request

the demon halo changes the base halo type icon path, which broke the alt halo item. This adds the correct typepaths to the alt halo item

## Changelog
:cl:
fix: alt halo loadout item works now
/:cl:
