### PR TITLE
Makes Mouse Army faction defines

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/space/mouse_army.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/space/mouse_army.dm
@@ -9,7 +9,7 @@
 	icon_living = "mouse_gray"
 	icon_dead = "mouse_gray_dead"
 	icon_rest = "mouse_gray_sleep"
-	faction = "mouse_army"
+	faction = FACTION_SYNDICATE
 
 	maxHealth = 50
 	health = 50
@@ -366,7 +366,7 @@
 	icon = 'icons/mob/mouse_army.dmi'
 	icon_state = "whisker"
 	wreckage = /obj/structure/loot_pile/mecha/mouse_tank
-	faction = "mouse_army"
+	faction = FACTION_SYNDICATE
 
 	maxHealth = 150
 	armor = list(


### PR DESCRIPTION

## About The Pull Request
## Changelog
:cl:
fix: mouse army uses defines for their faction
/:cl:
