### PR TITLE
fix some small carrier map issues

### DIFF
--- a/modular_chomp/maps/cetus/cetus-6.dmm
+++ b/modular_chomp/maps/cetus/cetus-6.dmm
@@ -2673,6 +2673,7 @@
 /obj/structure/cable/green{
 	icon_state = "0-4"
 	},
+/obj/machinery/power/smes/buildable/power_shuttle/max_charge_max_input_base_output,
 /turf/simulated/floor,
 /area/shuttle/ursula)
 "bYa" = (
@@ -30294,10 +30295,6 @@
 /turf/simulated/floor,
 /area/expoutpost/restrooms)
 "yjG" = (
-/obj/machinery/power/smes/buildable/max_charge_max_input{
-	RCon_tag = "Auxiliary Reactor - Aegis";
-	name = "Auxiliary Reactor SMES"
-	},
 /obj/item/smes_coil,
 /obj/item/smes_coil,
 /obj/effect/engine_setup/smes,
@@ -30305,6 +30302,10 @@
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/power/smes/buildable/engine_default{
+	name = "Auxiliary Reactor SMES";
+	RCon_tag = "Auxiliary Reactor - Aegis"
+	},
 /turf/simulated/floor,
 /area/expoutpost/engoffice)
 "ykl" = (

--- a/modular_chomp/maps/southern_cross/southern_cross-7.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-7.dmm
@@ -30280,10 +30280,6 @@
 /turf/simulated/floor,
 /area/expoutpost/restrooms)
 "yjG" = (
-/obj/machinery/power/smes/buildable/max_charge_max_input{
-	RCon_tag = "Auxiliary Reactor - Aegis";
-	name = "Auxiliary Reactor SMES"
-	},
 /obj/item/smes_coil,
 /obj/item/smes_coil,
 /obj/effect/engine_setup/smes,
@@ -30291,6 +30287,10 @@
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/power/smes/buildable/engine_default{
+	name = "Auxiliary Reactor SMES";
+	RCon_tag = "Auxiliary Reactor - Aegis"
+	},
 /turf/simulated/floor,
 /area/expoutpost/engoffice)
 "ykl" = (


### PR DESCRIPTION
## About The Pull Request
Fixes some reported smes issues.

## Changelog
SC: fixed carrier aux reactor smes not having output maxed 
Cetus: fixed carrier aux reactor smes not having output maxed 
Cetus: Fixed ursula carrier shuttle missing smes

:cl: Will
maptweak: Fixed Cetus and SC Carrier aux reactor smes not being maxed output on roundstart
maptweak: Ursula carrier shuttle missing smes on Cetus map
/:cl:
