### PR TITLE
Agate blob Stuff

### DIFF
--- a/modular_chomp/code/datums/diseases/symptom/agate_blob.dm
+++ b/modular_chomp/code/datums/diseases/symptom/agate_blob.dm
@@ -1,10 +1,10 @@
 /datum/symptom/blobspores/agate
 	name = "Agate Infection"
 	desc = "This symptom causes the host to produce blob spores, which will leave the host at the later stages, and if the host dies, all of the spores will erupt from the host at the same time, while also producing a blob tile."
-	stealth = 15
-	resistance = 15
+	stealth = 5
+	resistance = 7
 	stage_speed = -2
-	transmission = 15
+	transmission = -1
 	level = -1
 	severity = 3
 	naturally_occuring = FALSE

--- a/modular_chomp/code/datums/diseases/symptom/agate_blob.dm
+++ b/modular_chomp/code/datums/diseases/symptom/agate_blob.dm
@@ -5,7 +5,7 @@
 	resistance = 15
 	stage_speed = -2
 	transmission = 15
-	level = 9
+	level = -1
 	severity = 3
 	naturally_occuring = FALSE
 	symptom_delay_min = 20 SECONDS

--- a/modular_chomp/code/datums/diseases/symptom/agate_blob.dm
+++ b/modular_chomp/code/datums/diseases/symptom/agate_blob.dm
@@ -1,8 +1,8 @@
 /datum/symptom/blobspores/agate
 	name = "Agate Infection"
 	desc = "This symptom causes the host to produce blob spores, which will leave the host at the later stages, and if the host dies, all of the spores will erupt from the host at the same time, while also producing a blob tile."
-	stealth = 4
-	resistance = 7
+	stealth = 7
+	resistance = 3
 	stage_speed = -3
 	transmission = -1
 	level = -1

--- a/modular_chomp/code/datums/diseases/symptom/agate_blob.dm
+++ b/modular_chomp/code/datums/diseases/symptom/agate_blob.dm
@@ -1,10 +1,10 @@
 /datum/symptom/blobspores/agate
 	name = "Agate Infection"
 	desc = "This symptom causes the host to produce blob spores, which will leave the host at the later stages, and if the host dies, all of the spores will erupt from the host at the same time, while also producing a blob tile."
-	stealth = 7
+	stealth = 6
 	resistance = 3
 	stage_speed = -3
-	transmission = -1
+	transmission = -2
 	level = -1
 	severity = 3
 	naturally_occuring = FALSE

--- a/modular_chomp/code/datums/diseases/symptom/agate_blob.dm
+++ b/modular_chomp/code/datums/diseases/symptom/agate_blob.dm
@@ -1,9 +1,9 @@
 /datum/symptom/blobspores/agate
 	name = "Agate Infection"
 	desc = "This symptom causes the host to produce blob spores, which will leave the host at the later stages, and if the host dies, all of the spores will erupt from the host at the same time, while also producing a blob tile."
-	stealth = 5
+	stealth = 4
 	resistance = 7
-	stage_speed = -2
+	stage_speed = -3
 	transmission = -1
 	level = -1
 	severity = 3

--- a/modular_chomp/code/modules/blob2/agate_blob.dm
+++ b/modular_chomp/code/modules/blob2/agate_blob.dm
@@ -10,7 +10,6 @@
 	color = "#FF3300"
 	complementary_color = "#FF5125"
 	spread_modifier = 1.0
-	slow_spread_with_size = FALSE
 	ai_aggressiveness = 95
 	can_build_resources = TRUE
 	attack_message = "The tide tries to swallow you"
@@ -21,11 +20,11 @@
 	damage_type = SEARING
 	armor_check = "melee"
 	armor_pen = 30
-	damage_lower = 35
-	damage_upper = 35
+	damage_lower = 20
+	damage_upper = 20
 
-	brute_multiplier = 0.5
-	burn_multiplier = 0.5
+	brute_multiplier = 0.75
+	burn_multiplier = 0.75
 
 	can_build_factories = TRUE
 	can_build_resources = TRUE
@@ -46,7 +45,6 @@
 
 /datum/blob_type/living_agate/on_attack(obj/structure/blob/B, mob/living/victim, def_zone)
 	victim.electrocute_act(10, src, 1, def_zone)
-	victim.stun_effect_act(0, 40, BP_TORSO, src, electric = TRUE)
 
 /datum/blob_type/living_agate/on_spore_death(mob/living/simple_mob/blob/spore/S)
 	if(S.is_infesting)


### PR DESCRIPTION

## About The Pull Request

So naturally_occuring apparently doesn't do anything, bleh.
Also tone down the blob in case it somehow appears again outside of the hoops intended to leap through
## Changelog
:cl:
fix: Agate virus being grabbable outside of the one mob meant to inflict it
balance: Tones down the hidden Tyr blob
/:cl:
