### PR TITLE
Removed Useless Iconstate Code In Bodycams

### DIFF
--- a/code/game/objects/items/devices/tvcamera.dm
+++ b/code/game/objects/items/devices/tvcamera.dm
@@ -321,12 +321,6 @@
 
 /obj/item/clothing/accessory/bodycam/update_icon()
 	..()
-	if(bcamera.status)
-		icon_state = "eshield"
-		item_state = "eshield"
-	else
-		icon_state = "eshield"
-		item_state = "eshield"
 	var/mob/living/carbon/human/H = loc
 	if(istype(H))
 		H.update_inv_r_hand()


### PR DESCRIPTION
## About The Pull Request
Removes some code that does nothing.

## Changelog
Removes an if else block in bodycam code that sets the icon to the same thing in both conditions. Making it impossible to add uniquely sprited versions of bodycams, as they will reset on every icon update.

:cl: Will
code: Removed unneeded icon change in bodycam update_icon
/:cl:
