### PR TITLE
adds a shapeshifting trait

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/traits/positive.dm
@@ -26,6 +26,16 @@
 	custom_only = FALSE
 	banned_species = list(SPECIES_TAJARAN, SPECIES_SHADEKIN_CREW, SPECIES_SHADEKIN, SPECIES_XENOHYBRID, SPECIES_VULPKANIN, SPECIES_XENO, SPECIES_XENOCHIMERA, SPECIES_VASILISSAN, SPECIES_WEREBEAST) //These species already have strong darksight by default.
 
+/datum/trait/positive/shapeshifting
+	name = "Shapeshifter"
+	desc = "You're able to shift your appearance."
+	cost = 3 //this trait is functionally wholly cosmetic, but it is less flavor-restricted than cocoon, and takes less time, so it's a bit pricier
+	custom_only = FALSE
+
+/datum/trait/positive/shapeshifting/apply(var/datum/species/S,var/mob/living/carbon/human/H)
+	..()
+	add_verb(H, /mob/living/carbon/human/proc/innate_shapeshifting)
+
 /datum/trait/positive/endurance_high
 	cost = 3
 	excludes = list(/datum/trait/positive/endurance_very_high, /datum/trait/positive/endurance_extremely_high) // CHOMPEdit: Increased Endurance.


### PR DESCRIPTION

## About The Pull Request
adds a true shapeshifter trait. This allows for freely editing character appearance on the fly, and costs three points.
The three points is a compromise- It's less restrictive than the one-point cocoon, and I don't want every single character around to just suddenly be a shapeshifter. I'm very willing to change the point cost, make the trait neutral, whatever, if desired.

Made modular, I do not expect this to be desirable to virgo

## Changelog
:cl:
add: shapeshifter trait
/:cl:

