### PR TITLE
Prevent Prometheans and Proteans from taking Rotting Genetics

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/traits/negative_genes.dm
+++ b/code/modules/mob/living/carbon/human/species/station/traits/negative_genes.dm
@@ -170,7 +170,7 @@
 	primitive_expression_messages=list("shudders.","gasps.","chokes.")
 	added_component_path = /datum/component/rotting_disability
 
-	banned_species	= (/datum/species/protean, /datum/species/shapeshifter/promethean)	//CHOMPStation Edit - Prometheans and Proteans dont have Genetics. 
+	banned_species	= list(/datum/species/protean, /datum/species/shapeshifter/promethean)	//CHOMPStation Edit - Prometheans and Proteans dont have Genetics. 
 
 /datum/trait/negative/disability_gibbing
 	name = "Gibbingtons"


### PR DESCRIPTION

## About The Pull Request
Prevents Proteans and Prometheans from taking the rotting  Genetic trait as they dont have Genetics and are unaffected by the downsides.
## Changelog
:cl:
fix:Rotting genetics can no longer be taken by Prometheans and Proteans in Character setup
/:cl:
