### PR TITLE
Xenomorph Hybrid Oversight Fix

### DIFF
--- a/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
+++ b/modular_chomp/code/modules/mob/living/carbon/human/species/station/station_ch.dm
@@ -66,6 +66,7 @@
 	burn_mod = 2 // Fire does not mix well with their silicon carapace.
 	toxins_mod = 0.5 // Resistant to toxins.
 	trauma_mod = 0.3 // Highly resistant to pain.
+	pain_mod = 0.3 // Highly resistant to pain.
 	rad_removal_mod = 1.5 // Radiation leaves the body much faster.
 	chem_strength_heal = 0.1 // Acidic blood neutralizes most injected and ingested beneficial chemicals.
 	metabolic_rate = 1.3 // Very physically active species, thus requiring more nutritional intake.


### PR DESCRIPTION
I never actually added the pain_mod to the Xenomorph Hybrids despite saying I did in PR #12238 . They are currently not 'highly resistant' to pain and will still crumple over from a few taser shots. Oops.

This fixes that.

:cl:
fix: Actually makes Xenomorph Hybrids highly resistant to pain.
/:cl: