### PR TITLE
Shadekin Lingering Fire Fix

### DIFF
--- a/modular_chomp/code/ZAS/Fire.dm
+++ b/modular_chomp/code/ZAS/Fire.dm
@@ -94,7 +94,8 @@
 
 	// Affect contents
 	for(var/mob/living/L in loc)
-		L.FireBurn(firelevel, air_contents.temperature, air_contents.return_pressure()) // Burn the mobs!
+		if(!L.is_incorporeal())
+			L.FireBurn(firelevel, air_contents.temperature, air_contents.return_pressure()) // Burn the mobs!
 
 	loc.fire_act(air_contents, air_contents.temperature, air_contents.volume)
 	for(var/atom/A in loc)


### PR DESCRIPTION
## About The Pull Request
Adds a missing incorporeal check on lingering fire that normal fires have.

:cl: Will
fix: lingering fires no longer catch phased shadekin on fire
/:cl:
