### PR TITLE
Enabling the middle ground object vore

### DIFF
--- a/code/game/objects/trash_eating.dm
+++ b/code/game/objects/trash_eating.dm
@@ -41,19 +41,20 @@
 	if(is_type_in_list(src, GLOB.edible_tech) && user.isSynthetic())
 		return TRUE
 
-	return FALSE
-	/*
+	//CHOMPEdit Start. Enabling the middle ground.
+	// return FALSE
+
 	//The below allows checks for certain crtieria to decline it, otherwise allow it. Comented out until
 	if(force > 30 || throwforce > 30) //Swords, etc.
 		to_chat(user, span_warning("The [src] is too powerful to eat."))
 		return FALSE
 
-	if(w_class >= ITEMSIZE_NORMAL)
+	if(w_class > ITEMSIZE_NORMAL)
 		to_chat(user, span_warning("The [src] is too large to eat."))
 		return FALSE
 
 	return TRUE
-	*/
+	//CHOMPEdit End
 
 ///Recursively searches through items for invalid items.
 ///Returns the blacklisted item.


### PR DESCRIPTION

## About The Pull Request
Uncomments the middle ground functionality that was coded but never enabled upstream.

This also fixes the trash eating failure messages considering any unwhitelisted item as a blacklisted one with a needlessly harsh message. Also made it allow normal sized items rather than limiting it to pocket sized stuff.

I'm tired of waiting for this stuff while watching the consequences of the half-assed de-implementation souring the mood even further by having the condescending failure messages treat every non-whitelisted attempt as a blacklisted item worth a rule-breaky slap on the wrist.
## Changelog
:cl:
balance: Enabled the middle ground object vore. (with normal sized items)
balance: Fixed every nonwhitelisted object vore attempt being condescendingly treated as a blacklisted one worth a rule-breaky slap on the wrist.
/:cl:
