### PR TITLE
Fix M4A1 not cycling properly

### DIFF
--- a/code/modules/projectiles/guns/projectile/zz_ballistics_ch.dm
+++ b/code/modules/projectiles/guns/projectile/zz_ballistics_ch.dm
@@ -332,6 +332,7 @@
 	)
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY | LOCK_SLAPPABLE
 	load_method = MAGAZINE
+	manual_chamber = FALSE
 	muzzle_velocity = 910
 	w_class = ITEMSIZE_HUGE
 	one_handed_penalty = 50

--- a/modular_chomp/code/modules/projectiles/guns/zBallisticPort/bullet.dm
+++ b/modular_chomp/code/modules/projectiles/guns/zBallisticPort/bullet.dm
@@ -262,6 +262,7 @@
 		list(mode_name="semiauto",       burst=1, fire_delay=0,    move_delay=null, burst_accuracy=null, dispersion=null),
 		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4,    burst_accuracy=list(0,-10,-10), dispersion=list(0.0, 0.3, 0.6))
 	)
+	manual_chamber = FALSE
 	auto_loading_type = CLOSED_BOLT | LOCK_OPEN_EMPTY | LOCK_SLAPPABLE
 	load_method = MAGAZINE
 	w_class = ITEMSIZE_HUGE


### PR DESCRIPTION
## Changelog
Flags the M4A1 as not a manually cycled gun. Caused the chamber to not cycle properly.

:cl: Will
fix: M4A1 properly cycles rounds
/:cl:

