### PR TITLE
shotgun autolathe emp shell fix

### DIFF
--- a/code/datums/autolathe/arms_ch.dm
+++ b/code/datums/autolathe/arms_ch.dm
@@ -212,7 +212,7 @@
 
 /datum/category_item/autolathe/arms/b12g/emp
 	name = "ammo box (12 gauge EMP)"
-	path = /obj/item/ammo_magazine/ammo_box/b12g/beanbag
+	path = /obj/item/ammo_magazine/ammo_box/b12g/emp
 	hidden = 1
 
 /datum/category_item/autolathe/arms/b12g/flechette


### PR DESCRIPTION
## About The Pull Request
"ammo box (12 gauge EMP)" properly dispenses emp ammo and not beanbag

## Changelog
Fixed incorrect path for autolathed shotgun emp ammo

:cl: Will
fix: 12guage emp ammo from the autolathe is now emp shells and not beanbag shells
/:cl:

