### PR TITLE
Fossil Tank Bandaid thing

### DIFF
--- a/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/weather.dm
+++ b/modular_chomp/code/modules/mob/living/simple_mob/subtypes/vore/weather.dm
@@ -53,7 +53,6 @@
 	B.escapechance = 15
 
 /datum/ai_holder/simple_mob/fossiltank
-	use_astar = TRUE
 	hostile = TRUE
 	retaliate = TRUE
 	mauling = TRUE


### PR DESCRIPTION

## About The Pull Request

There is nothing really special about this Ai besides being extra snipery based
So guessing something Astar that causes the server to break when the mob melts something, but don't have time to look into it
Fortunately I think the fossil tank is the only mob capable of eating folks and uses Astar?

Mercs use Astar and I know they're being poked.
## Changelog
:cl:
fix: Alter Fossil Tank's Ai to hopefully not break everything as it enjoys a meal
/:cl:
