### PR TITLE
Removes the PISS

### DIFF
--- a/modular_chomp/maps/southern_cross/southern_cross-3.dmm
+++ b/modular_chomp/maps/southern_cross/southern_cross-3.dmm
@@ -55657,14 +55657,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/secondary/docking_hallway2)
-"kar" = (
-/obj/machinery/smartfridge/sheets/persistent_lossy{
-	desc = "An industrial sized storage unit for materials. Following company policy with B-Shift, this particular storage unit will retain a percentage of its material in-between crew transfers.";
-	name = "\improper Persistent Industrial Sheet Storage";
-	req_one_access = list(31,48)
-	},
-/turf/simulated/floor/tiled,
-/area/quartermaster/warehouse)
 "kay" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -98561,7 +98553,7 @@ aOj
 aQI
 aSR
 bxr
-kar
+bGn
 bAG
 qmn
 bEy


### PR DESCRIPTION

## About The Pull Request

Following staff discussion and asking players, the Persistant Industrial Sheet Storage doesn't seem to fit too well. This will remove it from Southern Cross.

## Changelog
:cl: Guti
maptweak: Removed the PISS from Southern Cross
/:cl:
