### PR TITLE
missing ammos in autolathe

### DIFF
--- a/modular_chomp/code/modules/research/tg/designs/ammunition_designs.dm
+++ b/modular_chomp/code/modules/research/tg/designs/ammunition_designs.dm
@@ -379,7 +379,7 @@
 	id = "ammobox_9mm_ap"
 	materials = list(MAT_STEEL = 1200, MAT_PLASTEEL = 600)
 	build_type = AUTOLATHE
-	build_path = /obj/item/ammo_magazine/ammo_box/b9mm/practice
+	build_path = /obj/item/ammo_magazine/ammo_box/b9mm/ap
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_HACKED,

--- a/modular_chomp/code/modules/research/tg/designs/ammunition_designs.dm
+++ b/modular_chomp/code/modules/research/tg/designs/ammunition_designs.dm
@@ -286,3 +286,137 @@
 		RND_CATEGORY_HACKED,
 		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_RIFLE
 	)
+
+// VP70
+
+/datum/design_techweb/pistol_mag_vp70
+	SET_AMMO_DESIGN_NAMEDESC("pistol magazine (vp70-9mm)")
+	id = "pistol_mag_vp70"
+	materials = list(MAT_STEEL = 1080)
+	build_type = AUTOLATHE
+	build_path = /obj/item/ammo_magazine/m9mm/vp70
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_HACKED,
+		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_PISTOL
+	)
+
+/datum/design_techweb/pistol_mag_vp70_ap
+	SET_AMMO_DESIGN_NAMEDESC("pistol magazine (vp70-9mm armor piercing)")
+	id = "pistol_mag_vp70_ap"
+	materials = list(MAT_STEEL = 1080, MAT_PLASTEEL = 600)
+	build_type = AUTOLATHE
+	build_path = /obj/item/ammo_magazine/m9mm/vp70/ap
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_HACKED,
+		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_PISTOL
+	)
+
+/datum/design_techweb/pistol_mag_vp70_hp
+	SET_AMMO_DESIGN_NAMEDESC("pistol magazine (vp70-9mm hollow point)")
+	id = "pistol_mag_vp70_hp"
+	materials = list(MAT_STEEL = 1080, MAT_PLASTIC = 600)
+	build_type = AUTOLATHE
+	build_path = /obj/item/ammo_magazine/m9mm/vp70/hp
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_HACKED,
+		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_PISTOL
+	)
+
+/datum/design_techweb/pistol_mag_vp70_rubber
+	SET_AMMO_DESIGN_NAMEDESC("pistol magazine (vp70-9mm rubber)")
+	id = "pistol_mag_vp70_rubber"
+	materials = list(MAT_STEEL = 900)
+	build_type = AUTOLATHE
+	build_path = /obj/item/ammo_magazine/m9mm/vp70/rubber
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_HACKED,
+		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_PISTOL
+	)
+
+/datum/design_techweb/pistol_mag_vp70_flash
+	SET_AMMO_DESIGN_NAMEDESC("pistol magazine (vp70-9mm flash)")
+	id = "pistol_mag_vp70_flash"
+	materials = list(MAT_STEEL = 900)
+	build_type = AUTOLATHE
+	build_path = /obj/item/ammo_magazine/m9mm/vp70/flash
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_HACKED,
+		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_PISTOL
+	)
+
+// 9mm ammo boxes
+
+/datum/design_techweb/ammobox_9mm
+	SET_AMMO_DESIGN_NAMEDESC("ammo box (9mm)")
+	id = "ammobox_9mm"
+	materials = list(MAT_STEEL = 1500)
+	build_type = AUTOLATHE
+	build_path = /obj/item/ammo_magazine/ammo_box/b9mm
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_HACKED,
+		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_BOXES
+	)
+
+/datum/design_techweb/ammobox_9mm_practice
+	SET_AMMO_DESIGN_NAMEDESC("ammo box (9mm practice)")
+	id = "ammobox_9mm_practice"
+	materials = list(MAT_STEEL = 1100)
+	build_type = AUTOLATHE
+	build_path = /obj/item/ammo_magazine/ammo_box/b9mm/practice
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_BOXES
+	)
+
+/datum/design_techweb/ammobox_9mm_ap
+	SET_AMMO_DESIGN_NAMEDESC("ammo box (9mm armor piercing)")
+	id = "ammobox_9mm_ap"
+	materials = list(MAT_STEEL = 1200, MAT_PLASTEEL = 600)
+	build_type = AUTOLATHE
+	build_path = /obj/item/ammo_magazine/ammo_box/b9mm/practice
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_HACKED,
+		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_BOXES
+	)
+
+/datum/design_techweb/ammobox_9mm_hp
+	SET_AMMO_DESIGN_NAMEDESC("ammo box (9mm hollow point)")
+	id = "ammobox_9mm_hp"
+	materials = list(MAT_STEEL = 1100)
+	build_type = AUTOLATHE
+	build_path = /obj/item/ammo_magazine/ammo_box/b9mm/hp
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_HACKED,
+		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_BOXES
+	)
+
+/datum/design_techweb/ammobox_9mm_rubber
+	SET_AMMO_DESIGN_NAMEDESC("ammo box (9mm hollow point)")
+	id = "ammobox_9mm_rubber"
+	materials = list(MAT_STEEL = 1100)
+	build_type = AUTOLATHE
+	build_path = /obj/item/ammo_magazine/ammo_box/b9mm/rubber
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_BOXES
+	)
+
+/datum/design_techweb/ammobox_9mm_flash
+	SET_AMMO_DESIGN_NAMEDESC("ammo box (9mm flash)")
+	id = "ammobox_9mm_flash"
+	materials = list(MAT_STEEL = 1100)
+	build_type = AUTOLATHE
+	build_path = /obj/item/ammo_magazine/ammo_box/b9mm/flash
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_HACKED,
+		RND_SUBCATEGORY_WEAPONS_AMMO + RND_SUBCATEGORY_WEAPONS_AMMO_BOXES
+	)

--- a/modular_chomp/code/modules/research/tg/techweb/nodes/security_nodes.dm
+++ b/modular_chomp/code/modules/research/tg/techweb/nodes/security_nodes.dm
@@ -34,4 +34,17 @@
 		"rifle_mag_mp59mm_rubber",
 		"rifle_mag_mp59mm_ap",
 		"rifle_mag_mp59mm_hp",
+
+		"pistol_mag_vp70",
+		"pistol_mag_vp70_ap",
+		"pistol_mag_vp70_hp",
+		"pistol_mag_vp70_rubber",
+		"pistol_mag_vp70_flash",
+
+		"ammobox_9mm",
+		"ammobox_9mm_practice",
+		"ammobox_9mm_ap",
+		"ammobox_9mm_hp",
+		"ammobox_9mm_rubber",
+		"ammobox_9mm_flash",
 	)


### PR DESCRIPTION
## About The Pull Request
What it says on the tin. Was requested in dev chat.

## Changelog
Adds chomp unique 9mm ammo boxes, and vp70 magazines.

:cl: Will
add: 9mm ammo boxes added to autolathe
add: vp70 magazines added to autolathe
/:cl:
