### PR TITLE
Fix bitwise operation for FAKEDEATH status check

### DIFF
--- a/code/game/objects/items/devices/scanners/sleevemate.dm
+++ b/code/game/objects/items/devices/scanners/sleevemate.dm
@@ -140,7 +140,7 @@ var/global/mob/living/carbon/human/dummy/mannequin/sleevemate_mob
 
 	//Body status
 	output += span_bold("Sleeve Status:") + " "
-	if(H.status_flags |= FAKEDEATH)
+	if(H.status_flags & FAKEDEATH)
 		output += span_warning("Deceased") + "<br>"
 	else
 		switch(H.stat)


### PR DESCRIPTION
Thanks copilot for the auto commit message...Now get out of here
## About The Pull Request
Copilot decided on the title so I'll let it keeep it.

Sleevemates are accidentally APPLYING fakedeath instead of CHECKING for fakedeath...This fixes it.
## Changelog
:cl: Diana
fix: Sleevemates will no longer apply fakedeath status instead of checking for it 
/:cl:
