### PR TITLE
Gets rid of unused interface window

### DIFF
--- a/code/modules/client/preference_setup/general/03_body.dm
+++ b/code/modules/client/preference_setup/general/03_body.dm
@@ -549,7 +549,6 @@
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 		if("marking_remove")
 			var/M = params["marking"]
-			winshow(user, "prefs_markings_subwindow", FALSE)
 			pref.body_markings -= M
 			return TOPIC_REFRESH_UPDATE_PREVIEW
 		if("marking_color")

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1411,30 +1411,6 @@ window "popupwindow"
 		statusbar = false
 		can-resize = false
 
-window "prefs_markings_subwindow"
-	elem "prefs_markings_subwindow"
-		type = MAIN
-		pos = 281,0
-		size = 400x400
-		anchor1 = -1,-1
-		anchor2 = -1,-1
-		background-color = none
-		is-visible = false
-		saved-params = "pos;size;is-minimized;is-maximized"
-		title = "Marking Selection Editing"
-		statusbar = false
-		can-minimize = false
-		outer-size = 416x439
-		inner-size = 400x400
-	elem "prefs_markings_browser"
-		type = BROWSER
-		pos = 0,0
-		size = 400x400
-		anchor1 = -1,-1
-		anchor2 = -1,-1
-		background-color = none
-		saved-params = ""
-
 window "rpane"
 	elem "rpane"
 		type = MAIN


### PR DESCRIPTION

## About The Pull Request

Most references to this window/element have been removed in PR #10930. These seem to have been some missed leftovers as the system was upgraded.

It is most noticeable on Linux playing the game through Wine, as there is a black/empty and non-closeable "Marking Selection Editing" window that spawns with the game itself.

## Changelog
:cl:
fix: Removes old/unused interface window/element
/:cl:
