### PR TITLE
[DRAFT] Aegis Update

### DIFF
--- a/modular_chomp/maps/common/common_presets.dm
+++ b/modular_chomp/maps/common/common_presets.dm
@@ -69,13 +69,33 @@
 	id = "Centcom Relay"
 	autolinkers = list("cnt_relay")
 
+/obj/machinery/telecomms/relay/preset/southerncross/echidna
+	id = "Echidna Relay"
+	autolinkers = list("echidna_relay")
+
+/obj/machinery/telecomms/relay/preset/southerncross/needle
+	id = "Needle Relay"
+	autolinkers = list("needle_relay")
+
+/obj/machinery/telecomms/relay/preset/southerncross/stargazer
+	id = "Stargazer Relay"
+	autolinkers = list("stargazer_relay")
+
+/obj/machinery/telecomms/relay/preset/southerncross/ursula
+	id = "Ursula Relay"
+	autolinkers = list("ursula_relay")
+
+/obj/machinery/telecomms/relay/preset/southerncross/baby_mammoth
+	id = "Baby Mammoth Relay"
+	autolinkers = list("baby_mammoth_relay")
+
 /obj/machinery/telecomms/hub/preset/southerncross
 	id = "Hub"
 	network = "tcommsat"
 	autolinkers = list("hub",
 		"d0_relay", "d1_relay", "d2_relay", "d3_relay", "pnt_relay", "cve_relay", "wld_relay", "tns_relay", "cnt_relay", "explorer", "exp_relay",
 		"science", "medical", "supply", "service", "common", "command", "engineering", "security", "unused",
-		"hb_relay", "receiverA", "broadcasterA"
+		"hb_relay", "receiverA", "broadcasterA", "echidna_relay", "needle_relay", "stargazer_relay", "ursula_relay", "baby_mammoth_relay"
 	)
 
 /obj/machinery/telecomms/hub/preset/southerncross/centcomm

--- a/modular_chomp/maps/southern_cross/southern_cross-7.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-7.dmm
@@ -1011,17 +1011,14 @@
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "ach" = (
-/obj/machinery/button/remote/airlock{
-	desiredstate = 1;
-	dir = 8;
-	id = "echidna_hatch";
-	name = "Rear Hatch Control";
-	pixel_x = 26;
-	req_access = list(67);
-	specialfunctions = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/space,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/engstorage)
 "aci" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
@@ -1171,40 +1168,47 @@
 /turf/simulated/floor/grass2,
 /area/expoutpost/slingcarrierdock)
 "acw" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
+/turf/simulated/wall/r_lead,
 /area/expoutpost/engstorage)
 "acx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/orange/bordercorner,
+/obj/machinery/vending/wardrobe/engidrobe,
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
 "acy" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/recharger,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
 	},
+/obj/effect/floor_decal/corner/brown/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/cargodrobe,
 /turf/simulated/floor/tiled,
-/area/expoutpost/engstorage)
+/area/expoutpost/miningfoyer)
 "acz" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/secdrobe,
+/turf/simulated/floor/tiled,
+/area/expoutpost/secoffice)
+"acA" = (
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/miningfoyer)
-"acA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/effect/floor_decal/corner/paleblue/border{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/miningfoyer)
+/obj/machinery/vending/wardrobe/medidrobe,
+/turf/simulated/floor/tiled/white,
+/area/expoutpost/medicalbay)
 "acB" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -1218,33 +1222,53 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
 "acC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/railing/overhang/waterless/grey{
+	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/miningfoyer)
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/machinery/light/floortube{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/staginghangar)
 "acD" = (
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/expoutpost/botany)
 "acE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/structure/railing/overhang/waterless/grey{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/miningfoyer)
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/machinery/light/floortube{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/staginghangar)
 "acF" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/structure/railing/overhang/waterless/grey,
+/obj/structure/railing/grey,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/gatewayeva)
+/obj/machinery/light/floortube,
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/staginghangar)
 "acG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/recharger/wallcharger{
+	pixel_x = 4;
+	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/gatewayeva)
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/light/floortube{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/staginghangar)
 "acH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -1255,95 +1279,126 @@
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
 "acI" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/explobriefroom)
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/staginghangar)
 "acJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/expoutpost/explobriefroom)
-"acK" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/breakroom)
-"acL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/expoutpost/gatewayeva)
-"acM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/expoutpost/explobriefroom)
-"acN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/breakroom)
-"acO" = (
-/obj/structure/bed/chair/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
-	},
-/obj/structure/bed/chair/wood{
-	dir = 1
-	},
-/obj/effect/landmark/start/intern,
-/turf/simulated/floor/carpet,
-/area/expoutpost/breakroom)
-"acP" = (
-/obj/structure/table/wooden_reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/floor_decal/techfloor/corner{
 	dir = 6
 	},
-/turf/simulated/floor/carpet,
-/area/expoutpost/breakroom)
-"acQ" = (
-/obj/structure/bed/chair/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/merge_conflict_marker{
-	name = "---Merge Conflict Marker---";
-	
-	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
-/obj/structure/bed/chair/wood,
-/obj/effect/landmark/start/intern,
-/turf/simulated/floor/carpet,
-/area/expoutpost/breakroom)
-"acR" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
-/area/expoutpost/breakroom)
-"acS" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/area/expoutpost/slingcarrierdock)
+"acK" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/slingcarrierdock)
+"acL" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/slingcarrierdock)
+"acM" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 9
+	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/portbowhallway)
+"acN" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/starbowhallway)
+"acO" = (
+/obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/secoffice)
-"acT" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/starbowhallway)
+"acP" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/visitor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/expoutpost/bar)
+"acQ" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/expoutpost/restrooms)
+"acR" = (
+/obj/structure/bed/chair/wood,
+/obj/effect/landmark/start/visitor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/secoffice)
-"acU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/turf/simulated/floor/wood,
+/area/expoutpost/bar)
+"acS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/civaccesshallway)
+"acT" = (
+/obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/secoffice)
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/civaccesshallway)
+"acU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/eva)
 "acV" = (
 /obj/machinery/light{
 	dir = 4
@@ -1351,12 +1406,286 @@
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/washroom)
 "acW" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/eva)
+"acX" = (
+/obj/effect/floor_decal/grass_edge{
+	dir = 4
+	},
+/obj/machinery/beehive,
+/turf/simulated/floor/grass2,
+/area/expoutpost/botany)
+"acY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/eva)
+"acZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/eva)
+"ada" = (
+/obj/effect/floor_decal/grass_edge{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/emerglocker/west,
+/turf/simulated/floor/grass2,
+/area/expoutpost/botany)
+"adb" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/eva)
+"adc" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/eva)
+"add" = (
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/eva)
+"ade" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/eva)
+"adf" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/effect/landmark/start/botanist,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/expoutpost/botany)
+"adg" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/expoutpost/botany)
+"adh" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/expoutpost/botany)
+"adi" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/eva)
+"adj" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/eva)
+"adk" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/grass2,
+/area/expoutpost/botany)
+"adl" = (
+/obj/effect/floor_decal/grass_edge{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/grass2,
+/area/expoutpost/botany)
+"adm" = (
+/obj/effect/floor_decal/grass_edge{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/grass2,
+/area/expoutpost/botany)
+"adn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_dirty,
+/area/expoutpost/botany)
+"ado" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/engstorage)
+"adp" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/recharger,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/engstorage)
+"adq" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/miningfoyer)
+"adr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/miningfoyer)
+"ads" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/miningfoyer)
+"adt" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/miningfoyer)
+"adu" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/gatewayeva)
+"adv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/gatewayeva)
+"adw" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/explobriefroom)
+"adx" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/expoutpost/explobriefroom)
+"ady" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/breakroom)
+"adz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/expoutpost/gatewayeva)
+"adA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/expoutpost/explobriefroom)
+"adB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/breakroom)
+"adC" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/intern,
+/turf/simulated/floor/carpet,
+/area/expoutpost/breakroom)
+"adD" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/carpet,
+/area/expoutpost/breakroom)
+"adE" = (
+/obj/structure/bed/chair/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/bed/chair/wood,
+/obj/effect/landmark/start/intern,
+/turf/simulated/floor/carpet,
+/area/expoutpost/breakroom)
+"adF" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/breakroom)
+"adG" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/secoffice)
+"adH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/secoffice)
+"adI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/secoffice)
+"adJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/wall/r_wall,
 /area/expoutpost/cic)
-"acX" = (
+"adK" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -1367,19 +1696,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"acY" = (
+"adL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"acZ" = (
+"adM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"ada" = (
+"adN" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1392,7 +1721,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
-"adb" = (
+"adO" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1405,7 +1734,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
-"adc" = (
+"adP" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1418,13 +1747,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
-"add" = (
+"adQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"ade" = (
+"adR" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1437,7 +1766,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarthree)
-"adf" = (
+"adS" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1450,7 +1779,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
-"adg" = (
+"adT" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/hangartwo)
+"adU" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1463,7 +1795,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarthree)
-"adh" = (
+"adV" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1476,7 +1808,7 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/expoutpost/hangarfour)
-"adi" = (
+"adW" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1489,7 +1821,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
-"adj" = (
+"adX" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1502,7 +1834,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
-"adk" = (
+"adY" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1518,7 +1850,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
-"adl" = (
+"adZ" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1534,9 +1866,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
-"adT" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/hangartwo)
 "aei" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -2024,6 +2353,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 6
 	},
+/obj/machinery/firealarm{
+	pixel_y = 26;
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/washroom)
 "aAV" = (
@@ -2301,6 +2634,9 @@
 /turf/simulated/floor/reinforced,
 /area/expoutpost/portbowairlock)
 "aKX" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/expoutpost/botany)
 "aKZ" = (
@@ -2449,10 +2785,6 @@
 	},
 /turf/simulated/floor,
 /area/expoutpost/atmospherics)
-"aRH" = (
-/obj/machinery/beehive,
-/turf/simulated/floor/grass2,
-/area/expoutpost/botany)
 "aRI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
@@ -2481,14 +2813,14 @@
 /area/expoutpost/rnd)
 "aTL" = (
 /obj/structure/table/rack/shelf,
-/obj/fiftyspawner/plastic,
-/obj/fiftyspawner/plastic,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
 	},
+/obj/fiftyspawner/glass,
+/obj/fiftyspawner/glass,
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
 "aVF" = (
@@ -2849,15 +3181,13 @@
 /turf/simulated/wall/r_wall,
 /area/expoutpost/secoffice)
 "biJ" = (
-/obj/structure/table/rack/shelf,
-/obj/fiftyspawner/glass,
-/obj/fiftyspawner/glass,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 10
 	},
+/obj/structure/reagent_dispensers/foam,
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
 "bjP" = (
@@ -3084,6 +3414,10 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/eva)
 "btY" = (
@@ -3252,6 +3586,9 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
+/obj/machinery/light/floortube{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
 "bDk" = (
@@ -3359,7 +3696,8 @@
 "bKJ" = (
 /obj/machinery/power/smes/buildable/max_charge_max_input{
 	RCon_tag = "Reactor Input - Aegis";
-	name = "Reactor SMES - Input"
+	name = "Reactor SMES - Input";
+	output_level = 200000
 	},
 /obj/item/smes_coil,
 /obj/item/smes_coil,
@@ -3627,14 +3965,26 @@
 /obj/effect/floor_decal/spline/fancy/wood/cee{
 	dir = 4
 	},
-/obj/machinery/button/remote/blast_door{
-	dir = 1;
-	id = "aeg_bar_blastdoor";
-	name = "Bar Blast Doors";
-	pixel_y = -28
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "aeg_bar_shutter";
+	name = "Bar Shutters";
+	req_access = list(25);
+	pixel_y = -24;
+	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
@@ -4100,14 +4450,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/slingcarrierdock)
 "coz" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/wall{
-	dir = 4;
-	pixel_x = -35
-	},
 /obj/effect/landmark/start/janitor,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/janitorial)
 "coY" = (
@@ -4186,6 +4537,12 @@
 	pixel_y = 4
 	},
 /obj/effect/landmark/start/bartender,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/bar)
 "csU" = (
@@ -4352,6 +4709,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "czV" = (
@@ -4489,8 +4849,27 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/starbowhallway)
 "cFG" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
+	},
+/obj/structure/cable/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = -12
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 4;
+	id = "aeg_seccomm_bolt";
+	name = "Door Bolt";
+	pixel_x = -24;
+	pixel_y = 12;
+	specialfunctions = 4
+	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/commanderroom)
 "cGr" = (
@@ -4797,6 +5176,14 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
+/obj/machinery/button/remote/airlock{
+	dir = 4;
+	id = "aeg_suitetwo_bolt";
+	name = "Door Bolt";
+	pixel_x = -24;
+	pixel_y = 12;
+	specialfunctions = 4
+	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/suite2)
 "cTT" = (
@@ -4999,6 +5386,9 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
 /turf/simulated/floor/grass2,
 /area/expoutpost/botany)
 "dey" = (
@@ -5209,6 +5599,10 @@
 /turf/simulated/floor/airless,
 /area/space)
 "dqm" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/starbowhallway)
 "dqy" = (
@@ -5397,6 +5791,12 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10
 	},
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "aeg_bar_blastdoor";
+	name = "Bar Window Blast Doors";
+	pixel_y = -28
+	},
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "dyS" = (
@@ -5453,6 +5853,10 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "0-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/washroom)
@@ -5954,9 +6358,6 @@
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/structure/table/rack/shelf,
 /obj/fiftyspawner/steel,
 /obj/fiftyspawner/steel,
@@ -6177,6 +6578,10 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
 "ejG" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/portbowhallway)
 "ejR" = (
@@ -6331,9 +6736,6 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 6
 	},
-/obj/structure/table/rack/shelf,
-/obj/item/stack/cable_coil/green,
-/obj/item/circuitboard/quantumpad,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/stationqpad)
 "eqN" = (
@@ -6459,6 +6861,9 @@
 	pixel_x = 28;
 	pixel_y = 8;
 	req_access = list(25)
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/bar)
@@ -6778,6 +7183,9 @@
 	pixel_x = -22
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
 "eIR" = (
@@ -6853,6 +7261,12 @@
 	name = "Station Intercom (General)";
 	pixel_y = -21
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/bar)
 "eKQ" = (
@@ -6860,15 +7274,21 @@
 	desc = "All you need to start your own honey farm.";
 	name = "beekeeping crate"
 	},
-/obj/item/beehive_assembly,
-/obj/item/bee_smoker,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
 /obj/item/honey_frame,
 /obj/item/honey_frame,
 /obj/item/honey_frame,
 /obj/item/honey_frame,
 /obj/item/honey_frame,
 /obj/item/bee_pack,
+/obj/item/bee_pack,
 /obj/item/tool/crowbar,
+/obj/item/bee_smoker,
+/obj/item/beehive_assembly,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/expoutpost/botany)
 "eKX" = (
@@ -6965,6 +7385,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/aicore)
 "eOx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/eva)
 "eOE" = (
@@ -7450,13 +7876,9 @@
 	pixel_y = -22
 	},
 /obj/structure/table/wooden_reinforced,
-/obj/machinery/button/remote/airlock{
-	dir = 8;
-	id = "aeg_suiteone_bolt";
-	name = "Door Bolt";
-	pixel_x = 24;
-	pixel_y = 8;
-	specialfunctions = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/suite1)
@@ -7502,6 +7924,10 @@
 /area/shuttle/ursula)
 "fkD" = (
 /obj/structure/catwalk,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor,
 /area/expoutpost/starboardbowairlock)
 "fkF" = (
@@ -7720,6 +8146,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/visitor,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "fvj" = (
@@ -7803,10 +8230,6 @@
 	},
 /obj/effect/floor_decal/corner/white/border{
 	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
@@ -8864,6 +9287,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/light,
 /turf/simulated/floor/grass2,
 /area/expoutpost/slingcarrierdock)
 "gyf" = (
@@ -9231,14 +9655,6 @@
 	pixel_y = 22
 	},
 /obj/machinery/papershredder,
-/obj/machinery/button/remote/airlock{
-	dir = 4;
-	id = "aeg_seccomm_bolt";
-	name = "Door Bolt";
-	pixel_x = -24;
-	pixel_y = -8;
-	specialfunctions = 4
-	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/commanderroom)
 "gNn" = (
@@ -9888,9 +10304,16 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
 "hpv" = (
-/obj/machinery/vending/security,
+/obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/secbowcheckpoint)
@@ -10297,9 +10720,6 @@
 /obj/structure/railing/grey{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -10667,6 +11087,10 @@
 /obj/effect/floor_decal/corner/purple/bordercorner{
 	dir = 4
 	},
+/obj/machinery/firealarm{
+	layer = 3.3;
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/rnd)
 "hVu" = (
@@ -10945,6 +11369,12 @@
 	pixel_y = 24
 	},
 /obj/effect/landmark/start/bartender,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/bar)
 "ijV" = (
@@ -11069,15 +11499,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/miningfoyer)
 "inK" = (
-/obj/structure/table/reinforced,
-/obj/fiftyspawner/steel,
-/obj/fiftyspawner/glass,
 /obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/robodrobe,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/rnd)
 "inU" = (
@@ -11256,6 +11684,13 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/floor_decal/grass_edge{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/grass2,
 /area/expoutpost/botany)
 "itM" = (
@@ -11377,6 +11812,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/steel,
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
 "iBg" = (
@@ -11387,6 +11824,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/civaccesshallway)
@@ -11522,10 +11963,10 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
 "iIw" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
 "iIB" = (
@@ -11605,16 +12046,13 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
 "iLf" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 5
 	},
-/obj/structure/table/steel_reinforced,
+/obj/machinery/vending/security,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/secbowcheckpoint)
 "iMD" = (
@@ -11632,7 +12070,6 @@
 	},
 /obj/merge_conflict_marker{
 	name = "---Merge Conflict Marker---";
-	
 	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
 	},
 /obj/structure/table/rack/shelf,
@@ -11690,9 +12127,7 @@
 	pixel_x = 16;
 	pixel_y = 18
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "iPo" = (
@@ -11883,6 +12318,12 @@
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medical EVA"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
@@ -12274,6 +12715,11 @@
 "jpr" = (
 /obj/machinery/light,
 /obj/structure/catwalk,
+/obj/structure/table/rack/shelf/steel,
+/obj/fiftyspawner/uranium,
+/obj/fiftyspawner/uranium,
+/obj/fiftyspawner/uranium,
+/obj/fiftyspawner/uranium,
 /turf/simulated/floor,
 /area/expoutpost/engstorage)
 "jpM" = (
@@ -12943,6 +13389,9 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/grass2,
 /area/expoutpost/botany)
 "jOn" = (
@@ -13015,7 +13464,7 @@
 /area/expoutpost/starfuelstorage)
 "jSQ" = (
 /obj/structure/sign/signnew/radiation,
-/turf/simulated/wall/r_wall,
+/turf/simulated/wall/r_lead,
 /area/expoutpost/engstorage)
 "jTc" = (
 /obj/structure/cable/green{
@@ -13035,6 +13484,10 @@
 /area/expoutpost/miningfoyer)
 "jTs" = (
 /obj/structure/catwalk,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor,
 /area/expoutpost/portbowairlock)
 "jTQ" = (
@@ -13092,13 +13545,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/eva)
 "jWf" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/purple/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/stationqpad)
 "jWh" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -13937,14 +14384,14 @@
 /area/expoutpost/portbowairlock)
 "kOi" = (
 /obj/structure/table/rack/shelf,
-/obj/fiftyspawner/steel,
-/obj/fiftyspawner/steel,
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
 	},
+/obj/fiftyspawner/plastic,
+/obj/fiftyspawner/plastic,
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
 "kOT" = (
@@ -14484,10 +14931,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/eva)
@@ -14520,6 +14965,9 @@
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#DDFFD3"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/portbowhallway)
@@ -14646,10 +15094,6 @@
 	},
 /obj/structure/railing/grey{
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
 	},
 /obj/structure/table/rack/shelf,
 /obj/item/storage/belt/utility/full,
@@ -14830,9 +15274,9 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 10
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -15479,6 +15923,9 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/white/border,
 /obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
 "lUw" = (
@@ -15882,15 +16329,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/secarmory)
-"mkR" = (
-/obj/structure/railing/overhang/waterless/grey,
-/obj/structure/railing/grey,
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/staginghangar)
 "mkU" = (
 /obj/structure/cable/blue{
 	icon_state = "1-2"
@@ -16073,6 +16511,17 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/door/blast/shutters{
+	dir = 8;
+	id = "aeg_bar_shutter";
+	name = "Bar Shutter"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/bar)
 "mrc" = (
@@ -16203,10 +16652,6 @@
 	},
 /obj/structure/railing/grey{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#DDFFD3"
 	},
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
@@ -16381,6 +16826,7 @@
 /obj/effect/floor_decal/corner/white/border{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
 "mGI" = (
@@ -16435,9 +16881,9 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/portbowhallway)
@@ -16519,7 +16965,9 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/secarmory)
 "mMj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -16532,6 +16980,13 @@
 "mMt" = (
 /obj/effect/floor_decal/borderfloorwhite/corner,
 /obj/effect/floor_decal/corner/purple/bordercorner,
+/obj/machinery/vending/nifsoft_shop{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/stationqpad)
 "mMF" = (
@@ -16554,6 +17009,9 @@
 	dir = 4
 	},
 /obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/machinery/light/floortube{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -16721,6 +17179,10 @@
 /obj/structure/cable/green,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/starqpadjunction)
 "mUI" = (
@@ -16776,6 +17238,10 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/grass2,
 /area/expoutpost/botany)
 "mWz" = (
@@ -17640,6 +18106,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/vending/wardrobe/atmosdrobe,
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
 "nyN" = (
@@ -18169,13 +18636,6 @@
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/starqpadjunction)
-"nUL" = (
-/obj/machinery/light,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/slingcarrierdock)
 "nVg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 1
@@ -18301,18 +18761,14 @@
 /turf/simulated/floor,
 /area/expoutpost/starfuelstorage)
 "oao" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light_switch{
+/obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = -12
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/commanderroom)
@@ -19195,12 +19651,22 @@
 /area/expoutpost/gatewayeva)
 "oLo" = (
 /obj/structure/table/steel,
+/obj/item/storage/box/mousetraps,
+/obj/item/storage/box/mousetraps,
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 21
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/janitorial)
 "oLH" = (
@@ -19245,7 +19711,9 @@
 /area/expoutpost/lowersternhallway)
 "oOD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -19527,7 +19995,7 @@
 "peA" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
@@ -20062,6 +20530,9 @@
 	dir = 8
 	},
 /obj/structure/railing/grey,
+/obj/machinery/light/floortube{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
 "pDV" = (
@@ -20164,12 +20635,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/lowersternhallway)
-"pIV" = (
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/portbowhallway)
 "pJe" = (
 /obj/machinery/power/apc/hyper{
 	coverlocked = 0;
@@ -20502,12 +20967,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/cic)
 "pYv" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 9
-	},
-/obj/effect/floor_decal/corner/purple/border{
-	dir = 9
-	},
 /obj/machinery/power/quantumpad,
 /obj/structure/cable/green{
 	icon_state = "0-4"
@@ -20728,6 +21187,7 @@
 /area/expoutpost/reactorroom)
 "qeT" = (
 /obj/structure/table/wooden_reinforced,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "qfx" = (
@@ -20740,9 +21200,9 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/starbowhallway)
@@ -20829,21 +21289,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
-"qjb" = (
-/obj/structure/railing/overhang/waterless/grey{
-	dir = 8
-	},
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/mining/brace,
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/staginghangar)
 "qjm" = (
 /obj/mecha/combat/fighter/pinnace/loaded,
 /obj/machinery/mech_recharger,
@@ -21106,6 +21551,12 @@
 /obj/machinery/door/airlock{
 	name = "Joint EVA";
 	req_one_access = list(1,43,67)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
@@ -21648,16 +22099,10 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/pathfinderroom)
 "qOD" = (
-/obj/effect/floor_decal/borderfloorwhite{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/purple/border{
-	dir = 10
-	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
-/obj/structure/frame,
+/obj/machinery/power/quantumpad,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/stationqpad)
 "qOH" = (
@@ -23010,19 +23455,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
-"rOU" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/white/border{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/eva)
 "rPc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23411,6 +23843,9 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 22
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
@@ -24106,9 +24541,7 @@
 /obj/structure/bed/chair/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/landmark/start/visitor,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
@@ -24399,6 +24832,9 @@
 	},
 /obj/structure/railing/grey{
 	dir = 1
+	},
+/obj/machinery/light/floortube{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
@@ -24759,6 +25195,9 @@
 /obj/structure/railing/grey{
 	dir = 8
 	},
+/obj/machinery/light/floortube{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
 "ttk" = (
@@ -24775,6 +25214,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
+/obj/machinery/light,
 /turf/simulated/floor/grass2,
 /area/expoutpost/slingcarrierdock)
 "tuN" = (
@@ -24976,6 +25416,9 @@
 /area/expoutpost/washroom)
 "tCO" = (
 /obj/machinery/honey_extractor,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/expoutpost/botany)
 "tCS" = (
@@ -25132,6 +25575,10 @@
 /obj/structure/cable/green,
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/portqpadjunction)
 "tJt" = (
@@ -25352,8 +25799,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/lowersternhallway)
 "tQz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -25377,6 +25828,9 @@
 /area/expoutpost/secoffice)
 "tRU" = (
 /obj/machinery/vending/boozeomat,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/bar)
 "tSg" = (
@@ -25485,9 +25939,9 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
 	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/slingcarrierdock)
@@ -25521,6 +25975,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel_dirty,
 /area/expoutpost/botany)
@@ -25737,9 +26194,12 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
 "udW" = (
-/obj/machinery/light,
 /obj/structure/railing/grey{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/slingcarrierdock)
@@ -25752,7 +26212,6 @@
 	},
 /obj/merge_conflict_marker{
 	name = "---Merge Conflict Marker---";
-	
 	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -26318,10 +26777,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
 	},
-/obj/machinery/firealarm{
-	layer = 3.3;
-	pixel_y = 26
-	},
+/obj/machinery/vending/wardrobe/scidrobe,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/rnd)
 "uBG" = (
@@ -26754,8 +27210,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -27686,6 +28142,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/mob/living/bot/farmbot,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/expoutpost/botany)
 "vGF" = (
@@ -27733,6 +28190,8 @@
 	name = "Station Intercom (General)";
 	pixel_y = 21
 	},
+/obj/fiftyspawner/steel,
+/obj/fiftyspawner/glass,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/rnd)
 "vJh" = (
@@ -27871,9 +28330,7 @@
 /obj/structure/bed/chair/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/start/visitor,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
@@ -27977,6 +28434,9 @@
 /obj/structure/railing/grey{
 	dir = 8
 	},
+/obj/machinery/light/floortube{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
 "vQf" = (
@@ -28001,6 +28461,10 @@
 /obj/item/reagent_containers/dropper,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/kitchen)
@@ -28598,11 +29062,26 @@
 /turf/simulated/floor,
 /area/expoutpost/portlowermaint)
 "wkV" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/structure/cable/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/firealarm{
+/obj/machinery/light_switch{
 	dir = 4;
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = -12
+	},
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "aeg_pathfinderroom_bolt";
+	name = "Door Bolt";
+	pixel_x = 24;
+	pixel_y = 12;
+	specialfunctions = 4
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/pathfinderroom)
@@ -28651,6 +29130,7 @@
 /obj/effect/floor_decal/grass_edge{
 	dir = 5
 	},
+/obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/grass2,
 /area/expoutpost/botany)
 "wlO" = (
@@ -28677,7 +29157,6 @@
 	},
 /obj/merge_conflict_marker{
 	name = "---Merge Conflict Marker---";
-	
 	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -28794,6 +29273,9 @@
 "wsW" = (
 /obj/structure/bed/chair/wood,
 /obj/effect/landmark/start/visitor,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "wte" = (
@@ -28891,9 +29373,6 @@
 /turf/simulated/floor,
 /area/expoutpost/portbowairlock)
 "wwc" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
@@ -28995,6 +29474,9 @@
 	pixel_y = 24
 	},
 /obj/effect/landmark/start/bartender,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/bar)
 "wBw" = (
@@ -29123,12 +29605,14 @@
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "wLS" = (
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21
-	},
 /obj/effect/landmark/start/janitor,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/wall{
+	dir = 8;
+	pixel_x = 35
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/janitorial)
 "wMp" = (
@@ -29349,6 +29833,9 @@
 /area/expoutpost/portexplomaint)
 "wUy" = (
 /obj/effect/landmark/start/janitor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/janitorial)
 "wVi" = (
@@ -29636,12 +30123,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/reactorcr)
 "xgp" = (
-/obj/effect/floor_decal/grass_edge,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/vending/wardrobe/hydrobe,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/simulated/floor/grass2,
+/turf/simulated/floor/tiled/steel_dirty,
 /area/expoutpost/botany)
 "xgL" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -29705,6 +30191,14 @@
 /obj/structure/cable/green{
 	icon_state = "0-2"
 	},
+/obj/machinery/button/remote/airlock{
+	dir = 8;
+	id = "aeg_suiteone_bolt";
+	name = "Door Bolt";
+	pixel_x = 24;
+	pixel_y = 13;
+	specialfunctions = 4
+	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/suite1)
 "xit" = (
@@ -29764,9 +30258,6 @@
 	dir = 4
 	},
 /obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/red,
@@ -29972,6 +30463,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
 "xss" = (
@@ -30113,13 +30607,9 @@
 	pixel_y = -22
 	},
 /obj/structure/table/wooden_reinforced,
-/obj/machinery/button/remote/airlock{
-	dir = 4;
-	id = "aeg_suitetwo_bolt";
-	name = "Door Bolt";
-	pixel_x = -24;
-	pixel_y = 8;
-	specialfunctions = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/suite2)
@@ -30313,18 +30803,14 @@
 /turf/space,
 /area/space)
 "xFv" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/structure/cable/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light_switch{
+/obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = 24;
-	pixel_y = -12
+	pixel_x = 24
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/pathfinderroom)
@@ -30597,14 +31083,6 @@
 	pixel_y = 22
 	},
 /obj/machinery/papershredder,
-/obj/machinery/button/remote/airlock{
-	dir = 8;
-	id = "aeg_pathfinderroom_bolt";
-	name = "Door Bolt";
-	pixel_x = 24;
-	pixel_y = -8;
-	specialfunctions = 4
-	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/pathfinderroom)
 "xOL" = (
@@ -30653,12 +31131,10 @@
 /area/expoutpost/suite2)
 "xPV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/table/steel,
-/obj/item/storage/box/mousetraps,
-/obj/item/storage/box/mousetraps,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/janidrobe,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/janitorial)
 "xQa" = (
@@ -30804,6 +31280,12 @@
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering EVA"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
 "xUr" = (
@@ -30811,9 +31293,6 @@
 	dir = 4
 	},
 /obj/structure/railing/grey{
-	dir = 4
-	},
-/obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/table/rack/shelf,
@@ -31320,10 +31799,6 @@
 	},
 /obj/structure/railing/grey{
 	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	layer = 3
 	},
 /obj/structure/table/steel_reinforced,
 /obj/machinery/cell_charger,
@@ -58095,7 +58570,7 @@ cxh
 enL
 jwx
 enL
-acz
+adq
 kgn
 lTk
 isM
@@ -58349,7 +58824,7 @@ eoO
 eoO
 eoO
 eoO
-eMB
+acy
 enL
 enL
 enL
@@ -58855,7 +59330,7 @@ rUs
 tis
 jGJ
 liP
-acI
+adw
 liP
 lyU
 xfE
@@ -58869,7 +59344,7 @@ uKT
 enL
 enm
 mkF
-acA
+adr
 lTw
 nvl
 viN
@@ -59382,7 +59857,7 @@ vCa
 vCa
 vCa
 pQt
-acC
+ads
 uSL
 uSL
 uSL
@@ -59640,7 +60115,7 @@ aFp
 mmN
 vCa
 eMB
-acE
+adt
 enL
 enL
 enL
@@ -59886,8 +60361,8 @@ qng
 qng
 qng
 xMn
-acM
-acJ
+adA
+adx
 lEO
 ejs
 xfE
@@ -60183,10 +60658,10 @@ abV
 iNh
 xnF
 bwJ
-roD
-roD
-roD
-roD
+acw
+acw
+acw
+acw
 tLe
 jOn
 jOn
@@ -60444,7 +60919,7 @@ wKr
 jSQ
 cHY
 dfH
-roD
+acw
 jKi
 ruI
 oFW
@@ -60696,13 +61171,13 @@ dqy
 tEW
 xJS
 xJS
-acw
+ach
 xJS
 xJS
 fgx
 jks
 jpr
-roD
+acw
 uFO
 spq
 spq
@@ -60903,9 +61378,9 @@ jnl
 jnl
 jZo
 jnl
-adc
-ada
-ada
+adP
+adN
+adN
 hlF
 bwS
 pEN
@@ -60916,10 +61391,10 @@ rEw
 wzH
 wzH
 kzZ
-acP
-acO
-acN
-acK
+adD
+adC
+adB
+ady
 wzH
 cCr
 wzH
@@ -60954,13 +61429,13 @@ jsl
 aPh
 iiF
 wZI
-acx
+ado
 wZI
 dEY
 jSQ
 uoI
 sfi
-roD
+acw
 qaG
 jOn
 aAt
@@ -61172,8 +61647,8 @@ tAp
 rqt
 rrG
 upj
-acR
-acQ
+adF
+adE
 sps
 oFq
 wzH
@@ -61212,13 +61687,13 @@ rKs
 aPh
 roD
 vJh
-acy
+adp
 gQK
 eQR
-roD
-roD
-roD
-roD
+acw
+acw
+acw
+acw
 ruI
 oFW
 ruI
@@ -61586,7 +62061,7 @@ ecU
 bQT
 uZP
 iSs
-iKy
+acQ
 jhQ
 iKy
 iKy
@@ -61821,14 +62296,14 @@ tdp
 fyn
 cMj
 qca
-rhP
+adb
 cMj
 uTc
-rhP
+adb
 cMj
 mGA
-rhP
-rhP
+acY
+acU
 lUp
 kBn
 voo
@@ -61988,7 +62463,7 @@ qOH
 abX
 nyK
 wZI
-dEY
+acx
 nZp
 gLE
 aDh
@@ -62085,8 +62560,8 @@ kUD
 iXd
 cMj
 vrY
-rhP
-rhP
+bjT
+nOj
 iSI
 kBn
 jVs
@@ -62102,7 +62577,7 @@ eqH
 kBn
 pgk
 uIT
-pIV
+mIm
 bVv
 bVv
 bVv
@@ -62118,7 +62593,7 @@ bVv
 bVv
 bVv
 bVv
-wCz
+acM
 uIT
 mIm
 tVP
@@ -62134,7 +62609,7 @@ omy
 tGt
 gyI
 nBk
-isx
+tVt
 ekf
 tGt
 aCC
@@ -62153,11 +62628,11 @@ uNn
 rUH
 rUH
 sjY
-adi
-adi
-adk
-adi
-adi
+adW
+adW
+adY
+adW
+adW
 bAg
 lGy
 tMo
@@ -62174,9 +62649,9 @@ vWD
 krs
 vWD
 vWD
-adg
-ade
-ade
+adU
+adR
+adR
 aFw
 tXN
 yjg
@@ -62337,14 +62812,14 @@ tam
 mdJ
 rcn
 igW
-mdJ
+add
 gKW
 mdJ
-mdJ
+adc
 bfK
 mdJ
-mdJ
-mdJ
+acZ
+acW
 jVO
 jmh
 aAP
@@ -62592,7 +63067,7 @@ llX
 hbj
 rdA
 vRX
-rhP
+adi
 cMj
 xsc
 eOx
@@ -62600,7 +63075,7 @@ oSr
 pDV
 oqq
 qIh
-rOU
+oqq
 gYx
 ope
 btC
@@ -62850,7 +63325,7 @@ lOd
 rhP
 rhP
 rhP
-rhP
+adj
 cMj
 kUD
 quy
@@ -63111,7 +63586,7 @@ xss
 bkv
 cMj
 oxi
-rhP
+ade
 soJ
 cMj
 cMj
@@ -63234,7 +63709,7 @@ gqv
 cXC
 faz
 juR
-acW
+adJ
 abd
 aaY
 azg
@@ -63948,11 +64423,11 @@ tHc
 uvM
 tux
 nOu
-nnn
+acG
 pQN
 qZg
 pQN
-aiL
+acF
 lkz
 taW
 xUr
@@ -63969,7 +64444,7 @@ mNd
 mwu
 yhb
 lMk
-xSb
+acC
 xkN
 bAe
 nOu
@@ -64210,7 +64685,7 @@ nnn
 pQN
 cbv
 pQN
-mkR
+aiL
 lkz
 lkz
 lkz
@@ -64464,11 +64939,11 @@ tHc
 eog
 gxB
 nOu
-nnn
+acG
 pQN
 uJB
 pQN
-aiL
+acF
 lkz
 tro
 lqy
@@ -64478,14 +64953,14 @@ jqy
 tVj
 ooz
 ooz
-qjb
+ooz
 pDu
 lkz
 vPD
 ykK
 kOZ
 dQK
-jqy
+acE
 hFX
 bkS
 nOu
@@ -64518,7 +64993,7 @@ jYi
 qIR
 cWs
 dal
-acX
+adK
 wPQ
 iNT
 jIv
@@ -64720,7 +65195,7 @@ jrB
 aCC
 gyI
 ojE
-nUL
+ojE
 nOu
 wwc
 dcL
@@ -64776,7 +65251,7 @@ wzz
 iBp
 iBp
 acc
-acY
+adL
 fkF
 iNT
 rcx
@@ -65034,7 +65509,7 @@ oYU
 yck
 iBp
 wJJ
-acY
+adL
 fkF
 iNT
 uxa
@@ -65149,8 +65624,8 @@ cwA
 cwA
 cwA
 cwA
-xEV
-xEV
+cwA
+cwA
 xEV
 xEV
 xEV
@@ -65169,13 +65644,13 @@ oWr
 oWr
 www
 dei
+pyi
 kJA
-kJA
-kSF
+adk
 ifz
-aKX
-oiA
-frm
+adh
+adg
+adf
 aKX
 llY
 www
@@ -65292,7 +65767,7 @@ xwv
 rIW
 iBp
 ljK
-acZ
+adM
 glR
 iNT
 iGn
@@ -65427,9 +65902,9 @@ giX
 gAj
 nuL
 vvK
-aLV
-aRH
-aRH
+adm
+kJA
+pyi
 bQe
 qwc
 oiA
@@ -65494,9 +65969,9 @@ jrB
 mYG
 gyI
 gyI
-msz
+acJ
 nOu
-uQT
+acI
 koU
 koU
 rOJ
@@ -65546,7 +66021,7 @@ uzW
 pnR
 pnR
 iBp
-add
+adQ
 iBp
 iBp
 iBp
@@ -65687,21 +66162,21 @@ www
 tWQ
 wlz
 wCK
-wCK
+adl
 pnG
 ivA
 oiA
 frm
 suq
 wCK
+acX
 wCK
-wCK
-wCK
+ada
 hJg
-wCK
+acX
 mWw
 umA
-uZC
+acT
 uZC
 ntZ
 uZC
@@ -65804,7 +66279,7 @@ iNT
 dqW
 yiB
 tKW
-xbm
+acA
 xbm
 jiK
 xbm
@@ -65943,7 +66418,7 @@ hMN
 rKf
 www
 uRJ
-ilP
+adn
 ilP
 ilP
 ilP
@@ -65967,7 +66442,7 @@ nCc
 nCc
 nCc
 tqk
-nCc
+acS
 niI
 aVF
 jJo
@@ -66239,14 +66714,14 @@ aNw
 nAE
 bVU
 hhH
-fKL
+acO
 cEh
 fKL
 fKL
 fKL
 fKL
 fKL
-xme
+acN
 tUr
 qgo
 rLw
@@ -66262,9 +66737,9 @@ iPo
 mBu
 gyI
 nBk
-msz
+acL
 axl
-mBu
+acK
 mYG
 gyI
 crf
@@ -66282,10 +66757,10 @@ xUc
 xUc
 gQk
 dya
-adj
-adl
-adj
-adj
+adX
+adZ
+adX
+adX
 lAT
 aci
 kKd
@@ -66302,9 +66777,9 @@ jEQ
 xoX
 iOC
 iOC
-adh
-adf
-adf
+adV
+adS
+adS
 dnG
 kLn
 gXs
@@ -66487,10 +66962,10 @@ nBd
 gLm
 qoJ
 jfu
-wsW
+acR
+peA
 qeT
-qeT
-fuN
+acP
 rKp
 rLI
 lZE
@@ -67612,8 +68087,8 @@ lrz
 gEi
 rKg
 ezt
-adb
-adb
+adO
+adO
 pzJ
 gUm
 kdc
@@ -67880,13 +68355,13 @@ tAp
 juR
 bie
 hQz
-acS
+adG
 jfJ
 bie
 eYr
 rwb
 gKD
-acF
+adu
 owV
 tjn
 jSE
@@ -68138,7 +68613,7 @@ tAp
 juR
 bie
 fhE
-acT
+adH
 gei
 bie
 jsf
@@ -68401,8 +68876,8 @@ ajM
 bep
 fEs
 vei
-acL
-acG
+adz
+adv
 owV
 oKC
 jSE
@@ -69169,8 +69644,8 @@ iGn
 tAp
 juR
 bie
-bQR
-acU
+acz
+adI
 jfJ
 bie
 lPb
@@ -69427,7 +69902,7 @@ iGn
 tAp
 emn
 bie
-pSN
+bQR
 jfX
 tRS
 bie
@@ -70418,7 +70893,7 @@ xEV
 xEV
 xEV
 cwA
-ach
+cwA
 cwA
 cwA
 cwA

--- a/modular_chomp/maps/southern_cross/southern_cross-7.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-7.dmm
@@ -45,14 +45,8 @@
 /turf/space,
 /area/expoutpost/reactorroom)
 "aaj" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/engstorage)
+/turf/simulated/wall/rplastitanium,
+/area/expoutpost/aicore)
 "aak" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -175,6 +169,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 4
 	},
+/obj/effect/landmark/start/commandsecretary,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/cic)
 "aaA" = (
@@ -287,6 +282,7 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
+/obj/effect/landmark/start/pilot,
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/cic)
 "aaO" = (
@@ -335,7 +331,8 @@
 /area/expoutpost/cic)
 "aaT" = (
 /obj/machinery/computer/ship/helm{
-	req_one_access = list(19,62,67)
+	req_one_access = list(19,62,67);
+	ai_control = 1
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/cic)
@@ -482,6 +479,7 @@
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
 	},
+/obj/structure/window/plastitanium,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/aicore)
 "abj" = (
@@ -502,12 +500,18 @@
 	dir = 8;
 	pixel_x = -21
 	},
+/obj/structure/window/plastitanium{
+	dir = 8
+	},
 /turf/simulated/floor/water/digestive_enzymes/nanites,
 /area/expoutpost/aicore)
 "abl" = (
 /obj/item/radio/intercom/private{
 	dir = 4;
 	pixel_x = 21
+	},
+/obj/structure/window/plastitanium{
+	dir = 4
 	},
 /turf/simulated/floor/water/digestive_enzymes/nanites,
 /area/expoutpost/aicore)
@@ -539,10 +543,6 @@
 "abo" = (
 /obj/machinery/porta_turret/ai_defense{
 	req_one_access = list(16)
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
 	},
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -920,102 +920,150 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/slingcarrierdock)
 "abV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/effect/landmark/start/engineer,
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
 "abW" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/recharger,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/effect/landmark/start/atmostech,
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
 "abX" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/orange/bordercorner,
+/obj/effect/landmark/start/atmostech,
 /turf/simulated/floor/tiled,
-/area/expoutpost/miningfoyer)
+/area/expoutpost/engstorage)
 "abY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 5
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
 "abZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
 "aca" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
 "acb" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/gatewayeva)
+/obj/effect/landmark/start/roboticist,
+/turf/simulated/floor/tiled/white,
+/area/expoutpost/rnd)
 "acc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/gatewayeva)
+/obj/effect/landmark/start/paramedic,
+/turf/simulated/floor/tiled/white,
+/area/expoutpost/medicalbay)
 "acd" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/shield_capacitor{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/explobriefroom)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/expoutpost/staginghangar)
 "ace" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/shield_capacitor{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/expoutpost/explobriefroom)
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/expoutpost/staginghangar)
 "acf" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/breakroom)
+/turf/simulated/floor/tiled/milspec,
+/area/shuttle/stargazer)
 "acg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
-/area/expoutpost/gatewayeva)
-"ach" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
-/area/expoutpost/explobriefroom)
-"aci" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/breakroom)
-"acj" = (
-/obj/structure/bed/chair/wood{
+/obj/effect/floor_decal/milspec/color/purple,
+/obj/machinery/telecomms/relay/preset/southerncross/ursula,
+/obj/machinery/door/window/survival_pod{
+	req_one_access = list(61);
+	dir = 2
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet,
-/area/expoutpost/breakroom)
-"ack" = (
-/obj/structure/table/wooden_reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
 	},
-/turf/simulated/floor/carpet,
-/area/expoutpost/breakroom)
+/turf/simulated/floor/tiled/milspec,
+/area/shuttle/ursula)
+"ach" = (
+/obj/machinery/button/remote/airlock{
+	desiredstate = 1;
+	dir = 8;
+	id = "echidna_hatch";
+	name = "Rear Hatch Control";
+	pixel_x = 26;
+	req_access = list(67);
+	specialfunctions = 4
+	},
+/turf/space,
+/area/space)
+"aci" = (
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/brown/border,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarsix)
+"acj" = (
+/obj/machinery/power/quantumpad{
+	map_pad_id = "aeg_miningship_padin_1";
+	map_pad_link_id = "aeg_miningship_padout_1";
+	name = "TO - REFINERY"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/structure/sign/directions/cargo/refinery{
+	dir = 10;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/expoutpost/hangarsix)
+"ack" = (
+/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/quantumpad{
+	map_pad_id = "aeg_miningship_padin_2";
+	map_pad_link_id = "aeg_miningship_padout_2";
+	name = "TO - REFINERY"
+	},
+/obj/structure/sign/directions/cargo/refinery{
+	dir = 10;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/expoutpost/hangarsix)
 "acl" = (
 /obj/machinery/atmospherics/pipe/tank/phoron/full,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -1025,132 +1073,138 @@
 /turf/simulated/floor/reinforced,
 /area/expoutpost/starfuelstorage)
 "acm" = (
-/obj/structure/bed/chair/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet,
-/area/expoutpost/breakroom)
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/camera/network/mining{
+	c_tag = "ECHIDNA - Cargo Bay";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/milspec,
+/area/shuttle/echidna)
 "acn" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/breakroom)
-"aco" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/telecomms/relay/preset/southerncross/echidna,
+/obj/machinery/door/window/survival_pod{
+	req_one_access = list(61);
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/secoffice)
-"acp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/secoffice)
-"acq" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/window/reinforced/survival_pod{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/secoffice)
-"acr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/expoutpost/cic)
-"acs" = (
+/turf/simulated/floor/tiled/milspec,
+/area/shuttle/echidna)
+"aco" = (
+/obj/effect/floor_decal/borderfloorwhite,
+/obj/effect/floor_decal/corner/purple/border,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white,
+/area/expoutpost/stationqpad)
+"acp" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/turf/simulated/floor/tiled/white,
+/area/expoutpost/stationqpad)
+"acq" = (
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/white,
+/area/expoutpost/stationqpad)
+"acr" = (
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/purple/border{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
-/area/expoutpost/medicalbay)
+/area/expoutpost/stationqpad)
+"acs" = (
+/obj/machinery/embedded_controller/radio/simple_docking_controller{
+	frequency = 1381;
+	id_tag = "exp_sling_outpost";
+	name = "shuttle bay controller";
+	pixel_x = 30;
+	req_one_access = list();
+	tag_door = "exp_sling_outpost_door"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/slingcarrierdock)
 "act" = (
+/obj/machinery/door/firedoor/glass,
+/obj/effect/wingrille_spawn/reinforced,
+/turf/simulated/floor,
+/area/expoutpost/slingcarrierdock)
+"acu" = (
+/obj/machinery/door/airlock/glass_external{
+	frequency = 1381;
+	icon_state = "door_locked";
+	id_tag = "exp_sling_outpost_door";
+	locked = 1;
+	name = "Carrier Sling Access";
+	req_access = list();
+	req_one_access = list(5,43,67)
+	},
+/obj/machinery/door/firedoor/glass,
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/slingcarrierdock)
+"acv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/floor_decal/grass_edge{
+	dir = 4
+	},
+/obj/effect/floor_decal/grass_edge,
+/turf/simulated/floor/grass2,
+/area/expoutpost/slingcarrierdock)
+"acw" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white,
-/area/expoutpost/medicalbay)
-"acu" = (
+/turf/simulated/floor/tiled,
+/area/expoutpost/engstorage)
+"acx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/engstorage)
+"acy" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/recharger,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/expoutpost/medicalbay)
-"acv" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled,
-/area/expoutpost/hangarone)
-"acw" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/hangartwo)
-"acx" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/hangarone)
-"acy" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/white,
-/area/expoutpost/medicalbay)
+/area/expoutpost/engstorage)
 "acz" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
-/area/expoutpost/hangarthree)
+/area/expoutpost/miningfoyer)
 "acA" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
-/area/expoutpost/hangarfour)
+/area/expoutpost/miningfoyer)
 "acB" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -1164,6 +1218,239 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
 "acC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/miningfoyer)
+"acD" = (
+/obj/machinery/seed_extractor,
+/turf/simulated/floor/tiled/steel_dirty,
+/area/expoutpost/botany)
+"acE" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/miningfoyer)
+"acF" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/gatewayeva)
+"acG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/gatewayeva)
+"acH" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/expoutpost/reactorroom)
+"acI" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/explobriefroom)
+"acJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/expoutpost/explobriefroom)
+"acK" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/breakroom)
+"acL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled,
+/area/expoutpost/gatewayeva)
+"acM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled,
+/area/expoutpost/explobriefroom)
+"acN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/breakroom)
+"acO" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/obj/effect/landmark/start/intern,
+/turf/simulated/floor/carpet,
+/area/expoutpost/breakroom)
+"acP" = (
+/obj/structure/table/wooden_reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/carpet,
+/area/expoutpost/breakroom)
+"acQ" = (
+/obj/structure/bed/chair/wood,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/bed/chair/wood,
+/obj/effect/landmark/start/intern,
+/turf/simulated/floor/carpet,
+/area/expoutpost/breakroom)
+"acR" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/breakroom)
+"acS" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/secoffice)
+"acT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/secoffice)
+"acU" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/secoffice)
+"acV" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/expoutpost/washroom)
+"acW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/wall/r_wall,
+/area/expoutpost/cic)
+"acX" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/expoutpost/medicalbay)
+"acY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/expoutpost/medicalbay)
+"acZ" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/expoutpost/medicalbay)
+"ada" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarone)
+"adb" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangartwo)
+"adc" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarone)
+"add" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/expoutpost/medicalbay)
+"ade" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarthree)
+"adf" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarfour)
+"adg" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1176,11 +1463,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarthree)
-"acD" = (
-/obj/machinery/seed_extractor,
-/turf/simulated/floor/tiled/steel_dirty,
-/area/expoutpost/botany)
-"acE" = (
+"adh" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1193,7 +1476,7 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/expoutpost/hangarfour)
-"acF" = (
+"adi" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1206,7 +1489,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
-"acG" = (
+"adj" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1219,16 +1502,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
-"acH" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/expoutpost/reactorroom)
-"acI" = (
+"adk" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1244,7 +1518,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
-"acJ" = (
+"adl" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1260,12 +1534,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
-"acV" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/freezer,
-/area/expoutpost/washroom)
 "adT" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/hangartwo)
@@ -1322,6 +1590,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/shuttle_landmark/southern_cross/carrier/needle_dock,
+/obj/structure/handrail,
 /turf/simulated/floor,
 /area/shuttle/needle)
 "afR" = (
@@ -1428,6 +1697,7 @@
 "ajU" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/hopdouble,
+/obj/effect/landmark/start/visitor,
 /turf/simulated/floor/carpet,
 /area/expoutpost/suite1)
 "akr" = (
@@ -1664,17 +1934,24 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
 "avU" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 1
+/obj/machinery/power/quantumpad{
+	map_pad_id = "aeg_miningship_padout_2";
+	map_pad_link_id = "aeg_miningship_padin_2";
+	name = "TO - ECHIDNA"
 	},
-/obj/effect/floor_decal/corner/brown/bordercorner{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 21
 	},
-/turf/simulated/floor/tiled,
+/obj/structure/sign/directions/cargo/mining{
+	dir = 5;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/miningfoyer)
 "awk" = (
 /obj/structure/cable/green{
@@ -1725,12 +2002,6 @@
 /obj/item/pen,
 /turf/simulated/floor/carpet,
 /area/expoutpost/breakroom)
-"ayE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/miningfoyer)
 "azg" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -1902,17 +2173,13 @@
 /turf/simulated/floor/reinforced,
 /area/expoutpost/disposals)
 "aGB" = (
-/obj/structure/window/reinforced/full,
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced{
-	dir = 4;
-	health = 1e+006
+/obj/effect/floor_decal/grass_edge{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/grass2,
 /area/expoutpost/slingcarrierdock)
 "aGE" = (
 /obj/effect/floor_decal/techfloor/corner{
@@ -1968,6 +2235,10 @@
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/smes_coil,
+/obj/item/smes_coil,
+/obj/item/smes_coil,
+/obj/item/smes_coil,
 /obj/effect/engine_setup/smes,
 /turf/simulated/floor,
 /area/expoutpost/reactoraccess)
@@ -2336,7 +2607,10 @@
 /area/expoutpost/portexplomaint)
 "aYM" = (
 /obj/structure/table/darkglass,
-/obj/item/gps,
+/obj/item/gps{
+	pixel_y = 3;
+	pixel_x = -3
+	},
 /obj/item/gps{
 	pixel_x = 3;
 	pixel_y = 3
@@ -3077,6 +3351,9 @@
 /obj/structure/cable/blue{
 	icon_state = "1-8"
 	},
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/baby_mammoth)
 "bKJ" = (
@@ -3094,6 +3371,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/engine_setup/smes,
 /turf/simulated/floor,
 /area/expoutpost/reactoraccess)
 "bLb" = (
@@ -3526,6 +3804,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
 	},
+/obj/structure/handrail,
 /turf/simulated/floor,
 /area/shuttle/needle)
 "ccN" = (
@@ -3571,6 +3850,7 @@
 /obj/structure/bed/chair/bay/comfy/captain{
 	dir = 1
 	},
+/obj/effect/landmark/start/miner,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "cev" = (
@@ -3677,6 +3957,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/expoutpost/gateway)
+"ciq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/miningfoyer)
 "ciy" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/cell_charger,
@@ -3821,6 +4107,7 @@
 	dir = 4;
 	pixel_x = -35
 	},
+/obj/effect/landmark/start/janitor,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/janitorial)
 "coY" = (
@@ -3898,6 +4185,7 @@
 	pixel_x = -18;
 	pixel_y = 4
 	},
+/obj/effect/landmark/start/bartender,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/bar)
 "csU" = (
@@ -3982,7 +4270,7 @@
 "cuB" = (
 /obj/machinery/door/window/survival_pod{
 	dir = 2;
-	req_one_access = list(67)
+	req_one_access = list(48,61,67)
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
@@ -4083,6 +4371,9 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "czY" = (
@@ -4151,6 +4442,9 @@
 	},
 /obj/item/bedsheet/rddouble,
 /obj/structure/curtain/open/bed,
+/obj/effect/landmark/start{
+	name = "Search and Rescue"
+	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/explodorm1)
 "cDc" = (
@@ -4175,6 +4469,11 @@
 /obj/machinery/computer/ship/engines,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "echidna_blast";
+	name = "remote blast shielding control";
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
@@ -4230,6 +4529,7 @@
 /obj/structure/bed/chair/bay/comfy/black{
 	dir = 8
 	},
+/obj/effect/landmark/start/security,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/secbowcheckpoint)
 "cHY" = (
@@ -4259,6 +4559,9 @@
 	},
 /obj/structure/cable/blue{
 	icon_state = "1-2"
+	},
+/obj/structure/handrail{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/stargazer)
@@ -4312,6 +4615,9 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
+/obj/structure/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/ursula)
 "cMj" = (
@@ -4343,6 +4649,10 @@
 /obj/structure/grille/rustic{
 	health = 25;
 	name = "reinforced grille"
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "echidna_blast";
+	name = "window blast shield"
 	},
 /turf/simulated/floor,
 /area/shuttle/echidna)
@@ -4493,11 +4803,16 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1381;
 	id_tag = "echidna_pump"
+	},
+/obj/structure/handrail{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/echidna)
@@ -4562,6 +4877,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/effect/landmark/start/engineer,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/reactorcr)
 "cXC" = (
@@ -4966,6 +5282,7 @@
 "dtF" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/hosdouble,
+/obj/effect/landmark/start/visitor,
 /turf/simulated/floor/carpet,
 /area/expoutpost/suite2)
 "dus" = (
@@ -5208,6 +5525,7 @@
 	frequency = 1381;
 	id_tag = "echidna_pump"
 	},
+/obj/structure/handrail,
 /turf/simulated/floor,
 /area/shuttle/echidna)
 "dEY" = (
@@ -5562,6 +5880,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
 	},
+/obj/effect/landmark/start/miner,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "dTM" = (
@@ -5802,9 +6121,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/slingcarrierdock)
 "ehn" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/flamp,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass2,
 /area/expoutpost/slingcarrierdock)
@@ -6014,6 +6331,9 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 6
 	},
+/obj/structure/table/rack/shelf,
+/obj/item/stack/cable_coil/green,
+/obj/item/circuitboard/quantumpad,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/stationqpad)
 "eqN" = (
@@ -6815,8 +7135,8 @@
 	id = "echidna_hatch";
 	name = "Rear Hatch Control";
 	pixel_x = 26;
-	req_access = list(67);
-	specialfunctions = 4
+	specialfunctions = 4;
+	req_one_access = list(48,61,67)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 8
@@ -6911,6 +7231,9 @@
 "eYq" = (
 /obj/effect/floor_decal/borderfloorwhite,
 /obj/effect/floor_decal/corner/purple/border,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/stationqpad)
 "eYr" = (
@@ -7310,6 +7633,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/landmark/start/botanist,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/expoutpost/botany)
 "frE" = (
@@ -7395,6 +7719,7 @@
 /obj/structure/bed/chair/wood{
 	dir = 1
 	},
+/obj/effect/landmark/start/visitor,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "fvj" = (
@@ -7512,6 +7837,7 @@
 	id_tag = "baby_mammoth_sensor";
 	pixel_y = 28
 	},
+/obj/structure/handrail,
 /turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "fzr" = (
@@ -8227,6 +8553,9 @@
 	id_tag = "baby_mammoth_pump"
 	},
 /obj/structure/closet/emcloset,
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "ghb" = (
@@ -8541,6 +8870,7 @@
 /obj/structure/bed/chair/bay/comfy/black{
 	dir = 8
 	},
+/obj/effect/landmark/start/security,
 /turf/simulated/floor/tiled,
 /area/expoutpost/secoffice)
 "gyq" = (
@@ -8819,6 +9149,9 @@
 /obj/machinery/door/blast/regular{
 	id = "AuxAICore";
 	name = "AI core maintenance hatch"
+	},
+/obj/structure/cable/blue{
+	icon_state = "1-10"
 	},
 /turf/simulated/floor,
 /area/expoutpost/aicore)
@@ -9099,6 +9432,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
+/obj/effect/landmark/start/scientist,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/rnd)
 "gXp" = (
@@ -9390,7 +9724,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
 "hjB" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/grass2,
 /area/shuttle/expoutpost/site)
 "hjG" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -9647,11 +9981,8 @@
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/staginghangar)
 "hsz" = (
-/obj/structure/closet/walllocker/emerglocker/south,
 /obj/machinery/power/smes/buildable/point_of_interest/max_input,
-/obj/structure/cable/green{
-	icon_state = "0-4"
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "htt" = (
@@ -9862,6 +10193,7 @@
 /obj/structure/bed/chair/bay/comfy/blue{
 	dir = 1
 	},
+/obj/effect/landmark/start/captain,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/cic)
 "hCD" = (
@@ -10016,6 +10348,7 @@
 /obj/structure/bed/chair/wood{
 	dir = 8
 	},
+/obj/effect/landmark/start/visitor,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "hGR" = (
@@ -10352,6 +10685,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/effect/landmark/start/chef,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/kitchen)
 "hXD" = (
@@ -10391,6 +10725,10 @@
 /obj/structure/grille/rustic{
 	health = 25;
 	name = "reinforced grille"
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "echidna_blast";
+	name = "window blast shield"
 	},
 /turf/simulated/floor,
 /area/shuttle/echidna)
@@ -10465,6 +10803,9 @@
 /obj/structure/closet/walllocker/emerglocker{
 	dir = 1;
 	pixel_y = -32
+	},
+/obj/structure/handrail{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
@@ -10603,6 +10944,7 @@
 /obj/machinery/chemical_dispenser/bar_coffee/full{
 	pixel_y = 24
 	},
+/obj/effect/landmark/start/bartender,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/bar)
 "ijV" = (
@@ -11276,9 +11618,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/secbowcheckpoint)
 "iMD" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/light/flamp,
 /turf/simulated/floor/grass2,
 /area/expoutpost/slingcarrierdock)
 "iNh" = (
@@ -11289,6 +11629,16 @@
 /obj/item/clothing/gloves/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/structure/table/rack/shelf,
+/obj/item/clothing/gloves/yellow,
+/obj/item/clothing/gloves/yellow{
+	pixel_y = 5
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
@@ -12351,7 +12701,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start{
-	name = "Pilot"
+	name = "Explorer"
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/explobriefroom)
@@ -12619,6 +12969,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
+/obj/effect/landmark/start/miner,
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
 "jQI" = (
@@ -12758,6 +13109,9 @@
 	dir = 1;
 	frequency = 1381;
 	id_tag = "stargazer_pump"
+	},
+/obj/structure/handrail{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/shuttle/stargazer)
@@ -12984,6 +13338,9 @@
 	dir = 1;
 	frequency = 1381;
 	id_tag = "ursula_pump"
+	},
+/obj/structure/handrail{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/ursula)
@@ -13255,10 +13612,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/cic)
-"kxg" = (
-/obj/machinery/power/quantumpad,
-/turf/simulated/floor/tiled/milspec/raised,
-/area/expoutpost/stationqpad)
 "kxx" = (
 /obj/structure/cable/blue{
 	icon_state = "1-2"
@@ -13315,6 +13668,7 @@
 /area/expoutpost/hangarone)
 "kzZ" = (
 /obj/structure/bed/chair/wood,
+/obj/effect/landmark/start/intern,
 /turf/simulated/floor/carpet,
 /area/expoutpost/breakroom)
 "kAp" = (
@@ -13856,6 +14210,20 @@
 /area/expoutpost/rnd)
 "kZQ" = (
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/telecomms/relay/preset/southerncross/needle,
+/obj/machinery/door/window/survival_pod{
+	req_one_access = list(61);
+	dir = 2
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/shuttle/needle)
 "lae" = (
@@ -14079,6 +14447,7 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/exploarmory)
 "ljI" = (
+/obj/structure/handrail,
 /turf/simulated/floor,
 /area/shuttle/needle)
 "ljK" = (
@@ -14589,6 +14958,7 @@
 	frequency = 1381;
 	id_tag = "stargazer_pump"
 	},
+/obj/structure/handrail,
 /turf/simulated/floor,
 /area/shuttle/stargazer)
 "lEc" = (
@@ -14658,7 +15028,7 @@
 "lGm" = (
 /obj/machinery/computer/ship/sensors,
 /obj/machinery/button/remote/blast_door{
-	dir = 4;
+	dir = 8;
 	id = "stargazer_blast";
 	name = "remote blast shielding control";
 	pixel_x = 27
@@ -14983,6 +15353,7 @@
 	pixel_x = -25;
 	pixel_y = 32
 	},
+/obj/structure/handrail,
 /turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "lRD" = (
@@ -15134,10 +15505,13 @@
 "lUK" = (
 /obj/machinery/vending/wallmed1{
 	dir = 4;
-	pixel_x = -23
+	pixel_x = -32
 	},
-/obj/machinery/light{
+/obj/machinery/light/floortube{
 	dir = 8
+	},
+/obj/structure/handrail{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/baby_mammoth)
@@ -15284,6 +15658,9 @@
 /obj/structure/panic_button{
 	pixel_x = -32
 	},
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/red,
 /area/shuttle/baby_mammoth)
 "mbg" = (
@@ -15427,6 +15804,7 @@
 "mgs" = (
 /obj/structure/bed/double/padded,
 /obj/item/bedsheet/yellowdouble,
+/obj/effect/landmark/start/hos,
 /turf/simulated/floor/carpet,
 /area/expoutpost/commanderroom)
 "mgE" = (
@@ -15441,6 +15819,10 @@
 "mgQ" = (
 /obj/machinery/power/smes/buildable/power_shuttle/max_charge_max_input_base_output,
 /obj/structure/cable/green,
+/obj/machinery/camera/network/mining{
+	c_tag = "ECHIDNA - Airlock";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "miL" = (
@@ -15456,7 +15838,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/gps,
+/obj/item/gps{
+	pixel_y = 3;
+	pixel_x = -3
+	},
 /obj/item/gps{
 	pixel_x = 3;
 	pixel_y = 3
@@ -16273,7 +16658,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/eva)
 "mRH" = (
-/obj/machinery/computer/ship/helm,
+/obj/machinery/computer/ship/helm{
+	ai_control = 1
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
 "mTc" = (
@@ -16412,9 +16799,6 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -16504,14 +16888,9 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
 "nbQ" = (
-/obj/structure/window/reinforced/full,
-/obj/structure/grille,
 /obj/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/grass_edge,
+/turf/simulated/floor/grass2,
 /area/expoutpost/slingcarrierdock)
 "nce" = (
 /obj/structure/table/rack/shelf,
@@ -16662,7 +17041,9 @@
 /turf/simulated/floor,
 /area/expoutpost/atmospherics)
 "nhn" = (
-/obj/machinery/computer/ship/helm,
+/obj/machinery/computer/ship/helm{
+	ai_control = 1
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "nhZ" = (
@@ -16804,11 +17185,14 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
@@ -16886,6 +17270,10 @@
 	},
 /obj/machinery/power/terminal{
 	dir = 4
+	},
+/obj/structure/panic_button{
+	pixel_y = -32;
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
@@ -17499,7 +17887,12 @@
 /obj/structure/window/plastitanium{
 	dir = 8
 	},
-/obj/structure/AIcore/deactivated,
+/obj/effect/landmark/start/ai,
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list(16);
+	req_one_access = list(16);
+	name = "Auxiliary AI Access"
+	},
 /turf/simulated/floor/water/digestive_enzymes/nanites,
 /area/expoutpost/aicore)
 "nGV" = (
@@ -17528,6 +17921,9 @@
 /obj/item/t_scanner,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/gloves/yellow,
+/obj/structure/handrail{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "nHj" = (
@@ -17641,7 +18037,9 @@
 /turf/simulated/floor,
 /area/expoutpost/staruppermaint)
 "nKT" = (
-/obj/machinery/computer/ship/helm,
+/obj/machinery/computer/ship/helm{
+	ai_control = 1
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "nLe" = (
@@ -17660,19 +18058,6 @@
 	},
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
-"nLN" = (
-/obj/machinery/door/airlock/glass_external{
-	frequency = 1381;
-	icon_state = "door_locked";
-	id_tag = "exp_sling_outpost_door";
-	locked = 1;
-	name = "Carrier Sling Access";
-	req_access = list();
-	req_one_access = list(5,43,67)
-	},
-/obj/machinery/door/firedoor/glass,
-/turf/simulated/floor/plating,
-/area/expoutpost/slingcarrierdock)
 "nLP" = (
 /obj/structure/shuttle/engine/heater,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -17892,7 +18277,7 @@
 /area/expoutpost/engstorage)
 "nZD" = (
 /obj/effect/shuttle_landmark/southern_cross/sling_outpost,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/grass2,
 /area/shuttle/expoutpost/site)
 "nZY" = (
 /obj/structure/table/steel,
@@ -18087,6 +18472,7 @@
 /obj/machinery/computer/shuttle_control/explore/stargazer{
 	dir = 4
 	},
+/obj/structure/closet/walllocker/emerglocker/north,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "ofo" = (
@@ -18131,16 +18517,6 @@
 	},
 /turf/space,
 /area/space)
-"oiz" = (
-/obj/structure/bed/chair/bay/comfy/green{
-	dir = 1
-	},
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_x = -25;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/milspec,
-/area/shuttle/stargazer)
 "oiA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18209,6 +18585,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = -21
 	},
+/obj/structure/window/plastitanium,
 /turf/simulated/floor/water/digestive_enzymes/nanites,
 /area/expoutpost/aicore)
 "ojK" = (
@@ -18281,6 +18658,7 @@
 /obj/structure/bed/chair/wood{
 	dir = 1
 	},
+/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "ooz" = (
@@ -18688,6 +19066,7 @@
 /obj/structure/bed/chair/wood{
 	dir = 1
 	},
+/obj/effect/landmark/start/intern,
 /turf/simulated/floor/carpet,
 /area/expoutpost/breakroom)
 "oFs" = (
@@ -18734,14 +19113,13 @@
 /turf/simulated/shuttle/floor/black,
 /area/shuttle/shuttle3/start)
 "oGw" = (
-/obj/structure/window/reinforced/full,
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/grass_edge{
+	dir = 1
+	},
+/turf/simulated/floor/grass2,
 /area/expoutpost/slingcarrierdock)
 "oHs" = (
 /obj/machinery/light,
@@ -18758,7 +19136,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/miningfoyer)
 "oHI" = (
-/obj/machinery/light,
+/obj/machinery/light/flamp,
 /obj/effect/floor_decal/grass_edge{
 	dir = 1
 	},
@@ -18924,19 +19302,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/lowersternhallway)
-"oRY" = (
-/obj/structure/window/reinforced/full,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced{
-	dir = 4;
-	health = 1e+006
-	},
-/turf/simulated/floor/plating,
-/area/expoutpost/slingcarrierdock)
 "oSr" = (
 /obj/effect/floor_decal/borderfloorblack/corner,
 /obj/effect/floor_decal/corner/white/bordercorner,
@@ -19216,6 +19581,9 @@
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/regular,
 /obj/effect/floor_decal/milspec/color/purple,
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "phG" = (
@@ -19336,16 +19704,10 @@
 /obj/item/clothing/glasses/goggles,
 /obj/item/t_scanner,
 /obj/item/clothing/glasses/welding,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 9
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning,
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_y = 32
-	},
 /turf/simulated/floor/tiled/red,
 /area/shuttle/stargazer)
 "pmr" = (
@@ -19371,7 +19733,10 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/gps,
+/obj/item/gps{
+	pixel_y = 3;
+	pixel_x = -3
+	},
 /obj/item/tank/phoron,
 /obj/item/tank/phoron,
 /turf/simulated/floor/tiled/milspec,
@@ -19915,18 +20280,19 @@
 /turf/simulated/wall/thull,
 /area/shuttle/ursula)
 "pNT" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
+/obj/machinery/power/quantumpad{
+	map_pad_id = "aeg_miningship_padout_1";
+	map_pad_link_id = "aeg_miningship_padin_1";
+	name = "TO - ECHIDNA"
 	},
-/obj/effect/floor_decal/corner/brown/border{
-	dir = 1
+/obj/structure/cable/green{
+	icon_state = "0-2"
 	},
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 22
+/obj/structure/sign/directions/cargo/mining{
+	dir = 5;
+	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/miningfoyer)
 "pNY" = (
 /obj/machinery/light{
@@ -20142,7 +20508,11 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/white,
+/obj/machinery/power/quantumpad,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/stationqpad)
 "pZh" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -20696,20 +21066,6 @@
 	},
 /turf/simulated/floor/tiled/red,
 /area/shuttle/needle)
-"qtv" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -27;
-	pixel_y = -4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/expoutpost/hangarfour)
 "qtA" = (
 /obj/machinery/door/airlock/voidcraft/vertical{
 	frequency = 1381;
@@ -20734,17 +21090,16 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/cic)
 "qtM" = (
-/obj/structure/window/reinforced/full,
-/obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	health = 1e+006
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/floor_decal/grass_edge{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/grass_edge{
+	dir = 1
+	},
+/turf/simulated/floor/grass2,
 /area/expoutpost/slingcarrierdock)
 "quy" = (
 /obj/machinery/door/firedoor/glass,
@@ -21029,13 +21384,20 @@
 	id = "AuxAICore";
 	name = "Auxiliary AI Maintenance Hatch";
 	pixel_y = 25;
-	req_access = list(16)
+	req_access = list(16);
+	pixel_x = 12
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
+	},
+/obj/structure/window/plastitanium{
+	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 22
 	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/aicore)
@@ -21171,6 +21533,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 4
 	},
+/obj/effect/landmark/start/miner,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "qLk" = (
@@ -21209,6 +21572,7 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
+/obj/structure/handrail,
 /turf/simulated/floor,
 /area/shuttle/ursula)
 "qLD" = (
@@ -21222,11 +21586,16 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/obj/machinery/light,
+/obj/structure/handrail{
+	dir = 1
+	},
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1;
 	frequency = 1381;
 	id_tag = "ursula_pump"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/shuttle/ursula)
@@ -21248,6 +21617,9 @@
 	},
 /obj/structure/cable/blue{
 	icon_state = "4-8"
+	},
+/obj/structure/handrail{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/ursula)
@@ -21282,7 +21654,11 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/white,
+/obj/structure/cable/green{
+	icon_state = "0-4"
+	},
+/obj/structure/frame,
+/turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/stationqpad)
 "qOH" = (
 /obj/structure/dispenser,
@@ -21571,6 +21947,10 @@
 	id_tag = "echidna_outer";
 	name = "External Access"
 	},
+/obj/machinery/camera/network/mining{
+	c_tag = "ECHIDNA - SMES";
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/echidna)
 "rdq" = (
@@ -21701,6 +22081,9 @@
 /area/expoutpost/eva)
 "rhS" = (
 /obj/structure/closet/walllocker_double/hydrant/west,
+/obj/structure/handrail{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/stargazer)
 "rij" = (
@@ -21754,7 +22137,9 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarthree)
 "rjE" = (
-/obj/machinery/computer/ship/helm,
+/obj/machinery/computer/ship/helm{
+	ai_control = 1
+	},
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
 	id = "stargazer_blast";
@@ -21771,13 +22156,10 @@
 /turf/simulated/floor,
 /area/expoutpost/starsciencemaint)
 "rki" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/brown/bordercorner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/alarm{
+	pixel_y = 22
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
 "rkp" = (
@@ -21962,6 +22344,9 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
 "rrj" = (
@@ -21999,20 +22384,17 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/commanderroom)
 "rrP" = (
-/obj/machinery/power/apc/hyper{
-	coverlocked = 0;
-	dir = 4;
-	environ = 1;
-	equipment = 1;
-	lighting = 1;
-	locked = 0;
-	pixel_x = 23
+/obj/machinery/telecomms/relay/preset/southerncross/stargazer,
+/obj/machinery/door/window/survival_pod{
+	req_one_access = list(61);
+	dir = 1
 	},
-/obj/structure/panic_button{
-	pixel_y = -32
+/obj/structure/window/reinforced/survival_pod{
+	dir = 4
 	},
-/obj/structure/cable/green{
-	icon_state = "0-8"
+/obj/structure/window/reinforced/survival_pod,
+/obj/structure/window/reinforced/survival_pod{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
@@ -22446,6 +22828,9 @@
 /area/expoutpost/staginghangar)
 "rKb" = (
 /obj/machinery/computer/ship/navigation,
+/obj/machinery/camera/network/mining{
+	c_tag = "ECHIDNA - Helm"
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "rKf" = (
@@ -22887,6 +23272,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/shuttle_landmark/southern_cross/carrier/ursula_dock,
+/obj/structure/handrail,
 /turf/simulated/floor,
 /area/shuttle/ursula)
 "rXD" = (
@@ -22931,6 +23317,7 @@
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
 	},
+/obj/structure/window/plastitanium,
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/aicore)
 "saI" = (
@@ -23100,6 +23487,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/effect/landmark/start/chef,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/kitchen)
 "sjY" = (
@@ -23351,6 +23739,7 @@
 /obj/structure/bed/chair/bay/shuttle{
 	dir = 8
 	},
+/obj/effect/landmark/start/commandsecretary,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/cic)
 "swn" = (
@@ -23478,6 +23867,7 @@
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/regular,
 /obj/item/roller,
 /turf/simulated/floor/tiled/milspec,
@@ -23559,7 +23949,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/washroom)
 "sGU" = (
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
@@ -23567,6 +23959,10 @@
 	dir = 1;
 	frequency = 1381;
 	id_tag = "stargazer_pump"
+	},
+/obj/structure/closet/walllocker/emerglocker/south,
+/obj/structure/handrail{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/shuttle/stargazer)
@@ -23713,6 +24109,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/effect/landmark/start/visitor,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "sPR" = (
@@ -24174,6 +24571,9 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/red,
 /area/shuttle/needle)
 "tis" = (
@@ -24286,13 +24686,17 @@
 /turf/simulated/floor/wood,
 /area/expoutpost/washroom)
 "tou" = (
-/obj/machinery/light{
+/obj/machinery/light/floortube{
 	dir = 8
+	},
+/obj/structure/handrail{
+	dir = 4
 	},
 /obj/machinery/computer/ship/navigation/telescreen{
 	pixel_x = -32;
-	pixel_y = -4
+	pixel_y = -34
 	},
+/obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "tpm" = (
@@ -24406,6 +24810,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
+/obj/effect/landmark/start/medical,
 /turf/simulated/floor/carpet/blue,
 /area/expoutpost/medicalbay)
 "txi" = (
@@ -24666,6 +25071,9 @@
 /obj/effect/floor_decal/corner/purple/bordercorner{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/stationqpad)
 "tHc" = (
@@ -24679,14 +25087,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/reactorcr)
 "tHw" = (
-/obj/machinery/embedded_controller/radio/simple_docking_controller{
-	frequency = 1381;
-	id_tag = "exp_sling_outpost";
-	name = "shuttle bay controller";
-	pixel_x = 30;
-	req_one_access = list();
-	tag_door = "exp_sling_outpost_door"
-	},
 /obj/effect/floor_decal/grass_edge{
 	dir = 8
 	},
@@ -24995,6 +25395,9 @@
 	pixel_x = -25;
 	pixel_y = -1
 	},
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/echidna)
 "tTX" = (
@@ -25059,6 +25462,12 @@
 /obj/machinery/ai_slipper{
 	icon_state = "motion0"
 	},
+/obj/structure/cable/blue{
+	icon_state = "0-5"
+	},
+/obj/structure/window/plastitanium{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/aicore)
 "tVj" = (
@@ -25083,7 +25492,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/slingcarrierdock)
 "tVD" = (
-/obj/machinery/mineral/equipment_vendor,
+/obj/machinery/mineral/equipment_vendor{
+	dir = 8;
+	pixel_x = 4
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
 "tVP" = (
@@ -25156,6 +25568,9 @@
 	pixel_y = 5
 	},
 /obj/effect/floor_decal/milspec/color/purple,
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "tYC" = (
@@ -25335,6 +25750,20 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/landmark/start{
+	name = "Search and Rescue"
+	},
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/explobriefroom)
 "ueM" = (
@@ -25381,7 +25810,8 @@
 /area/expoutpost/staruppermaint)
 "ugc" = (
 /obj/machinery/computer/ship/helm{
-	dir = 4
+	dir = 4;
+	ai_control = 1
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
@@ -25676,6 +26106,9 @@
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/structure/handrail{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/echidna)
@@ -26450,6 +26883,7 @@
 	frequency = 1381;
 	id_tag = "stargazer_pump"
 	},
+/obj/structure/handrail,
 /turf/simulated/floor,
 /area/shuttle/stargazer)
 "uWW" = (
@@ -26657,6 +27091,10 @@
 /obj/structure/grille/rustic{
 	health = 25;
 	name = "reinforced grille"
+	},
+/obj/machinery/door/blast/regular/open{
+	id = "echidna_blast";
+	name = "window blast shield"
 	},
 /turf/simulated/floor,
 /area/shuttle/echidna)
@@ -26991,6 +27429,9 @@
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/surgery,
 /obj/item/storage/firstaid/adv,
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/baby_mammoth)
 "vvK" = (
@@ -27055,6 +27496,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
 	},
+/obj/structure/handrail,
 /turf/simulated/floor,
 /area/shuttle/echidna)
 "vxd" = (
@@ -27062,13 +27504,24 @@
 /turf/simulated/floor,
 /area/expoutpost/staruppermaint)
 "vxK" = (
-/obj/machinery/light{
+/obj/machinery/light/floortube{
 	dir = 4
 	},
-/obj/structure/closet/walllocker/emerglocker{
-	pixel_x = 32
+/obj/structure/handrail{
+	dir = 8
 	},
-/obj/structure/bed/chair/bay/shuttle,
+/obj/machinery/power/apc/hyper{
+	coverlocked = 0;
+	dir = 4;
+	environ = 1;
+	equipment = 1;
+	lighting = 1;
+	locked = 0;
+	pixel_x = 23
+	},
+/obj/structure/cable/green{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
 "vxS" = (
@@ -27421,6 +27874,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/effect/landmark/start/visitor,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "vMu" = (
@@ -27556,6 +28010,7 @@
 	dir = 1
 	},
 /obj/machinery/recharge_station,
+/obj/structure/closet/walllocker/emerglocker/west,
 /turf/simulated/floor/tiled/red,
 /area/shuttle/stargazer)
 "vQy" = (
@@ -27919,6 +28374,9 @@
 	dir = 1
 	},
 /obj/structure/curtain/open/bed,
+/obj/effect/landmark/start{
+	name = "Search and Rescue"
+	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/explodorm2)
 "wdS" = (
@@ -27933,7 +28391,12 @@
 	frequency = 1381;
 	id_tag = "baby_mammoth_pump"
 	},
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/shuttle/baby_mammoth)
 "wed" = (
@@ -28212,6 +28675,23 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/merge_conflict_marker{
+	name = "---Merge Conflict Marker---";
+	
+	desc = "A best-effort merge was performed. You must resolve this conflict yourself (manually) and remove this object once complete."
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
 "woo" = (
@@ -28313,6 +28793,7 @@
 /area/expoutpost/secarmory)
 "wsW" = (
 /obj/structure/bed/chair/wood,
+/obj/effect/landmark/start/visitor,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "wte" = (
@@ -28513,6 +28994,7 @@
 /obj/machinery/chemical_dispenser/bar_soft/full{
 	pixel_y = 24
 	},
+/obj/effect/landmark/start/bartender,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/bar)
 "wBw" = (
@@ -28646,6 +29128,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = 21
 	},
+/obj/effect/landmark/start/janitor,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/janitorial)
 "wMp" = (
@@ -28790,6 +29273,9 @@
 /obj/fiftyspawner/glass,
 /obj/fiftyspawner/steel,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/structure/handrail{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/red,
 /area/shuttle/needle)
 "wQA" = (
@@ -28828,6 +29314,9 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
+/obj/structure/handrail{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/echidna)
 "wSp" = (
@@ -28859,6 +29348,7 @@
 /turf/simulated/floor,
 /area/expoutpost/portexplomaint)
 "wUy" = (
+/obj/effect/landmark/start/janitor,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/janitorial)
 "wVi" = (
@@ -29178,7 +29668,10 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/gps,
+/obj/item/gps{
+	pixel_y = 3;
+	pixel_x = -3
+	},
 /obj/structure/closet/walllocker_double/kitchen/east,
 /obj/item/storage/mre/random,
 /obj/item/storage/mre/random,
@@ -29187,6 +29680,9 @@
 /obj/item/storage/mre/random,
 /obj/item/storage/mre/random,
 /obj/item/storage/mre/random,
+/obj/structure/handrail{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/baby_mammoth)
 "xii" = (
@@ -29251,12 +29747,9 @@
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/firedoor/glass,
-/obj/machinery/door/airlock/silver{
-	icon_state = "door_locked";
-	locked = 1;
-	name = "IN CONSTRUCTION"
+/obj/machinery/door/airlock/glass{
+	name = "Teleportation Hub"
 	},
-/obj/item/tape/engineering,
 /turf/simulated/floor,
 /area/expoutpost/stationqpad)
 "xku" = (
@@ -29770,6 +30263,7 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/wood,
+/obj/effect/landmark/start/entrepreneur,
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "xCA" = (
@@ -29876,6 +30370,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
+	},
+/obj/structure/handrail{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/yellow,
 /area/shuttle/echidna)
@@ -30079,6 +30576,10 @@
 	health = 25;
 	name = "reinforced grille"
 	},
+/obj/machinery/door/blast/regular/open{
+	id = "echidna_blast";
+	name = "window blast shield"
+	},
 /turf/simulated/floor,
 /area/shuttle/echidna)
 "xOk" = (
@@ -30164,6 +30665,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/chef,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/kitchen)
 "xQB" = (
@@ -30238,6 +30740,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/effect/landmark/start/engineer,
 /turf/simulated/floor/tiled,
 /area/expoutpost/engoffice)
 "xSb" = (
@@ -30314,8 +30817,8 @@
 	dir = 4
 	},
 /obj/structure/table/rack/shelf,
-/obj/item/clothing/gloves/yellow,
-/obj/item/clothing/gloves/yellow{
+/obj/item/clothing/gloves/fyellow,
+/obj/item/clothing/gloves/fyellow{
 	pixel_y = 5
 	},
 /turf/simulated/floor/tiled/dark,
@@ -30369,6 +30872,9 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/stationqpad)
@@ -57589,7 +58095,7 @@ cxh
 enL
 jwx
 enL
-abX
+acz
 kgn
 lTk
 isM
@@ -57847,7 +58353,7 @@ eMB
 enL
 enL
 enL
-ayE
+ciq
 enL
 kuk
 nyN
@@ -58105,7 +58611,7 @@ rGI
 enL
 enL
 enL
-ayE
+ciq
 enL
 nvl
 vwg
@@ -58349,7 +58855,7 @@ rUs
 tis
 jGJ
 liP
-acd
+acI
 liP
 lyU
 xfE
@@ -58363,7 +58869,7 @@ uKT
 enL
 enm
 mkF
-abY
+acA
 lTw
 nvl
 viN
@@ -58622,7 +59128,7 @@ enL
 jcy
 mkF
 enL
-ayE
+ciq
 nvl
 lJc
 fse
@@ -58876,7 +59382,7 @@ vCa
 vCa
 vCa
 pQt
-abZ
+acC
 uSL
 uSL
 uSL
@@ -59134,7 +59640,7 @@ aFp
 mmN
 vCa
 eMB
-aca
+acE
 enL
 enL
 enL
@@ -59380,8 +59886,8 @@ qng
 qng
 qng
 xMn
-ach
-ace
+acM
+acJ
 lEO
 ejs
 xfE
@@ -59673,7 +60179,7 @@ lFp
 yjG
 wlq
 wzy
-wZI
+abV
 iNh
 xnF
 bwJ
@@ -59909,7 +60415,7 @@ vCa
 vCa
 rki
 iHQ
-lTw
+abY
 fse
 nun
 jTc
@@ -60166,8 +60672,8 @@ lri
 vNa
 fse
 pNT
-enL
-ayE
+abZ
+jrL
 aGJ
 enL
 ujM
@@ -60190,7 +60696,7 @@ dqy
 tEW
 xJS
 xJS
-aaj
+acw
 xJS
 xJS
 fgx
@@ -60397,9 +60903,9 @@ jnl
 jnl
 jZo
 jnl
-acx
-acv
-acv
+adc
+ada
+ada
 hlF
 bwS
 pEN
@@ -60410,10 +60916,10 @@ rEw
 wzH
 wzH
 kzZ
-ack
-acj
-aci
-acf
+acP
+acO
+acN
+acK
 wzH
 cCr
 wzH
@@ -60424,7 +60930,7 @@ nkx
 xJr
 fse
 avU
-uSL
+aca
 nlk
 pVK
 bgb
@@ -60448,7 +60954,7 @@ jsl
 aPh
 iiF
 wZI
-abV
+acx
 wZI
 dEY
 jSQ
@@ -60599,9 +61105,9 @@ anJ
 upU
 gAi
 aXH
-jWf
+acr
 tGD
-kxg
+wjm
 eYq
 tMo
 kXV
@@ -60629,7 +61135,7 @@ bYa
 bYa
 bYa
 cPL
-mmL
+acg
 fQz
 phx
 nVg
@@ -60666,8 +61172,8 @@ tAp
 rqt
 rrG
 upj
-acn
-acm
+acR
+acQ
 sps
 oFq
 wzH
@@ -60706,7 +61212,7 @@ rKs
 aPh
 roD
 vJh
-abW
+acy
 gQK
 eQR
 roD
@@ -60858,9 +61364,9 @@ gDm
 gAi
 wrQ
 xVG
-wjm
-wjm
-eYq
+acq
+acp
+aco
 tMo
 kXV
 jcG
@@ -60963,7 +61469,7 @@ kTo
 hoO
 aPh
 lpT
-wZI
+abW
 mfd
 mfd
 wKr
@@ -61221,7 +61727,7 @@ uPJ
 uPJ
 aPh
 nDZ
-wZI
+abW
 wZI
 wZI
 wZI
@@ -61479,7 +61985,7 @@ xzP
 xzP
 aPh
 qOH
-dEY
+abX
 nyK
 wZI
 dEY
@@ -61647,11 +62153,11 @@ uNn
 rUH
 rUH
 sjY
-acF
-acF
-acI
-acF
-acF
+adi
+adi
+adk
+adi
+adi
 bAg
 lGy
 tMo
@@ -61668,9 +62174,9 @@ vWD
 krs
 vWD
 vWD
-acC
-acz
-acz
+adg
+ade
+ade
 aFw
 tXN
 yjg
@@ -62141,7 +62647,7 @@ sFu
 sFu
 gyI
 jHk
-gyI
+acs
 sFu
 sFu
 sFu
@@ -62397,9 +62903,9 @@ cCs
 ylW
 vNj
 xVq
-jrB
-jHk
-tHc
+itM
+acu
+itM
 aKP
 tHw
 vFc
@@ -62653,13 +63159,13 @@ cwA
 cwA
 ead
 oHI
-itM
+bhq
+acv
+act
+jHk
+act
 qtM
-qtM
-nLN
-qtM
-qtM
-itM
+bhq
 iMD
 mpb
 jrB
@@ -62728,7 +63234,7 @@ gqv
 cXC
 faz
 juR
-acr
+acW
 abd
 aaY
 azg
@@ -63469,7 +63975,7 @@ bAe
 nOu
 mef
 fXV
-oFQ
+acd
 hLp
 hsy
 nOu
@@ -63685,13 +64191,13 @@ cwA
 itM
 ead
 oHI
-itM
+nbQ
 hjB
 hjB
 hjB
 hjB
 hjB
-itM
+oGw
 ehn
 mpb
 jrB
@@ -63985,7 +64491,7 @@ bkS
 nOu
 hCD
 fXV
-oFQ
+ace
 oON
 swn
 nOu
@@ -64012,7 +64518,7 @@ jYi
 qIR
 cWs
 dal
-acs
+acX
 wPQ
 iNT
 jIv
@@ -64269,8 +64775,8 @@ xhJ
 wzz
 iBp
 iBp
-iBp
-act
+acc
+acY
 fkF
 iNT
 rcx
@@ -64528,7 +65034,7 @@ oYU
 yck
 iBp
 wJJ
-act
+acY
 fkF
 iNT
 uxa
@@ -64717,13 +65223,13 @@ cwA
 cwA
 ead
 oHI
-itM
+bhq
 aGB
 aGB
-oRY
 aGB
 aGB
-itM
+aGB
+bhq
 iMD
 mpb
 jrB
@@ -64786,7 +65292,7 @@ xwv
 rIW
 iBp
 ljK
-acu
+acZ
 glR
 iNT
 iGn
@@ -65040,7 +65546,7 @@ uzW
 pnR
 pnR
 iBp
-acy
+add
 iBp
 iBp
 iBp
@@ -65776,12 +66282,12 @@ xUc
 xUc
 gQk
 dya
-acG
-acJ
-acG
-acG
+adj
+adl
+adj
+adj
 lAT
-wxi
+aci
 kKd
 sem
 gee
@@ -65794,11 +66300,11 @@ quK
 jEQ
 jEQ
 xoX
-qtv
 iOC
-acE
-acA
-acA
+iOC
+adh
+adf
+adf
 dnG
 kLn
 gXs
@@ -65866,7 +66372,7 @@ noT
 eRE
 gzy
 abm
-gzy
+aaj
 aao
 gzy
 glI
@@ -66039,7 +66545,7 @@ ncz
 lvT
 lvT
 lBp
-wxi
+aci
 kKd
 sem
 cyD
@@ -66297,7 +66803,7 @@ ncz
 ncz
 lvT
 lBp
-wxi
+aci
 kKd
 sem
 cyD
@@ -66555,7 +67061,7 @@ xFy
 gqr
 uQs
 lBp
-wxi
+aci
 kKd
 sem
 cyD
@@ -66813,7 +67319,7 @@ bwn
 gqr
 gqr
 lBp
-wxi
+aci
 kKd
 sem
 cyD
@@ -66898,7 +67404,7 @@ lZt
 kQI
 gzy
 abo
-gzy
+aaj
 abj
 gzy
 qpg
@@ -67063,21 +67569,21 @@ ces
 kDE
 rsv
 xFR
-xFR
+acm
 xFR
 kHv
 gxw
 nMs
 eCl
 lvT
-lBp
-wxi
+xmx
+acj
 kKd
 sem
 cyD
 jnf
 nhn
-oiz
+gAU
 fEH
 iBn
 dMm
@@ -67106,8 +67612,8 @@ lrz
 gEi
 rKg
 ezt
-acw
-acw
+adb
+adb
 pzJ
 gUm
 kdc
@@ -67329,7 +67835,7 @@ eVe
 eCl
 lvT
 xmx
-rrd
+ack
 kKd
 sQK
 cyD
@@ -67374,13 +67880,13 @@ tAp
 juR
 bie
 hQz
-aco
+acS
 jfJ
 bie
 eYr
 rwb
 gKD
-acb
+acF
 owV
 tjn
 jSE
@@ -67596,7 +68102,7 @@ lGm
 gAU
 fEH
 iBn
-iBn
+acf
 hsz
 fVa
 fEH
@@ -67632,7 +68138,7 @@ tAp
 juR
 bie
 fhE
-acp
+acT
 gei
 bie
 jsf
@@ -67834,7 +68340,7 @@ lvT
 gKs
 cDX
 ipz
-kDE
+flk
 isj
 vGF
 vGF
@@ -67895,8 +68401,8 @@ ajM
 bep
 fEs
 vei
-acg
-acc
+acL
+acG
 owV
 oKC
 jSE
@@ -68092,7 +68598,7 @@ lvT
 ncz
 ncz
 dTw
-flk
+acn
 eTt
 xHV
 wRB
@@ -68664,7 +69170,7 @@ tAp
 juR
 bie
 bQR
-acq
+acU
 jfJ
 bie
 lPb
@@ -69711,7 +70217,7 @@ jxP
 qkj
 imA
 cgS
-iNm
+acb
 fnc
 eAW
 eAW
@@ -69912,7 +70418,7 @@ xEV
 xEV
 xEV
 cwA
-cwA
+ach
 cwA
 cwA
 cwA

--- a/modular_chomp/maps/southern_cross/southern_cross-7.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-7.dmm
@@ -45,9 +45,14 @@
 /turf/space,
 /area/expoutpost/reactorroom)
 "aaj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
-/turf/simulated/wall/r_wall,
-/area/expoutpost/techstorage)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/engstorage)
 "aak" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
@@ -73,14 +78,18 @@
 /turf/space,
 /area/expoutpost/reactorroom)
 "aao" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/porta_turret/ai_defense{
+	req_one_access = list(16)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/window/plastitanium{
+	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/engstorage)
+/obj/structure/window/plastitanium{
+	dir = 8
+	},
+/obj/structure/window/plastitanium,
+/turf/simulated/floor/redgrid,
+/area/expoutpost/aicore)
 "aap" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 6
@@ -98,13 +107,13 @@
 	dir = 5
 	},
 /turf/simulated/wall/r_wall,
-/area/expoutpost/techstorage)
+/area/expoutpost/aicore)
 "aas" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 10
 	},
 /turf/simulated/wall/r_wall,
-/area/expoutpost/techstorage)
+/area/expoutpost/aicore)
 "aat" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
 	dir = 8
@@ -467,37 +476,57 @@
 /turf/simulated/wall/r_wall,
 /area/expoutpost/reactorroom)
 "abi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/ai_slipper{
+	icon_state = "motion0"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
+/area/expoutpost/aicore)
+"abj" = (
+/obj/machinery/porta_turret/ai_defense{
+	req_one_access = list(16)
+	},
+/obj/structure/window/plastitanium{
+	dir = 1
+	},
+/obj/structure/window/plastitanium{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/engstorage)
-"abj" = (
-/obj/structure/table/steel_reinforced,
-/obj/machinery/recharger,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/structure/window/plastitanium,
+/turf/simulated/floor/redgrid,
+/area/expoutpost/aicore)
+"abk" = (
+/obj/item/radio/intercom/custom{
+	dir = 8;
+	pixel_x = -21
+	},
+/turf/simulated/floor/water/digestive_enzymes/nanites,
+/area/expoutpost/aicore)
+"abl" = (
+/obj/item/radio/intercom/private{
+	dir = 4;
+	pixel_x = 21
+	},
+/turf/simulated/floor/water/digestive_enzymes/nanites,
+/area/expoutpost/aicore)
+"abm" = (
+/obj/machinery/porta_turret/ai_defense{
+	req_one_access = list(16)
+	},
+/obj/machinery/requests_console{
+	pixel_y = 32
+	},
+/obj/structure/window/plastitanium{
+	dir = 1
+	},
+/obj/structure/window/plastitanium{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/engstorage)
-"abk" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/miningfoyer)
-"abl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/miningfoyer)
-"abm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/miningfoyer)
+/obj/structure/window/plastitanium,
+/turf/simulated/floor/redgrid,
+/area/expoutpost/aicore)
 "abn" = (
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 1
@@ -508,30 +537,445 @@
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
 "abo" = (
+/obj/machinery/porta_turret/ai_defense{
+	req_one_access = list(16)
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
+	},
+/obj/structure/window/plastitanium{
+	dir = 1
+	},
+/obj/structure/window/plastitanium{
+	dir = 4
+	},
+/obj/structure/window/plastitanium,
+/turf/simulated/floor/redgrid,
+/area/expoutpost/aicore)
+"abp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/telecomms)
+"abq" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/loading/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abr" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abs" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abt" = (
+/obj/effect/catwalk_plated/techfloor,
+/obj/machinery/door/airlock/engineering{
+	name = "Secure Storage";
+	req_one_access = list(10,30)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/expoutpost/techstorage)
+"abu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/secureaccess)
+"abv" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abw" = (
+/obj/structure/railing/overhang/hazard/nanite{
+	dir = 8
+	},
+/obj/structure/railing/overhang/hazard/nanite,
+/obj/structure/railing/overhang/hazard/nanite{
+	dir = 4
+	},
+/turf/simulated/floor/water/digestive_enzymes/nanites,
+/area/expoutpost/aicore)
+"abx" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 9
+	},
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 9
+	},
+/obj/structure/table/rack/shelf,
+/turf/simulated/floor/tiled,
+/area/expoutpost/techstorage)
+"aby" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/radio/intercom{
+	dir = 1;
+	name = "Station Intercom (General)";
+	pixel_y = 21
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/techstorage)
+"abz" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	name = "light switch ";
+	pixel_x = 26;
+	pixel_y = -11;
+	on = 0
+	},
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/techstorage)
+"abA" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/camera/network/command{
+	dir = 4;
+	c_tag = "AI - Auxiliary Access 1"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abB" = (
+/obj/structure/railing/overhang/hazard/nanite{
+	dir = 8
+	},
+/turf/simulated/floor/water/digestive_enzymes/nanites,
+/area/expoutpost/aicore)
+"abC" = (
+/obj/structure/railing/overhang/hazard/nanite{
+	dir = 4
+	},
+/turf/simulated/floor/water/digestive_enzymes/nanites,
+/area/expoutpost/aicore)
+"abD" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abE" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 9
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/secureaccess)
+"abF" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/secureaccess)
+"abG" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/secureaccess)
+"abH" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/porta_turret/ai_defense{
+	req_one_access = list(16)
+	},
+/turf/simulated/floor/redgrid,
+/area/expoutpost/aicore)
+"abI" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abJ" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 3;
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abK" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 3;
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abL" = (
+/obj/effect/floor_decal/industrial/warning{
+	layer = 3;
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	layer = 3;
+	dir = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abN" = (
+/obj/structure/railing/overhang/hazard/nanite,
+/turf/simulated/floor/water/digestive_enzymes/nanites,
+/area/expoutpost/aicore)
+"abO" = (
+/obj/structure/sign/warning/acid,
+/turf/simulated/wall/r_wall,
+/area/expoutpost/aicore)
+"abP" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 10
+	},
+/obj/machinery/camera/network/command{
+	dir = 4;
+	c_tag = "Aegis - Secure Access Corridor"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/secureaccess)
+"abQ" = (
+/obj/structure/sign/warning/secure_area,
+/turf/simulated/wall/r_wall,
+/area/expoutpost/secureaccess)
+"abR" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Auxiliary AI Core";
+	req_access = list(16);
+	req_one_access = list(16)
+	},
+/obj/effect/catwalk_plated/techfloor,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/expoutpost/aicore)
+"abS" = (
+/obj/structure/railing/overhang/hazard/nanite{
+	dir = 1
+	},
+/obj/structure/railing/overhang/hazard/nanite{
+	dir = 8
+	},
+/turf/simulated/floor/water/digestive_enzymes/nanites,
+/area/expoutpost/aicore)
+"abT" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/camera/network/command{
+	c_tag = "AI - Auxiliary Access 2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
+"abU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/bluespace_beacon{
+	alpha = 0;
+	desc = "A device that draws power from bluespace and creates a permanent tracking beacon. This one has a cloaking field. How keen of you to notice!";
+	name = "Aegis Bluespace Gigabeacon"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/slingcarrierdock)
+"abV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/engstorage)
+"abW" = (
+/obj/structure/table/steel_reinforced,
+/obj/machinery/recharger,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/engstorage)
+"abX" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/miningfoyer)
+"abY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/miningfoyer)
+"abZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/miningfoyer)
+"aca" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
-"abp" = (
+"acb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
-"abq" = (
+"acc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
-"abr" = (
+"acd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
-"abs" = (
+"ace" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -539,73 +983,81 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
-"abt" = (
+"acf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/breakroom)
-"abu" = (
+"acg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
-"abv" = (
+"ach" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
-"abw" = (
+"aci" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/breakroom)
-"abx" = (
+"acj" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/carpet,
 /area/expoutpost/breakroom)
-"aby" = (
+"ack" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/breakroom)
-"abz" = (
+"acl" = (
+/obj/machinery/atmospherics/pipe/tank/phoron/full,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/reinforced,
+/area/expoutpost/starfuelstorage)
+"acm" = (
 /obj/structure/bed/chair/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
 /area/expoutpost/breakroom)
-"abA" = (
+"acn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/breakroom)
-"abB" = (
+"aco" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/secoffice)
-"abC" = (
+"acp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/secoffice)
-"abD" = (
+"acq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/secoffice)
-"abE" = (
+"acr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/wall/r_wall,
 /area/expoutpost/cic)
-"abF" = (
+"acs" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -616,19 +1068,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"abG" = (
+"act" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"abH" = (
+"acu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"abI" = (
+"acv" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -641,7 +1093,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
-"abJ" = (
+"acw" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -654,7 +1106,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
-"abK" = (
+"acx" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -667,13 +1119,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
-"abL" = (
+"acy" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"abM" = (
+"acz" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -686,7 +1138,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarthree)
-"abN" = (
+"acA" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -699,98 +1151,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
-"abO" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/hangarthree)
-"abP" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/steel,
-/area/expoutpost/hangarfour)
-"abQ" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/hangarfive)
-"abR" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/hangarsix)
-"abS" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/hangarfive)
-"abT" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/hangarsix)
-"acl" = (
-/obj/machinery/atmospherics/pipe/tank/phoron/full,
-/obj/effect/floor_decal/industrial/outline/red,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced,
-/area/expoutpost/starfuelstorage)
 "acB" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -803,10 +1163,62 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
+"acC" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarthree)
 "acD" = (
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/steel_dirty,
 /area/expoutpost/botany)
+"acE" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/expoutpost/hangarfour)
+"acF" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarfive)
+"acG" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarsix)
 "acH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -816,6 +1228,38 @@
 	},
 /turf/simulated/floor,
 /area/expoutpost/reactorroom)
+"acI" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarfive)
+"acJ" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarsix)
 "acV" = (
 /obj/machinery/light{
 	dir = 4
@@ -888,17 +1332,12 @@
 /turf/simulated/floor,
 /area/expoutpost/starlowermaint)
 "ahy" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
 "ahC" = (
 /obj/structure/lattice,
 /obj/machinery/shield_diffuser,
@@ -1110,14 +1549,12 @@
 /turf/simulated/wall/thull,
 /area/shuttle/ursula)
 "apr" = (
-/obj/effect/floor_decal/borderfloorblack/corner{
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/orange/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
 "aqD" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -1141,7 +1578,7 @@
 /area/expoutpost/staginghangar)
 "arw" = (
 /obj/effect/floor_decal/techfloor{
-	dir = 1
+	dir = 5
 	},
 /obj/item/radio/intercom{
 	dir = 1;
@@ -1801,12 +2238,14 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/effect/catwalk_plated/techfloor,
-/obj/machinery/door/airlock/engineering{
-	name = "Telecomms"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/expoutpost/telecomms)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/secureaccess)
 "aWi" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning{
@@ -2350,12 +2789,6 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/secureaccess)
 "btA" = (
@@ -2443,12 +2876,10 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/multi_tile/glass{
-	dir = 1
-	},
 /obj/machinery/door/blast/regular{
 	id = "aeg_securestorage_blastdoor"
 	},
+/obj/machinery/door/firedoor/glass,
 /turf/simulated/floor/reinforced,
 /area/expoutpost/secureaccess)
 "bwc" = (
@@ -2716,12 +3147,8 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/secureaccess)
 "bMy" = (
@@ -3616,15 +4043,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
-"cxz" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/secureaccess)
 "cyf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -3990,10 +4408,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/starbowhallway)
-"cQE" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced,
-/area/expoutpost/telecomms)
 "cRL" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5010,13 +5424,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/midsternhallway)
-"dKQ" = (
-/obj/structure/table/rack/shelf,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
 "dLo" = (
 /obj/structure/flora/pottedplant/minitree,
 /obj/effect/floor_decal/borderfloorblack,
@@ -5254,10 +5661,8 @@
 /turf/simulated/wall/r_wall,
 /area/expoutpost/slingcarrierdock)
 "eaE" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/dummystairs/hazardledge,
+/turf/simulated/floor/water/digestive_enzymes/nanites,
 /area/expoutpost/aicore)
 "ech" = (
 /obj/machinery/vending/hydroseeds{
@@ -5612,10 +6017,7 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/stationqpad)
 "eqN" = (
-/obj/structure/cable/blue{
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/bluegrid,
+/turf/simulated/floor/water/digestive_enzymes/nanites,
 /area/expoutpost/aicore)
 "era" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -6237,8 +6639,10 @@
 /obj/structure/cable/blue{
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/aicore)
 "eOx" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -6307,21 +6711,6 @@
 /obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
-"eRh" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/techstorage)
 "eRs" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/silver{
@@ -6331,8 +6720,15 @@
 /turf/simulated/floor/tiled/freezer,
 /area/expoutpost/washroom)
 "eRE" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced,
+/obj/effect/landmark/free_ai_shell,
+/obj/effect/floor_decal/industrial/bot_outline/blue,
+/obj/effect/floor_decal/spline/plain/cee{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/arrows/blue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/expoutpost/aicore)
 "eRI" = (
 /obj/effect/catwalk_plated/techfloor,
@@ -7604,6 +8000,9 @@
 /turf/simulated/wall/rplastihull,
 /area/shuttle/needle)
 "gaf" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/secureaccess)
 "gap" = (
@@ -7830,18 +8229,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor,
 /area/shuttle/baby_mammoth)
-"ggX" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular{
-	id = "aeg_securestorage_blastdoor"
-	},
-/turf/simulated/floor/reinforced,
-/area/expoutpost/secureaccess)
 "ghb" = (
 /obj/structure/closet/walllocker/emerglocker{
 	pixel_x = -25;
@@ -8422,12 +8809,16 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "gKJ" = (
-/obj/structure/cable/blue{
-	icon_state = "1-2"
-	},
 /obj/effect/catwalk_plated/techfloor,
-/obj/machinery/door/airlock/engineering{
-	name = "Auxiliary AI Core"
+/obj/machinery/door/airlock/vault/bolted{
+	name = "Auxiliary AI Core";
+	req_access = list(16);
+	req_one_access = list(16)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	id = "AuxAICore";
+	name = "AI core maintenance hatch"
 	},
 /turf/simulated/floor,
 /area/expoutpost/aicore)
@@ -8494,7 +8885,12 @@
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/staginghangar)
 "gMK" = (
-/obj/structure/table/rack/shelf,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/techstorage)
 "gMY" = (
@@ -8813,10 +9209,11 @@
 /turf/simulated/floor,
 /area/expoutpost/portsternairlock)
 "hby" = (
-/obj/effect/floor_decal/borderfloorblack,
-/obj/effect/floor_decal/corner/orange/border,
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
+/obj/machinery/porta_turret/ai_defense{
+	req_one_access = list(16)
+	},
+/turf/simulated/floor/redgrid,
+/area/expoutpost/aicore)
 "hbG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8871,29 +9268,6 @@
 /obj/random/maintenance/cargo,
 /turf/simulated/floor,
 /area/expoutpost/staruppermaint)
-"hfj" = (
-/obj/structure/cable/green{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	lighting = 0;
-	name = "north bump";
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	dir = 1;
-	pixel_x = 12;
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
 "hfm" = (
 /obj/effect/floor_decal/grass_edge,
 /obj/effect/floor_decal/grass_edge{
@@ -8974,11 +9348,17 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+	dir = 1
+	},
+/obj/machinery/ai_slipper{
+	icon_state = "motion0"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/secureaccess)
@@ -9027,6 +9407,9 @@
 	dir = 8;
 	name = "Station Intercom (General)";
 	pixel_x = -21
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/expoutpost/telecomms)
@@ -9112,10 +9495,17 @@
 /turf/simulated/floor,
 /area/shuttle/echidna)
 "hmz" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/structure/catwalk,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/simulated/floor/reinforced,
 /area/expoutpost/telecomms)
 "hol" = (
@@ -9142,18 +9532,12 @@
 /area/expoutpost/atmospherics)
 "hpe" = (
 /obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/dark,
 /area/expoutpost/secureaccess)
 "hpq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9270,12 +9654,6 @@
 	},
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/stargazer)
-"hsO" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/techstorage)
 "htt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9355,9 +9733,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/catwalk_plated/techfloor,
-/obj/machinery/door/airlock/engineering{
-	name = "Telecomms"
+/obj/machinery/door/airlock/highsecurity{
+	name = "Telecommunications";
+	req_access = list(61);
+	req_one_access = list(61)
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/expoutpost/telecomms)
 "hxp" = (
@@ -9528,15 +9909,12 @@
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/rnd)
 "hEM" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 8
-	},
 /obj/item/geiger/wall/west,
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
 "hFP" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/borderfloorblack{
@@ -10332,6 +10710,15 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/rnd)
 "inm" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/ai_slipper{
+	icon_state = "motion0"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/aicore)
 "inz" = (
@@ -10558,10 +10945,20 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/lowersternhallway)
 "ivr" = (
-/obj/effect/floor_decal/borderfloorblack/corner,
-/obj/effect/floor_decal/corner/orange/bordercorner,
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
+/obj/structure/dummystairs/hazardledge{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/water/digestive_enzymes/nanites,
+/area/expoutpost/aicore)
 "ivA" = (
 /obj/structure/table/wooden_reinforced,
 /obj/item/storage/rollingpapers,
@@ -11146,6 +11543,14 @@
 "iYR" = (
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
+	},
+/obj/machinery/button/remote/blast_door{
+	dir = 8;
+	id = "aeg_securestorage_blastdoor";
+	name = "Secure Storage";
+	pixel_x = 24;
+	pixel_y = 8;
+	req_one_access = list(10,16,30)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/secureaccess)
@@ -12101,18 +12506,15 @@
 /turf/simulated/floor,
 /area/expoutpost/portfuelstorage)
 "jKB" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 8;
 	layer = 3
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
 "jKJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
@@ -12504,15 +12906,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/hangartwo)
-"kfa" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/techstorage)
 "kfO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13260,10 +13653,17 @@
 /area/expoutpost/hangarfive)
 "kQI" = (
 /obj/structure/cable/blue{
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced,
+/obj/machinery/power/smes/buildable/engine_default{
+	name = "AI Core SMES"
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/flasher{
+	id = "AuxAI";
+	pixel_y = -24
+	},
+/turf/simulated/floor,
 /area/expoutpost/aicore)
 "kSe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14391,11 +14791,11 @@
 /turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/starqpadjunction)
 "lMc" = (
-/obj/structure/cable/green{
-	icon_state = "2-4"
+/obj/structure/railing/overhang/hazard/nanite{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/techstorage)
+/turf/simulated/floor/water/digestive_enzymes/nanites,
+/area/expoutpost/aicore)
 "lMj" = (
 /obj/structure/railing/grey,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -14598,21 +14998,19 @@
 /turf/simulated/floor/carpet,
 /area/expoutpost/commanderroom)
 "lSo" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable/green{
-	icon_state = "0-8"
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/catwalk,
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/turf/simulated/floor/reinforced,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/aicore)
 "lSp" = (
 /turf/simulated/wall/r_wall,
@@ -14820,18 +15218,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
 "lZt" = (
-/obj/machinery/power/smes/buildable/engine_default{
-	name = "AI Core SMES"
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/cable/blue{
-	icon_state = "0-2"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced,
+/obj/machinery/power/terminal,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/aicore)
 "lZE" = (
 /obj/structure/table/marble,
@@ -15922,6 +16323,7 @@
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 10
 	},
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled,
 /area/expoutpost/techstorage)
 "mUj" = (
@@ -16182,8 +16584,12 @@
 /turf/simulated/floor/grass2,
 /area/expoutpost/botany)
 "ndN" = (
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/full,
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
 "ndZ" = (
 /obj/machinery/light{
 	dir = 8;
@@ -16528,8 +16934,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/aicore)
 "npc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16573,10 +16981,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/civaccesshallway)
 "nsn" = (
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 10
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/secureaccess)
 "nsu" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -16950,16 +17364,13 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
 	},
-/obj/structure/sign/warning/secure_area{
-	pixel_x = -32
-	},
 /obj/machinery/button/remote/blast_door{
 	dir = 4;
 	id = "aeg_securestorage_blastdoor";
 	name = "Secure Storage";
 	pixel_x = -24;
 	pixel_y = 8;
-	req_one_access = list(10,30)
+	req_one_access = list(10,16,30)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/lowersternhallway)
@@ -17089,7 +17500,7 @@
 	dir = 8
 	},
 /obj/structure/AIcore/deactivated,
-/turf/simulated/floor/tiled/milspec/raised,
+/turf/simulated/floor/water/digestive_enzymes/nanites,
 /area/expoutpost/aicore)
 "nGV" = (
 /obj/effect/floor_decal/techfloor{
@@ -17657,7 +18068,7 @@
 /turf/simulated/floor,
 /area/expoutpost/starfuelstorage)
 "oet" = (
-/obj/machinery/shield_gen/external,
+/obj/machinery/shield_gen/external/advanced,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -17778,8 +18189,27 @@
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/slingcarrierdock)
 "ojI" = (
-/obj/machinery/light,
-/turf/simulated/floor/bluegrid,
+/obj/machinery/camera/xray/command{
+	c_tag = "AI - Auxiliary Core";
+	dir = 1
+	},
+/obj/machinery/turretid/stun{
+	check_synth = 1;
+	name = "Auxiliary AI Chamber turret control";
+	pixel_x = -30;
+	pixel_y = -24
+	},
+/obj/machinery/flasher{
+	id = "AuxAI";
+	pixel_x = 24;
+	pixel_y = -25
+	},
+/obj/item/radio/intercom{
+	broadcasting = 1;
+	name = "Station Intercom (General)";
+	pixel_y = -21
+	},
+/turf/simulated/floor/water/digestive_enzymes/nanites,
 /area/expoutpost/aicore)
 "ojK" = (
 /obj/structure/ore_box,
@@ -17987,10 +18417,16 @@
 /turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "ovS" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Telecommunications";
+	req_access = list(61);
+	req_one_access = list(61)
 	},
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/catwalk_plated/techfloor,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
 /area/expoutpost/telecomms)
 "owv" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -18985,18 +19421,6 @@
 	},
 /turf/simulated/floor,
 /area/expoutpost/starsciencemaint)
-"pqm" = (
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
 "pqo" = (
 /obj/structure/catwalk,
 /obj/machinery/power/apc{
@@ -19321,18 +19745,6 @@
 "pEN" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/hangarone)
-"pFd" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/techstorage)
 "pGn" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -19460,18 +19872,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
-"pMk" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/techstorage)
 "pMn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -19541,14 +19941,12 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarthree)
 "pOJ" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 9
+/obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/porta_turret/ai_defense{
+	req_one_access = list(16)
 	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
+/turf/simulated/floor/redgrid,
+/area/expoutpost/aicore)
 "pPW" = (
 /obj/effect/floor_decal/borderfloorblack/corner{
 	dir = 4
@@ -20626,11 +21024,20 @@
 /turf/simulated/floor,
 /area/expoutpost/engoffice)
 "qFg" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/button/remote/blast_door{
+	desc = "A remote control-switch for the AI core maintenance door.";
+	id = "AuxAICore";
+	name = "Auxiliary AI Maintenance Hatch";
+	pixel_y = 25;
+	req_access = list(16)
 	},
-/turf/simulated/floor/bluegrid,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10
+	},
+/obj/machinery/ai_slipper{
+	icon_state = "motion0"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/aicore)
 "qFz" = (
 /obj/effect/floor_decal/borderfloorblack{
@@ -21754,12 +22161,12 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/secarmory)
 "rvG" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 6
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 6
-	},
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled,
 /area/expoutpost/techstorage)
 "rwb" = (
@@ -21877,6 +22284,7 @@
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
 	},
+/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled,
 /area/expoutpost/techstorage)
 "rBJ" = (
@@ -22253,16 +22661,6 @@
 	},
 /turf/simulated/floor,
 /area/expoutpost/medbaylobby)
-"rPi" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/effect/catwalk_plated/techfloor,
-/obj/machinery/door/airlock/engineering{
-	name = "Auxiliary AI Core"
-	},
-/turf/simulated/floor,
-/area/expoutpost/aicore)
 "rPk" = (
 /obj/structure/table/steel_reinforced,
 /obj/effect/floor_decal/borderfloorblack{
@@ -22527,7 +22925,13 @@
 /turf/simulated/floor,
 /area/expoutpost/staruppermaint)
 "rZM" = (
-/turf/simulated/floor/bluegrid,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/machinery/ai_slipper{
+	icon_state = "motion0"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/aicore)
 "saI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -23054,20 +23458,6 @@
 /obj/structure/sign/warning/airlock,
 /turf/simulated/wall/r_wall,
 /area/expoutpost/starsternairlock)
-"sAX" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	dir = 1;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
 "sBB" = (
 /obj/structure/railing/overhang/waterless/grey{
 	dir = 4
@@ -23465,12 +23855,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/starsternairlock)
-"sVd" = (
-/obj/structure/sign/warning/secure_area{
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/lowersternhallway)
 "sVJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -23973,15 +24357,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
-"tsj" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/techstorage)
 "ttk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23991,17 +24366,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor,
 /area/expoutpost/portlowermaint)
-"tui" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced,
-/area/expoutpost/telecomms)
 "tux" = (
 /obj/effect/floor_decal/grass_edge/corner{
 	dir = 8
@@ -24685,14 +25049,17 @@
 /area/expoutpost/starbowhallway)
 "tUV" = (
 /obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
 	},
-/obj/structure/cable/blue{
-	icon_state = "0-4"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 6
 	},
-/turf/simulated/floor/bluegrid,
+/obj/machinery/ai_slipper{
+	icon_state = "motion0"
+	},
+/turf/simulated/floor/tiled/milspec/raised,
 /area/expoutpost/aicore)
 "tVj" = (
 /obj/structure/railing/overhang/waterless/grey{
@@ -25113,18 +25480,17 @@
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/rnd)
 "ulL" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
+/obj/structure/railing/overhang/hazard/nanite,
+/obj/structure/railing/overhang/hazard/nanite{
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#DDFFD3"
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
+/turf/simulated/floor/water/digestive_enzymes/nanites,
+/area/expoutpost/aicore)
 "ulN" = (
 /obj/machinery/door/firedoor/glass,
 /obj/machinery/door/airlock/engineering{
@@ -25373,13 +25739,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/cic)
-"uwE" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/table/rack/shelf,
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
 "uwQ" = (
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/needle)
@@ -26039,13 +26398,7 @@
 /turf/simulated/floor,
 /area/expoutpost/starsternairlock)
 "uVx" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/secureaccess)
 "uWq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -27599,11 +27952,14 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "wer" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/structure/railing/overhang/hazard/nanite{
+	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/reinforced,
+/obj/structure/railing/overhang/hazard/nanite,
+/obj/structure/railing/overhang/hazard/nanite{
+	dir = 8
+	},
+/turf/simulated/floor/water/digestive_enzymes/nanites,
 /area/expoutpost/aicore)
 "wey" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -27667,7 +28023,7 @@
 	pixel_y = 24
 	},
 /obj/effect/floor_decal/techfloor{
-	dir = 1
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/secureaccess)
@@ -28671,6 +29027,9 @@
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/orange/border,
 /obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/techstorage)
 "xcO" = (
@@ -29232,14 +29591,9 @@
 /turf/simulated/floor/reinforced,
 /area/expoutpost/hangarfive)
 "xwm" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/techstorage)
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/aicore)
 "xwv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -29504,11 +29858,14 @@
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/echidna)
 "xGP" = (
-/obj/effect/floor_decal/borderfloorblack{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/orange/border{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/techstorage)
@@ -30328,24 +30685,9 @@
 /turf/simulated/floor,
 /area/expoutpost/staruppermaint)
 "yij" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/techfloor,
-/obj/machinery/door/airlock/engineering{
-	icon_state = "door_locked";
-	locked = 1;
-	name = "Secure Storage"
-	},
-/obj/item/tape/engineering,
-/turf/simulated/floor,
-/area/expoutpost/techstorage)
+/obj/structure/sign/warning/lethal_turrets,
+/turf/simulated/wall/r_wall,
+/area/expoutpost/aicore)
 "yit" = (
 /obj/structure/shuttle/engine/heater,
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow{
@@ -57247,7 +57589,7 @@ cxh
 enL
 jwx
 enL
-abk
+abX
 kgn
 lTk
 isM
@@ -58007,7 +58349,7 @@ rUs
 tis
 jGJ
 liP
-abr
+acd
 liP
 lyU
 xfE
@@ -58021,7 +58363,7 @@ uKT
 enL
 enm
 mkF
-abl
+abY
 lTw
 nvl
 viN
@@ -58534,7 +58876,7 @@ vCa
 vCa
 vCa
 pQt
-abm
+abZ
 uSL
 uSL
 uSL
@@ -58792,7 +59134,7 @@ aFp
 mmN
 vCa
 eMB
-abo
+aca
 enL
 enL
 enL
@@ -59038,8 +59380,8 @@ qng
 qng
 qng
 xMn
-abv
-abs
+ach
+ace
 lEO
 ejs
 xfE
@@ -59848,7 +60190,7 @@ dqy
 tEW
 xJS
 xJS
-aao
+aaj
 xJS
 xJS
 fgx
@@ -60055,9 +60397,9 @@ jnl
 jnl
 jZo
 jnl
-abK
-abI
-abI
+acx
+acv
+acv
 hlF
 bwS
 pEN
@@ -60068,10 +60410,10 @@ rEw
 wzH
 wzH
 kzZ
-aby
-abx
-abw
-abt
+ack
+acj
+aci
+acf
 wzH
 cCr
 wzH
@@ -60106,7 +60448,7 @@ jsl
 aPh
 iiF
 wZI
-abi
+abV
 wZI
 dEY
 jSQ
@@ -60324,8 +60666,8 @@ tAp
 rqt
 rrG
 upj
-abA
-abz
+acn
+acm
 sps
 oFq
 wzH
@@ -60364,7 +60706,7 @@ rKs
 aPh
 roD
 vJh
-abj
+abW
 gQK
 eQR
 roD
@@ -61305,11 +61647,11 @@ uNn
 rUH
 rUH
 sjY
-abQ
-abQ
-abS
-abQ
-abQ
+acF
+acF
+acI
+acF
+acF
 bAg
 lGy
 tMo
@@ -61326,9 +61668,9 @@ vWD
 krs
 vWD
 vWD
-abO
-abM
-abM
+acC
+acz
+acz
 aFw
 tXN
 yjg
@@ -62386,7 +62728,7 @@ gqv
 cXC
 faz
 juR
-abE
+acr
 abd
 aaY
 azg
@@ -63353,7 +63695,7 @@ itM
 ehn
 mpb
 jrB
-aCC
+abU
 tHc
 eJv
 hfm
@@ -63670,7 +64012,7 @@ jYi
 qIR
 cWs
 dal
-abF
+acs
 wPQ
 iNT
 jIv
@@ -63928,7 +64270,7 @@ wzz
 iBp
 iBp
 iBp
-abG
+act
 fkF
 iNT
 rcx
@@ -64186,7 +64528,7 @@ oYU
 yck
 iBp
 wJJ
-abG
+act
 fkF
 iNT
 uxa
@@ -64444,7 +64786,7 @@ xwv
 rIW
 iBp
 ljK
-abH
+acu
 glR
 iNT
 iGn
@@ -64698,7 +65040,7 @@ uzW
 pnR
 pnR
 iBp
-abL
+acy
 iBp
 iBp
 iBp
@@ -65001,7 +65343,7 @@ mbg
 iKm
 rto
 iOM
-xsP
+gzy
 gzy
 gzy
 mbg
@@ -65255,11 +65597,11 @@ krN
 fwT
 vxU
 aas
-aaj
-aaj
-aaj
-aaj
-aaj
+aag
+aag
+aag
+aag
+aag
 aag
 aag
 aag
@@ -65434,10 +65776,10 @@ xUc
 xUc
 gQk
 dya
-abR
-abT
-abR
-abR
+acG
+acJ
+acG
+acG
 lAT
 wxi
 kKd
@@ -65454,9 +65796,9 @@ jEQ
 xoX
 qtv
 iOC
-abP
-abN
-abN
+acE
+acA
+acA
 dnG
 kLn
 gXs
@@ -65515,17 +65857,17 @@ vxU
 pOJ
 jKB
 hEM
-rBb
+abv
 jKB
-mTR
-gzy
-eRE
+abH
+abA
+abv
 noT
 eRE
 gzy
+abm
 gzy
-gzy
-gzy
+aao
 gzy
 glI
 lGF
@@ -65769,20 +66111,20 @@ hRb
 jAV
 dTM
 dHk
-xsP
-xwm
-gMK
-gMK
-gMK
-gMK
-apr
 gzy
-eRE
-eRE
-eRE
+xwm
+abS
+abB
+abB
+abB
+abB
+abB
+abw
+abr
+abq
 gzy
 tUV
-rZM
+abk
 rZM
 gzy
 sTM
@@ -66027,14 +66369,14 @@ waj
 hIK
 ujy
 xJr
-xsP
+gzy
 ahy
 lMc
-hsO
-hsO
-hsO
-hsO
-rPi
+eqN
+eqN
+eqN
+eqN
+eqN
 eaE
 inm
 fDo
@@ -66285,21 +66627,21 @@ npf
 nAP
 jtd
 qkj
-xsP
-xwm
-tsj
-dKQ
-gMK
-gMK
-ivr
 gzy
+xwm
+lMc
+eqN
+eqN
+abC
+abC
+abC
 wer
-eRE
+abs
 eOp
 gzy
 qFg
-rZM
-rZM
+abl
+abi
 gzy
 sTM
 njl
@@ -66543,21 +66885,21 @@ iaL
 qKs
 jtd
 qkj
-xsP
-sAX
-kfa
-ndN
-ndN
-ndN
-xbV
 gzy
+xwm
+lMc
+eqN
+abN
+abI
+abD
+abD
 lSo
 lZt
 kQI
 gzy
+abo
 gzy
-gzy
-gzy
+abj
 gzy
 qpg
 geU
@@ -66764,8 +67106,8 @@ lrz
 gEi
 rKg
 ezt
-abJ
-abJ
+acw
+acw
 pzJ
 gUm
 kdc
@@ -66801,12 +67143,12 @@ iaL
 qKs
 jtd
 qkj
-xsP
-xwm
-pFd
-uwE
-gMK
-gMK
+gzy
+abT
+lMc
+eqN
+abN
+abJ
 hby
 gzy
 gzy
@@ -67032,13 +67374,13 @@ tAp
 juR
 bie
 hQz
-abB
+aco
 jfJ
 bie
 eYr
 rwb
 gKD
-abp
+acb
 owV
 tjn
 jSE
@@ -67059,15 +67401,15 @@ iaL
 oNO
 jtd
 qkj
-xsP
+gzy
 ahy
-pMk
-ndN
-ndN
-ndN
+lMc
+eqN
+abN
+abK
 apr
-rBb
-rBb
+xsP
+abx
 rBb
 mTR
 oPi
@@ -67290,7 +67632,7 @@ tAp
 juR
 bie
 fhE
-abC
+acp
 gei
 bie
 jsf
@@ -67317,15 +67659,15 @@ iaL
 ezs
 jtd
 qkj
-xsP
-pqm
-pMk
-gMK
-gMK
-gMK
+gzy
+xwm
+lMc
+eqN
+abN
+abL
 ndN
-gMK
-gMK
+xsP
+aby
 gMK
 xbV
 oPi
@@ -67553,8 +67895,8 @@ ajM
 bep
 fEs
 vei
-abu
-abq
+acg
+acc
 owV
 oKC
 jSE
@@ -67575,15 +67917,15 @@ imA
 qKs
 jtd
 qkj
-xsP
-hfj
-eRh
+gzy
+xwm
+lMc
 ivr
 ulL
-xGP
-xGP
-xGP
-xGP
+abM
+hby
+xsP
+abz
 xGP
 rvG
 oPi
@@ -67833,16 +68175,16 @@ imA
 xOX
 jtd
 qkj
-xsP
-xsP
+gzy
+gzy
 yij
+abR
+abO
+gzy
+gzy
 xsP
 xsP
-xsP
-xsP
-xsP
-xsP
-xsP
+abt
 xsP
 oPi
 oPi
@@ -68095,13 +68437,13 @@ lro
 wha
 hpe
 nsn
-ggy
+abP
 xKp
 ggy
-ggy
+abE
 uVx
+abu
 oPi
-cQE
 hjQ
 vfm
 xQZ
@@ -68322,7 +68664,7 @@ tAp
 juR
 bie
 bQR
-abD
+acq
 jfJ
 bie
 lPb
@@ -68356,11 +68698,11 @@ hhN
 jDv
 jDv
 jDv
-jDv
+abF
 bMo
 aVI
 ovS
-dWr
+abp
 dWr
 dWr
 iSg
@@ -68614,10 +68956,10 @@ lWf
 iYR
 qRd
 sgW
+abG
 sgW
-cxz
+sgW
 oPi
-tui
 hmz
 aqD
 jbR
@@ -68867,14 +69209,14 @@ jtd
 xJG
 lro
 lro
-ggX
+abQ
 bvO
+abQ
 lro
 lro
 lro
 lro
 lro
-oPi
 oPi
 oPi
 oPi
@@ -69124,7 +69466,7 @@ qKs
 jtd
 nkx
 lpf
-sVd
+nkx
 nkx
 oRl
 nCG

--- a/modular_chomp/maps/southern_cross/southern_cross-7.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-7.dmm
@@ -1011,14 +1011,14 @@
 /turf/simulated/floor/tiled/milspec,
 /area/shuttle/ursula)
 "ach" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/engstorage)
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/uppersternhallway)
 "aci" = (
 /obj/effect/floor_decal/borderfloorblack,
 /obj/effect/floor_decal/corner/brown/border,
@@ -1372,18 +1372,14 @@
 /turf/simulated/floor/wood,
 /area/expoutpost/bar)
 "acS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/civaccesshallway)
+/turf/simulated/floor/tiled,
+/area/expoutpost/engstorage)
 "acT" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 8
@@ -1542,12 +1538,116 @@
 /turf/simulated/floor/tiled/steel_dirty,
 /area/expoutpost/botany)
 "ado" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/paleblue/border,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarthree)
+"adp" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarfour)
+"adq" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 5
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/staginghangar)
+"adr" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/paleblue/bordercorner,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarthree)
+"ads" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/staginghangar)
+"adt" = (
+/obj/effect/floor_decal/techfloor/corner{
+	dir = 6
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark,
+/area/expoutpost/staginghangar)
+"adu" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarfour)
+"adv" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/borderfloorblack,
+/obj/effect/floor_decal/corner/green/border,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarfive)
+"adw" = (
+/obj/effect/floor_decal/borderfloorblack/corner,
+/obj/effect/floor_decal/corner/green/bordercorner,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarfive)
+"adx" = (
+/obj/effect/floor_decal/borderfloorblack/corner{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/brown/bordercorner{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarsix)
+"ady" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
-"adp" = (
+"adz" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1555,49 +1655,49 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/engstorage)
-"adq" = (
+"adA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
-"adr" = (
+"adB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
-"ads" = (
+"adC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
-"adt" = (
+"adD" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/miningfoyer)
-"adu" = (
+"adE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
-"adv" = (
+"adF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
-"adw" = (
+"adG" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
-"adx" = (
+"adH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -1605,26 +1705,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
-"ady" = (
+"adI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/breakroom)
-"adz" = (
+"adJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
-"adA" = (
+"adK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled,
 /area/expoutpost/explobriefroom)
-"adB" = (
+"adL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/breakroom)
-"adC" = (
+"adM" = (
 /obj/structure/bed/chair/wood{
 	dir = 1
 	},
@@ -1639,14 +1739,14 @@
 /obj/effect/landmark/start/intern,
 /turf/simulated/floor/carpet,
 /area/expoutpost/breakroom)
-"adD" = (
+"adN" = (
 /obj/structure/table/wooden_reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/floor/carpet,
 /area/expoutpost/breakroom)
-"adE" = (
+"adO" = (
 /obj/structure/bed/chair/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/merge_conflict_marker{
@@ -1657,35 +1757,38 @@
 /obj/effect/landmark/start/intern,
 /turf/simulated/floor/carpet,
 /area/expoutpost/breakroom)
-"adF" = (
+"adP" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/breakroom)
-"adG" = (
+"adQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/secoffice)
-"adH" = (
+"adR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/secoffice)
-"adI" = (
+"adS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/secoffice)
-"adJ" = (
+"adT" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/expoutpost/hangartwo)
+"adU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /turf/simulated/wall/r_wall,
 /area/expoutpost/cic)
-"adK" = (
+"adV" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -1696,19 +1799,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"adL" = (
+"adW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"adM" = (
+"adX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"adN" = (
+"adY" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1721,7 +1824,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
-"adO" = (
+"adZ" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1734,7 +1837,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
-"adP" = (
+"aea" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1747,13 +1850,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
-"adQ" = (
+"aeb" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/medicalbay)
-"adR" = (
+"aec" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1766,7 +1869,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarthree)
-"adS" = (
+"aed" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1779,10 +1882,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
-"adT" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/expoutpost/hangartwo)
-"adU" = (
+"aee" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1795,7 +1895,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarthree)
-"adV" = (
+"aef" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1808,7 +1908,7 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/expoutpost/hangarfour)
-"adW" = (
+"aeg" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 8
 	},
@@ -1821,7 +1921,7 @@
 	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfive)
-"adX" = (
+"aeh" = (
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
 	},
@@ -1829,38 +1929,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/hangarsix)
-"adY" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled,
-/area/expoutpost/hangarfive)
-"adZ" = (
-/obj/effect/floor_decal/borderfloorblack{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
@@ -1877,6 +1945,38 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/expoutpost/rnd)
+"aej" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarfive)
+"aek" = (
+/obj/effect/floor_decal/borderfloorblack{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/expoutpost/hangarsix)
 "aeJ" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/floor_decal/borderfloorblack{
@@ -2090,6 +2190,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 1
+	},
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -3878,6 +3981,10 @@
 	},
 /obj/structure/handrail{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
@@ -6775,6 +6882,10 @@
 /obj/effect/floor_decal/corner/red/bordercorner{
 	dir = 8
 	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarfour)
 "esV" = (
@@ -6838,8 +6949,8 @@
 /turf/simulated/wall/rpshull,
 /area/shuttle/baby_mammoth)
 "euW" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /obj/effect/floor_decal/borderfloorblack{
 	dir = 4
@@ -9814,6 +9925,7 @@
 /obj/effect/floor_decal/corner/brown/bordercorner{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
 "gWG" = (
@@ -10212,7 +10324,6 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarone)
 "hlV" = (
-/obj/machinery/light,
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
 	},
@@ -12669,6 +12780,9 @@
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 1
 	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangartwo)
 "jnl" = (
@@ -14031,6 +14145,9 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 10
 	},
+/obj/machinery/light/floortube{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
 "kwr" = (
@@ -14352,17 +14469,6 @@
 "kMk" = (
 /turf/simulated/floor/tiled,
 /area/expoutpost/rnd)
-"kMp" = (
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 10
-	},
-/obj/item/radio/intercom{
-	dir = 8;
-	name = "Station Intercom (General)";
-	pixel_x = -21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/staginghangar)
 "kMR" = (
 /obj/structure/catwalk,
 /obj/structure/table/steel_reinforced,
@@ -15181,6 +15287,9 @@
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -21
+	},
+/obj/machinery/light/floortube{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
@@ -22792,6 +22901,10 @@
 /obj/structure/cable/green{
 	icon_state = "1-4"
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
 "rrj" = (
@@ -23444,17 +23557,6 @@
 /obj/machinery/light,
 /turf/simulated/floor,
 /area/shuttle/needle)
-"rOJ" = (
-/obj/effect/floor_decal/techfloor/corner{
-	dir = 6
-	},
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 21
-	},
-/turf/simulated/floor/tiled/dark,
-/area/expoutpost/staginghangar)
 "rPc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25176,12 +25278,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/expoutpost/civaccesshallway)
 "tqQ" = (
-/obj/machinery/light,
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
@@ -25648,12 +25753,16 @@
 /obj/effect/floor_decal/techfloor/corner{
 	dir = 6
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/structure/handrail{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/staginghangar)
@@ -28577,7 +28686,10 @@
 /turf/simulated/floor/tiled,
 /area/expoutpost/gatewayeva)
 "vUf" = (
-/obj/machinery/light,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled,
 /area/expoutpost/hangarsix)
 "vUT" = (
@@ -29225,6 +29337,10 @@
 	},
 /obj/structure/cable/green{
 	icon_state = "0-4"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/expoutpost/civaccesshallway)
@@ -58570,7 +58686,7 @@ cxh
 enL
 jwx
 enL
-adq
+adA
 kgn
 lTk
 isM
@@ -59330,7 +59446,7 @@ rUs
 tis
 jGJ
 liP
-adw
+adG
 liP
 lyU
 xfE
@@ -59344,7 +59460,7 @@ uKT
 enL
 enm
 mkF
-adr
+adB
 lTw
 nvl
 viN
@@ -59857,7 +59973,7 @@ vCa
 vCa
 vCa
 pQt
-ads
+adC
 uSL
 uSL
 uSL
@@ -60115,7 +60231,7 @@ aFp
 mmN
 vCa
 eMB
-adt
+adD
 enL
 enL
 enL
@@ -60361,8 +60477,8 @@ qng
 qng
 qng
 xMn
-adA
-adx
+adK
+adH
 lEO
 ejs
 xfE
@@ -61171,7 +61287,7 @@ dqy
 tEW
 xJS
 xJS
-ach
+acS
 xJS
 xJS
 fgx
@@ -61378,9 +61494,9 @@ jnl
 jnl
 jZo
 jnl
-adP
-adN
-adN
+aea
+adY
+adY
 hlF
 bwS
 pEN
@@ -61391,10 +61507,10 @@ rEw
 wzH
 wzH
 kzZ
-adD
-adC
-adB
-ady
+adN
+adM
+adL
+adI
 wzH
 cCr
 wzH
@@ -61429,7 +61545,7 @@ jsl
 aPh
 iiF
 wZI
-ado
+ady
 wZI
 dEY
 jSQ
@@ -61647,8 +61763,8 @@ tAp
 rqt
 rrG
 upj
-adF
-adE
+adP
+adO
 sps
 oFq
 wzH
@@ -61687,7 +61803,7 @@ rKs
 aPh
 roD
 vJh
-adp
+adz
 gQK
 eQR
 acw
@@ -62628,11 +62744,11 @@ uNn
 rUH
 rUH
 sjY
-adW
-adW
-adY
-adW
-adW
+aeg
+aeg
+aej
+aeg
+aeg
 bAg
 lGy
 tMo
@@ -62649,9 +62765,9 @@ vWD
 krs
 vWD
 vWD
-adU
-adR
-adR
+aee
+aec
+aec
 aFw
 tXN
 yjg
@@ -62878,7 +62994,7 @@ tMo
 xBG
 fbe
 fbe
-iKE
+adw
 efF
 qpw
 efF
@@ -62892,12 +63008,12 @@ ocH
 vZP
 fbe
 qrJ
-vlk
+adv
 tMo
 pNY
 dQy
 dQy
-oeA
+adr
 gnO
 bZy
 gnO
@@ -62911,7 +63027,7 @@ ezJ
 fxo
 dQy
 vYC
-qbW
+ado
 yjg
 vQD
 jnK
@@ -63394,10 +63510,10 @@ nOu
 bgV
 koU
 koU
-kMp
+ads
 fXg
 uFv
-dTh
+aGE
 mPE
 mPE
 mPE
@@ -63408,12 +63524,12 @@ fXg
 aGE
 koU
 vTm
-blv
+ads
 uzs
 dTh
 koU
 koU
-blv
+ads
 dTh
 pVg
 blv
@@ -63709,7 +63825,7 @@ gqv
 cXC
 faz
 juR
-adJ
+adU
 abd
 aaY
 azg
@@ -64203,7 +64319,7 @@ koU
 koU
 tqQ
 nOu
-pWz
+ach
 rxe
 tZF
 mAn
@@ -64993,7 +65109,7 @@ jYi
 qIR
 cWs
 dal
-adK
+adV
 wPQ
 iNT
 jIv
@@ -65251,7 +65367,7 @@ wzz
 iBp
 iBp
 acc
-adL
+adW
 fkF
 iNT
 rcx
@@ -65509,7 +65625,7 @@ oYU
 yck
 iBp
 wJJ
-adL
+adW
 fkF
 iNT
 uxa
@@ -65767,7 +65883,7 @@ xwv
 rIW
 iBp
 ljK
-adM
+adX
 glR
 iNT
 iGn
@@ -65974,10 +66090,10 @@ nOu
 acI
 koU
 koU
-rOJ
+adt
 xIx
 vLN
-uQT
+wMp
 vnD
 rXD
 bOz
@@ -65988,12 +66104,12 @@ xIx
 wMp
 koU
 vTm
-xqa
+adt
 xLz
 uQT
 koU
 koU
-xqa
+adt
 uQT
 eGv
 xqa
@@ -66004,12 +66120,12 @@ uQT
 eGv
 xqa
 rVg
-uQT
+adq
 koU
 vTm
 tKP
 nOu
-pWz
+ach
 saI
 oFc
 nTf
@@ -66021,7 +66137,7 @@ uzW
 pnR
 pnR
 iBp
-adQ
+aeb
 iBp
 iBp
 iBp
@@ -66442,7 +66558,7 @@ nCc
 nCc
 nCc
 tqk
-acS
+nCc
 niI
 aVF
 jJo
@@ -66490,7 +66606,7 @@ kKd
 oWP
 eTu
 eTu
-gWs
+adx
 lFv
 ndZ
 lFv
@@ -66509,7 +66625,7 @@ kKd
 sQK
 vJo
 vJo
-esf
+adu
 dvg
 sFf
 dvg
@@ -66523,7 +66639,7 @@ eiY
 nsv
 vJo
 nyj
-akr
+adp
 gXs
 eWp
 saI
@@ -66757,10 +66873,10 @@ xUc
 xUc
 gQk
 dya
-adX
-adZ
-adX
-adX
+aeh
+aek
+aeh
+aeh
 lAT
 aci
 kKd
@@ -66777,9 +66893,9 @@ jEQ
 xoX
 iOC
 iOC
-adV
-adS
-adS
+aef
+aed
+aed
 dnG
 kLn
 gXs
@@ -68087,8 +68203,8 @@ lrz
 gEi
 rKg
 ezt
-adO
-adO
+adZ
+adZ
 pzJ
 gUm
 kdc
@@ -68355,13 +68471,13 @@ tAp
 juR
 bie
 hQz
-adG
+adQ
 jfJ
 bie
 eYr
 rwb
 gKD
-adu
+adE
 owV
 tjn
 jSE
@@ -68613,7 +68729,7 @@ tAp
 juR
 bie
 fhE
-adH
+adR
 gei
 bie
 jsf
@@ -68876,8 +68992,8 @@ ajM
 bep
 fEs
 vei
-adz
-adv
+adJ
+adF
 owV
 oKC
 jSE
@@ -69645,7 +69761,7 @@ tAp
 juR
 bie
 acz
-adI
+adS
 jfJ
 bie
 lPb


### PR DESCRIPTION
## About The Pull Request

The goal of this PR is to update the Aegis carrier to have a proper AI core and camera network.

Secondary goal, make people actually like going onboard the Aegis.

TODO:
Full camera network.

COMPLETED:
Bluespace Gigabeacon (to allow command / synths access to the carrier in the event of a power outage)

AI core and AI access hallway, with nanite tiles and turrets.

Revamped all the shuttles with telecom relays.

Gave miners access to the mining shuttle. Gave the mining shuttle blast windows.

Added a bunch of spawn points for those that ready up at round start.

Small construction room is the main teleportation hub now. Still only one roundstart Qpad though.

Reworked the sling arrival area to be a bit more cozy, and allow a break-in should power be out.

Added Qpads to and from the mining shuttle and refinery.

## Changelog

:cl:
add: Added an AI core and AI access hallway to the Aegis, as well as gave the beast a full camera network. You'll also find an extra AI shell there now!
/:cl: