### PR TITLE
Object Vore Liberation

### DIFF
--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -23,6 +23,7 @@
 	add_verb(src, /mob/living/proc/mute_entry)
 	add_verb(src, /mob/living/proc/liquidbelly_visuals)
 	add_verb(src, /mob/living/proc/fix_vore_effects)
+	add_verb(src, /mob/living/proc/restrict_trasheater) //CHOMPAdd
 
 	if(!no_vore)
 		add_verb(src, /mob/living/proc/vorebelly_printout)

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -1612,6 +1612,7 @@
 	set desc = "Toggle Trash Eater restriction level."
 	adminbus_trash = !adminbus_trash
 	to_chat(src, span_vwarning("Trash Eater restriction level set to [adminbus_trash ? "everything not blacklisted" : "only whitelisted items"]."))
+	log_and_message_admins("toggled their trash eater restriction level to [adminbus_trash ? "loose" : "strict"]. [ADMIN_FLW(src)]", src) //CHOMPAdd
 
 /mob/living/proc/liquidbelly_visuals()
 	set name = "Toggle Liquidbelly Visuals"


### PR DESCRIPTION

## About The Pull Request
Something fun a lot of people had been wishing for, including myself.
Adds the trash eater restriction toggle verb to the vore verbs on living mob login and an admin log alert for sussing out possible abuse when the verb is used.
## Changelog
:cl:
add: Added trash eater toggle to the vore verbs on living mob login.
add: Added an admin log alert for the trash eater toggle verb for sussing out possible abuse.
/:cl:
