### PR TITLE
Obliterates combat medkit from security armory

### DIFF
--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -3811,7 +3811,8 @@
 /obj/machinery/hologram/holopad,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/steel,
-/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
 /obj/item/personal_shield_generator/belt/security/loaded,
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)


### PR DESCRIPTION
After some discussion, I thought it was best to replace the combat medkit with some advanced medkits in the security armory, instead. The combat medkit is an extremely powerful set of chemicals that can nullify pretty much every health condition.

Alongside the recent positive changes made to medical code that makes the overall health experience better and more playable, placing more emphasis on security relying on medical during emergencies, or security reaching out to cargo/medical to secure resources/equipment, is better overall for inter-departmental gameplay.

:cl:
balance: Removed the combat medkit from the security armory on Southern Cross. Replaced with two advanced (red) medkits.
/:cl: