### PR TITLE
Fixes a division by 0 in gas mixtures

### DIFF
--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -178,7 +178,7 @@
 	which is bit more realistic (natural log), and returns a fairly accurate entropy around room temperatures and pressures.
 */
 /datum/gas_mixture/proc/specific_entropy_gas(var/gasid)
-	if (!(gasid in gas) || gas[gasid] == 0)
+	if (!(gasid in gas) || gas[gasid] == 0 || temperature == 0) // CHOMPEdit - Temperature
 		return SPECIFIC_ENTROPY_VACUUM	//that gas isn't here
 
 	//group_multiplier gets divided out in volume/gas[gasid] - also, V/(m*T) = R/(partial pressure)


### PR DESCRIPTION

## About The Pull Request

Title

## Changelog
:cl:
fix: Fixed a division by 0 in gas mixtures
/:cl:
