### PR TITLE
Security Armor Vendor Redux

### DIFF
--- a/modular_chomp/code/game/machinery/vending.dm
+++ b/modular_chomp/code/game/machinery/vending.dm
@@ -123,37 +123,43 @@
 
 /obj/machinery/vending/security_armor
 	name = "Security Plate Carrier Vendor"
-	desc = "A large vending machine stocked with a variety of plate carriers and accessories to accompany them."
+	desc = "A large vending machine stocked with plate carriers and accessories to accompany them."
 	vend_delay = 1
 	icon_state = "sec"
 	req_access = list(ACCESS_SECURITY)
 	products = list(
-				// The vests. No green, don't want to confuse exploration
-					/obj/item/clothing/suit/armor/pcarrier = 5,
-					/obj/item/clothing/suit/armor/pcarrier/blue = 5,
-					/obj/item/clothing/suit/armor/pcarrier/tan = 5,
-					/obj/item/clothing/suit/armor/pcarrier/navy = 5,
+				// The vests. Just in black and red, to maintain the security appearance.
+					/obj/item/clothing/suit/armor/pcarrier = 8,
+					/obj/item/clothing/head/helmet = 8,
 				// Accessories
-					/obj/item/clothing/accessory/armor/tag/nt = 5,
-					/obj/item/clothing/accessory/armor/tag/sec = 5,
-					/obj/item/clothing/accessory/storage/pouches/large = 5,
-					/obj/item/clothing/accessory/storage/pouches/large/blue = 5,
-					/obj/item/clothing/accessory/storage/pouches/large/tan = 5,
-					/obj/item/clothing/accessory/storage/pouches/large/navy = 5,
+					/obj/item/clothing/accessory/armor/tag/nt = 8,
+					/obj/item/clothing/accessory/storage/pouches = 8,
 				// Armor fittings
-					/obj/item/clothing/accessory/armor/armguards = 5,
-					/obj/item/clothing/accessory/armor/armguards/blue = 5,
-					/obj/item/clothing/accessory/armor/armguards/tan = 5,
-					/obj/item/clothing/accessory/armor/armguards/navy = 5,
-					/obj/item/clothing/accessory/armor/armguards/merc = 5,
-					/obj/item/clothing/accessory/armor/legguards = 5,
-					/obj/item/clothing/accessory/armor/legguards/blue = 5,
-					/obj/item/clothing/accessory/armor/legguards/tan = 5,
-					/obj/item/clothing/accessory/armor/legguards/navy = 5,
-					/obj/item/clothing/accessory/armor/legguards/merc = 5,
-					/obj/item/clothing/accessory/armor/armorplate/tactical = 5
+					/obj/item/clothing/accessory/armor/armguards/security = 8,
+					/obj/item/clothing/accessory/armor/legguards/security = 8,
+					/obj/item/clothing/accessory/armor/armorplate/medium = 8
 				)
 
+/obj/machinery/vending/security_armory_armor
+	name = "Security Armory Plate Carrier Vendor"
+	desc = "A large vending machine stocked with advanced plate carriers and improved accessories to accompany them."
+	vend_delay = 1
+	icon_state = "sec"
+	req_access = list(ACCESS_SECURITY)
+	products = list(
+				// The vests. Now in black, red and white to highlight the 'combat' aspect of the armor
+					/obj/item/clothing/suit/armor/pcarrier = 6,
+					/obj/item/clothing/head/helmet = 6,
+				// Accessories
+					/obj/item/clothing/accessory/armor/tag/ntwhite = 6,
+					/obj/item/clothing/accessory/storage/pouches/large = 6,
+					/obj/item/clothing/accessory/armor/helmcover/ntblack = 6,
+					/obj/item/clothing/accessory/armor/helmcover/nt = 6,
+				// Armor fittings
+					/obj/item/clothing/accessory/armor/armguards/security/white = 6,
+					/obj/item/clothing/accessory/armor/legguards/security/white = 6,
+					/obj/item/clothing/accessory/armor/armorplate/merc = 6
+				)
 
 //Temp Starhunter Fix
 /obj/machinery/vending/starhunter_farmer

--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -3059,27 +3059,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
 "agi" = (
-/obj/structure/table/rack{
-	dir = 8;
-	layer = 2.6
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	health = 1e+006
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/yellow/full{
 	dir = 1
 	},
-/obj/item/clothing/gloves/arm_guard/combat,
-/obj/item/clothing/shoes/leg_guard/combat,
-/obj/item/clothing/suit/armor/combat,
-/obj/item/clothing/head/helmet/combat,
-/obj/machinery/door/window/brigdoor/westright{
-	name = "Combat Armor"
-	},
+/obj/machinery/vending/security_armory_armor,
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
 "agn" = (
@@ -3836,6 +3819,13 @@
 /obj/machinery/door/window/brigdoor/westleft{
 	name = "Combat Armor"
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/clothing/head/helmet/combat,
+/obj/item/clothing/suit/armor/combat,
+/obj/item/clothing/shoes/leg_guard/combat,
+/obj/item/clothing/gloves/arm_guard/combat,
 /turf/simulated/floor/tiled/dark,
 /area/security/tactical)
 "aiv" = (


### PR DESCRIPTION
Updates the plate carrier vendor in security. The armor values on it were previously combat-armor-level, making them superior to all security vests while still being accessible without armory access. This reverts them back to regular security vest protection levels.

Additionally, the excess accessories and colors have been removed in favor of maintaining the normal security color scheme of red/black for easier identification.

Instead, I created a new version of the plate carrier armor upstream in a different color, and have placed them into a new vendor. This vendor has been placed into the armory, and has red/black/white armor with combat-level protection. Additionally, I've added the previously unobtainable accessory helmet covers to them.

:cl:
add: Added a new armor vendor to the security armory.
balance: Reduced the strength of the default plate carrier equipment available in security.
maptweak: Added a new vendor to the security armory, consolidated the regular combat armor into one tile.
/:cl: