### PR TITLE
Fixes webbing price

### DIFF
--- a/modular_chomp/maps/common/common_loadout.dm
+++ b/modular_chomp/maps/common/common_loadout.dm
@@ -1,3 +1,6 @@
+/datum/gear/accessory/webbing_selector
+	cost = 1 //The below added the highercost/special ones to the loadout for 1 point.
+
 /datum/gear/accessory/brown_vest
 	display_name = "webbing, brown"
 	path = /obj/item/clothing/accessory/storage/brown_vest


### PR DESCRIPTION

## About The Pull Request
Makes the webbing selector 1 point instead of 2.

All the webbings accessible via it (the highest capacity one is Drop Pouches) already are available in loadout for 1 point.
## Changelog
:cl: Diana
balance: Lowered the price of the webbing selector to 1 point, on par with all the other webbings.
/:cl:
