### PR TITLE
Minor Swoopie adjustments

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/swoopie.dm
@@ -99,8 +99,8 @@
 	B.digest_burn = 3
 	B.fancy_vore = 1
 	B.vore_sound = "Stomach Move"
-	B.belly_fullscreen = "VBO_belly9"
-	B.belly_fullscreen_color = "#555B34"
+	B.belly_fullscreen = "VBOanim_belly9"
+	B.belly_fullscreen_color = "#202020"
 	B.sound_volume = 25
 	B.count_items_for_sprite = TRUE
 
@@ -123,7 +123,7 @@
 	B.affects_vore_sprites = TRUE
 	B.belly_sprite_to_affect = "neck1"
 	B.name = "vacuum hose"
-	B.autotransferlocation = "vacuum hose 2"
+	B.autotransferlocation = "upper vacuum hose"
 	B.fancy_vore = 1
 	B.vore_sound = "Stomach Move"
 	B.sound_volume = 100
@@ -131,8 +131,8 @@
 	B = new /obj/belly/longneck(src)
 	B.affects_vore_sprites = TRUE
 	B.belly_sprite_to_affect = "neck2"
-	B.name = "vacuum hose 2"
-	B.autotransferlocation = "vacuum hose 3"
+	B.name = "upper vacuum hose"
+	B.autotransferlocation = "midway vacuum hose"
 	B.desc = "It feels very tight in here..."
 	B.fancy_vore = 1
 	B.vore_sound = "Stomach Move"
@@ -141,8 +141,8 @@
 	B = new /obj/belly/longneck(src)
 	B.affects_vore_sprites = TRUE
 	B.belly_sprite_to_affect = "neck3"
-	B.name = "vacuum hose 3"
-	B.autotransferlocation = "vacuum hose 4"
+	B.name = "midway vacuum hose"
+	B.autotransferlocation = "lower vacuum hose"
 	B.desc = "Looks like it's gonna be all downhill from here..."
 	B.fancy_vore = 1
 	B.vore_sound = "Stomach Move"
@@ -151,7 +151,7 @@
 	B = new /obj/belly/longneck(src)
 	B.affects_vore_sprites = TRUE
 	B.belly_sprite_to_affect = "neck4"
-	B.name = "vacuum hose 4"
+	B.name = "lower vacuum hose"
 	B.autotransferlocation = "Churno-Vac"
 	B.desc = "Thank you for your biofuel contribution~"
 	B.fancy_vore = 1
@@ -173,7 +173,7 @@
 	autotransferlocation = "Churno-Vac"
 	vore_verb = "suck"
 	belly_fullscreen_color = "#4d4d4d"
-	belly_fullscreen = "a_tumby"
+	belly_fullscreen = "VBOanim_gullet1"
 	human_prey_swallow_time = 1
 	nonhuman_prey_swallow_time = 1
 	autotransfer_max_amount = 2


### PR DESCRIPTION
:cl:
image: Modified the Swoopie fullscreen overlays to use animated versions.
spellcheck: Modified the Swoopie vac-hose vbelly names to use flair words instead of numbers to denote progress.
/:cl: