### PR TITLE
Nerf Durasteel Hull

### DIFF
--- a/modular_chomp/code/modules/materials/materials/metals/metals.dm
+++ b/modular_chomp/code/modules/materials/materials/metals/metals.dm
@@ -1,6 +1,9 @@
 /datum/material/durasteel //Slightly nerfed protectivness
 	protectiveness = 55
 
+/datum/material/durasteel/hull //Severly reduces protectivness
+	protectiveness = 45
+
 /datum/material/titanium //Adjusted hardness, reflective, and protection
 	hardness = 60
 	protectiveness = 30


### PR DESCRIPTION
So Durasteel Hull is just better Durasteel meant for spaceships. Tone down the protectiveness to try and tone down the 'free' durasteel upgrade
## About The Pull Request
## Changelog
:cl:
balance: Durasteel hull nerfed
/:cl:
