### PR TITLE
fix: update_dna no longer resets SE blocks, fixing morph gene wipe bug

### DIFF
--- a/code/modules/mob/living/carbon/human/appearance.dm
+++ b/code/modules/mob/living/carbon/human/appearance.dm
@@ -171,8 +171,8 @@
 
 /mob/living/carbon/human/proc/update_dna()
 	check_dna()
-	dna.ready_dna(src)
-	sync_organ_dna(dna)
+	dna.ResetUIFrom(src) // Do not call ready_dna here: it resets ALL SE blocks, wiping trait gene state
+	sync_organ_dna()
 
 /mob/living/carbon/human/proc/generate_valid_species(var/check_whitelist = 1, var/list/whitelist = list(), var/list/blacklist = list())
 	var/list/valid_species = new()


### PR DESCRIPTION
## About The Pull Request
update_dna() was calling dna.ready_dna(), which internally calls ResetSE() and sets every SE block to rand(1,1024) (the OFF range for all bound types). Any subsequent domutcheck(MUTCHK_FORCED) call would then read every gene as inactive and deactivate them all, including the gene that triggered the appearance editor in the first place.
The same bug affected change_gender(), add_marking(), remove_marking(), change_priority_of_marking(), and change_marking_color(), all of which call update_dna().


Change validated on test server.

## Changelog
:cl:ARGUS
fix: Using the Morph appearance editor no longer silently deactivates all trait genes, including Morph itself.
fix: Changing gender or markings via appearance tools no longer wipes active genetic traits.
/:cl:
