### PR TITLE
Some experimental Vac-Pack stuff

### DIFF
--- a/code/game/objects/items/devices/vacpack.dm
+++ b/code/game/objects/items/devices/vacpack.dm
@@ -118,7 +118,7 @@
 	if(isturf(target))
 		if(overpowered && vac_power >= 6)
 			playsound(src, 'sound/machines/hiss.ogg', 100, 1, -1)
-			var/obj/effect/temp_visual/V = new()
+			var/obj/effect/temp_visual/V = new(target)
 			V.duration = 20
 			V.icon = 'icons/effects/anomalies.dmi'
 			V.icon_state = "vortex"


### PR DESCRIPTION

## About The Pull Request
-New subtype "Scoop Hopper" that kinda does the same but without the animation queue and has different sounds and verbs. (no custom sprites yet tho)
-Suck sounds and verbs and animation toggle are now editable variables.
-New experimental "overpowered" mode that gravity pulls valid targets from 3x3 grid before doing the suck. (currently only available via varedit)

Proper testing pending...
## Changelog
:cl:
add: Added a new vacpack subtype and a special mode (currently varedit only)
qol: Vacpack sounds and verbs and anim toggle are now vareditable
/:cl:
